### PR TITLE
Fix crashing on APDU error during TAPSIGNER setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed unsealed TAPSIGNER being detected as already initialized
 - Show full address derivation path including the keychain index
+- Fix crashing on APDU NFC error
 
 ## [1.0.0] - 2025-06-11
 

--- a/ios/Cove.xcodeproj/project.pbxproj
+++ b/ios/Cove.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				CODE_SIGN_ENTITLEMENTS = Cove/Cove.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"Cove/Preview Content\"";
 				DEVELOPMENT_TEAM = Q8UP8C53Y8;
 				ENABLE_PREVIEWS = YES;
@@ -354,7 +354,7 @@
 				CODE_SIGN_ENTITLEMENTS = Cove/Cove.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"Cove/Preview Content\"";
 				DEVELOPMENT_TEAM = Q8UP8C53Y8;
 				ENABLE_PREVIEWS = YES;

--- a/ios/Cove/Extention/Error+Ext.swift
+++ b/ios/Cove/Extention/Error+Ext.swift
@@ -27,6 +27,10 @@ extension TransportError {
     init(code: Int, message: String) {
         self = createTransportErrorFromCode(code: UInt16(code), message: message)
     }
+    
+    var describe: String {
+        describeTransportError(error: self)
+    }
 }
 
 extension TapSignerReaderError {

--- a/ios/Cove/Extention/Error+Ext.swift
+++ b/ios/Cove/Extention/Error+Ext.swift
@@ -27,7 +27,7 @@ extension TransportError {
     init(code: Int, message: String) {
         self = createTransportErrorFromCode(code: UInt16(code), message: message)
     }
-    
+
     var describe: String {
         describeTransportError(error: self)
     }

--- a/ios/Cove/TapSignerNFC.swift
+++ b/ios/Cove/TapSignerNFC.swift
@@ -264,9 +264,6 @@ private class TapCardNFC: NSObject, NFCTagReaderSessionDelegate {
         tapSignerReader = nil
         tapSignerCmd = nil
 
-        //  self.satsCardReader = nil
-        //  self.satsCardReader = nil
-
         tag = nil
         session = nil
         transport = nil

--- a/ios/Cove/TapSignerNFC.swift
+++ b/ios/Cove/TapSignerNFC.swift
@@ -123,7 +123,7 @@ class TapSignerNFC {
                             return
                         }
 
-                        if let error = self.nfc.tapSignerError {
+                        if let error: TapSignerReaderError = self.nfc.tapSignerError {
                             continuation.resume(throwing: error)
                             return
                         }
@@ -418,7 +418,7 @@ class TapCardTransport: TapcardTransportProtocol, @unchecked Sendable {
 
                 if let error {
                     logger.error("APDU error: \(error)")
-                    continuation.resume(throwing: error)
+                    continuation.resume(throwing: TransportError.UnknownError(error.localizedDescription))
                     return
                 }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -21383,6 +21383,8 @@ public enum TransportError: Swift.Error {
     )
     case CvcChangeError(String
     )
+    case UnknownError(String
+    )
 }
 
 
@@ -21415,6 +21417,9 @@ public struct FfiConverterTypeTransportError: FfiConverterRustBuffer {
             try FfiConverterString.read(from: &buf)
             )
         case 6: return .CvcChangeError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 7: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -21456,6 +21461,11 @@ public struct FfiConverterTypeTransportError: FfiConverterRustBuffer {
         
         case let .CvcChangeError(v1):
             writeInt(&buf, Int32(6))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .UnknownError(v1):
+            writeInt(&buf, Int32(7))
             FfiConverterString.write(v1, into: &buf)
             
         }
@@ -27908,10 +27918,10 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitSendFlowManagerReconciler()
     uniffiCallbackInitTapcardTransportProtocol()
     uniffiCallbackInitWalletManagerReconciler()
-    uniffiEnsureCoveTapCardInitialized()
+    uniffiEnsureCoveTypesInitialized()
     uniffiEnsureCoveNfcInitialized()
     uniffiEnsureCoveDeviceInitialized()
-    uniffiEnsureCoveTypesInitialized()
+    uniffiEnsureCoveTapCardInitialized()
     return InitializationResult.ok
 }()
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -26314,6 +26314,13 @@ public func describeTapSignerReaderError(error: TapSignerReaderError) -> String 
     )
 })
 }
+public func describeTransportError(error: TransportError) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_cove_fn_func_describe_transport_error(
+        FfiConverterTypeTransportError_lower(error),$0
+    )
+})
+}
 public func describeWalletError(error: WalletError) -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_cove_fn_func_describe_wallet_error(
@@ -26697,6 +26704,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_describe_tap_signer_reader_error() != 18001) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_describe_transport_error() != 49523) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_describe_wallet_error() != 7428) {
@@ -27918,10 +27928,10 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitSendFlowManagerReconciler()
     uniffiCallbackInitTapcardTransportProtocol()
     uniffiCallbackInitWalletManagerReconciler()
-    uniffiEnsureCoveTypesInitialized()
     uniffiEnsureCoveNfcInitialized()
-    uniffiEnsureCoveDeviceInitialized()
+    uniffiEnsureCoveTypesInitialized()
     uniffiEnsureCoveTapCardInitialized()
+    uniffiEnsureCoveDeviceInitialized()
     return InitializationResult.ok
 }()
 

--- a/rust/src/tap_card.rs
+++ b/rust/src/tap_card.rs
@@ -180,3 +180,8 @@ pub fn is_valid_chain_code(chain_code: String) -> bool {
     let Ok(chain_code) = hex::decode(chain_code) else { return false };
     chain_code.len() == 32
 }
+
+#[uniffi::export]
+fn describe_transport_error(error: TransportError) -> String {
+    error.to_string()
+}

--- a/rust/src/tap_card.rs
+++ b/rust/src/tap_card.rs
@@ -23,6 +23,9 @@ pub enum TransportError {
 
     #[error("CvcChangeError: {0}")]
     CvcChangeError(String),
+
+    #[error("UnknownError: {0}")]
+    UnknownError(String),
 }
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, thiserror::Error, uniffi::Error)]
@@ -104,6 +107,7 @@ impl From<TransportError> for ApduError {
             TransportError::IncorrectSignature(msg) => ApduError::IncorrectSignature(msg),
             TransportError::UnknownCardType(msg) => ApduError::UnknownCardType(msg),
             TransportError::CvcChangeError(_) => ApduError::CkTap(CkTapError::BadArguments.into()),
+            TransportError::UnknownError(_) => ApduError::CkTap(CkTapError::BadArguments.into()),
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue causing the app to crash on APDU NFC errors.
- **Chores**
	- Updated the app version number.
	- Improved error descriptions for NFC transport errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->