### PR TITLE
Add custom network fee option and UI

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -89,5 +89,8 @@
     <string name="label_fee_fast">Fast</string>
     <string name="label_fee_medium">Medium</string>
     <string name="label_fee_slow">Slow</string>
+    <string name="label_fee_custom">Custom</string>
     <string name="btn_customize_fee">Customize Fee</string>
+    <string name="title_set_custom_network_fee">Set Custom Network Fee</string>
+    <string name="btn_done">Done</string>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Custom network fee option. Users can set a fee rate via slider, see estimated confirmation time, and view fees in sats and local currency, then apply with Done.

- UI/UX Improvements
  - Network Fee bottom sheet now supports a dedicated custom fee flow with clearer labels (“Custom”, “Set Custom Network Fee”, “Done”).
  - Numbers and currency in the custom fee view use locale-aware formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->