### PR TITLE
Show cached fiat amounts immediately on transaction details

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsWidget.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsWidget.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.ui.theme.CoveColor
+import org.bitcoinppl.cove.views.AsyncText
 import org.bitcoinppl.cove.views.AutoSizeText
 import org.bitcoinppl.cove_core.TransactionDetails
 import org.bitcoinppl.cove_core.WalletMetadata
@@ -36,9 +37,9 @@ import org.bitcoinppl.cove_core.WalletMetadata
 internal fun TransactionDetailsWidget(
     transactionDetails: TransactionDetails,
     numberOfConfirmations: Int?,
-    feeFiatFmt: String,
-    sentSansFeeFiatFmt: String,
-    totalSpentFiatFmt: String,
+    feeFiatFmt: String?,
+    sentSansFeeFiatFmt: String?,
+    totalSpentFiatFmt: String?,
     metadata: WalletMetadata,
 ) {
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
@@ -207,10 +208,8 @@ internal fun DetailsWidget(
         }
         Column(horizontalAlignment = Alignment.End) {
             AutoSizeText(primary, color = primaryColor, maxFontSize = 14.sp, minimumScaleFactor = 0.90f, fontWeight = FontWeight.SemiBold)
-            if (!secondary.isNullOrEmpty()) {
-                Spacer(Modifier.height(6.dp))
-                Text(secondary, color = sub, fontSize = 12.sp)
-            }
+            Spacer(Modifier.height(6.dp))
+            AsyncText(text = secondary, color = sub, style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp))
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1625,6 +1625,8 @@ external fun uniffi_cove_checksum_method_transactiondetails_amount_fiat(
 ): Short
 external fun uniffi_cove_checksum_method_transactiondetails_amount_fiat_fmt(
 ): Short
+external fun uniffi_cove_checksum_method_transactiondetails_amount_fiat_fmt_cached(
+): Short
 external fun uniffi_cove_checksum_method_transactiondetails_amount_fmt(
 ): Short
 external fun uniffi_cove_checksum_method_transactiondetails_block_number(
@@ -1635,6 +1637,8 @@ external fun uniffi_cove_checksum_method_transactiondetails_confirmation_date_ti
 ): Short
 external fun uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt(
 ): Short
+external fun uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt_cached(
+): Short
 external fun uniffi_cove_checksum_method_transactiondetails_fee_fmt(
 ): Short
 external fun uniffi_cove_checksum_method_transactiondetails_is_confirmed(
@@ -1644,6 +1648,8 @@ external fun uniffi_cove_checksum_method_transactiondetails_is_received(
 external fun uniffi_cove_checksum_method_transactiondetails_is_sent(
 ): Short
 external fun uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fiat_fmt(
+): Short
+external fun uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fiat_fmt_cached(
 ): Short
 external fun uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fmt(
 ): Short
@@ -2677,6 +2683,8 @@ external fun uniffi_cove_fn_method_transactiondetails_amount_fiat(`ptr`: Long,
 ): Long
 external fun uniffi_cove_fn_method_transactiondetails_amount_fiat_fmt(`ptr`: Long,
 ): Long
+external fun uniffi_cove_fn_method_transactiondetails_amount_fiat_fmt_cached(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_amount_fmt(`ptr`: Long,`unit`: RustBufferBitcoinUnit.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_block_number(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -2687,6 +2695,8 @@ external fun uniffi_cove_fn_method_transactiondetails_confirmation_date_time(`pt
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt(`ptr`: Long,
 ): Long
+external fun uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt_cached(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_fee_fmt(`ptr`: Long,`unit`: RustBufferBitcoinUnit.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_is_confirmed(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -2697,6 +2707,8 @@ external fun uniffi_cove_fn_method_transactiondetails_is_sent(`ptr`: Long,uniffi
 ): Byte
 external fun uniffi_cove_fn_method_transactiondetails_sent_sans_fee_fiat_fmt(`ptr`: Long,
 ): Long
+external fun uniffi_cove_fn_method_transactiondetails_sent_sans_fee_fiat_fmt_cached(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_sent_sans_fee_fmt(`ptr`: Long,`unit`: RustBufferBitcoinUnit.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_fn_method_transactiondetails_transaction_label(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -4108,6 +4120,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_transactiondetails_amount_fiat_fmt() != 17226.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_transactiondetails_amount_fiat_fmt_cached() != 11182.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_transactiondetails_amount_fmt() != 13996.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4123,6 +4138,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt() != 57101.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt_cached() != 1845.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_transactiondetails_fee_fmt() != 37631.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4136,6 +4154,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fiat_fmt() != 61624.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fiat_fmt_cached() != 42399.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fmt() != 64427.toShort()) {
@@ -20359,6 +20380,8 @@ public interface TransactionDetailsInterface {
     
     suspend fun `amountFiatFmt`(): kotlin.String
     
+    fun `amountFiatFmtCached`(): kotlin.String?
+    
     fun `amountFmt`(`unit`: BitcoinUnit): kotlin.String
     
     fun `blockNumber`(): kotlin.UInt?
@@ -20369,6 +20392,8 @@ public interface TransactionDetailsInterface {
     
     suspend fun `feeFiatFmt`(): kotlin.String
     
+    fun `feeFiatFmtCached`(): kotlin.String?
+    
     fun `feeFmt`(`unit`: BitcoinUnit): kotlin.String?
     
     fun `isConfirmed`(): kotlin.Boolean
@@ -20378,6 +20403,8 @@ public interface TransactionDetailsInterface {
     fun `isSent`(): kotlin.Boolean
     
     suspend fun `sentSansFeeFiatFmt`(): kotlin.String
+    
+    fun `sentSansFeeFiatFmtCached`(): kotlin.String?
     
     fun `sentSansFeeFmt`(`unit`: BitcoinUnit): kotlin.String?
     
@@ -20567,6 +20594,19 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     )
     }
 
+    override fun `amountFiatFmtCached`(): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_transactiondetails_amount_fiat_fmt_cached(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
     override fun `amountFmt`(`unit`: BitcoinUnit): kotlin.String {
             return FfiConverterString.lift(
     callWithHandle {
@@ -20640,6 +20680,19 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     )
     }
 
+    override fun `feeFiatFmtCached`(): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt_cached(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
     override fun `feeFmt`(`unit`: BitcoinUnit): kotlin.String? {
             return FfiConverterOptionalString.lift(
     callWithHandle {
@@ -20712,6 +20765,19 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
         TransactionDetailException.ErrorHandler,
     )
     }
+
+    override fun `sentSansFeeFiatFmtCached`(): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_transactiondetails_sent_sans_fee_fiat_fmt_cached(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
 
     override fun `sentSansFeeFmt`(`unit`: BitcoinUnit): kotlin.String? {
             return FfiConverterOptionalString.lift(

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/SentDetailsExpandedView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/SentDetailsExpandedView.swift
@@ -75,7 +75,10 @@ struct SentDetailsExpandedView: View {
 
                 VStack(alignment: .trailing) {
                     Text(transactionDetails.feeFmt(unit: metadata.selectedUnit) ?? "")
-                    AsyncView(operation: transactionDetails.feeFiatFmt) { amount in
+                    AsyncView(
+                        cachedValue: transactionDetails.feeFiatFmtCached(),
+                        operation: transactionDetails.feeFiatFmt
+                    ) { amount in
                         Text(amount).foregroundStyle(.secondary)
                             .font(.caption)
                             .padding(.top, 2)
@@ -91,7 +94,10 @@ struct SentDetailsExpandedView: View {
 
                 VStack(alignment: .trailing) {
                     Text(transactionDetails.sentSansFeeFmt(unit: metadata.selectedUnit) ?? "")
-                    AsyncView(operation: transactionDetails.sentSansFeeFiatFmt) { amount in
+                    AsyncView(
+                        cachedValue: transactionDetails.sentSansFeeFiatFmtCached(),
+                        operation: transactionDetails.sentSansFeeFiatFmt
+                    ) { amount in
                         Text(amount).foregroundStyle(.secondary)
                             .font(.caption)
                             .padding(.top, 2)
@@ -110,7 +116,10 @@ struct SentDetailsExpandedView: View {
                 Spacer()
                 VStack(alignment: .trailing) {
                     Text(transactionDetails.amountFmt(unit: metadata.selectedUnit))
-                    AsyncView(operation: transactionDetails.amountFiatFmt) { amount in
+                    AsyncView(
+                        cachedValue: transactionDetails.amountFiatFmtCached(),
+                        operation: transactionDetails.amountFiatFmt
+                    ) { amount in
                         Text(amount).foregroundStyle(.secondary)
                             .font(.caption)
                             .padding(.top, 2)

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -104,7 +104,10 @@ struct TransactionDetailsView: View {
                 .fontWeight(.bold)
                 .padding(.top, 12)
 
-            AsyncView(operation: transactionDetails.amountFiatFmt) { amount in
+            AsyncView(
+                cachedValue: transactionDetails.amountFiatFmtCached(),
+                operation: transactionDetails.amountFiatFmt
+            ) { amount in
                 Text(amount).foregroundStyle(.primary.opacity(0.8))
             }
         }
@@ -188,7 +191,10 @@ struct TransactionDetailsView: View {
                 .fontWeight(.bold)
                 .padding(.top, 12)
 
-            AsyncView(operation: transactionDetails.amountFiatFmt) { amount in
+            AsyncView(
+                cachedValue: transactionDetails.amountFiatFmtCached(),
+                operation: transactionDetails.amountFiatFmt
+            ) { amount in
                 Text(amount).foregroundStyle(.primary.opacity(0.8))
             }
         }

--- a/ios/Cove/Views/AsyncView.swift
+++ b/ios/Cove/Views/AsyncView.swift
@@ -28,22 +28,41 @@ struct AsyncText: View {
 }
 
 struct AsyncView<Success, Content: View>: View {
+    let cachedValue: Success?
     let operation: () async throws -> Success
     let content: (Success) -> Content
     let errorView: some View = Text("")
 
     @State private var result: Result<Success, Error>?
 
+    init(
+        cachedValue: Success? = nil,
+        operation: @escaping () async throws -> Success,
+        @ViewBuilder content: @escaping (Success) -> Content
+    ) {
+        self.cachedValue = cachedValue
+        self.operation = operation
+        self.content = content
+    }
+
     var body: some View {
         Group {
             switch result {
             case .none:
-                ProgressView()
-                    .tint(.primary)
+                if let cachedValue {
+                    content(cachedValue)
+                } else {
+                    ProgressView()
+                        .tint(.primary)
+                }
             case let .success(value):
                 content(value)
             case .failure:
-                errorView
+                if let cachedValue {
+                    content(cachedValue)
+                } else {
+                    errorView
+                }
             }
         }
         .task {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -9093,6 +9093,8 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
     
     func amountFiatFmt() async throws  -> String
     
+    func amountFiatFmtCached()  -> String?
+    
     func amountFmt(unit: BitcoinUnit)  -> String
     
     func blockNumber()  -> UInt32?
@@ -9103,6 +9105,8 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
     
     func feeFiatFmt() async throws  -> String
     
+    func feeFiatFmtCached()  -> String?
+    
     func feeFmt(unit: BitcoinUnit)  -> String?
     
     func isConfirmed()  -> Bool
@@ -9112,6 +9116,8 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
     func isSent()  -> Bool
     
     func sentSansFeeFiatFmt() async throws  -> String
+    
+    func sentSansFeeFiatFmtCached()  -> String?
     
     func sentSansFeeFmt(unit: BitcoinUnit)  -> String?
     
@@ -9276,6 +9282,14 @@ open func amountFiatFmt()async throws  -> String  {
         )
 }
     
+open func amountFiatFmtCached() -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_cove_fn_method_transactiondetails_amount_fiat_fmt_cached(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
 open func amountFmt(unit: BitcoinUnit) -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_cove_fn_method_transactiondetails_amount_fmt(
@@ -9326,6 +9340,14 @@ open func feeFiatFmt()async throws  -> String  {
         )
 }
     
+open func feeFiatFmtCached() -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt_cached(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
 open func feeFmt(unit: BitcoinUnit) -> String?  {
     return try!  FfiConverterOptionString.lift(try! rustCall() {
     uniffi_cove_fn_method_transactiondetails_fee_fmt(
@@ -9374,6 +9396,14 @@ open func sentSansFeeFiatFmt()async throws  -> String  {
             liftFunc: FfiConverterString.lift,
             errorHandler: FfiConverterTypeTransactionDetailError_lift
         )
+}
+    
+open func sentSansFeeFiatFmtCached() -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_cove_fn_method_transactiondetails_sent_sans_fee_fiat_fmt_cached(
+            self.uniffiCloneHandle(),$0
+    )
+})
 }
     
 open func sentSansFeeFmt(unit: BitcoinUnit) -> String?  {
@@ -29269,6 +29299,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_transactiondetails_amount_fiat_fmt() != 17226) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_transactiondetails_amount_fiat_fmt_cached() != 11182) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_transactiondetails_amount_fmt() != 13996) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -29284,6 +29317,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt() != 57101) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt_cached() != 1845) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_transactiondetails_fee_fmt() != 37631) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -29297,6 +29333,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fiat_fmt() != 61624) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fiat_fmt_cached() != 42399) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_sent_sans_fee_fmt() != 64427) {

--- a/rust/src/transaction/transaction_details.rs
+++ b/rust/src/transaction/transaction_details.rs
@@ -231,6 +231,13 @@ impl TransactionDetails {
     }
 
     #[uniffi::method]
+    pub fn amount_fiat_fmt_cached(&self) -> Option<String> {
+        let amount = self.amount();
+        let fiat = FIAT_CLIENT.value_in_currency_cached(amount, currency())?;
+        Some(fiat_amount_fmt(fiat))
+    }
+
+    #[uniffi::method]
     pub fn fee_fmt(&self, unit: Unit) -> Option<String> {
         let fee = self.fee?;
         Some(fee.fmt_string_with_unit(unit))
@@ -249,6 +256,13 @@ impl TransactionDetails {
         .unwrap()?;
 
         Ok(fiat_amount_fmt(fiat))
+    }
+
+    #[uniffi::method]
+    pub fn fee_fiat_fmt_cached(&self) -> Option<String> {
+        let fee = self.fee?;
+        let fiat = FIAT_CLIENT.value_in_currency_cached(fee, currency())?;
+        Some(fiat_amount_fmt(fiat))
     }
 
     #[uniffi::method]
@@ -286,6 +300,13 @@ impl TransactionDetails {
         .unwrap()?;
 
         Ok(fiat_amount_fmt(fiat))
+    }
+
+    #[uniffi::method]
+    pub fn sent_sans_fee_fiat_fmt_cached(&self) -> Option<String> {
+        let amount = self.sent_sans_fee()?;
+        let fiat = FIAT_CLIENT.value_in_currency_cached(amount, currency())?;
+        Some(fiat_amount_fmt(fiat))
     }
 
     #[uniffi::method]


### PR DESCRIPTION
- Add synchronous cached fiat methods to Rust TransactionDetails: amountFiatFmtCached, feeFiatFmtCached, sentSansFeeFiatFmtCached
- Update iOS/Android AsyncView to accept optional cachedValue parameter
- Display cached fiat values instantly, show spinner only when no cache
- Both platforms now have consistent behavior for fiat amount loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction details now display cached fiat amounts immediately while background updates occur, reducing perceived loading time.

* **Bug Fixes**
  * Fiat amount fetch failures now preserve previously cached values instead of showing placeholder text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->