### PR TITLE
Add Advanced Details bottom sheet UI

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/send/advanced_details/AdvancedDetailsBottomSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/send/advanced_details/AdvancedDetailsBottomSheet.kt
@@ -1,0 +1,354 @@
+package org.bitcoinppl.cove.send.advanced_details
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.cove.R
+
+data class UtxoItem(
+    val label: String,
+    val amount: String,
+    val address: String
+)
+
+data class AdvancedDetailsData(
+    val utxosUsed: List<UtxoItem>,
+    val sentToSelf: List<UtxoItem>,
+    val fee: String
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun AdvancedDetailsContentPreview() {
+    val sampleData = AdvancedDetailsData(
+        utxosUsed = listOf(
+            UtxoItem(
+                label = "Sold a bear",
+                amount = "34,945 sats",
+                address = "tb1qh hu40r grzxy 50r46 axhdj hntra cgkq7 mtyn9 yk"
+            )
+        ),
+        sentToSelf = listOf(
+            UtxoItem(
+                label = "",
+                amount = "25,555 sats",
+                address = "tb1qt 5alnv 8pm66 hv2zd cdzxr kyqfn wpuh8 9zrey kx"
+            ),
+            UtxoItem(
+                label = "",
+                amount = "8,262 sats",
+                address = "tb1qa edzdp 4nwjs qy2w6 e3l25 l3c8a cr0x4 qmsyd kc"
+            )
+        ),
+        fee = "1,128 sats"
+    )
+    AdvancedDetailsBottomSheet(
+        data = sampleData,
+        onDismiss = {}
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+private fun AdvancedDetailsBottomSheetPreview() {
+    var showBottomSheet by remember { mutableStateOf(false) }
+    val sampleData = AdvancedDetailsData(
+        utxosUsed = listOf(
+            UtxoItem(
+                label = "Sold a bear",
+                amount = "34,945 sats",
+                address = "tb1qh hu40r grzxy 50r46 axhdj hntra cgkq7 mtyn9 yk"
+            )
+        ),
+        sentToSelf = listOf(
+            UtxoItem(
+                label = "",
+                amount = "25,555 sats",
+                address = "tb1qt 5alnv 8pm66 hv2zd cdzxr kyqfn wpuh8 9zrey kx"
+            ),
+            UtxoItem(
+                label = "",
+                amount = "8,262 sats",
+                address = "tb1qa edzdp 4nwjs qy2w6 e3l25 l3c8a cr0x4 qmsyd kc"
+            )
+        ),
+        fee = "1,128 sats"
+    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Button(
+            onClick = { showBottomSheet = true },
+            modifier = Modifier.align(Alignment.Center)
+        ) {
+            Text("Show Advanced Details")
+        }
+        if (showBottomSheet) {
+            val bottomSheetState = rememberModalBottomSheetState(
+                skipPartiallyExpanded = true
+            )
+            ModalBottomSheet(
+                onDismissRequest = { showBottomSheet = false },
+                sheetState = bottomSheetState,
+                containerColor = Color(0xFFF3F4F6),
+                dragHandle = null,
+                shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
+            ) {
+                AdvancedDetailsBottomSheet(
+                    data = sampleData,
+                    onDismiss = { showBottomSheet = false }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun AdvancedDetailsBottomSheet(
+    data: AdvancedDetailsData,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFFF3F4F6))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(36.dp)
+                    .height(4.dp)
+                    .background(
+                        Color(0xFFD1D5DB),
+                        RoundedCornerShape(2.dp)
+                    )
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.title_advanced_details),
+                    color = Color(0xFF101010),
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.subtitle_advanced_details),
+                    color = Color(0xFF9CA3AF),
+                    fontSize = 14.sp,
+                )
+            }
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.size(40.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close",
+                    tint = Color(0xFF6B7280),
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(20.dp))
+        HorizontalDivider(
+            color = Color(0xFFD1D5DB),
+            thickness = 1.dp,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(top = 20.dp, bottom = 40.dp)
+        ) {
+            if (data.utxosUsed.isNotEmpty()) {
+                Text(
+                    text = stringResource(R.string.label_utxos_used),
+                    color = Color(0xFF9CA3AF),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(start = 12.dp)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                data.utxosUsed.forEach { utxo ->
+                    UtxoCard(
+                        item = utxo,
+                    )
+                }
+                Spacer(modifier = Modifier.height(20.dp))
+            }
+            HorizontalDivider(
+                color = Color(0xFFD1D5DB),
+                thickness = 1.dp,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            if (data.sentToSelf.isNotEmpty()) {
+                Text(
+                    text = stringResource(R.string.label_sent_to_self),
+                    color = Color(0xFF9CA3AF),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(start = 12.dp)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                SentToSelfCard(
+                    items = data.sentToSelf,
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+            }
+            HorizontalDivider(
+                color = Color(0xFFD1D5DB),
+                thickness = 1.dp,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.label_fee),
+                    color = Color(0xFF9CA3AF),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 14.sp
+                )
+                Text(
+                    text = data.fee,
+                    color = Color(0xFF101010),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UtxoCard(
+    item: UtxoItem,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        border = null
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                if (item.label.isNotEmpty()) {
+                    Text(
+                        text = item.label,
+                        color = Color(0xFF101010),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+                Text(
+                    text = item.address,
+                    color = Color(0xFF9CA3AF),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Normal,
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = item.amount,
+                color = Color(0xFF101010),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}
+
+@Composable
+private fun SentToSelfCard(
+    items: List<UtxoItem>,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        border = null
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items.forEachIndexed { index, item ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Text(
+                        text = item.address,
+                        color = Color(0xFF9CA3AF),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Normal,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = item.amount,
+                        color = Color(0xFF101010),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                if (index < items.size - 1) {
+                    HorizontalDivider(
+                        color = Color(0xFFD1D5DB),
+                        thickness = 1.dp,
+                        modifier = Modifier.padding(start = 12.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -91,6 +91,11 @@
     <string name="label_fee_slow">Slow</string>
     <string name="label_fee_custom">Custom</string>
     <string name="btn_customize_fee">Customize Fee</string>
+    <string name="title_advanced_details">Advanced Details</string>
+    <string name="subtitle_advanced_details">View current transaction breakdown</string>
+    <string name="label_utxos_used">UTXOs Used</string>
+    <string name="label_sent_to_self">Sent To Self</string>
+    <string name="label_fee">Fee</string>
     <string name="title_set_custom_network_fee">Set Custom Network Fee</string>
     <string name="btn_done">Done</string>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an advanced transaction details bottom sheet in the send flow.
  - Displays used inputs, sent-to-self entries, and total fee in clear, sectioned cards with scrollable content.
  - Includes a top bar with title and close action for quick dismissal.
  - Improved labels and copy to enhance readability and consistency.
  - Added new strings to support localization of titles and section labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->