### PR TITLE
Extract reusable ColumnMajorGrid component

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
@@ -58,6 +58,7 @@ import org.bitcoinppl.cove.ui.theme.CoveColor
 import org.bitcoinppl.cove.ui.theme.ForceLightStatusBarIcons
 import org.bitcoinppl.cove.utils.intoRoute
 import org.bitcoinppl.cove.views.AutoSizeText
+import org.bitcoinppl.cove.views.ColumnMajorGrid
 import org.bitcoinppl.cove.views.DotMenuView
 import org.bitcoinppl.cove.views.DotMenuViewCircle
 import org.bitcoinppl.cove.views.ImageButton
@@ -343,58 +344,42 @@ private fun WordCardView(
     words: List<GroupedWord>,
     modifier: Modifier = Modifier,
 ) {
-    val numColumns = 3
-    val wordsPerColumn = words.size / numColumns
-
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        repeat(numColumns) { col ->
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(18.dp),
+    ColumnMajorGrid(
+        items = words,
+        modifier = modifier,
+    ) { _, groupedWord ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = CoveColor.btnPrimary,
+                        shape =
+                            androidx.compose.foundation.shape
+                                .RoundedCornerShape(10.dp),
+                    ).padding(horizontal = 12.dp, vertical = 12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                repeat(wordsPerColumn) { row ->
-                    val index = col * wordsPerColumn + row
-                    if (index < words.size) {
-                        val groupedWord = words[index]
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .background(
-                                        color = CoveColor.btnPrimary,
-                                        shape =
-                                            androidx.compose.foundation.shape
-                                                .RoundedCornerShape(10.dp),
-                                    ).padding(horizontal = 12.dp, vertical = 12.dp),
-                        ) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                AutoSizeText(
-                                    text = "${groupedWord.number}.",
-                                    color = Color.Black.copy(alpha = 0.5f),
-                                    fontWeight = FontWeight.Medium,
-                                    maxFontSize = 12.sp,
-                                    minimumScaleFactor = 0.8f,
-                                )
-                                Spacer(Modifier.weight(1f))
-                                AutoSizeText(
-                                    text = groupedWord.word,
-                                    color = CoveColor.midnightBlue,
-                                    fontWeight = FontWeight.Medium,
-                                    maxFontSize = 14.sp,
-                                    minimumScaleFactor = 0.2f,
-                                )
-                                Spacer(Modifier.weight(1f))
-                            }
-                        }
-                    }
-                }
+                AutoSizeText(
+                    text = "${groupedWord.number}.",
+                    color = Color.Black.copy(alpha = 0.5f),
+                    fontWeight = FontWeight.Medium,
+                    maxFontSize = 12.sp,
+                    minimumScaleFactor = 0.8f,
+                )
+                Spacer(Modifier.weight(1f))
+                AutoSizeText(
+                    text = groupedWord.word,
+                    color = CoveColor.midnightBlue,
+                    fontWeight = FontWeight.Medium,
+                    maxFontSize = 14.sp,
+                    minimumScaleFactor = 0.2f,
+                )
+                Spacer(Modifier.weight(1f))
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -41,6 +40,7 @@ import org.bitcoinppl.cove.Auth
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.ui.theme.CoveColor
 import org.bitcoinppl.cove.ui.theme.ForceLightStatusBarIcons
+import org.bitcoinppl.cove.views.ColumnMajorGrid
 import org.bitcoinppl.cove.views.RecoveryWordChip
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.types.*
@@ -206,38 +206,23 @@ fun SecretWordsScreen(
 }
 
 /**
- * recovery words grid for viewing only (non-selectable)
- * uses column-major ordering (words flow down columns first)
+ * Recovery words grid for viewing only (non-selectable)
+ * Uses column-major ordering (words flow down columns first)
  */
 @Composable
 private fun RecoveryWordsGrid(
     words: List<String>,
     modifier: Modifier = Modifier,
 ) {
-    val numColumns = 3
-    val wordsPerColumn = words.size / numColumns
-
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        repeat(numColumns) { col ->
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(18.dp),
-            ) {
-                repeat(wordsPerColumn) { row ->
-                    val index = col * wordsPerColumn + row
-                    if (index < words.size) {
-                        RecoveryWordChip(
-                            index = index + 1,
-                            word = words[index],
-                            selected = false,
-                            onClick = null,
-                        )
-                    }
-                }
-            }
-        }
+    ColumnMajorGrid(
+        items = words,
+        modifier = modifier,
+    ) { index, word ->
+        RecoveryWordChip(
+            index = index + 1,
+            word = word,
+            selected = false,
+            onClick = null,
+        )
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/ColumnMajorGrid.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/ColumnMajorGrid.kt
@@ -1,0 +1,53 @@
+package org.bitcoinppl.cove.views
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A grid that displays items in column-major order (top-to-bottom, then left-to-right)
+ *
+ * For a list [1,2,3,4,5,6] with 3 columns, displays as:
+ * ```
+ * 1  3  5
+ * 2  4  6
+ * ```
+ */
+@Composable
+fun <T> ColumnMajorGrid(
+    items: List<T>,
+    modifier: Modifier = Modifier,
+    numColumns: Int = 3,
+    horizontalSpacing: Dp = 12.dp,
+    verticalSpacing: Dp = 18.dp,
+    content: @Composable (index: Int, item: T) -> Unit,
+) {
+    require(items.size % numColumns == 0) {
+        "Item count (${items.size}) must be divisible by $numColumns"
+    }
+    val itemsPerColumn = items.size / numColumns
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(horizontalSpacing),
+    ) {
+        repeat(numColumns) { col ->
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(verticalSpacing),
+            ) {
+                repeat(itemsPerColumn) { row ->
+                    val index = col * itemsPerColumn + row
+                    if (index < items.size) {
+                        content(index, items[index])
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/RecoveryWords.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/RecoveryWords.kt
@@ -84,32 +84,17 @@ private fun RecoveryWordsGrid(
     selected: Set<Int> = emptySet(),
     onToggleIndex: ((Int) -> Unit)? = null,
 ) {
-    val numColumns = 3
-    val wordsPerColumn = words.size / numColumns
-
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        repeat(numColumns) { col ->
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(18.dp),
-            ) {
-                repeat(wordsPerColumn) { row ->
-                    val index = col * wordsPerColumn + row
-                    if (index < words.size) {
-                        val globalIndex = startIndexOffset + index + 1
-                        RecoveryWordChip(
-                            index = globalIndex,
-                            word = words[index],
-                            selected = selected.contains(globalIndex),
-                            onClick = { onToggleIndex?.invoke(globalIndex) },
-                        )
-                    }
-                }
-            }
-        }
+    ColumnMajorGrid(
+        items = words,
+        modifier = modifier,
+    ) { index, word ->
+        val globalIndex = startIndexOffset + index + 1
+        RecoveryWordChip(
+            index = globalIndex,
+            word = word,
+            selected = selected.contains(globalIndex),
+            onClick = { onToggleIndex?.invoke(globalIndex) },
+        )
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
@@ -210,53 +210,41 @@ struct WordCardView: View {
     @Environment(\.sizeCategory) var sizeCategory
     let words: [GroupedWord]
 
-    private let numberOfColumns = 3
-
-    var numberOfRows: Int {
-        words.count / numberOfColumns
-    }
-
-    var rows: [GridItem] {
-        Array(repeating: .init(.flexible()), count: numberOfRows)
-    }
-
     var body: some View {
-        LazyHGrid(rows: rows, spacing: 12) {
-            ForEach(words, id: \.self) { group in
-                HStack(spacing: 0) {
-                    Text("\(String(format: "%d", group.number)). ")
-                        .fontWeight(.medium)
-                        .foregroundColor(.black.opacity(0.5))
-                        .multilineTextAlignment(.leading)
-                        .frame(alignment: .leading)
-                        .minimumScaleFactor(0.8)
-                        .lineLimit(sizeCategory >= .extraExtraLarge ? 3 : 1)
-                        .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .caption)
+        ColumnMajorGrid(items: words) { _, group in
+            HStack(spacing: 0) {
+                Text("\(String(format: "%d", group.number)). ")
+                    .fontWeight(.medium)
+                    .foregroundColor(.black.opacity(0.5))
+                    .multilineTextAlignment(.leading)
+                    .frame(alignment: .leading)
+                    .minimumScaleFactor(0.8)
+                    .lineLimit(sizeCategory >= .extraExtraLarge ? 3 : 1)
+                    .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .caption)
 
-                    Spacer()
+                Spacer()
 
-                    Text(group.word)
-                        .fontWeight(.medium)
-                        .foregroundStyle(.midnightBlue)
-                        .multilineTextAlignment(.center)
-                        .frame(alignment: .leading)
-                        .minimumScaleFactor(0.2)
-                        .lineLimit(sizeCategory >= .extraExtraLarge ? 5 : 1)
-                        .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .footnote)
+                Text(group.word)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.midnightBlue)
+                    .multilineTextAlignment(.center)
+                    .frame(alignment: .leading)
+                    .minimumScaleFactor(0.2)
+                    .lineLimit(sizeCategory >= .extraExtraLarge ? 5 : 1)
+                    .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .footnote)
 
-                    Spacer()
-                }
-                .padding(.horizontal)
-                .padding(.vertical, 12)
-                .frame(width: (screenWidth * 0.33) - 20)
-                .background(Color.btnPrimary)
-                .cornerRadius(10)
-                .contextMenu {
-                    isMiniDeviceOrLargeText(sizeCategory)
-                        ? Button(action: {}) {
-                            Text("\(String(format: "%d", group.number)). \(group.word)")
-                        } : nil
-                }
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+            .frame(width: (screenWidth * 0.33) - 20)
+            .background(Color.btnPrimary)
+            .cornerRadius(10)
+            .contextMenu {
+                isMiniDeviceOrLargeText(sizeCategory)
+                    ? Button(action: {}) {
+                        Text("\(String(format: "%d", group.number)). \(group.word)")
+                    } : nil
             }
         }
     }

--- a/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
@@ -24,10 +24,6 @@ struct SecretWordsScreen: View {
         (words?.words().count ?? 24) / numberOfColumns
     }
 
-    var rows: [GridItem] {
-        Array(repeating: GridItem(.flexible()), count: numberOfRows)
-    }
-
     var body: some View {
         VStack {
             Spacer()
@@ -35,26 +31,24 @@ struct SecretWordsScreen: View {
             Group {
                 if let words {
                     GroupBox {
-                        LazyHGrid(rows: rows, spacing: 12) {
-                            ForEach(words.allWords(), id: \.number) { word in
-                                HStack {
-                                    Text("\(word.number).")
-                                        .fontWeight(.medium)
-                                        .foregroundStyle(.secondary)
-                                        .fontDesign(.monospaced)
-                                        .multilineTextAlignment(.leading)
-                                        .minimumScaleFactor(0.5)
+                        ColumnMajorGrid(items: words.allWords()) { _, word in
+                            HStack {
+                                Text("\(word.number).")
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(.secondary)
+                                    .fontDesign(.monospaced)
+                                    .multilineTextAlignment(.leading)
+                                    .minimumScaleFactor(0.5)
 
-                                    Text(word.word)
-                                        .fontWeight(.bold)
-                                        .fontDesign(.monospaced)
-                                        .multilineTextAlignment(.leading)
-                                        .minimumScaleFactor(0.75)
-                                        .lineLimit(1)
-                                        .fixedSize()
+                                Text(word.word)
+                                    .fontWeight(.bold)
+                                    .fontDesign(.monospaced)
+                                    .multilineTextAlignment(.leading)
+                                    .minimumScaleFactor(0.75)
+                                    .lineLimit(1)
+                                    .fixedSize()
 
-                                    Spacer()
-                                }
+                                Spacer()
                             }
                         }
                     }

--- a/ios/Cove/Views/ColumnMajorGrid.swift
+++ b/ios/Cove/Views/ColumnMajorGrid.swift
@@ -1,0 +1,56 @@
+//
+//  ColumnMajorGrid.swift
+//  Cove
+//
+//  Created by Praveen Perera on 1/16/26.
+//
+
+import SwiftUI
+
+/// A grid that displays items in column-major order (top-to-bottom, then left-to-right)
+///
+/// For a list [1,2,3,4,5,6] with 3 columns, displays as:
+/// ```
+/// 1  3  5
+/// 2  4  6
+/// ```
+struct ColumnMajorGrid<Item, Content: View>: View {
+    let items: [Item]
+    let numberOfColumns: Int
+    let spacing: CGFloat
+    let content: (Int, Item) -> Content
+
+    init(
+        items: [Item],
+        numberOfColumns: Int = 3,
+        spacing: CGFloat = 12,
+        @ViewBuilder content: @escaping (Int, Item) -> Content
+    ) {
+        self.items = items
+        self.numberOfColumns = numberOfColumns
+        self.spacing = spacing
+        self.content = content
+    }
+
+    private var itemsPerColumn: Int {
+        precondition(
+            items.count % numberOfColumns == 0,
+            "Item count (\(items.count)) must be divisible by \(numberOfColumns)"
+        )
+        return items.count / numberOfColumns
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: spacing) {
+            ForEach(0 ..< numberOfColumns, id: \.self) { col in
+                VStack(spacing: spacing) {
+                    ForEach(0 ..< itemsPerColumn, id: \.self) { row in
+                        let index = col * itemsPerColumn + row
+                        content(index, items[index])
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated column-major grid layout logic into reusable `ColumnMajorGrid` components
- Android: New `ColumnMajorGrid.kt` composable in views package
- iOS: New `ColumnMajorGrid.swift` view in Views folder
- Refactors 5 files to use the new components

## Changes
- **Android**: `RecoveryWords.kt`, `SecretWordsScreen.kt`, `HotWalletCreateScreen.kt`
- **iOS**: `HotWalletCreateScreen.swift`, `SecretWordsScreen.swift`

Closes #505

## Test plan
- [ ] Verify seed word display in wallet creation flow (12 and 24 words)
- [ ] Verify seed word display in recovery words screen
- [ ] Verify word order is top-to-bottom, left-to-right (column-major)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced multiple custom grid implementations with a new unified column-major grid used for mnemonic/recovery word lists and word cards.
  * Visual appearance, spacing, and interactions are preserved while layout logic is consolidated for consistency across platforms (Android and iOS).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->