### PR TITLE
Hide PIN digits on all iOS PIN entry screens

### DIFF
--- a/ios/Cove/Flows/SettingsFlow/SettingsScreen/ChangePinView.swift
+++ b/ios/Cove/Flows/SettingsFlow/SettingsScreen/ChangePinView.swift
@@ -40,7 +40,6 @@ struct ChangePinView: View {
                 NumberPadPinView(
                     title: "Enter new PIN",
                     isPinCorrect: { _ in true },
-                    showPin: true,
                     backAction: backAction,
                     onUnlock: { enteredPin in
                         withAnimation {

--- a/ios/Cove/Flows/SettingsFlow/SettingsScreen/NewPinView.swift
+++ b/ios/Cove/Flows/SettingsFlow/SettingsScreen/NewPinView.swift
@@ -26,7 +26,6 @@ struct NewPinView: View {
                 NumberPadPinView(
                     title: "Enter New PIN",
                     isPinCorrect: { _ in true },
-                    showPin: true,
                     backAction: backAction,
                     onUnlock: { enteredPin in
                         withAnimation {

--- a/ios/Cove/Flows/SettingsFlow/SettingsScreen/WipePin.swift
+++ b/ios/Cove/Flows/SettingsFlow/SettingsScreen/WipePin.swift
@@ -41,7 +41,6 @@ struct WipePin: View {
                 NumberPadPinView(
                     title: "Enter Wipe Me PIN",
                     isPinCorrect: { _ in true },
-                    showPin: true,
                     backAction: backAction,
                     onUnlock: { enteredPin in
                         withAnimation {
@@ -53,7 +52,6 @@ struct WipePin: View {
                 NumberPadPinView(
                     title: "Confirm Wipe Me PIN",
                     isPinCorrect: { $0 == pinToConfirm },
-                    showPin: true,
                     backAction: backAction,
                     onUnlock: onComplete
                 )

--- a/ios/Cove/Views/LockView.swift
+++ b/ios/Cove/Views/LockView.swift
@@ -62,7 +62,7 @@ struct LockView<Content: View>: View {
     init(
         lockType: AuthType,
         isPinCorrect: @escaping (String) -> Bool,
-        showPin: Bool = true,
+        showPin: Bool = false,
         lockState: Binding<LockState>? = nil,
         bioMetricUnlockMessage: String = "Unlock your wallet",
         onUnlock: @escaping (String) -> Void = { _ in },

--- a/ios/Cove/Views/NumberPadPinView.swift
+++ b/ios/Cove/Views/NumberPadPinView.swift
@@ -32,7 +32,7 @@ struct NumberPadPinView: View {
         title: String = "Enter Pin",
         lockState: Binding<LockState> = .constant(.unlocked),
         isPinCorrect: @escaping (String) -> Bool,
-        showPin: Bool = true,
+        showPin: Bool = false,
         pinLength: Int = 6,
         backAction: (() -> Void)? = nil,
         onUnlock: @escaping (String) -> Void = { _ in },


### PR DESCRIPTION
Change showPin default to false and remove explicit showPin: true flags so PIN digits are always hidden for better security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced PIN security by changing the default behavior to hide PIN entries across all setup and authentication screens. PIN visibility is now opt-in rather than always displayed by default, giving users control over when PIN characters are shown and reducing unintended exposure of sensitive credentials in shared or public settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->