### PR TITLE
Replace MessageSender trait with struct

### DIFF
--- a/rust/crates/cove-macros/src/lib.rs
+++ b/rust/crates/cove-macros/src/lib.rs
@@ -104,18 +104,3 @@ macro_rules! new_type {
         pub struct $name(Vec<$type>);
     };
 }
-
-#[macro_export]
-#[allow(clippy::crate_in_macro_def)]
-macro_rules! impl_manager_message_send {
-    ($manager:ident) => {
-        impl crate::manager::deferred_sender::ManagerMessageSend<Message>
-            for std::sync::Arc<$manager>
-        {
-            fn send(&self, msgs: SingleOrMany) {
-                // just forward to the UDL-generated `send`
-                self.send(msgs);
-            }
-        }
-    };
-}

--- a/rust/src/manager/deferred_sender.rs
+++ b/rust/src/manager/deferred_sender.rs
@@ -102,9 +102,11 @@ where
     T: Debug + Send + Sync + 'static,
 {
     fn drop(&mut self) {
-        let msgs = std::mem::take(&mut self.buffer);
-        if !msgs.is_empty() {
-            self.sender.send(SingleOrMany::Many(msgs));
+        let mut msgs = std::mem::take(&mut self.buffer);
+        match msgs.len() {
+            0 => {}
+            1 => self.sender.send(SingleOrMany::Single(msgs.pop().expect("just checked len"))),
+            _ => self.sender.send(SingleOrMany::Many(msgs)),
         }
     }
 }

--- a/rust/src/manager/deferred_sender.rs
+++ b/rust/src/manager/deferred_sender.rs
@@ -1,4 +1,10 @@
-/// 1) One generic enum to replace all of your `Messages` enums.
+use std::fmt::Debug;
+
+use flume::{Sender, TrySendError};
+use tracing::{debug, error, warn};
+
+use crate::task;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum SingleOrMany<T> {
     Single(T),
@@ -17,39 +23,88 @@ impl<T> From<Vec<T>> for SingleOrMany<T> {
     }
 }
 
-pub trait ManagerMessageSend<T>: Clone + Send + Sync + 'static {
-    fn send(&self, msgs: SingleOrMany<T>);
-}
-
-pub struct DeferredSender<M, T>
+#[derive(Debug, Clone)]
+pub struct DeferredSender<T>
 where
-    M: ManagerMessageSend<T>,
+    T: Debug + Send + Sync + 'static,
 {
-    manager: M,
+    sender: MessageSender<T>,
     buffer: Vec<T>,
 }
 
-impl<M, T> DeferredSender<M, T>
+impl<T> DeferredSender<T>
 where
-    M: ManagerMessageSend<T>,
+    T: Debug + Send + Sync + 'static,
 {
-    pub fn new(manager: M) -> Self {
-        DeferredSender { manager, buffer: Vec::new() }
+    pub fn new(sender: MessageSender<T>) -> Self {
+        Self { sender, buffer: vec![] }
     }
 
-    pub fn queue(&mut self, msg: T) {
-        self.buffer.push(msg);
+    pub fn queue(&mut self, message: T) {
+        self.buffer.push(message);
     }
 }
 
-impl<M, T> Drop for DeferredSender<M, T>
+#[derive(Debug)]
+pub struct MessageSender<T> {
+    sender: Sender<SingleOrMany<T>>,
+}
+
+impl<T> Clone for MessageSender<T> {
+    fn clone(&self) -> Self {
+        Self { sender: self.sender.clone() }
+    }
+}
+
+impl<T> MessageSender<T>
 where
-    M: ManagerMessageSend<T>,
+    T: Debug + Send + Sync + 'static,
+{
+    pub fn new(sender: Sender<SingleOrMany<T>>) -> Self {
+        Self { sender }
+    }
+
+    pub fn send(&self, message: impl Into<SingleOrMany<T>>) {
+        let message = message.into();
+        debug!("send: {message:?}");
+        match self.sender.try_send(message) {
+            Ok(_) => {}
+            Err(TrySendError::Full(message)) => {
+                warn!("[WARN] unable to send, queue is full, sending async");
+
+                let me = self.clone();
+                task::spawn(async move { me.send_async(message).await });
+            }
+            Err(e) => {
+                error!("unable to send message to send flow manager: {e:?}");
+            }
+        }
+    }
+
+    pub fn try_send(
+        &self,
+        message: impl Into<SingleOrMany<T>>,
+    ) -> Result<(), TrySendError<SingleOrMany<T>>> {
+        self.sender.try_send(message.into())
+    }
+
+    pub async fn send_async(&self, message: impl Into<SingleOrMany<T>>) {
+        let message = message.into();
+        debug!("send_async: {message:?}");
+        if let Err(err) = self.sender.send_async(message).await {
+            error!("unable to send message to send flow manager: {err}");
+        }
+    }
+}
+
+impl<T> Drop for DeferredSender<T>
+where
+    T: Debug + Send + Sync + 'static,
 {
     fn drop(&mut self) {
         let msgs = std::mem::take(&mut self.buffer);
         if !msgs.is_empty() {
-            self.manager.send(SingleOrMany::Many(msgs));
+            self.sender.send(SingleOrMany::Many(msgs));
         }
     }
 }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -59,7 +59,6 @@ type Action = WalletManagerAction;
 type Message = WalletManagerReconcileMessage;
 type Reconciler = dyn WalletManagerReconciler;
 pub type SingleOrMany = deferred_sender::SingleOrMany<Message>;
-cove_macros::impl_manager_message_send!(RustWalletManager);
 
 #[derive(Debug, Clone, Eq, PartialEq, uniffi::Enum)]
 pub enum WalletManagerReconcileMessage {


### PR DESCRIPTION
closes: #269 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized and streamlined message sending by introducing a new `MessageSender` abstraction, replacing direct use of channels and macros across managers.
  - Simplified deferred message handling with an updated `DeferredSender`.
  - Removed redundant macros and trait implementations related to message sending.
  - Updated managers to use the new message sending approach internally without changing public APIs.

- **Bug Fixes**
  - Improved error handling and logging for message dispatch, including fallback to asynchronous sending if channels are full.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->