### PR TITLE
Replace custom error `describe` with the now built in uniffi export

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -991,22 +991,6 @@ external fun uniffi_cove_checksum_func_default_node_selection(
 ): Short
 external fun uniffi_cove_checksum_func_default_wallet_colors(
 ): Short
-external fun uniffi_cove_checksum_func_describe_auth_manager_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_multi_format_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_send_flow_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_send_flow_fiat_on_change_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_tap_signer_reader_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_transport_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_wallet_error(
-): Short
-external fun uniffi_cove_checksum_func_describe_wallet_manager_error(
-): Short
 external fun uniffi_cove_checksum_func_discovery_state_is_equal(
 ): Short
 external fun uniffi_cove_checksum_func_ffi_min_send_amount(
@@ -1834,10 +1818,10 @@ internal object UniffiLib {
         uniffiCallbackInterfaceSendFlowManagerReconciler.register(this)
         uniffiCallbackInterfaceTapcardTransportProtocol.register(this)
         uniffiCallbackInterfaceWalletManagerReconciler.register(this)
-        org.bitcoinppl.cove_core.tapcard.uniffiEnsureInitialized()
-        org.bitcoinppl.cove_core.nfc.uniffiEnsureInitialized()
         org.bitcoinppl.cove_core.types.uniffiEnsureInitialized()
+        org.bitcoinppl.cove_core.nfc.uniffiEnsureInitialized()
         org.bitcoinppl.cove_core.device.uniffiEnsureInitialized()
+        org.bitcoinppl.cove_core.tapcard.uniffiEnsureInitialized()
         
     }
     external fun uniffi_cove_fn_clone_addressargs(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -2770,6 +2754,22 @@ external fun uniffi_cove_fn_init_callback_vtable_tapcardtransportprotocol(`vtabl
 ): Unit
 external fun uniffi_cove_fn_init_callback_vtable_walletmanagerreconciler(`vtable`: UniffiVTableCallbackInterfaceWalletManagerReconciler,
 ): Unit
+external fun uniffi_cove_fn_method_authmanagererror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_multiformaterror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_sendflowerror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_sendflowfiatonchangeerror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_tapsignerreadererror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_transporterror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_walleterror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_cove_fn_method_walletmanagererror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 external fun uniffi_cove_fn_func_address_error_to_alert_state(`error`: RustBufferAddressError.ByValue,`address`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_func_after_pin_action_user_message(`action`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -2783,22 +2783,6 @@ external fun uniffi_cove_fn_func_create_transport_error_from_code(`code`: Short,
 external fun uniffi_cove_fn_func_default_node_selection(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_func_default_wallet_colors(uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_auth_manager_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_multi_format_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_send_flow_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_send_flow_fiat_on_change_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_tap_signer_reader_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_transport_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_wallet_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_fn_func_describe_wallet_manager_error(`error`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_func_discovery_state_is_equal(`lhs`: RustBuffer.ByValue,`rhs`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Byte
@@ -3026,30 +3010,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_default_wallet_colors() != 39034.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_auth_manager_error() != 9186.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_multi_format_error() != 25386.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_send_flow_error() != 40406.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_send_flow_fiat_on_change_error() != 38097.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_tap_signer_reader_error() != 18001.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_transport_error() != 49523.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_wallet_error() != 7428.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_describe_wallet_manager_error() != 13784.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_discovery_state_is_equal() != 12390.toShort()) {
@@ -24864,7 +24824,7 @@ public object FfiConverterTypeWalletMetadata: FfiConverterRustBuffer<WalletMetad
 
 
 
-sealed class AfterPinAction: Disposable  {
+sealed class AfterPinAction :Disposable {
     
     object Derive : AfterPinAction()
     
@@ -24905,6 +24865,8 @@ sealed class AfterPinAction: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -24979,7 +24941,7 @@ public object FfiConverterTypeAfterPinAction : FfiConverterRustBuffer<AfterPinAc
 
 
 
-sealed class AmountOrMax: Disposable  {
+sealed class AmountOrMax :Disposable {
     
     data class Amount(
         val v1: org.bitcoinppl.cove_core.types.Amount) : AmountOrMax()
@@ -25010,6 +24972,8 @@ sealed class AmountOrMax: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -25068,6 +25032,8 @@ enum class ApiType {
     ESPLORA,
     ELECTRUM,
     RPC;
+
+
     companion object
 }
 
@@ -25093,7 +25059,7 @@ public object FfiConverterTypeApiType: FfiConverterRustBuffer<ApiType> {
 
 
 
-sealed class AppAction: Disposable  {
+sealed class AppAction :Disposable {
     
     data class UpdateRoute(
         val `routes`: List<org.bitcoinppl.cove_core.Route>) : AppAction()
@@ -25214,6 +25180,8 @@ sealed class AppAction: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -25384,6 +25352,7 @@ sealed class AppException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<AppException> {
         override fun lift(error_buf: RustBuffer.ByValue): AppException = FfiConverterTypeAppError.lift(error_buf)
     }
@@ -25443,7 +25412,7 @@ public object FfiConverterTypeAppError : FfiConverterRustBuffer<AppException> {
 
 
 
-sealed class AppStateReconcileMessage: Disposable  {
+sealed class AppStateReconcileMessage :Disposable {
     
     data class DefaultRouteChanged(
         val v1: org.bitcoinppl.cove_core.Route, 
@@ -25625,6 +25594,8 @@ sealed class AppStateReconcileMessage: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -25871,6 +25842,7 @@ sealed class AuthException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<AuthException> {
         override fun lift(error_buf: RustBuffer.ByValue): AuthException = FfiConverterTypeAuthError.lift(error_buf)
     }
@@ -26006,6 +25978,8 @@ sealed class AuthManagerAction {
     
 
     
+
+
     companion object
 }
 
@@ -26146,6 +26120,16 @@ sealed class AuthManagerException: kotlin.Exception() {
     }
     
 
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_authmanagererror_uniffi_trait_display(FfiConverterTypeAuthManagerError.lower(this),
+        _status)
+}
+    )
+    }
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<AuthManagerException> {
         override fun lift(error_buf: RustBuffer.ByValue): AuthManagerException = FfiConverterTypeAuthManagerError.lift(error_buf)
     }
@@ -26237,6 +26221,8 @@ sealed class AuthManagerReconcileMessage {
     
 
     
+
+
     companion object
 }
 
@@ -26307,6 +26293,8 @@ enum class AuthType {
     BIOMETRIC,
     BOTH,
     NONE;
+
+
     companion object
 }
 
@@ -26372,6 +26360,7 @@ sealed class Bip39Exception: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<Bip39Exception> {
         override fun lift(error_buf: RustBuffer.ByValue): Bip39Exception = FfiConverterTypeBip39Error.lift(error_buf)
@@ -26484,6 +26473,7 @@ sealed class BitcoinTransactionException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<BitcoinTransactionException> {
         override fun lift(error_buf: RustBuffer.ByValue): BitcoinTransactionException = FfiConverterTypeBitcoinTransactionError.lift(error_buf)
     }
@@ -26559,6 +26549,8 @@ sealed class ButtonPresentation {
     
 
     
+
+
     companion object
 }
 
@@ -26621,6 +26613,7 @@ sealed class ByteReaderException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<ByteReaderException> {
         override fun lift(error_buf: RustBuffer.ByValue): ByteReaderException = FfiConverterTypeByteReaderError.lift(error_buf)
@@ -26734,6 +26727,7 @@ sealed class CkTapException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<CkTapException> {
         override fun lift(error_buf: RustBuffer.ByValue): CkTapException = FfiConverterTypeCkTapError.lift(error_buf)
@@ -26907,6 +26901,8 @@ sealed class CoinControlListSort {
     
 
     
+
+
     companion object
 }
 
@@ -27000,6 +26996,8 @@ enum class CoinControlListSortKey {
     NAME,
     AMOUNT,
     CHANGE;
+
+
     companion object
 }
 
@@ -27047,6 +27045,8 @@ sealed class CoinControlListSortState {
     
 
     
+
+
     companion object
 }
 
@@ -27103,7 +27103,7 @@ public object FfiConverterTypeCoinControlListSortState : FfiConverterRustBuffer<
 
 
 
-sealed class CoinControlManagerAction: Disposable  {
+sealed class CoinControlManagerAction :Disposable {
     
     data class ChangeSort(
         val v1: org.bitcoinppl.cove_core.CoinControlListSortKey) : CoinControlManagerAction()
@@ -27176,6 +27176,8 @@ sealed class CoinControlManagerAction: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -27280,7 +27282,7 @@ public object FfiConverterTypeCoinControlManagerAction : FfiConverterRustBuffer<
 
 
 
-sealed class CoinControlManagerReconcileMessage: Disposable  {
+sealed class CoinControlManagerReconcileMessage :Disposable {
     
     object ClearSort : CoinControlManagerReconcileMessage()
     
@@ -27393,6 +27395,8 @@ sealed class CoinControlManagerReconcileMessage: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -27536,6 +27540,8 @@ sealed class CoinControlRoute {
     
 
     
+
+
     companion object
 }
 
@@ -27581,6 +27587,8 @@ public object FfiConverterTypeCoinControlRoute : FfiConverterRustBuffer<CoinCont
 enum class ColdWalletRoute {
     
     QR_CODE;
+
+
     companion object
 }
 
@@ -27618,6 +27626,7 @@ sealed class ConverterException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<ConverterException> {
         override fun lift(error_buf: RustBuffer.ByValue): ConverterException = FfiConverterTypeConverterError.lift(error_buf)
@@ -27741,6 +27750,7 @@ sealed class DatabaseException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<DatabaseException> {
         override fun lift(error_buf: RustBuffer.ByValue): DatabaseException = FfiConverterTypeDatabaseError.lift(error_buf)
@@ -27999,6 +28009,7 @@ sealed class DescriptorException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<DescriptorException> {
         override fun lift(error_buf: RustBuffer.ByValue): DescriptorException = FfiConverterTypeDescriptorError.lift(error_buf)
     }
@@ -28191,7 +28202,7 @@ public object FfiConverterTypeDescriptorError : FfiConverterRustBuffer<Descripto
 
 
 
-sealed class DiscoveryState: Disposable  {
+sealed class DiscoveryState :Disposable {
     
     object Single : DiscoveryState()
     
@@ -28271,6 +28282,8 @@ sealed class DiscoveryState: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -28405,6 +28418,7 @@ sealed class FiatAmountException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<FiatAmountException> {
         override fun lift(error_buf: RustBuffer.ByValue): FiatAmountException = FfiConverterTypeFiatAmountError.lift(error_buf)
     }
@@ -28461,6 +28475,8 @@ enum class FiatCurrency {
     GBP,
     CHF,
     JPY;
+
+
     companion object
 }
 
@@ -28491,6 +28507,8 @@ enum class FiatOrBtc {
     
     BTC,
     FIAT;
+
+
     companion object
 }
 
@@ -28550,6 +28568,7 @@ sealed class FileHandlerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<FileHandlerException> {
         override fun lift(error_buf: RustBuffer.ByValue): FileHandlerException = FfiConverterTypeFileHandlerError.lift(error_buf)
@@ -28643,6 +28662,7 @@ sealed class FingerprintException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<FingerprintException> {
         override fun lift(error_buf: RustBuffer.ByValue): FingerprintException = FfiConverterTypeFingerprintError.lift(error_buf)
     }
@@ -28705,6 +28725,7 @@ sealed class GlobalCacheTableException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<GlobalCacheTableException> {
         override fun lift(error_buf: RustBuffer.ByValue): GlobalCacheTableException = FfiConverterTypeGlobalCacheTableError.lift(error_buf)
@@ -28814,6 +28835,8 @@ sealed class GlobalConfigKey {
     
 
     
+
+
     companion object
 }
 
@@ -29014,6 +29037,7 @@ sealed class GlobalConfigTableException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<GlobalConfigTableException> {
         override fun lift(error_buf: RustBuffer.ByValue): GlobalConfigTableException = FfiConverterTypeGlobalConfigTableError.lift(error_buf)
     }
@@ -29087,6 +29111,8 @@ enum class GlobalFlagKey {
     
     COMPLETED_ONBOARDING,
     ACCEPTED_TERMS;
+
+
     companion object
 }
 
@@ -29132,6 +29158,7 @@ sealed class GlobalFlagTableException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<GlobalFlagTableException> {
         override fun lift(error_buf: RustBuffer.ByValue): GlobalFlagTableException = FfiConverterTypeGlobalFlagTableError.lift(error_buf)
@@ -29192,9 +29219,9 @@ public object FfiConverterTypeGlobalFlagTableError : FfiConverterRustBuffer<Glob
 
 
 
-sealed class HardwareWalletMetadata: Disposable  {
+sealed class HardwareWalletMetadata :Disposable {
     
-    data class TapSignerCard(
+    data class TapSigner(
         val v1: org.bitcoinppl.cove_core.tapcard.TapSigner) : HardwareWalletMetadata()
         
     {
@@ -29208,7 +29235,7 @@ sealed class HardwareWalletMetadata: Disposable  {
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
-            is HardwareWalletMetadata.TapSignerCard -> {
+            is HardwareWalletMetadata.TapSigner -> {
                 
     Disposable.destroy(
         this.v1
@@ -29218,6 +29245,8 @@ sealed class HardwareWalletMetadata: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -29227,7 +29256,7 @@ sealed class HardwareWalletMetadata: Disposable  {
 public object FfiConverterTypeHardwareWalletMetadata : FfiConverterRustBuffer<HardwareWalletMetadata>{
     override fun read(buf: ByteBuffer): HardwareWalletMetadata {
         return when(buf.getInt()) {
-            1 -> HardwareWalletMetadata.TapSignerCard(
+            1 -> HardwareWalletMetadata.TapSigner(
                 FfiConverterTypeTapSigner.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -29235,7 +29264,7 @@ public object FfiConverterTypeHardwareWalletMetadata : FfiConverterRustBuffer<Ha
     }
 
     override fun allocationSize(value: HardwareWalletMetadata) = when(value) {
-        is HardwareWalletMetadata.TapSignerCard -> {
+        is HardwareWalletMetadata.TapSigner -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -29246,7 +29275,7 @@ public object FfiConverterTypeHardwareWalletMetadata : FfiConverterRustBuffer<Ha
 
     override fun write(value: HardwareWalletMetadata, buf: ByteBuffer) {
         when(value) {
-            is HardwareWalletMetadata.TapSignerCard -> {
+            is HardwareWalletMetadata.TapSigner -> {
                 buf.putInt(1)
                 FfiConverterTypeTapSigner.write(value.v1, buf)
                 Unit
@@ -29274,6 +29303,7 @@ sealed class HistoricalPriceRecordException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<HistoricalPriceRecordException> {
         override fun lift(error_buf: RustBuffer.ByValue): HistoricalPriceRecordException = FfiConverterTypeHistoricalPriceRecordError.lift(error_buf)
@@ -29347,6 +29377,7 @@ sealed class HistoricalPriceTableException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<HistoricalPriceTableException> {
         override fun lift(error_buf: RustBuffer.ByValue): HistoricalPriceTableException = FfiConverterTypeHistoricalPriceTableError.lift(error_buf)
@@ -29451,6 +29482,8 @@ sealed class HotWalletRoute {
     
 
     
+
+
     companion object
 }
 
@@ -29542,6 +29575,8 @@ enum class ImportType {
     MANUAL,
     NFC,
     QR;
+
+
     companion object
 }
 
@@ -29619,6 +29654,7 @@ sealed class ImportWalletException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<ImportWalletException> {
         override fun lift(error_buf: RustBuffer.ByValue): ImportWalletException = FfiConverterTypeImportWalletError.lift(error_buf)
@@ -29735,6 +29771,8 @@ public object FfiConverterTypeImportWalletError : FfiConverterRustBuffer<ImportW
 enum class ImportWalletManagerAction {
     
     NO_OP;
+
+
     companion object
 }
 
@@ -29764,6 +29802,8 @@ public object FfiConverterTypeImportWalletManagerAction: FfiConverterRustBuffer<
 enum class ImportWalletManagerReconcileMessage {
     
     NO_OP;
+
+
     companion object
 }
 
@@ -29811,6 +29851,8 @@ sealed class InsertOrUpdate {
     
 
     
+
+
     companion object
 }
 
@@ -29887,6 +29929,7 @@ sealed class LabelDbException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<LabelDbException> {
         override fun lift(error_buf: RustBuffer.ByValue): LabelDbException = FfiConverterTypeLabelDbError.lift(error_buf)
@@ -30031,6 +30074,7 @@ sealed class LabelManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<LabelManagerException> {
         override fun lift(error_buf: RustBuffer.ByValue): LabelManagerException = FfiConverterTypeLabelManagerError.lift(error_buf)
@@ -30200,6 +30244,8 @@ enum class ListSortDirection {
     
     ASCENDING,
     DESCENDING;
+
+
     companion object
 }
 
@@ -30245,6 +30291,7 @@ sealed class MnemonicException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<MnemonicException> {
         override fun lift(error_buf: RustBuffer.ByValue): MnemonicException = FfiConverterTypeMnemonicError.lift(error_buf)
@@ -30320,6 +30367,7 @@ sealed class MnemonicParseException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<MnemonicParseException> {
         override fun lift(error_buf: RustBuffer.ByValue): MnemonicParseException = FfiConverterTypeMnemonicParseError.lift(error_buf)
     }
@@ -30369,7 +30417,7 @@ public object FfiConverterTypeMnemonicParseError : FfiConverterRustBuffer<Mnemon
 
 
 
-sealed class MultiFormat: Disposable  {
+sealed class MultiFormat :Disposable {
     
     data class Address(
         val v1: org.bitcoinppl.cove_core.types.AddressWithNetwork) : MultiFormat()
@@ -30380,7 +30428,7 @@ sealed class MultiFormat: Disposable  {
         companion object
     }
     
-    data class Hardware(
+    data class HardwareExport(
         val v1: org.bitcoinppl.cove_core.HardwareExport) : MultiFormat()
         
     {
@@ -30389,7 +30437,7 @@ sealed class MultiFormat: Disposable  {
         companion object
     }
     
-    data class Mnem(
+    data class Mnemonic(
         val v1: org.bitcoinppl.cove_core.Mnemonic) : MultiFormat()
         
     {
@@ -30407,7 +30455,7 @@ sealed class MultiFormat: Disposable  {
         companion object
     }
     
-    data class Labels(
+    data class Bip329Labels(
         val v1: org.bitcoinppl.cove_core.Bip329Labels) : MultiFormat()
         
     {
@@ -30452,14 +30500,14 @@ sealed class MultiFormat: Disposable  {
     )
                 
             }
-            is MultiFormat.Hardware -> {
+            is MultiFormat.HardwareExport -> {
                 
     Disposable.destroy(
         this.v1
     )
                 
             }
-            is MultiFormat.Mnem -> {
+            is MultiFormat.Mnemonic -> {
                 
     Disposable.destroy(
         this.v1
@@ -30473,7 +30521,7 @@ sealed class MultiFormat: Disposable  {
     )
                 
             }
-            is MultiFormat.Labels -> {
+            is MultiFormat.Bip329Labels -> {
                 
     Disposable.destroy(
         this.v1
@@ -30497,6 +30545,8 @@ sealed class MultiFormat: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -30509,16 +30559,16 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
             1 -> MultiFormat.Address(
                 FfiConverterTypeAddressWithNetwork.read(buf),
                 )
-            2 -> MultiFormat.Hardware(
+            2 -> MultiFormat.HardwareExport(
                 FfiConverterTypeHardwareExport.read(buf),
                 )
-            3 -> MultiFormat.Mnem(
+            3 -> MultiFormat.Mnemonic(
                 FfiConverterTypeMnemonic.read(buf),
                 )
             4 -> MultiFormat.Transaction(
                 FfiConverterTypeBitcoinTransaction.read(buf),
                 )
-            5 -> MultiFormat.Labels(
+            5 -> MultiFormat.Bip329Labels(
                 FfiConverterTypeBip329Labels.read(buf),
                 )
             6 -> MultiFormat.TapSignerReady(
@@ -30539,14 +30589,14 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
                 + FfiConverterTypeAddressWithNetwork.allocationSize(value.v1)
             )
         }
-        is MultiFormat.Hardware -> {
+        is MultiFormat.HardwareExport -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
                 + FfiConverterTypeHardwareExport.allocationSize(value.v1)
             )
         }
-        is MultiFormat.Mnem -> {
+        is MultiFormat.Mnemonic -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -30560,7 +30610,7 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
                 + FfiConverterTypeBitcoinTransaction.allocationSize(value.v1)
             )
         }
-        is MultiFormat.Labels -> {
+        is MultiFormat.Bip329Labels -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -30590,12 +30640,12 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
                 FfiConverterTypeAddressWithNetwork.write(value.v1, buf)
                 Unit
             }
-            is MultiFormat.Hardware -> {
+            is MultiFormat.HardwareExport -> {
                 buf.putInt(2)
                 FfiConverterTypeHardwareExport.write(value.v1, buf)
                 Unit
             }
-            is MultiFormat.Mnem -> {
+            is MultiFormat.Mnemonic -> {
                 buf.putInt(3)
                 FfiConverterTypeMnemonic.write(value.v1, buf)
                 Unit
@@ -30605,7 +30655,7 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
                 FfiConverterTypeBitcoinTransaction.write(value.v1, buf)
                 Unit
             }
-            is MultiFormat.Labels -> {
+            is MultiFormat.Bip329Labels -> {
                 buf.putInt(5)
                 FfiConverterTypeBip329Labels.write(value.v1, buf)
                 Unit
@@ -30666,6 +30716,16 @@ sealed class MultiFormatException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_multiformaterror_uniffi_trait_display(FfiConverterTypeMultiFormatError.lower(this),
+        _status)
+}
+    )
+    }
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<MultiFormatException> {
         override fun lift(error_buf: RustBuffer.ByValue): MultiFormatException = FfiConverterTypeMultiFormatError.lift(error_buf)
@@ -30820,6 +30880,7 @@ sealed class MultiQrException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<MultiQrException> {
         override fun lift(error_buf: RustBuffer.ByValue): MultiQrException = FfiConverterTypeMultiQrError.lift(error_buf)
     }
@@ -30950,9 +31011,9 @@ public object FfiConverterTypeMultiQrError : FfiConverterRustBuffer<MultiQrExcep
 
 
 
-sealed class MultiQrScanResult: Disposable  {
+sealed class MultiQrScanResult :Disposable {
     
-    data class Seed(
+    data class SeedQr(
         val v1: org.bitcoinppl.cove_core.SeedQr) : MultiQrScanResult()
         
     {
@@ -30993,7 +31054,7 @@ sealed class MultiQrScanResult: Disposable  {
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
-            is MultiQrScanResult.Seed -> {
+            is MultiQrScanResult.SeedQr -> {
                 
     Disposable.destroy(
         this.v1
@@ -31024,6 +31085,8 @@ sealed class MultiQrScanResult: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -31033,7 +31096,7 @@ sealed class MultiQrScanResult: Disposable  {
 public object FfiConverterTypeMultiQrScanResult : FfiConverterRustBuffer<MultiQrScanResult>{
     override fun read(buf: ByteBuffer): MultiQrScanResult {
         return when(buf.getInt()) {
-            1 -> MultiQrScanResult.Seed(
+            1 -> MultiQrScanResult.SeedQr(
                 FfiConverterTypeSeedQr.read(buf),
                 )
             2 -> MultiQrScanResult.Single(
@@ -31050,7 +31113,7 @@ public object FfiConverterTypeMultiQrScanResult : FfiConverterRustBuffer<MultiQr
     }
 
     override fun allocationSize(value: MultiQrScanResult) = when(value) {
-        is MultiQrScanResult.Seed -> {
+        is MultiQrScanResult.SeedQr -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -31082,7 +31145,7 @@ public object FfiConverterTypeMultiQrScanResult : FfiConverterRustBuffer<MultiQr
 
     override fun write(value: MultiQrScanResult, buf: ByteBuffer) {
         when(value) {
-            is MultiQrScanResult.Seed -> {
+            is MultiQrScanResult.SeedQr -> {
                 buf.putInt(1)
                 FfiConverterTypeSeedQr.write(value.v1, buf)
                 Unit
@@ -31135,6 +31198,8 @@ sealed class NewWalletRoute {
     
 
     
+
+
     companion object
 }
 
@@ -31224,6 +31289,8 @@ sealed class NodeSelection {
     
 
     
+
+
     companion object
 }
 
@@ -31317,6 +31384,7 @@ sealed class NodeSelectorException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<NodeSelectorException> {
         override fun lift(error_buf: RustBuffer.ByValue): NodeSelectorException = FfiConverterTypeNodeSelectorError.lift(error_buf)
     }
@@ -31407,6 +31475,8 @@ enum class NumberOfBip39Words {
     
     TWELVE,
     TWENTY_FOUR;
+
+
     companion object
 }
 
@@ -31454,6 +31524,8 @@ sealed class PendingOrConfirmed {
     
 
     
+
+
     companion object
 }
 
@@ -31523,6 +31595,8 @@ sealed class PendingWalletManagerAction {
     
 
     
+
+
     companion object
 }
 
@@ -31584,6 +31658,7 @@ sealed class PendingWalletManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<PendingWalletManagerException> {
         override fun lift(error_buf: RustBuffer.ByValue): PendingWalletManagerException = FfiConverterTypePendingWalletManagerError.lift(error_buf)
@@ -31657,6 +31732,8 @@ sealed class PendingWalletManagerReconcileMessage {
     
 
     
+
+
     companion object
 }
 
@@ -31698,7 +31775,7 @@ public object FfiConverterTypePendingWalletManagerReconcileMessage : FfiConverte
 
 
 
-sealed class Route: Disposable  {
+sealed class Route :Disposable {
     
     data class LoadAndReset(
         val `resetTo`: List<org.bitcoinppl.cove_core.BoxedRoute>, 
@@ -31749,7 +31826,7 @@ sealed class Route: Disposable  {
         companion object
     }
     
-    data class TxDetails(
+    data class TransactionDetails(
         val `id`: org.bitcoinppl.cove_core.types.WalletId, 
         val `details`: org.bitcoinppl.cove_core.TransactionDetails) : Route()
         
@@ -31820,7 +31897,7 @@ sealed class Route: Disposable  {
     )
                 
             }
-            is Route.TxDetails -> {
+            is Route.TransactionDetails -> {
                 
     Disposable.destroy(
         this.`id`,
@@ -31845,6 +31922,8 @@ sealed class Route: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -31871,7 +31950,7 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
             6 -> Route.SecretWords(
                 FfiConverterTypeWalletId.read(buf),
                 )
-            7 -> Route.TxDetails(
+            7 -> Route.TransactionDetails(
                 FfiConverterTypeWalletId.read(buf),
                 FfiConverterTypeTransactionDetails.read(buf),
                 )
@@ -31928,7 +32007,7 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
                 + FfiConverterTypeWalletId.allocationSize(value.v1)
             )
         }
-        is Route.TxDetails -> {
+        is Route.TransactionDetails -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -31984,7 +32063,7 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
                 FfiConverterTypeWalletId.write(value.v1, buf)
                 Unit
             }
-            is Route.TxDetails -> {
+            is Route.TransactionDetails -> {
                 buf.putInt(7)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
                 FfiConverterTypeTransactionDetails.write(value.`details`, buf)
@@ -32027,6 +32106,8 @@ sealed class ScanState {
     
 
     
+
+
     companion object
 }
 
@@ -32106,6 +32187,8 @@ sealed class ScannerResponse {
     
 
     
+
+
     companion object
 }
 
@@ -32192,6 +32275,7 @@ sealed class SeedQrException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<SeedQrException> {
         override fun lift(error_buf: RustBuffer.ByValue): SeedQrException = FfiConverterTypeSeedQrError.lift(error_buf)
@@ -32297,6 +32381,8 @@ sealed class SendFlowAlertState {
     
 
     
+
+
     companion object
 }
 
@@ -32356,7 +32442,7 @@ public object FfiConverterTypeSendFlowAlertState : FfiConverterRustBuffer<SendFl
 
 
 
-sealed class SendFlowEnterMode: Disposable  {
+sealed class SendFlowEnterMode :Disposable {
     
     object SetAmount : SendFlowEnterMode()
     
@@ -32387,6 +32473,8 @@ sealed class SendFlowEnterMode: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -32545,6 +32633,16 @@ sealed class SendFlowException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_sendflowerror_uniffi_trait_display(FfiConverterTypeSendFlowError.lower(this),
+        _status)
+}
+    )
+    }
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<SendFlowException> {
         override fun lift(error_buf: RustBuffer.ByValue): SendFlowException = FfiConverterTypeSendFlowError.lift(error_buf)
@@ -32761,6 +32859,8 @@ sealed class SendFlowErrorAlert {
     
 
     
+
+
     companion object
 }
 
@@ -32817,89 +32917,102 @@ public object FfiConverterTypeSendFlowErrorAlert : FfiConverterRustBuffer<SendFl
 
 
 
-sealed class SendFlowFiatOnChangeError {
+
+
+sealed class SendFlowFiatOnChangeException: kotlin.Exception() {
     
-    data class InvalidFiatAmount(
+    class InvalidFiatAmount(
+        
         val `error`: kotlin.String, 
-        val `input`: kotlin.String) : SendFlowFiatOnChangeError()
         
-    {
-        
-
-        companion object
+        val `input`: kotlin.String
+        ) : SendFlowFiatOnChangeException() {
+        override val message
+            get() = "error=${ `error` }, input=${ `input` }"
     }
     
-    data class Converter(
-        val v1: org.bitcoinppl.cove_core.ConverterException) : SendFlowFiatOnChangeError()
+    class Converter(
         
-    {
-        
-
-        companion object
+        val v1: ConverterException
+        ) : SendFlowFiatOnChangeException() {
+        override val message
+            get() = "v1=${ v1 }"
     }
     
 
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_sendflowfiatonchangeerror_uniffi_trait_display(FfiConverterTypeSendFlowFiatOnChangeError.lower(this),
+        _status)
+}
+    )
+    }
+
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<SendFlowFiatOnChangeException> {
+        override fun lift(error_buf: RustBuffer.ByValue): SendFlowFiatOnChangeException = FfiConverterTypeSendFlowFiatOnChangeError.lift(error_buf)
+    }
+
     
-    companion object
 }
 
 /**
  * @suppress
  */
-public object FfiConverterTypeSendFlowFiatOnChangeError : FfiConverterRustBuffer<SendFlowFiatOnChangeError>{
-    override fun read(buf: ByteBuffer): SendFlowFiatOnChangeError {
+public object FfiConverterTypeSendFlowFiatOnChangeError : FfiConverterRustBuffer<SendFlowFiatOnChangeException> {
+    override fun read(buf: ByteBuffer): SendFlowFiatOnChangeException {
+        
+
         return when(buf.getInt()) {
-            1 -> SendFlowFiatOnChangeError.InvalidFiatAmount(
+            1 -> SendFlowFiatOnChangeException.InvalidFiatAmount(
                 FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
-            2 -> SendFlowFiatOnChangeError.Converter(
+            2 -> SendFlowFiatOnChangeException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
     }
 
-    override fun allocationSize(value: SendFlowFiatOnChangeError) = when(value) {
-        is SendFlowFiatOnChangeError.InvalidFiatAmount -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
+    override fun allocationSize(value: SendFlowFiatOnChangeException): ULong {
+        return when(value) {
+            is SendFlowFiatOnChangeException.InvalidFiatAmount -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.`error`)
                 + FfiConverterString.allocationSize(value.`input`)
             )
-        }
-        is SendFlowFiatOnChangeError.Converter -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
+            is SendFlowFiatOnChangeException.Converter -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterTypeConverterError.allocationSize(value.v1)
             )
         }
     }
 
-    override fun write(value: SendFlowFiatOnChangeError, buf: ByteBuffer) {
+    override fun write(value: SendFlowFiatOnChangeException, buf: ByteBuffer) {
         when(value) {
-            is SendFlowFiatOnChangeError.InvalidFiatAmount -> {
+            is SendFlowFiatOnChangeException.InvalidFiatAmount -> {
                 buf.putInt(1)
                 FfiConverterString.write(value.`error`, buf)
                 FfiConverterString.write(value.`input`, buf)
                 Unit
             }
-            is SendFlowFiatOnChangeError.Converter -> {
+            is SendFlowFiatOnChangeException.Converter -> {
                 buf.putInt(2)
                 FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
+
 }
 
 
 
-
-
-sealed class SendFlowManagerAction: Disposable  {
+sealed class SendFlowManagerAction :Disposable {
     
     data class ChangeEnteringAddress(
         val v1: kotlin.String) : SendFlowManagerAction()
@@ -33216,6 +33329,8 @@ sealed class SendFlowManagerAction: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -33567,7 +33682,7 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
 
 
 
-sealed class SendFlowManagerReconcileMessage: Disposable  {
+sealed class SendFlowManagerReconcileMessage :Disposable {
     
     data class UpdateEnteringBtcAmount(
         val v1: kotlin.String) : SendFlowManagerReconcileMessage()
@@ -33768,6 +33883,8 @@ sealed class SendFlowManagerReconcileMessage: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -33992,7 +34109,7 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
 
 
 
-sealed class SendRoute: Disposable  {
+sealed class SendRoute :Disposable {
     
     data class SetAmount(
         val `id`: org.bitcoinppl.cove_core.types.WalletId, 
@@ -34074,6 +34191,8 @@ sealed class SendRoute: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -34193,6 +34312,7 @@ sealed class SerdeException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<SerdeException> {
         override fun lift(error_buf: RustBuffer.ByValue): SerdeException = FfiConverterTypeSerdeError.lift(error_buf)
     }
@@ -34257,6 +34377,8 @@ enum class SetAmountFocusField {
     
     AMOUNT,
     ADDRESS;
+
+
     companion object
 }
 
@@ -34314,6 +34436,8 @@ sealed class SettingsRoute {
     
 
     
+
+
     companion object
 }
 
@@ -34424,9 +34548,9 @@ public object FfiConverterTypeSettingsRoute : FfiConverterRustBuffer<SettingsRou
 
 
 
-sealed class SetupCmdResponse: Disposable  {
+sealed class SetupCmdResponse :Disposable {
     
-    data class Init(
+    data class ContinueFromInit(
         val v1: org.bitcoinppl.cove_core.ContinueFromInit) : SetupCmdResponse()
         
     {
@@ -34435,7 +34559,7 @@ sealed class SetupCmdResponse: Disposable  {
         companion object
     }
     
-    data class Backup(
+    data class ContinueFromBackup(
         val v1: org.bitcoinppl.cove_core.ContinueFromBackup) : SetupCmdResponse()
         
     {
@@ -34444,7 +34568,7 @@ sealed class SetupCmdResponse: Disposable  {
         companion object
     }
     
-    data class Derive(
+    data class ContinueFromDerive(
         val v1: org.bitcoinppl.cove_core.ContinueFromDerive) : SetupCmdResponse()
         
     {
@@ -34467,21 +34591,21 @@ sealed class SetupCmdResponse: Disposable  {
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
-            is SetupCmdResponse.Init -> {
+            is SetupCmdResponse.ContinueFromInit -> {
                 
     Disposable.destroy(
         this.v1
     )
                 
             }
-            is SetupCmdResponse.Backup -> {
+            is SetupCmdResponse.ContinueFromBackup -> {
                 
     Disposable.destroy(
         this.v1
     )
                 
             }
-            is SetupCmdResponse.Derive -> {
+            is SetupCmdResponse.ContinueFromDerive -> {
                 
     Disposable.destroy(
         this.v1
@@ -34498,6 +34622,8 @@ sealed class SetupCmdResponse: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -34507,13 +34633,13 @@ sealed class SetupCmdResponse: Disposable  {
 public object FfiConverterTypeSetupCmdResponse : FfiConverterRustBuffer<SetupCmdResponse>{
     override fun read(buf: ByteBuffer): SetupCmdResponse {
         return when(buf.getInt()) {
-            1 -> SetupCmdResponse.Init(
+            1 -> SetupCmdResponse.ContinueFromInit(
                 FfiConverterTypeContinueFromInit.read(buf),
                 )
-            2 -> SetupCmdResponse.Backup(
+            2 -> SetupCmdResponse.ContinueFromBackup(
                 FfiConverterTypeContinueFromBackup.read(buf),
                 )
-            3 -> SetupCmdResponse.Derive(
+            3 -> SetupCmdResponse.ContinueFromDerive(
                 FfiConverterTypeContinueFromDerive.read(buf),
                 )
             4 -> SetupCmdResponse.Complete(
@@ -34524,21 +34650,21 @@ public object FfiConverterTypeSetupCmdResponse : FfiConverterRustBuffer<SetupCmd
     }
 
     override fun allocationSize(value: SetupCmdResponse) = when(value) {
-        is SetupCmdResponse.Init -> {
+        is SetupCmdResponse.ContinueFromInit -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
                 + FfiConverterTypeContinueFromInit.allocationSize(value.v1)
             )
         }
-        is SetupCmdResponse.Backup -> {
+        is SetupCmdResponse.ContinueFromBackup -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
                 + FfiConverterTypeContinueFromBackup.allocationSize(value.v1)
             )
         }
-        is SetupCmdResponse.Derive -> {
+        is SetupCmdResponse.ContinueFromDerive -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -34556,17 +34682,17 @@ public object FfiConverterTypeSetupCmdResponse : FfiConverterRustBuffer<SetupCmd
 
     override fun write(value: SetupCmdResponse, buf: ByteBuffer) {
         when(value) {
-            is SetupCmdResponse.Init -> {
+            is SetupCmdResponse.ContinueFromInit -> {
                 buf.putInt(1)
                 FfiConverterTypeContinueFromInit.write(value.v1, buf)
                 Unit
             }
-            is SetupCmdResponse.Backup -> {
+            is SetupCmdResponse.ContinueFromBackup -> {
                 buf.putInt(2)
                 FfiConverterTypeContinueFromBackup.write(value.v1, buf)
                 Unit
             }
-            is SetupCmdResponse.Derive -> {
+            is SetupCmdResponse.ContinueFromDerive -> {
                 buf.putInt(3)
                 FfiConverterTypeContinueFromDerive.write(value.v1, buf)
                 Unit
@@ -34589,6 +34715,8 @@ enum class StoreType {
     
     SQLITE,
     FILE_STORE;
+
+
     companion object
 }
 
@@ -34639,6 +34767,8 @@ sealed class StringOrData {
     
 
     
+
+
     companion object
 }
 
@@ -34695,7 +34825,7 @@ public object FfiConverterTypeStringOrData : FfiConverterRustBuffer<StringOrData
 
 
 
-sealed class TapSignerCmd: Disposable  {
+sealed class TapSignerCmd :Disposable {
     
     data class Setup(
         val v1: org.bitcoinppl.cove_core.SetupCmd) : TapSignerCmd()
@@ -34789,6 +34919,8 @@ sealed class TapSignerCmd: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -34905,6 +35037,8 @@ enum class TapSignerPinAction {
     
     SETUP,
     CHANGE;
+
+
     companion object
 }
 
@@ -35010,6 +35144,16 @@ sealed class TapSignerReaderException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_tapsignerreadererror_uniffi_trait_display(FfiConverterTypeTapSignerReaderError.lower(this),
+        _status)
+}
+    )
+    }
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<TapSignerReaderException> {
         override fun lift(error_buf: RustBuffer.ByValue): TapSignerReaderException = FfiConverterTypeTapSignerReaderError.lift(error_buf)
@@ -35166,7 +35310,7 @@ public object FfiConverterTypeTapSignerReaderError : FfiConverterRustBuffer<TapS
 
 
 
-sealed class TapSignerResponse: Disposable  {
+sealed class TapSignerResponse :Disposable {
     
     data class Setup(
         val v1: org.bitcoinppl.cove_core.SetupCmdResponse) : TapSignerResponse()
@@ -35245,6 +35389,8 @@ sealed class TapSignerResponse: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -35342,7 +35488,7 @@ public object FfiConverterTypeTapSignerResponse : FfiConverterRustBuffer<TapSign
 
 
 
-sealed class TapSignerRoute: Disposable  {
+sealed class TapSignerRoute :Disposable {
     
     data class InitSelect(
         val v1: org.bitcoinppl.cove_core.tapcard.TapSigner) : TapSignerRoute()
@@ -35522,6 +35668,8 @@ sealed class TapSignerRoute: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -35713,7 +35861,7 @@ public object FfiConverterTypeTapSignerRoute : FfiConverterRustBuffer<TapSignerR
 
 
 
-sealed class Transaction: Disposable  {
+sealed class Transaction :Disposable {
     
     data class Confirmed(
         val v1: org.bitcoinppl.cove_core.ConfirmedTransaction) : Transaction()
@@ -35755,6 +35903,8 @@ sealed class Transaction: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -35855,6 +36005,7 @@ sealed class TransactionDetailException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<TransactionDetailException> {
         override fun lift(error_buf: RustBuffer.ByValue): TransactionDetailException = FfiConverterTypeTransactionDetailError.lift(error_buf)
@@ -35959,6 +36110,8 @@ enum class TransactionState {
     
     PENDING,
     CONFIRMED;
+
+
     companion object
 }
 
@@ -36044,6 +36197,16 @@ sealed class TransportException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_transporterror_uniffi_trait_display(FfiConverterTypeTransportError.lower(this),
+        _status)
+}
+    )
+    }
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<TransportException> {
         override fun lift(error_buf: RustBuffer.ByValue): TransportException = FfiConverterTypeTransportError.lift(error_buf)
@@ -36210,6 +36373,7 @@ sealed class TrickPinException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<TrickPinException> {
         override fun lift(error_buf: RustBuffer.ByValue): TrickPinException = FfiConverterTypeTrickPinError.lift(error_buf)
     }
@@ -36306,6 +36470,7 @@ sealed class UnsignedTransactionsTableException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<UnsignedTransactionsTableException> {
         override fun lift(error_buf: RustBuffer.ByValue): UnsignedTransactionsTableException = FfiConverterTypeUnsignedTransactionsTableError.lift(error_buf)
     }
@@ -36380,6 +36545,8 @@ enum class WalletAddressType {
     NATIVE_SEGWIT,
     WRAPPED_SEGWIT,
     LEGACY;
+
+
     companion object
 }
 
@@ -36474,6 +36641,8 @@ sealed class WalletColor {
     
 
     
+
+
     companion object
 }
 
@@ -36772,6 +36941,7 @@ sealed class WalletCreationException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<WalletCreationException> {
         override fun lift(error_buf: RustBuffer.ByValue): WalletCreationException = FfiConverterTypeWalletCreationError.lift(error_buf)
     }
@@ -36924,6 +37094,7 @@ sealed class WalletDataException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<WalletDataException> {
         override fun lift(error_buf: RustBuffer.ByValue): WalletDataException = FfiConverterTypeWalletDataError.lift(error_buf)
     }
@@ -37028,6 +37199,8 @@ sealed class WalletDataKey {
     
 
     
+
+
     companion object
 }
 
@@ -37165,6 +37338,16 @@ sealed class WalletException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_walleterror_uniffi_trait_display(FfiConverterTypeWalletError.lower(this),
+        _status)
+}
+    )
+    }
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<WalletException> {
         override fun lift(error_buf: RustBuffer.ByValue): WalletException = FfiConverterTypeWalletError.lift(error_buf)
@@ -37363,6 +37546,8 @@ sealed class WalletErrorAlert {
     
 
     
+
+
     companion object
 }
 
@@ -37415,7 +37600,7 @@ public object FfiConverterTypeWalletErrorAlert : FfiConverterRustBuffer<WalletEr
 
 
 
-sealed class WalletLoadState: Disposable  {
+sealed class WalletLoadState :Disposable {
     
     object Loading : WalletLoadState()
     
@@ -37462,6 +37647,8 @@ sealed class WalletLoadState: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -37529,7 +37716,7 @@ public object FfiConverterTypeWalletLoadState : FfiConverterRustBuffer<WalletLoa
 
 
 
-sealed class WalletManagerAction: Disposable  {
+sealed class WalletManagerAction :Disposable {
     
     data class UpdateName(
         val v1: kotlin.String) : WalletManagerAction()
@@ -37670,6 +37857,8 @@ sealed class WalletManagerAction: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -38072,6 +38261,16 @@ sealed class WalletManagerException: kotlin.Exception() {
     }
     
 
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_walletmanagererror_uniffi_trait_display(FfiConverterTypeWalletManagerError.lower(this),
+        _status)
+}
+    )
+    }
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<WalletManagerException> {
         override fun lift(error_buf: RustBuffer.ByValue): WalletManagerException = FfiConverterTypeWalletManagerError.lift(error_buf)
     }
@@ -38434,7 +38633,7 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
 
 
 
-sealed class WalletManagerReconcileMessage: Disposable  {
+sealed class WalletManagerReconcileMessage :Disposable {
     
     object StartedInitialFullScan : WalletManagerReconcileMessage()
     
@@ -38630,6 +38829,8 @@ sealed class WalletManagerReconcileMessage: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -38848,6 +39049,8 @@ enum class WalletMode {
     
     MAIN,
     DECOY;
+
+
     companion object
 }
 
@@ -38899,6 +39102,7 @@ sealed class WalletScannerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<WalletScannerException> {
         override fun lift(error_buf: RustBuffer.ByValue): WalletScannerException = FfiConverterTypeWalletScannerError.lift(error_buf)
@@ -38973,6 +39177,8 @@ enum class WalletSettingsRoute {
     
     MAIN,
     CHANGE_NAME;
+
+
     companion object
 }
 
@@ -39024,6 +39230,7 @@ sealed class WalletTableException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<WalletTableException> {
         override fun lift(error_buf: RustBuffer.ByValue): WalletTableException = FfiConverterTypeWalletTableError.lift(error_buf)
@@ -39103,6 +39310,8 @@ enum class WalletType {
      * deprecated, use XpubOnly instead
      */
     WATCH_ONLY;
+
+
     companion object
 }
 
@@ -39176,6 +39385,7 @@ sealed class XpubException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<XpubException> {
         override fun lift(error_buf: RustBuffer.ByValue): XpubException = FfiConverterTypeXpubError.lift(error_buf)
@@ -41540,86 +41750,6 @@ object AddressExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<A
     UniffiLib.uniffi_cove_fn_func_default_wallet_colors(
     
         _status)
-}
-    )
-    }
-    
- fun `describeAuthManagerError`(`error`: AuthManagerException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_auth_manager_error(
-    
-        FfiConverterTypeAuthManagerError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeMultiFormatError`(`error`: MultiFormatException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_multi_format_error(
-    
-        FfiConverterTypeMultiFormatError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeSendFlowError`(`error`: SendFlowException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_send_flow_error(
-    
-        FfiConverterTypeSendFlowError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeSendFlowFiatOnChangeError`(`error`: SendFlowFiatOnChangeError): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_send_flow_fiat_on_change_error(
-    
-        FfiConverterTypeSendFlowFiatOnChangeError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeTapSignerReaderError`(`error`: TapSignerReaderException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_tap_signer_reader_error(
-    
-        FfiConverterTypeTapSignerReaderError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeTransportError`(`error`: TransportException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_transport_error(
-    
-        FfiConverterTypeTransportError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeWalletError`(`error`: WalletException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_wallet_error(
-    
-        FfiConverterTypeWalletError.lower(`error`),_status)
-}
-    )
-    }
-    
- fun `describeWalletManagerError`(`error`: WalletManagerException): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_describe_wallet_manager_error(
-    
-        FfiConverterTypeWalletManagerError.lower(`error`),_status)
 }
     )
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/device/cove_device.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/device/cove_device.kt
@@ -1674,6 +1674,7 @@ sealed class KeychainException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<KeychainException> {
         override fun lift(error_buf: RustBuffer.ByValue): KeychainException = FfiConverterTypeKeychainError.lift(error_buf)
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/nfc/cove_nfc.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/nfc/cove_nfc.kt
@@ -2720,6 +2720,8 @@ sealed class NdefPayload {
     
 
     
+
+
     companion object
 }
 
@@ -2787,6 +2789,8 @@ enum class NdefType {
     UNKNOWN,
     UNCHANGED,
     RESERVED;
+
+
     companion object
 }
 
@@ -2822,6 +2826,7 @@ sealed class NfcMessageException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<NfcMessageException> {
         override fun lift(error_buf: RustBuffer.ByValue): NfcMessageException = FfiConverterTypeNfcMessageError.lift(error_buf)
@@ -2889,6 +2894,7 @@ sealed class NfcReaderException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<NfcReaderException> {
         override fun lift(error_buf: RustBuffer.ByValue): NfcReaderException = FfiConverterTypeNfcReaderError.lift(error_buf)
@@ -2983,6 +2989,8 @@ sealed class ParseResult {
     
 
     
+
+
     companion object
 }
 
@@ -3061,6 +3069,8 @@ sealed class ParserState {
     
 
     
+
+
     companion object
 }
 
@@ -3174,6 +3184,7 @@ sealed class ResumeException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<ResumeException> {
         override fun lift(error_buf: RustBuffer.ByValue): ResumeException = FfiConverterTypeResumeError.lift(error_buf)
     }
@@ -3268,6 +3279,8 @@ enum class TextPayloadFormat {
     
     UTF8,
     UTF16;
+
+
     companion object
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/tapcard/cove_tap_card.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/tapcard/cove_tap_card.kt
@@ -1406,6 +1406,8 @@ enum class Field {
     NONCE,
     SLOT_NUMBER,
     ADDRESS;
+
+
     companion object
 }
 
@@ -1437,6 +1439,8 @@ enum class SatsCardState {
     SEALED,
     UNSEALED,
     ERROR;
+
+
     companion object
 }
 
@@ -1462,9 +1466,9 @@ public object FfiConverterTypeSatsCardState: FfiConverterRustBuffer<SatsCardStat
 
 
 
-sealed class TapCard: Disposable  {
+sealed class TapCard :Disposable {
     
-    data class Sats(
+    data class SatsCard(
         val v1: org.bitcoinppl.cove_core.tapcard.SatsCard) : TapCard()
         
     {
@@ -1473,7 +1477,7 @@ sealed class TapCard: Disposable  {
         companion object
     }
     
-    data class Tap(
+    data class TapSigner(
         val v1: org.bitcoinppl.cove_core.tapcard.TapSigner) : TapCard()
         
     {
@@ -1487,14 +1491,14 @@ sealed class TapCard: Disposable  {
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
-            is TapCard.Sats -> {
+            is TapCard.SatsCard -> {
                 
     Disposable.destroy(
         this.v1
     )
                 
             }
-            is TapCard.Tap -> {
+            is TapCard.TapSigner -> {
                 
     Disposable.destroy(
         this.v1
@@ -1504,6 +1508,8 @@ sealed class TapCard: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
+
+
     companion object
 }
 
@@ -1513,10 +1519,10 @@ sealed class TapCard: Disposable  {
 public object FfiConverterTypeTapCard : FfiConverterRustBuffer<TapCard>{
     override fun read(buf: ByteBuffer): TapCard {
         return when(buf.getInt()) {
-            1 -> TapCard.Sats(
+            1 -> TapCard.SatsCard(
                 FfiConverterTypeSatsCard.read(buf),
                 )
-            2 -> TapCard.Tap(
+            2 -> TapCard.TapSigner(
                 FfiConverterTypeTapSigner.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -1524,14 +1530,14 @@ public object FfiConverterTypeTapCard : FfiConverterRustBuffer<TapCard>{
     }
 
     override fun allocationSize(value: TapCard) = when(value) {
-        is TapCard.Sats -> {
+        is TapCard.SatsCard -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
                 + FfiConverterTypeSatsCard.allocationSize(value.v1)
             )
         }
-        is TapCard.Tap -> {
+        is TapCard.TapSigner -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -1542,12 +1548,12 @@ public object FfiConverterTypeTapCard : FfiConverterRustBuffer<TapCard>{
 
     override fun write(value: TapCard, buf: ByteBuffer) {
         when(value) {
-            is TapCard.Sats -> {
+            is TapCard.SatsCard -> {
                 buf.putInt(1)
                 FfiConverterTypeSatsCard.write(value.v1, buf)
                 Unit
             }
-            is TapCard.Tap -> {
+            is TapCard.TapSigner -> {
                 buf.putInt(2)
                 FfiConverterTypeTapSigner.write(value.v1, buf)
                 Unit
@@ -1624,6 +1630,7 @@ sealed class TapCardParseException: kotlin.Exception() {
             get() = ""
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<TapCardParseException> {
         override fun lift(error_buf: RustBuffer.ByValue): TapCardParseException = FfiConverterTypeTapCardParseError.lift(error_buf)
@@ -1760,6 +1767,8 @@ enum class TapSignerState {
     SEALED,
     UNUSED,
     ERROR;
+
+
     companion object
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -8605,6 +8605,7 @@ sealed class AddressException: kotlin.Exception() {
     }
     
 
+
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<AddressException> {
         override fun lift(error_buf: RustBuffer.ByValue): AddressException = FfiConverterTypeAddressError.lift(error_buf)
     }
@@ -8708,6 +8709,8 @@ enum class BitcoinUnit {
     
     BTC,
     SAT;
+
+
     companion object
 }
 
@@ -8739,6 +8742,8 @@ enum class ColorSchemeSelection {
     LIGHT,
     DARK,
     SYSTEM;
+
+
     companion object
 }
 
@@ -8776,6 +8781,7 @@ sealed class ConfirmDetailsException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<ConfirmDetailsException> {
         override fun lift(error_buf: RustBuffer.ByValue): ConfirmDetailsException = FfiConverterTypeConfirmDetailsError.lift(error_buf)
@@ -8845,6 +8851,8 @@ sealed class FeeSpeed {
     
 
     
+
+
     companion object
 }
 
@@ -9032,6 +9040,8 @@ sealed class FfiColor {
     
 
     
+
+
     companion object
 }
 
@@ -9246,6 +9256,8 @@ enum class FfiColorScheme {
     
     LIGHT,
     DARK;
+
+
     companion object
 }
 
@@ -9278,6 +9290,8 @@ enum class Network {
     TESTNET,
     TESTNET4,
     SIGNET;
+
+
     companion object
 }
 
@@ -9333,6 +9347,7 @@ sealed class PsbtException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<PsbtException> {
         override fun lift(error_buf: RustBuffer.ByValue): PsbtException = FfiConverterTypePsbtError.lift(error_buf)
@@ -9412,6 +9427,8 @@ enum class TransactionDirection {
     
     INCOMING,
     OUTGOING;
+
+
     companion object
 }
 
@@ -9442,6 +9459,8 @@ enum class UtxoType {
     
     OUTPUT,
     CHANGE;
+
+
     companion object
 }
 

--- a/ios/Cove/CoveApp.swift
+++ b/ios/Cove/CoveApp.swift
@@ -440,9 +440,9 @@ struct CoveApp: App {
             switch error {
             case let multiFormatError as MultiFormatError:
                 Log.error(
-                    "MultiFormat not recognized: \(multiFormatError): \(multiFormatError.describe)"
+                    "MultiFormat not recognized: \(multiFormatError): \(multiFormatError.description)"
                 )
-                app.alertState = TaggedItem(.invalidFormat(multiFormatError.describe))
+                app.alertState = TaggedItem(.invalidFormat(multiFormatError.description))
 
             default:
                 Log.error("Unable to handle scanned code, error: \(error)")
@@ -554,9 +554,9 @@ struct CoveApp: App {
             switch error {
             case let multiFormatError as MultiFormatError:
                 Log.error(
-                    "MultiFormat not recognized: \(multiFormatError): \(multiFormatError.describe)"
+                    "MultiFormat not recognized: \(multiFormatError): \(multiFormatError.description)"
                 )
-                app.alertState = TaggedItem(.invalidFormat(multiFormatError.describe))
+                app.alertState = TaggedItem(.invalidFormat(multiFormatError.description))
 
             default:
                 Log.error("Unable to handle scanned code, error: \(error)")
@@ -575,9 +575,9 @@ struct CoveApp: App {
             switch error {
             case let multiFormatError as MultiFormatError:
                 Log.error(
-                    "MultiFormat not recognized: \(multiFormatError): \(multiFormatError.describe)"
+                    "MultiFormat not recognized: \(multiFormatError): \(multiFormatError.description)"
                 )
-                app.alertState = TaggedItem(.invalidFormat(multiFormatError.describe))
+                app.alertState = TaggedItem(.invalidFormat(multiFormatError.description))
 
             default:
                 Log.error("Unable to handle scanned code, error: \(error)")

--- a/ios/Cove/Extention/Error+Ext.swift
+++ b/ios/Cove/Extention/Error+Ext.swift
@@ -5,56 +5,18 @@
 //  Created by Praveen Perera on 12/17/24.
 //
 
-extension AuthManagerError {
-    var describe: String {
-        describeAuthManagerError(error: self)
-    }
-}
-
-extension MultiFormatError {
-    var describe: String {
-        describeMultiFormatError(error: self)
-    }
-}
-
-extension WalletError {
-    var describe: String {
-        describeWalletError(error: self)
-    }
-}
-
 extension TransportError {
     init(code: Int, message: String) {
         self = createTransportErrorFromCode(code: UInt16(code), message: message)
     }
-
-    var describe: String {
-        describeTransportError(error: self)
-    }
 }
 
 extension TapSignerReaderError {
-    var describe: String {
-        describeTapSignerReaderError(error: self)
-    }
-
     var isAuthError: Bool {
         tapSignerErrorIsAuthError(error: self)
     }
 
     var isNoBackupError: Bool {
         tapSignerErrorIsNoBackupError(error: self)
-    }
-}
-
-extension WalletManagerError {
-    var describe: String {
-        describeWalletManagerError(error: self)
-    }
-}
-
-extension SendFlowFiatOnChangeError {
-    var describe: String {
-        describeSendFlowFiatOnChangeError(error: self)
     }
 }

--- a/ios/Cove/Flows/NewWalletFlow/ColdWallet/QrCodeImportScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/ColdWallet/QrCodeImportScreen.swift
@@ -146,7 +146,7 @@ struct QrCodeImportScreen: View {
                 try app.rust.selectWallet(id: id)
             } catch let WalletError.MultiFormat(error) {
                 app.popRoute()
-                self.alert = AlertItem(type: .error(error.describe, "Invalid Format"))
+                self.alert = AlertItem(type: .error(error.description, "Invalid Format"))
             } catch let WalletError.WalletAlreadyExists(id) {
                 self.alert = AlertItem(type: .success("Wallet already exists: \(id)"))
                 if (try? app.rust.selectWallet(id: id)) == nil {

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -53,7 +53,7 @@ struct SendFlowConfirmScreen: View {
                     do {
                         signedTransaction = try await manager.rust.finalizePsbt(psbt: psbt)
                     } catch let error as WalletManagerError {
-                        app.alertState = .init(.general(title: "Unable to finalize transaction", message: error.describe))
+                        app.alertState = .init(.general(title: "Unable to finalize transaction", message: error.description))
                     } catch {
                         app.alertState = .init(.general(title: "Unknown error", message: error.localizedDescription))
                     }
@@ -177,7 +177,7 @@ struct SendFlowConfirmScreen: View {
                             isShowingAlert = true
                             auth.unlock()
                         } catch let error as WalletManagerError {
-                            sendState = .error(error.describe)
+                            sendState = .error(error.description)
                             isShowingErrorAlert = true
                         } catch {
                             sendState = .error(error.localizedDescription)

--- a/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
@@ -120,7 +120,7 @@ import SwiftUI
         case .UnableToGetFeeRate:
             "Are you connected to the internet?"
         case let .WalletManager(msg):
-            msg.describe
+            msg.description
         case let .UnableToGetFeeDetails(msg):
             msg
         case let .UnableToBuildTxn(msg):

--- a/ios/Cove/Flows/SettingsFlow/MainSettingsScreen.swift
+++ b/ios/Cove/Flows/SettingsFlow/MainSettingsScreen.swift
@@ -647,7 +647,7 @@ struct MainSettingsScreen: View {
 
         do { try auth.rust.setWipeDataPin(pin: pin) } catch {
             let error = error as! AuthManagerError
-            alertState = .init(.extraSetPinError(error.describe))
+            alertState = .init(.extraSetPinError(error.description))
         }
     }
 
@@ -657,7 +657,7 @@ struct MainSettingsScreen: View {
 
         do { try auth.rust.setDecoyPin(pin: pin) } catch {
             let error = error as! AuthManagerError
-            alertState = .init(.extraSetPinError(error.describe))
+            alertState = .init(.extraSetPinError(error.description))
         }
     }
 }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerConfirmPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerConfirmPinView.swift
@@ -58,7 +58,7 @@ struct TapSignerConfirmPinView: View {
                     // failed to setup and can't continue from a screen, send back to home and ask them to restart the process
                     Log.error("Failed to setup TapSigner: \(error)")
                     app.sheetState = .none
-                    app.alertState = .init(.tapSignerSetupFailed(error.describe))
+                    app.alertState = .init(.tapSignerSetupFailed(error.description))
                 }
             }
         }
@@ -81,7 +81,7 @@ struct TapSignerConfirmPinView: View {
             case let .failure(error):
                 if error.isAuthError { return app.alertState = .init(.tapSignerInvalidAuth) }
                 if error.isNoBackupError { return app.alertState = .init(.tapSignerNoBackup(args.tapSigner)) }
-                app.alertState = .init(.general(title: "Error", message: error.describe))
+                app.alertState = .init(.general(title: "Error", message: error.description))
             }
         }
     }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
@@ -51,7 +51,7 @@ struct TapSignerEnterPin: View {
                 manager.resetRoute(to: .importSuccess(tapSigner, deriveInfo))
             case let .failure(error):
                 if !error.isAuthError {
-                    app.alertState = .init(.tapSignerDeriveFailed(error.describe))
+                    app.alertState = .init(.tapSignerDeriveFailed(error.description))
                 }
             }
 
@@ -68,7 +68,7 @@ struct TapSignerEnterPin: View {
             case let .failure(error):
                 if !error.isAuthError {
                     app.alertState = .init(
-                        .general(title: "Backup Failed!", message: error.describe))
+                        .general(title: "Backup Failed!", message: error.description))
                 }
 
                 await MainActor.run { self.pin = "" }
@@ -108,7 +108,7 @@ struct TapSignerEnterPin: View {
             case let .failure(error):
                 if !error.isAuthError {
                     app.alertState = .init(
-                        .general(title: "Signing Failed!", message: error.describe))
+                        .general(title: "Signing Failed!", message: error.description))
 
                     app.sheetState = .none
                 }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerImportRetryView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerImportRetryView.swift
@@ -68,7 +68,7 @@ struct TapSignerImportRetry: View {
                         case let .success(deriveInfo):
                             manager.resetRoute(to: .importSuccess(tapSigner, deriveInfo))
                         case let .failure(error):
-                            app.alertState = .init(.tapSignerDeriveFailed(error.describe))
+                            app.alertState = .init(.tapSignerDeriveFailed(error.description))
                         }
                     }
                 }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerSetupRetryView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerSetupRetryView.swift
@@ -71,7 +71,7 @@ struct TapSignerSetupRetry: View {
                                 .tapSignerSetupFailed("Failed to setup TapSigner"))
                         case let .failure(error):
                             app.sheetState = nil
-                            app.alertState = .init(.tapSignerSetupFailed(error.describe))
+                            app.alertState = .init(.tapSignerSetupFailed(error.description))
                         }
                     }
                 }

--- a/ios/Cove/TapSignerNFC.swift
+++ b/ios/Cove/TapSignerNFC.swift
@@ -77,12 +77,12 @@ class TapSignerNFC {
                                 self.nfc.session?.invalidate()
                             } else if let error = self.nfc.tapSignerError {
                                 continuation.resume(returning: .failure(error))
-                                self.nfc.session?.invalidate(errorMessage: error.describe)
+                                self.nfc.session?.invalidate(errorMessage: error.description)
                             } else {
                                 Log.error("Unknown error response: \(String(describing: self.nfc.tapSignerResponse)), error: \(String(describing: self.nfc.tapSignerError))")
                                 let error = TapSignerReaderError.Unknown("Unknown error occurred")
                                 continuation.resume(returning: .failure(error))
-                                self.nfc.session?.invalidate(errorMessage: error.describe)
+                                self.nfc.session?.invalidate(errorMessage: error.description)
                             }
                         }
                     }
@@ -92,7 +92,7 @@ class TapSignerNFC {
                 }
             }
         } catch let error as TapSignerReaderError {
-            self.nfc.session?.invalidate(errorMessage: error.describe)
+            self.nfc.session?.invalidate(errorMessage: error.description)
             return .failure(error)
         } catch {
             nfc.session?.invalidate(errorMessage: "Something went wrong!")
@@ -351,7 +351,7 @@ private class TapCardNFC: NSObject, NFCTagReaderSessionDelegate {
             if case .TapSignerError(.CkTap(.BadAuth)) = error {
                 return session.invalidate(errorMessage: "Wrong PIN, please try again")
             }
-            session.invalidate(errorMessage: "TapSigner error: \(error.describe)")
+            session.invalidate(errorMessage: "TapSigner error: \(error.description)")
         } catch {
             logger.error("Error creating reader: \(error)")
             session.invalidate(errorMessage: "Error creating reader: \(error.localizedDescription)")

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -12805,6 +12805,16 @@ public enum AuthManagerError: Swift.Error, Equatable, Hashable, Foundation.Local
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_authmanagererror_uniffi_trait_display(
+            FfiConverterTypeAuthManagerError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -16747,6 +16757,16 @@ public enum MultiFormatError: Swift.Error, Equatable, Hashable, Foundation.Local
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_multiformaterror_uniffi_trait_display(
+            FfiConverterTypeMultiFormatError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -18196,6 +18216,16 @@ public enum SendFlowError: Swift.Error, Equatable, Hashable, Foundation.Localize
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_sendflowerror_uniffi_trait_display(
+            FfiConverterTypeSendFlowError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -18417,18 +18447,33 @@ public func FfiConverterTypeSendFlowErrorAlert_lower(_ value: SendFlowErrorAlert
 }
 
 
-// Note that we don't yet support `indirect` for enums.
-// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
-public enum SendFlowFiatOnChangeError: Equatable, Hashable {
+public enum SendFlowFiatOnChangeError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
+
     
-    case invalidFiatAmount(error: String, input: String
+    
+    case InvalidFiatAmount(error: String, input: String
     )
-    case converter(ConverterError
+    case Converter(ConverterError
     )
 
+    
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_sendflowfiatonchangeerror_uniffi_trait_display(
+            FfiConverterTypeSendFlowFiatOnChangeError_lower(self),$0
+    )
+}
+    )
+}
 
-
+    
+    public var errorDescription: String? {
+        String(reflecting: self)
+    }
+    
 }
 
 #if compiler(>=6)
@@ -18444,28 +18489,36 @@ public struct FfiConverterTypeSendFlowFiatOnChangeError: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SendFlowFiatOnChangeError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
+
         
-        case 1: return .invalidFiatAmount(error: try FfiConverterString.read(from: &buf), input: try FfiConverterString.read(from: &buf)
-        )
+
         
-        case 2: return .converter(try FfiConverterTypeConverterError.read(from: &buf)
-        )
-        
-        default: throw UniffiInternalError.unexpectedEnumCase
+        case 1: return .InvalidFiatAmount(
+            error: try FfiConverterString.read(from: &buf), 
+            input: try FfiConverterString.read(from: &buf)
+            )
+        case 2: return .Converter(
+            try FfiConverterTypeConverterError.read(from: &buf)
+            )
+
+         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: SendFlowFiatOnChangeError, into buf: inout [UInt8]) {
         switch value {
+
+        
+
         
         
-        case let .invalidFiatAmount(error,input):
+        case let .InvalidFiatAmount(error,input):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(error, into: &buf)
             FfiConverterString.write(input, into: &buf)
             
         
-        case let .converter(v1):
+        case let .Converter(v1):
             writeInt(&buf, Int32(2))
             FfiConverterTypeConverterError.write(v1, into: &buf)
             
@@ -18487,7 +18540,6 @@ public func FfiConverterTypeSendFlowFiatOnChangeError_lift(_ buf: RustBuffer) th
 public func FfiConverterTypeSendFlowFiatOnChangeError_lower(_ value: SendFlowFiatOnChangeError) -> RustBuffer {
     return FfiConverterTypeSendFlowFiatOnChangeError.lower(value)
 }
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -19705,6 +19757,16 @@ public enum TapSignerReaderError: Swift.Error, Equatable, Hashable, Foundation.L
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_tapsignerreadererror_uniffi_trait_display(
+            FfiConverterTypeTapSignerReaderError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -20357,6 +20419,16 @@ public enum TransportError: Swift.Error, Equatable, Hashable, Foundation.Localiz
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_transporterror_uniffi_trait_display(
+            FfiConverterTypeTransportError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -21233,6 +21305,16 @@ public enum WalletError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_walleterror_uniffi_trait_display(
+            FfiConverterTypeWalletError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -21740,6 +21822,16 @@ public enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.Loc
     )
 
     
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_walletmanagererror_uniffi_trait_display(
+            FfiConverterTypeWalletManagerError_lower(self),$0
+    )
+}
+    )
+}
 
     
     public var errorDescription: String? {
@@ -25241,62 +25333,6 @@ public func defaultWalletColors() -> [WalletColor]  {
     )
 })
 }
-public func describeAuthManagerError(error: AuthManagerError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_auth_manager_error(
-        FfiConverterTypeAuthManagerError_lower(error),$0
-    )
-})
-}
-public func describeMultiFormatError(error: MultiFormatError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_multi_format_error(
-        FfiConverterTypeMultiFormatError_lower(error),$0
-    )
-})
-}
-public func describeSendFlowError(error: SendFlowError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_send_flow_error(
-        FfiConverterTypeSendFlowError_lower(error),$0
-    )
-})
-}
-public func describeSendFlowFiatOnChangeError(error: SendFlowFiatOnChangeError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_send_flow_fiat_on_change_error(
-        FfiConverterTypeSendFlowFiatOnChangeError_lower(error),$0
-    )
-})
-}
-public func describeTapSignerReaderError(error: TapSignerReaderError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_tap_signer_reader_error(
-        FfiConverterTypeTapSignerReaderError_lower(error),$0
-    )
-})
-}
-public func describeTransportError(error: TransportError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_transport_error(
-        FfiConverterTypeTransportError_lower(error),$0
-    )
-})
-}
-public func describeWalletError(error: WalletError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_wallet_error(
-        FfiConverterTypeWalletError_lower(error),$0
-    )
-})
-}
-public func describeWalletManagerError(error: WalletManagerError) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_fn_func_describe_wallet_manager_error(
-        FfiConverterTypeWalletManagerError_lower(error),$0
-    )
-})
-}
 public func discoveryStateIsEqual(lhs: DiscoveryState, rhs: DiscoveryState) -> Bool  {
     return try!  FfiConverterBool.lift(try! rustCall() {
     uniffi_cove_fn_func_discovery_state_is_equal(
@@ -25651,30 +25687,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_default_wallet_colors() != 39034) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_auth_manager_error() != 9186) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_multi_format_error() != 25386) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_send_flow_error() != 40406) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_send_flow_fiat_on_change_error() != 38097) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_tap_signer_reader_error() != 18001) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_transport_error() != 49523) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_wallet_error() != 7428) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_describe_wallet_manager_error() != 13784) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_discovery_state_is_equal() != 12390) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "uniffi"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "camino",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "askama",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "camino",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3195,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "camino",
  "fs-err",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "uniffi_pipeline"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "heck",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "camino",
@@ -3312,12 +3312,12 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.30.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta 0.30.0",
- "weedle2 5.0.0 (git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn)",
+ "weedle2 5.0.0 (git+https://github.com/praveenperera/uniffi-rs?branch=dev)",
 ]
 
 [[package]]
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/praveenperera/uniffi-rs?branch=kotlin-fqtn#62374671f3481bf765ffb9d735bae34122e79add"
+source = "git+https://github.com/praveenperera/uniffi-rs?branch=dev#492327cfb5a62a4d919998bcccbc0bc842e75a94"
 dependencies = [
  "nom",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ members = ["crates/*"]
 ## MARK: WORKSPACE DEPENDENCIES
 [workspace.dependencies]
 # bindings
-uniffi = { git = "https://github.com/praveenperera/uniffi-rs", branch = "kotlin-fqtn", features = ["tokio"] }
+uniffi = { git = "https://github.com/praveenperera/uniffi-rs", branch = "dev", features = ["tokio"] }
 
 # sync
 parking_lot = { version = "0.12.3" }

--- a/rust/src/manager/auth_manager.rs
+++ b/rust/src/manager/auth_manager.rs
@@ -53,6 +53,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 type Error = AuthManagerError;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Error, thiserror::Error)]
+#[uniffi::export(Display)]
 pub enum AuthManagerError {
     #[error("Unable to set the wipe data PIN, because {0}")]
     WipeDataSet(TrickPinError),
@@ -62,11 +63,6 @@ pub enum AuthManagerError {
 
     #[error("There was a database error: {0}")]
     Database(#[from] database::Error),
-}
-
-#[uniffi::export]
-fn describe_auth_manager_error(error: AuthManagerError) -> String {
-    error.to_string()
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Error, thiserror::Error)]

--- a/rust/src/manager/send_flow_manager/error.rs
+++ b/rust/src/manager/send_flow_manager/error.rs
@@ -3,6 +3,7 @@ use cove_types::{Network, address::AddressError};
 use crate::manager::wallet_manager::WalletManagerError;
 
 #[derive(Debug, Clone, Eq, PartialEq, uniffi::Error, thiserror::Error)]
+#[uniffi::export(Display)]
 pub enum SendFlowError {
     #[error("empty address")]
     EmptyAddress,
@@ -59,9 +60,4 @@ impl SendFlowError {
             _ => Self::InvalidAddress(address),
         }
     }
-}
-
-#[uniffi::export]
-fn describe_send_flow_error(error: SendFlowError) -> String {
-    error.to_string()
 }

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -40,7 +40,8 @@ impl Changeset {
 pub type Error = SendFlowFiatOnChangeError;
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Clone, uniffi::Enum, thiserror::Error)]
+#[derive(Debug, Clone, uniffi::Error, thiserror::Error)]
+#[uniffi::export(Display)]
 pub enum SendFlowFiatOnChangeError {
     #[error("invalid fiat amount: {error} ({input})")]
     InvalidFiatAmount { error: String, input: String },
@@ -169,9 +170,4 @@ impl FiatOnChangeHandler {
 
         Ok(changes)
     }
-}
-
-#[uniffi::export]
-fn describe_send_flow_fiat_on_change_error(error: SendFlowFiatOnChangeError) -> String {
-    error.to_string()
 }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -145,6 +145,7 @@ pub struct RustWalletManager {
 
 pub type Error = WalletManagerError;
 #[derive(Debug, Clone, Eq, PartialEq, uniffi::Error, thiserror::Error)]
+#[uniffi::export(Display)]
 pub enum WalletManagerError {
     #[error("failed to get selected wallet: {0}")]
     GetSelectedWalletError(String),
@@ -1082,9 +1083,4 @@ impl Drop for RustWalletManager {
 #[uniffi::export]
 fn wallet_state_is_equal(lhs: WalletLoadState, rhs: WalletLoadState) -> bool {
     lhs == rhs
-}
-
-#[uniffi::export]
-fn describe_wallet_manager_error(error: WalletManagerError) -> String {
-    error.to_string()
 }

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -31,6 +31,7 @@ pub enum MultiFormat {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Error, thiserror::Error)]
+#[uniffi::export(Display)]
 pub enum MultiFormatError {
     #[error(transparent)]
     InvalidSeedQr(#[from] crate::seed_qr::SeedQrError),
@@ -183,11 +184,6 @@ fn string_or_data_try_into_multi_format(
     string_or_data: StringOrData,
 ) -> Result<MultiFormat, MultiFormatError> {
     string_or_data.try_into()
-}
-
-#[uniffi::export]
-fn describe_multi_format_error(error: MultiFormatError) -> String {
-    error.to_string()
 }
 
 #[derive(

--- a/rust/src/tap_card.rs
+++ b/rust/src/tap_card.rs
@@ -5,6 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 
 // Define error types
 #[derive(Debug, Clone, Hash, PartialEq, Eq, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Display)]
 pub enum TransportError {
     #[error("CiborDe: {0}")]
     CiborDe(String),
@@ -179,9 +180,4 @@ pub fn create_transport_error_from_code(code: u16, message: String) -> Transport
 pub fn is_valid_chain_code(chain_code: String) -> bool {
     let Ok(chain_code) = hex::decode(chain_code) else { return false };
     chain_code.len() == 32
-}
-
-#[uniffi::export]
-fn describe_transport_error(error: TransportError) -> String {
-    error.to_string()
 }

--- a/rust/src/tap_card/tap_signer_reader.rs
+++ b/rust/src/tap_card/tap_signer_reader.rs
@@ -20,6 +20,7 @@ use cove_util::result_ext::ResultExt as _;
 use super::{CkTapError, TapcardTransport, TapcardTransportProtocol, TransportError};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Display)]
 pub enum TapSignerReaderError {
     #[error(transparent)]
     TapSignerError(#[from] TransportError),
@@ -581,11 +582,6 @@ mod ffi {
     #[uniffi::export]
     fn tap_signer_response_sign_response(response: TapSignerResponse) -> Option<Arc<Psbt>> {
         response.sign_response()
-    }
-
-    #[uniffi::export]
-    fn describe_tap_signer_reader_error(error: TapSignerReaderError) -> String {
-        error.to_string()
     }
 
     #[uniffi::export]

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -37,6 +37,7 @@ pub type AddressWithNetwork = address::AddressWithNetwork;
 pub type AddressInfo = address::AddressInfo;
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Error, thiserror::Error)]
+#[uniffi::export(Display)]
 pub enum WalletError {
     #[error("failed to create wallet: {0}")]
     BdkError(String),
@@ -683,9 +684,4 @@ mod tests {
         let _ = delete_wallet_specific_data(&metadata.id);
         assert_eq!("73c5da0a", fingerprint.as_str());
     }
-}
-
-#[uniffi::export]
-fn describe_wallet_error(error: WalletError) -> String {
-    error.to_string()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Updated Tap card terminology in the app: “SatsCard” and “TapSigner” replace older names.

- Bug Fixes
  - Improved app stability by preventing rare crashes related to native resource cleanup and concurrent access.

- Refactor
  - Standardized error messaging across iOS screens (QR import, Send, TapSigner flows) for clearer, more consistent alerts.
  - Unified error handling on Android (NFC and device interactions) for consistent messages from native layers.
  - Internal lifecycle and handle management streamlined for safer, more reliable operation without changing core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->