### PR TITLE
Add Send Screen UI and related string resources

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/send/SendScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/send/SendScreen.kt
@@ -1,0 +1,434 @@
+package org.bitcoinppl.cove.send
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CurrencyBitcoin
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.cove.R
+import org.bitcoinppl.cove.views.ImageButton
+
+@Preview()
+@Composable
+private fun SendScreenPreview() {
+    val snack = remember { SnackbarHostState() }
+    SendScreen(
+        onBack = {},
+        onNext = {},
+        onScanQr = {},
+        onChangeSpeed = {},
+        onToggleBalanceVisibility = {},
+        isBalanceHidden = false,
+        balanceAmount = "1,166,369",
+        balanceDenomination = "sats",
+        amountText = "25,555",
+        amountDenomination = "sats",
+        dollarEquivalentText = "$28.87",
+        initialAddress = "tb1qt 5alnv 8pm66 hv2zd cdzxr kyqfn wpuh8 9zrey kx",
+        accountShort = "560072A4",
+        feeEta = "30 minutes",
+        feeAmount = "451 sats",
+        totalSpendingCrypto = "26,006 sats",
+        totalSpendingFiat = "≈ $29.38",
+        snackbarHostState = snack,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SendScreen(
+    onBack: () -> Unit,
+    onNext: () -> Unit,
+    onScanQr: () -> Unit,
+    onChangeSpeed: () -> Unit,
+    onToggleBalanceVisibility: () -> Unit = {},
+    isBalanceHidden: Boolean = false,
+    balanceAmount: String,
+    balanceDenomination: String,
+    amountText: String,
+    amountDenomination: String,
+    dollarEquivalentText: String,
+    initialAddress: String,
+    accountShort: String,
+    feeEta: String,
+    feeAmount: String,
+    totalSpendingCrypto: String,
+    totalSpendingFiat: String,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+) {
+    val midnightBlue = Color(0xFF0D1B2A)
+    val lightBg = Color(0xFFFFFFFF)
+
+    Scaffold(
+        containerColor = midnightBlue,
+        topBar = {
+            CenterAlignedTopAppBar(
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = Color.Transparent,
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White,
+                ),
+                title = { Text("") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.image_chain_code_pattern_horizontal),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .align(Alignment.TopCenter)
+                    .offset(y = (-40).dp)
+                    .graphicsLayer(alpha = 0.25f)
+            )
+            Column(modifier = Modifier.fillMaxSize()) {
+                BalanceWidget(
+                    amount = balanceAmount,
+                    denomination = balanceDenomination,
+                    isHidden = isBalanceHidden,
+                    onToggleVisibility = onToggleBalanceVisibility
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .clip(RoundedCornerShape(topStart = 0.dp, topEnd = 0.dp))
+                        .background(lightBg)
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp)
+                ) {
+                    AmountWidget(
+                        initialAmount = amountText,
+                        denomination = amountDenomination,
+                        dollarText = dollarEquivalentText,
+                    )
+                    HorizontalDivider(color = Color(0xFFE5E5EA), thickness = 1.dp)
+                    AddressWidget(
+                        onScanQr = onScanQr,
+                        initialAddress = initialAddress
+                    )
+                    HorizontalDivider(color = Color(0xFFE5E5EA), thickness = 1.dp)
+                    SpendingWidget(
+                        accountShort = accountShort,
+                        feeEta = feeEta,
+                        feeAmount = feeAmount,
+                        totalSpendingCrypto = totalSpendingCrypto,
+                        totalSpendingFiat = totalSpendingFiat,
+                        onChangeSpeed = onChangeSpeed,
+                    )
+                    Spacer(Modifier.weight(1f))
+                    ImageButton(
+                        text = stringResource(R.string.btn_next),
+                        onClick = onNext,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = midnightBlue,
+                            contentColor = Color.White
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 24.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BalanceWidget(
+    amount: String,
+    denomination: String,
+    isHidden: Boolean,
+    onToggleVisibility: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(160.dp)
+            .padding(horizontal = 16.dp, vertical = 20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.label_balance),
+                    color = Color(0xB3FFFFFF),
+                    fontSize = 14.sp
+                )
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.Bottom) {
+                    Text(
+                        text = if (isHidden) "••••••" else amount,
+                        color = Color.White,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.size(6.dp))
+                    Text(
+                        denomination,
+                        color = Color.White,
+                        fontSize = 14.sp,
+                        modifier = Modifier.offset(y = (-4).dp)
+                    )
+                }
+            }
+            IconButton(
+                onClick = onToggleVisibility,
+                modifier = Modifier.offset(y = 8.dp, x = 8.dp)
+            ) {
+                Icon(
+                    imageVector = if (isHidden) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                    contentDescription = null,
+                    tint = Color.White
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AmountWidget(
+    initialAmount: String,
+    denomination: String,
+    dollarText: String,
+) {
+    var amount by remember { mutableStateOf(initialAmount) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Spacer(Modifier.height(20.dp))
+        Text(
+            stringResource(R.string.label_enter_amount),
+            color = Color(0xFF101010),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            stringResource(R.string.label_how_much_to_send),
+            color = Color(0xFF8F8F95),
+            fontSize = 14.sp
+        )
+        Spacer(Modifier.height(24.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                BasicTextField(
+                    value = amount,
+                    onValueChange = { amount = it },
+                    textStyle = TextStyle(
+                        color = Color(0xFF000000),
+                        fontSize = 48.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Right
+                    ),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Spacer(Modifier.width(32.dp))
+            Row(verticalAlignment = Alignment.Bottom, modifier = Modifier.offset(y = (-4).dp)) {
+                Text(denomination, color = Color(0xFF101010), fontSize = 18.sp, maxLines = 1)
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Filled.ArrowDropDown,
+                    contentDescription = null,
+                    tint = Color(0xFF101010),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Text(
+            dollarText,
+            color = Color(0xFF8F8F95),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun AddressWidget(
+    onScanQr: () -> Unit,
+    initialAddress: String,
+) {
+    var address by remember { mutableStateOf(initialAddress) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Spacer(Modifier.height(20.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.label_enter_address),
+                    color = Color(0xFF101010),
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    stringResource(R.string.label_where_send_to),
+                    color = Color(0xFF8F8F95),
+                    fontSize = 14.sp
+                )
+            }
+            IconButton(
+                onClick = onScanQr,
+                modifier = Modifier.offset(x = 8.dp)
+
+            ) {
+                Icon(Icons.Filled.QrCode2, contentDescription = null, tint = Color(0xFF6F6F75))
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        BasicTextField(
+            value = address,
+            onValueChange = { address = it },
+            textStyle = TextStyle(
+                color = Color(0xFF101010),
+                fontSize = 15.sp,
+                lineHeight = 20.sp,
+                fontWeight = FontWeight.Medium,
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun SpendingWidget(
+    accountShort: String,
+    feeEta: String,
+    feeAmount: String,
+    totalSpendingCrypto: String,
+    totalSpendingFiat: String,
+    onChangeSpeed: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Spacer(Modifier.height(20.dp))
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                stringResource(R.string.label_account),
+                color = Color(0xFF8F8F95),
+                fontSize = 14.sp,
+                modifier = Modifier.weight(1f)
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.CurrencyBitcoin,
+                    contentDescription = null,
+                    tint = Color(0xFFF59E0B),
+                    modifier = Modifier.size(28.dp)
+                )
+                Spacer(Modifier.size(8.dp))
+                Column(horizontalAlignment = Alignment.Start) {
+                    Text(accountShort, color = Color(0xFF8F8F95), fontSize = 14.sp)
+                    Spacer(Modifier.size(4.dp))
+                    Text(
+                        stringResource(R.string.label_main),
+                        color = Color(0xFF101010),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(24.dp))
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.label_network_fee),
+                    color = Color(0xFF8F8F95),
+                    fontSize = 14.sp
+                )
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(feeEta, color = Color(0xFF8F8F95), fontSize = 12.sp)
+                    Spacer(Modifier.size(4.dp))
+                    Text(
+                        stringResource(R.string.btn_change_speed),
+                        color = Color(0xFF007AFF),
+                        fontSize = 12.sp,
+                        modifier = Modifier
+                            .clickable(onClick = onChangeSpeed)
+                            .padding(4.dp)
+                    )
+                }
+            }
+            Text(feeAmount, color = Color(0xFF8F8F95), fontSize = 14.sp)
+        }
+        Spacer(Modifier.height(24.dp))
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+            Text(
+                stringResource(R.string.label_total_spending),
+                color = Color(0xFF101010),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f)
+            )
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    totalSpendingCrypto,
+                    color = Color(0xFF101010),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    totalSpendingFiat,
+                    color = Color(0xFF8F8F95),
+                    fontSize = 12.sp,
+                    textAlign = TextAlign.End
+                )
+            }
+        }
+        Spacer(Modifier.height(20.dp))
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -70,4 +70,13 @@
     <string name="denotes_utxo_change">Denotes UTXO change</string>
     <string name="continue_button">Continue</string>
     <string name="continue_with_count">Continue (%1$d)</string>
+    <string name="label_balance">Balance</string>
+    <string name="label_enter_amount">Enter amount</string>
+    <string name="label_how_much_to_send">How much would you like to send?</string>
+    <string name="label_enter_address">Enter address</string>
+    <string name="label_where_send_to">Where do you want to send to?</string>
+    <string name="label_account">Account</string>
+    <string name="label_main">Main</string>
+    <string name="btn_change_speed">Change speed</string>
+    <string name="label_total_spending">Total Spending</string>
 </resources>

--- a/ios/Cove/Extention/Color+Ext.swift
+++ b/ios/Cove/Extention/Color+Ext.swift
@@ -126,7 +126,7 @@ extension Color {
             format: "#%02lX%02lX%02lX",
             lround(r * 255),
             lround(g * 255),
-            lround(b * 255),
+            lround(b * 255)
         )
 
         if a == 1 {

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -221,7 +221,7 @@ struct UtxoListScreen: View {
                         RouteFactory()
                             .coinControlSend(
                                 id: manager.rust.id(),
-                                utxos: manager.rust.selectedUtxos(),
+                                utxos: manager.rust.selectedUtxos()
                             )
                     )
                 }

--- a/ios/Cove/Flows/SendFlow/Common/SendFlowFlowAdvancedDetailsView.swift
+++ b/ios/Cove/Flows/SendFlow/Common/SendFlowFlowAdvancedDetailsView.swift
@@ -247,7 +247,7 @@ private struct SectionCard: View {
         .environment(
             SendFlowPresenter(
                 app: AppManager.shared,
-                manager: WalletManager(preview: "preview_only"),
+                manager: WalletManager(preview: "preview_only")
             )
         )
     }

--- a/ios/Cove/Flows/SendFlow/SendFlowSetAmountScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowSetAmountScreen.swift
@@ -591,7 +591,7 @@ struct SendFlowSetAmountScreen: View {
             let manager = WalletManager(preview: "preview_only")
 
             SendFlowSetAmountScreen(
-                id: WalletId(),
+                id: WalletId()
             )
             .environment(manager)
             .environment(AppManager.shared)
@@ -606,7 +606,7 @@ struct SendFlowSetAmountScreen: View {
             let manager = WalletManager(preview: "preview_only")
 
             SendFlowSetAmountScreen(
-                id: WalletId(),
+                id: WalletId()
             )
             .environment(manager)
             .environment(AppManager.shared)

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
@@ -88,7 +88,7 @@ struct TapSignerEnterPin: View {
                         .sendConfirm(
                             id: record.walletId(),
                             details: record.confirmDetails(),
-                            signedPsbt: signedPsbt,
+                            signedPsbt: signedPsbt
                         )
 
                     await MainActor.run {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new Send screen with a streamlined payment flow.
  - View/hide balance with denomination display.
  - Enter amount with live fiat equivalent.
  - Input destination address with QR scan option.
  - Review spending summary: account info, network fee with change-speed action, and total.
  - Navigate with Back/Next actions and inline snackbars for feedback.
  - Added new UI text labels to support the send experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->