### PR TITLE
COVE-358: Use BuildConfig.VERSION_NAME for app version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,6 +39,7 @@ android {
         jvmTarget = "1.8"
     }
     buildFeatures {
+        buildConfig = true
         compose = true
     }
     composeOptions {

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -168,8 +168,7 @@ class AppManager private constructor() : FfiReconcile {
 
     val fullVersionId: String
         get() {
-            // TODO: get app version from BuildConfig or similar
-            val appVersion = "0.0.1" // placeholder
+            val appVersion = BuildConfig.VERSION_NAME
             if (appVersion != rust.version()) {
                 return "MISMATCH ${rust.version()} || $appVersion (${rust.gitShortHash()})"
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected app version display to show accurate version information instead of placeholder values.
  * Added version validation that detects and reports mismatches between the app version and underlying system components.

* **Chores**
  * Updated build configuration to properly generate and embed version information during the application build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->