### PR TITLE
Fix numbering on Seed Import

### DIFF
--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreen.swift
@@ -165,7 +165,7 @@ struct HotWalletImportScreen: View {
                     }()
 
             // see if its single qr or seed qr
-            if let words = try multiQr.getGroupedWords(qr: qr, groupsOf: UInt8(6)) {
+            if let words = try multiQr.getGroupedWords(qr: qr, groupsOf: UInt8(groupsOf)) {
                 setWords(words)
             }
         } catch {
@@ -491,7 +491,7 @@ struct HotWalletImportScreen: View {
         // try string first
         if let string = new?.string() {
             do {
-                let words = try groupedPlainWordsOf(mnemonic: string, groups: 6)
+                let words = try groupedPlainWordsOf(mnemonic: string, groups: UInt8(groupsOf))
                 return setWords(words)
             } catch {
                 Log.error("Error NFC word parsing: \(error)")
@@ -502,7 +502,7 @@ struct HotWalletImportScreen: View {
         guard let data = new?.data() else { return }
         do {
             let seedQR = try SeedQr.newFromData(data: data)
-            let words = seedQR.groupedPlainWords()
+            let words = seedQR.groupedPlainWords(groupsOf: UInt8(groupsOf))
             setWords(words)
         } catch {
             Log.error("Error NFC word parsing from data: \(error)")

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -8610,7 +8610,7 @@ public protocol SeedQrProtocol: AnyObject, Sendable {
     
     func getWords()  -> [String]
     
-    func groupedPlainWords()  -> [[String]]
+    func groupedPlainWords(groupsOf: UInt8)  -> [[String]]
     
 }
 open class SeedQr: SeedQrProtocol, @unchecked Sendable {
@@ -8688,9 +8688,10 @@ open func getWords() -> [String]  {
 })
 }
     
-open func groupedPlainWords() -> [[String]]  {
+open func groupedPlainWords(groupsOf: UInt8) -> [[String]]  {
     return try!  FfiConverterSequenceSequenceString.lift(try! rustCall() {
-    uniffi_cove_fn_method_seedqr_grouped_plain_words(self.uniffiClonePointer(),$0
+    uniffi_cove_fn_method_seedqr_grouped_plain_words(self.uniffiClonePointer(),
+        FfiConverterUInt8.lower(groupsOf),$0
     )
 })
 }
@@ -27550,7 +27551,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_seedqr_get_words() != 64188) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_seedqr_grouped_plain_words() != 35569) {
+    if (uniffi_cove_checksum_method_seedqr_grouped_plain_words() != 5692) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_tapsignerreader_continue_setup() != 43346) {
@@ -27893,9 +27894,9 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitSendFlowManagerReconciler()
     uniffiCallbackInitTapcardTransportProtocol()
     uniffiCallbackInitWalletManagerReconciler()
+    uniffiEnsureCoveTypesInitialized()
     uniffiEnsureCoveTapCardInitialized()
     uniffiEnsureCoveNfcInitialized()
-    uniffiEnsureCoveTypesInitialized()
     uniffiEnsureCoveDeviceInitialized()
     return InitializationResult.ok
 }()

--- a/rust/src/mnemonic.rs
+++ b/rust/src/mnemonic.rs
@@ -88,7 +88,7 @@ pub fn grouped_plain_words_of(
                 )
             })?;
 
-            Ok(seed_qr.mnemonic().grouped_plain_words_of(6))
+            Ok(seed_qr.mnemonic().grouped_plain_words_of(groups as usize))
         }
     }
 }

--- a/rust/src/seed_qr.rs
+++ b/rust/src/seed_qr.rs
@@ -100,8 +100,8 @@ impl SeedQr {
     }
 
     #[uniffi::method]
-    pub fn grouped_plain_words(&self) -> Vec<Vec<String>> {
-        self.mnemonic().grouped_plain_words_of(6)
+    pub fn grouped_plain_words(&self, groups_of: u8) -> Vec<Vec<String>> {
+        self.mnemonic().grouped_plain_words_of(groups_of as usize)
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved flexibility for importing wallet mnemonics by allowing dynamic grouping of words during QR code and NFC scanning, instead of using a fixed group size.
- **Bug Fixes**
	- Ensured consistent handling of mnemonic word grouping across different import methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->