### PR TITLE
COVE-394: Implement TapSigner backup export functionality

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/tapsigner/BackupExportUtils.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/tapsigner/BackupExportUtils.kt
@@ -1,0 +1,64 @@
+package org.bitcoinppl.cove.tapsigner
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.bitcoinppl.cove.AppAlertState
+import org.bitcoinppl.cove.AppManager
+import org.bitcoinppl.cove.TaggedItem
+import org.bitcoinppl.cove_core.util.hexEncode
+
+/**
+ * Creates a launcher for exporting TapSigner backups as hex-encoded text files
+ *
+ * @param app The app manager for showing alerts
+ * @param getBackup Suspend function that retrieves the backup bytes
+ * @return ActivityResultLauncher that can be triggered with a file name
+ */
+@Composable
+fun rememberBackupExportLauncher(
+    app: AppManager,
+    getBackup: suspend () -> ByteArray,
+): ActivityResultLauncher<String> {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    return rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("text/plain"),
+    ) { uri ->
+        uri?.let {
+            scope.launch {
+                try {
+                    withContext(Dispatchers.IO) {
+                        val backup = getBackup()
+                        val hexBackup = hexEncode(backup)
+                        context.contentResolver.openOutputStream(uri)?.use { output ->
+                            output.write(hexBackup.toByteArray())
+                        } ?: throw java.io.IOException("Failed to open output stream")
+                    }
+                    app.alertState =
+                        TaggedItem(
+                            AppAlertState.General(
+                                title = "Backup Saved!",
+                                message = "Your backup has been saved successfully!",
+                            ),
+                        )
+                } catch (e: Exception) {
+                    app.alertState =
+                        TaggedItem(
+                            AppAlertState.General(
+                                title = "Saving Backup Failed!",
+                                message = "Failed to save backup: ${e.message ?: "Unknown error occurred"}",
+                            ),
+                        )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add file export capability for TapSigner backups in both the PIN entry screen and setup success screen. Backups are exported as hex-encoded text files with proper error handling and user feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can export and download their backup as a text file via a “Download Backup” flow.
  * Backup files are named for clarity and formatted for secure storage.
  * Export runs off the main UI thread to avoid interruptions and provides success/failure alerts to the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->