### PR TITLE
Fixe unsealed TAPSIGNER being detected as already initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Fixed unsealed TAPSIGNER being detected as already initialized
+- Show full address derivation path including the keychain index
+
 ## [1.0.0] - 2025-06-11
 
 - Fix import words view being cut off on smaller screens and iPads

--- a/ios/Cove.xcodeproj/project.pbxproj
+++ b/ios/Cove.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				CODE_SIGN_ENTITLEMENTS = Cove/Cove.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_ASSET_PATHS = "\"Cove/Preview Content\"";
 				DEVELOPMENT_TEAM = Q8UP8C53Y8;
 				ENABLE_PREVIEWS = YES;
@@ -330,7 +330,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = org.bitcoinppl.cove;
@@ -354,7 +354,7 @@
 				CODE_SIGN_ENTITLEMENTS = Cove/Cove.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_ASSET_PATHS = "\"Cove/Preview Content\"";
 				DEVELOPMENT_TEAM = Q8UP8C53Y8;
 				ENABLE_PREVIEWS = YES;
@@ -377,7 +377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = org.bitcoinppl.cove;

--- a/ios/Cove/CoveApp.swift
+++ b/ios/Cove/CoveApp.swift
@@ -360,9 +360,9 @@ struct CoveApp: App {
                 handleAddress(addressWithNetwork)
             case let .transaction(txn):
                 handleTransaction(txn)
-            case let .tapSignerInit(tapSigner):
+            case let .tapSignerUnused(tapSigner):
                 app.sheetState = .init(.tapSigner(TapSignerRoute.initSelect(tapSigner)))
-            case let .tapSigner(tapSigner):
+            case let .tapSignerReady(tapSigner):
                 let panic =
                     "TAPSIGNER not implemented \(tapSigner) doesn't make sense for file import"
                 Log.error(panic)
@@ -415,9 +415,9 @@ struct CoveApp: App {
                 handleAddress(addressWithNetwork)
             case let .transaction(transaction):
                 handleTransaction(transaction)
-            case let .tapSignerInit(tapSigner):
+            case let .tapSignerUnused(tapSigner):
                 app.alertState = .init(.uninitializedTapSigner(tapSigner))
-            case let .tapSigner(tapSigner):
+            case let .tapSignerReady(tapSigner):
                 if let wallet = app.findTapSignerWallet(tapSigner) {
                     app.alertState = .init(.tapSignerWalletFound(wallet.id))
                 } else {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -17509,12 +17509,12 @@ public enum MultiFormat {
     /**
      * TAPSIGNER has not been initialized yet
      */
-    case tapSigner(TapSigner
+    case tapSignerReady(TapSigner
     )
     /**
      * TAPSIGNER has not been initialized yet
      */
-    case tapSignerInit(TapSigner
+    case tapSignerUnused(TapSigner
     )
 }
 
@@ -17548,10 +17548,10 @@ public struct FfiConverterTypeMultiFormat: FfiConverterRustBuffer {
         case 5: return .bip329Labels(try FfiConverterTypeBip329Labels.read(from: &buf)
         )
         
-        case 6: return .tapSigner(try FfiConverterTypeTapSigner.read(from: &buf)
+        case 6: return .tapSignerReady(try FfiConverterTypeTapSigner.read(from: &buf)
         )
         
-        case 7: return .tapSignerInit(try FfiConverterTypeTapSigner.read(from: &buf)
+        case 7: return .tapSignerUnused(try FfiConverterTypeTapSigner.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -17587,12 +17587,12 @@ public struct FfiConverterTypeMultiFormat: FfiConverterRustBuffer {
             FfiConverterTypeBip329Labels.write(v1, into: &buf)
             
         
-        case let .tapSigner(v1):
+        case let .tapSignerReady(v1):
             writeInt(&buf, Int32(6))
             FfiConverterTypeTapSigner.write(v1, into: &buf)
             
         
-        case let .tapSignerInit(v1):
+        case let .tapSignerUnused(v1):
             writeInt(&buf, Int32(7))
             FfiConverterTypeTapSigner.write(v1, into: &buf)
             
@@ -27909,9 +27909,9 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitTapcardTransportProtocol()
     uniffiCallbackInitWalletManagerReconciler()
     uniffiEnsureCoveTapCardInitialized()
+    uniffiEnsureCoveNfcInitialized()
     uniffiEnsureCoveDeviceInitialized()
     uniffiEnsureCoveTypesInitialized()
-    uniffiEnsureCoveNfcInitialized()
     return InitializationResult.ok
 }()
 

--- a/rust/crates/cove-tap-card/src/parse.rs
+++ b/rust/crates/cove-tap-card/src/parse.rs
@@ -307,6 +307,13 @@ mod tests {
             _ => panic!("not a tap signer"),
         };
 
+        match ts.state {
+            TapSignerState::Sealed => {
+                assert!(true)
+            }
+            _ => panic!("not unused"),
+        }
+
         let readable_ident = &ts.full_card_ident();
         assert_eq!(readable_ident, "XUFC5-2SWY2-PX24Q-IZC7W")
     }


### PR DESCRIPTION
- **Bug Fixes**
  - Resolved an issue where unsealed TAPSIGNER cards were incorrectly detected as already initialized.

- **Style**
  - Updated naming of TAPSIGNER-related statuses and options in the app for improved clarity and consistency.