### PR TITLE
Add dynamic BBQr QR animation interval based on density

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/BbqrExportView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/BbqrExportView.kt
@@ -74,10 +74,10 @@ fun QrExportView(
         generateQrCodes()
     }
 
-    // animation interval: 250ms for BBQR, dynamic for UR based on density
+    // animation interval: dynamic based on density for both formats
     val animationDelayMs =
         when (selectedFormat) {
-            QrExportFormat.BBQR -> 250L
+            QrExportFormat.BBQR -> density.bbqrAnimationIntervalMs().toLong()
             QrExportFormat.UR -> density.urAnimationIntervalMs().toLong()
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -760,6 +760,8 @@ external fun uniffi_cove_types_checksum_method_confirmdetails_sending_to(
 ): Short
 external fun uniffi_cove_types_checksum_method_confirmdetails_spending_amount(
 ): Short
+external fun uniffi_cove_types_checksum_method_qrdensity_bbqr_animation_interval_ms(
+): Short
 external fun uniffi_cove_types_checksum_method_qrdensity_bbqr_max_version(
 ): Short
 external fun uniffi_cove_types_checksum_method_qrdensity_can_decrease(
@@ -1056,6 +1058,8 @@ external fun uniffi_cove_types_fn_free_qrdensity(`handle`: Long,uniffi_out_err: 
 ): Unit
 external fun uniffi_cove_types_fn_constructor_qrdensity_new(uniffi_out_err: UniffiRustCallStatus, 
 ): Long
+external fun uniffi_cove_types_fn_method_qrdensity_bbqr_animation_interval_ms(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Int
 external fun uniffi_cove_types_fn_method_qrdensity_bbqr_max_version(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Byte
 external fun uniffi_cove_types_fn_method_qrdensity_can_decrease(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -1587,6 +1591,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_confirmdetails_spending_amount() != 58334.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_types_checksum_method_qrdensity_bbqr_animation_interval_ms() != 33981.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_qrdensity_bbqr_max_version() != 14183.toShort()) {
@@ -7255,6 +7262,12 @@ public object FfiConverterTypePsbt: FfiConverter<Psbt, Long> {
  */
 public interface QrDensityInterface {
     
+    /**
+     * Get the recommended animation interval in milliseconds for BBQR format
+     * Lower density (smaller max version) = slower animation for better scanning
+     */
+    fun `bbqrAnimationIntervalMs`(): kotlin.UInt
+    
     fun `bbqrMaxVersion`(): kotlin.UByte
     
     fun `canDecrease`(): kotlin.Boolean
@@ -7392,6 +7405,23 @@ open class QrDensity: Disposable, AutoCloseable, QrDensityInterface
             UniffiLib.uniffi_cove_types_fn_clone_qrdensity(handle, status)
         }
     }
+
+    
+    /**
+     * Get the recommended animation interval in milliseconds for BBQR format
+     * Lower density (smaller max version) = slower animation for better scanning
+     */override fun `bbqrAnimationIntervalMs`(): kotlin.UInt {
+            return FfiConverterUInt.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_types_fn_method_qrdensity_bbqr_animation_interval_ms(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
 
     override fun `bbqrMaxVersion`(): kotlin.UByte {
             return FfiConverterUByte.lift(

--- a/ios/Cove/Flows/SendFlow/SendFlowHardwareScreen/SendFlowQrExport.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowHardwareScreen/SendFlowQrExport.swift
@@ -21,10 +21,10 @@ struct SendFlowQrExport: View {
 
     let startedAt: Date = .now
 
-    /// Animation interval: 250ms for BBQR, dynamic for UR based on density
+    /// Animation interval: dynamic based on density for both formats
     var animationInterval: TimeInterval {
         switch selectedFormat {
-        case .bbqr: 0.250
+        case .bbqr: Double(density.bbqrAnimationIntervalMs()) / 1000.0
         case .ur: Double(density.urAnimationIntervalMs()) / 1000.0
         }
     }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -3209,6 +3209,12 @@ public func FfiConverterTypePsbt_lower(_ value: Psbt) -> UInt64 {
  */
 public protocol QrDensityProtocol: AnyObject, Sendable {
     
+    /**
+     * Get the recommended animation interval in milliseconds for BBQR format
+     * Lower density (smaller max version) = slower animation for better scanning
+     */
+    func bbqrAnimationIntervalMs()  -> UInt32
+    
     func bbqrMaxVersion()  -> UInt8
     
     func canDecrease()  -> Bool
@@ -3300,6 +3306,18 @@ public convenience init() {
 
     
 
+    
+    /**
+     * Get the recommended animation interval in milliseconds for BBQR format
+     * Lower density (smaller max version) = slower animation for better scanning
+     */
+open func bbqrAnimationIntervalMs() -> UInt32  {
+    return try!  FfiConverterUInt32.lift(try! rustCall() {
+    uniffi_cove_types_fn_method_qrdensity_bbqr_animation_interval_ms(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
     
 open func bbqrMaxVersion() -> UInt8  {
     return try!  FfiConverterUInt8.lift(try! rustCall() {
@@ -6195,6 +6213,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_confirmdetails_spending_amount() != 58334) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_types_checksum_method_qrdensity_bbqr_animation_interval_ms() != 33981) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_qrdensity_bbqr_max_version() != 14183) {

--- a/rust/crates/cove-types/src/confirm.rs
+++ b/rust/crates/cove-types/src/confirm.rs
@@ -163,6 +163,18 @@ impl QrDensity {
             0..50 => 500,
         }
     }
+
+    /// Get the recommended animation interval in milliseconds for BBQR format
+    /// Lower density (smaller max version) = slower animation for better scanning
+    pub fn bbqr_animation_interval_ms(&self) -> u32 {
+        match self.bbqr_max_version {
+            15.. => 250,
+            11..15 => 300,
+            9..11 => 350,
+            7..9 => 400,
+            0..7 => 500,
+        }
+    }
 }
 
 /// Check if two QrDensity values are equal (for Swift Equatable conformance)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BBQR QR code animation intervals now dynamically adjust based on QR density settings, aligning behavior with UR format animations on iOS and Android.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->