### PR TITLE
Fix NFC charset usage and error display

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flow/new_wallet/hot_wallet/HotWalletImportScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flow/new_wallet/hot_wallet/HotWalletImportScreen.kt
@@ -1062,16 +1062,32 @@ private fun NfcScannerSheet(
                     color = Color.White.copy(alpha = 0.7f),
                     textAlign = TextAlign.Center,
                 )
+            } else {
+                // show icon and error message when not scanning
+                Icon(
+                    imageVector = Icons.Default.Nfc,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.padding(16.dp),
+                )
 
-                if (errorMessage != null) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = errorMessage!!,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = CoveColor.ErrorRed,
-                        textAlign = TextAlign.Center,
-                    )
-                }
+                Text(
+                    text = "NFC Unavailable",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                )
+            }
+
+            // show error message regardless of scanning state
+            if (errorMessage != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = errorMessage!!,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CoveColor.ErrorRed,
+                    textAlign = TextAlign.Center,
+                )
             }
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/android/app/src/main/java/org/bitcoinppl/cove/nfc/NfcReader.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/nfc/NfcReader.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.setValue
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
+import java.nio.charset.Charset
 
 class NfcReader(private val activity: Activity) {
     private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
@@ -115,14 +116,14 @@ class NfcReader(private val activity: Activity) {
                             payload,
                             languageCodeLength + 1,
                             payload.size - languageCodeLength - 1,
-                            charset(textEncoding),
+                            Charset.forName(textEncoding),
                         )
                     textContent = text
                     Log.d("NfcReader", "Found text: $text")
                 } else {
                     // try as raw string
                     try {
-                        val text = String(payload, charset("UTF-8"))
+                        val text = String(payload, Charsets.UTF_8)
                         if (text.isNotBlank()) {
                             textContent = text
                             Log.d("NfcReader", "Found raw text: $text")


### PR DESCRIPTION
Replace experimental charset() calls with stable Java APIs and fix error message visibility when NFC scanning fails to start.

Changes:
- Replace charset(textEncoding) with Charset.forName(textEncoding) in NfcReader
- Replace charset("UTF-8") with Charsets.UTF_8 for UTF-8 decoding
- Show NFC error messages even when isScanning is false
- Display "NFC Unavailable" message when scanning cannot start
- Move error message display outside isScanning guard in NfcScannerSheet

This ensures users see proper feedback when NFC is not supported or disabled, and removes dependency on experimental Kotlin APIs.
