### PR TITLE
Consistently use balance `spendable` instead of `total`

### DIFF
--- a/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
@@ -207,7 +207,7 @@ struct SelectedWalletScreen: View {
     var MainContent: some View {
         VStack(spacing: 0) {
             WalletBalanceHeaderView(
-                balance: manager.balance.total(),
+                balance: manager.balance.spendable(),
                 metadata: manager.walletMetadata,
                 updater: updater,
                 showReceiveSheet: showReceiveSheet
@@ -222,7 +222,9 @@ struct SelectedWalletScreen: View {
             Transactions
                 .environment(manager)
 
-            SelctedWalletScreenExporterView(labelManager: labelManager, metadata: metadata, exporting: $exporting)
+            SelctedWalletScreenExporterView(
+                labelManager: labelManager, metadata: metadata, exporting: $exporting
+            )
         }
         .background(Color.coveBg)
         .toolbar { MainToolBar }
@@ -315,7 +317,9 @@ struct SelectedWalletScreen: View {
         .onAppear {
             // make sure the wallet is marked as selected
             if Database().globalConfig().selectedWallet() != metadata.id {
-                Log.warn("Wallet was not selected, but when to selected wallet screen, updating database")
+                Log.warn(
+                    "Wallet was not selected, but when to selected wallet screen, updating database"
+                )
                 try? Database().globalConfig().selectWallet(id: metadata.id)
             }
         }

--- a/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
@@ -13,7 +13,7 @@ struct WalletBalanceHeaderView: View {
     @Environment(WalletManager.self) var manager
 
     // args
-    // confirmed balance
+    // trusted spendable balance
     let balance: Amount
     @State var fiatBalance: Double? = nil
     let metadata: WalletMetadata

--- a/ios/Cove/Flows/SendFlow/SendFlowContainer.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowContainer.swift
@@ -85,7 +85,7 @@ public struct SendFlowContainer: View {
             .environment(sendFlowManager)
             .onAppear {
                 // if zero balance, show alert and send back
-                if manager.balance.total().asSats() == 0 {
+                if manager.balance.spendable().asSats() == 0 {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                         withAnimation(.easeInOut(duration: 0.4)) {
                             presenter.focusField = .none

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -1094,8 +1094,6 @@ public protocol BalanceProtocol: AnyObject, Sendable {
     
     func spendable()  -> Amount
     
-    func total()  -> Amount
-    
 }
 open class Balance: BalanceProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -1159,13 +1157,6 @@ public static func zero() -> Balance  {
 open func spendable() -> Amount  {
     return try!  FfiConverterTypeAmount_lift(try! rustCall() {
     uniffi_cove_fn_method_balance_spendable(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func total() -> Amount  {
-    return try!  FfiConverterTypeAmount_lift(try! rustCall() {
-    uniffi_cove_fn_method_balance_total(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -26833,9 +26824,6 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_balance_spendable() != 18496) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_balance_total() != 44866) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_cove_checksum_method_bbqrjoinresult_final_result() != 44157) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -27905,10 +27893,10 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitSendFlowManagerReconciler()
     uniffiCallbackInitTapcardTransportProtocol()
     uniffiCallbackInitWalletManagerReconciler()
-    uniffiEnsureCoveTypesInitialized()
     uniffiEnsureCoveTapCardInitialized()
-    uniffiEnsureCoveDeviceInitialized()
     uniffiEnsureCoveNfcInitialized()
+    uniffiEnsureCoveTypesInitialized()
+    uniffiEnsureCoveDeviceInitialized()
     return InitializationResult.ok
 }()
 

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -504,7 +504,7 @@ impl RustWalletManager {
             .await
             .map_err(|_| Error::WalletBalanceError("unable to get balance".to_string()))?;
 
-        self.amount_in_fiat(balance.total().into()).await
+        self.amount_in_fiat(balance.spendable().into()).await
     }
 
     #[uniffi::method]

--- a/rust/src/wallet/balance.rs
+++ b/rust/src/wallet/balance.rs
@@ -22,11 +22,6 @@ impl Balance {
     }
 
     #[uniffi::method]
-    pub fn total(&self) -> Amount {
-        self.0.total().into()
-    }
-
-    #[uniffi::method]
     pub fn spendable(&self) -> Amount {
         self.0.trusted_spendable().into()
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Wallet balance displays now show the trusted spendable balance instead of the total balance.
- **Bug Fixes**
	- Zero balance alerts and related UI behavior are now based on spendable balance, ensuring more accurate notifications.
- **Documentation**
	- Updated comments to clarify that the displayed balance refers to the trusted spendable amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->