### PR TITLE
Refresh wallets list when sidebar becomes visible

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
@@ -27,7 +27,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,12 +61,18 @@ fun SidebarView(
 ) {
     val coroutineScope = rememberCoroutineScope()
 
-    val wallets =
-        try {
-            Database().wallets().all()
-        } catch (e: Exception) {
-            emptyList()
+    var wallets by remember { mutableStateOf<List<WalletMetadata>>(emptyList()) }
+
+    LaunchedEffect(app.isSidebarVisible) {
+        if (app.isSidebarVisible) {
+            wallets =
+                try {
+                    Database().wallets().all()
+                } catch (e: Exception) {
+                    emptyList()
+                }
         }
+    }
 
     Column(
         modifier =

--- a/ios/Cove/Views/SidebarView.swift
+++ b/ios/Cove/Views/SidebarView.swift
@@ -155,6 +155,14 @@ struct SidebarView: View {
                 Log.error("Failed to get wallets \(error)")
             }
         }
+        .onChange(of: app.isSidebarVisible) { _, visible in
+            guard visible else { return }
+            do {
+                self.wallets = try Database().wallets().all()
+            } catch {
+                Log.error("Failed to get wallets \(error)")
+            }
+        }
         .padding(20)
         .frame(maxWidth: .infinity)
         .background(.midnightBlue)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized wallet data loading on both Android and iOS. Wallet information now loads only when the sidebar becomes visible, reducing unnecessary data fetches and improving app performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->