### PR TITLE
Fix received transaction details to match iOS parity

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/ReceivedTransactionDetails.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/ReceivedTransactionDetails.kt
@@ -4,8 +4,6 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,12 +12,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -31,8 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -40,8 +33,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import org.bitcoinppl.cove.R
-import org.bitcoinppl.cove.ui.theme.CoveColor
 import org.bitcoinppl.cove_core.TransactionDetails
+import java.text.NumberFormat
 
 @Composable
 internal fun ReceivedTransactionDetails(
@@ -54,7 +47,48 @@ internal fun ReceivedTransactionDetails(
     val fg = MaterialTheme.colorScheme.onBackground
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        // received at address with copy button
+        // for confirmed transactions, show Confirmations and Block Number first (matching iOS)
+        if (transactionDetails.isConfirmed()) {
+            // Confirmations row
+            Text(
+                stringResource(R.string.label_confirmations),
+                color = sub,
+                fontSize = 12.sp,
+            )
+            Spacer(Modifier.height(8.dp))
+            if (numberOfConfirmations != null) {
+                Text(
+                    NumberFormat.getNumberInstance().format(numberOfConfirmations),
+                    color = fg,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            } else {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = fg,
+                )
+            }
+            Spacer(Modifier.height(14.dp))
+
+            // Block Number row
+            Text(
+                stringResource(R.string.label_block_number),
+                color = sub,
+                fontSize = 12.sp,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                transactionDetails.blockNumberFmt() ?: "",
+                color = fg,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(14.dp))
+        }
+
+        // "Received At" section with address and copy button
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.Top,
@@ -105,43 +139,6 @@ internal fun ReceivedTransactionDetails(
             if (isCopied) {
                 delay(5000)
                 isCopied = false
-            }
-        }
-
-        // show block number and confirmations for confirmed received transactions
-        if (transactionDetails.isConfirmed() && numberOfConfirmations != null) {
-            Spacer(Modifier.height(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                val blockNumber = transactionDetails.blockNumberFmt()
-                if (blockNumber != null) {
-                    Text(
-                        blockNumber,
-                        color = sub,
-                        fontSize = 14.sp,
-                    )
-                    Text(" | ", color = sub, fontSize = 14.sp)
-                }
-                Text(
-                    numberOfConfirmations.toString(),
-                    color = sub,
-                    fontSize = 14.sp,
-                )
-                Spacer(Modifier.size(4.dp))
-                Box(
-                    modifier =
-                        Modifier
-                            .size(14.dp)
-                            .clip(CircleShape)
-                            .background(CoveColor.SuccessGreen),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Check,
-                        contentDescription = null,
-                        tint = Color.White,
-                        modifier = Modifier.size(10.dp),
-                    )
-                }
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsWidget.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsWidget.kt
@@ -58,74 +58,68 @@ internal fun TransactionDetailsWidget(
         )
         Spacer(Modifier.height(24.dp))
 
-        // address (sent to / received from)
-        val addressLabel =
-            stringResource(
-                if (isSent) R.string.label_sent_to else R.string.label_received_from,
-            )
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Text(
-                addressLabel,
-                color = sub,
-                fontSize = 12.sp,
-            )
-            Spacer(Modifier.height(8.dp))
-            Text(
-                transactionDetails.addressSpacedOut(),
-                color = fg,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                lineHeight = 18.sp,
-            )
-
-            // show block number and confirmations for confirmed sent transactions
-            if (isSent && isConfirmed) {
+        if (isSent) {
+            // "Sent to" section - only for sent transactions
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    stringResource(R.string.label_sent_to),
+                    color = sub,
+                    fontSize = 12.sp,
+                )
                 Spacer(Modifier.height(8.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        transactionDetails.blockNumberFmt() ?: "",
-                        color = sub,
-                        fontSize = 14.sp,
-                    )
-                    Text(" | ", color = sub, fontSize = 14.sp)
-                    if (numberOfConfirmations != null) {
+                Text(
+                    transactionDetails.addressSpacedOut(),
+                    color = fg,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    lineHeight = 18.sp,
+                )
+
+                // show block number and confirmations for confirmed sent transactions
+                if (isConfirmed) {
+                    Spacer(Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            numberOfConfirmations.toString(),
+                            transactionDetails.blockNumberFmt() ?: "",
                             color = sub,
                             fontSize = 14.sp,
                         )
-                        Spacer(Modifier.size(4.dp))
-                        Box(
-                            modifier =
-                                Modifier
-                                    .size(14.dp)
-                                    .clip(CircleShape)
-                                    .background(CoveColor.SuccessGreen),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(10.dp),
+                        Text(" | ", color = sub, fontSize = 14.sp)
+                        if (numberOfConfirmations != null) {
+                            Text(
+                                numberOfConfirmations.toString(),
+                                color = sub,
+                                fontSize = 14.sp,
                             )
+                            Spacer(Modifier.size(4.dp))
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(14.dp)
+                                        .clip(CircleShape)
+                                        .background(CoveColor.SuccessGreen),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = null,
+                                    tint = Color.White,
+                                    modifier = Modifier.size(10.dp),
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
-        Spacer(Modifier.height(24.dp))
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(dividerColor),
-        )
-        Spacer(Modifier.height(24.dp))
-
-        // network fee (for sent transactions)
-        if (isSent) {
+            Spacer(Modifier.height(24.dp))
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(dividerColor),
+            )
+            Spacer(Modifier.height(24.dp))
             DetailsWidget(
                 label = stringResource(R.string.label_network_fee),
                 primary = transactionDetails.feeFmt(unit = metadata.selectedUnit),


### PR DESCRIPTION
## Summary
- Remove duplicate "Received from" section for received transactions
- Restructure ReceivedTransactionDetails to match iOS layout
- Show Confirmations and Block Number as separate rows at the top (for confirmed transactions)
- Show "Received At" with address and copy button below

## Test plan
- [ ] Open a confirmed received transaction and verify "More Details" shows: Confirmations, Block Number, then Received At with address
- [ ] Open a pending received transaction and verify "More Details" only shows: Received At with address and copy button
- [ ] Verify sent transactions are unchanged (Sent to with block/confirmations, fee details, etc.)
- [ ] Compare with iOS to confirm visual parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reorganized transaction details display for improved clarity.
  * Confirmed transactions now more prominently display confirmation count and block number.
  * Enhanced "Sent to" section for sent transactions with clearer visual organization.
  * Streamlined layout to reduce clutter in transaction detail views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->