### PR TITLE
Prefer StrongBox hardware security module for Android keychain

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/Security.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/Security.kt
@@ -20,6 +20,7 @@ class KeychainAccessor(
             MasterKey
                 .Builder(context)
                 .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .setRequestStrongBoxBacked(true)
                 .build()
 
         // create encrypted shared preferences


### PR DESCRIPTION
## Summary
- Add `.setRequestStrongBoxBacked(true)` to prefer the dedicated StrongBox secure chip when available for keychain encryption

## Details
StrongBox is a dedicated hardware security module available on some Android devices (Pixel 3+, Samsung Galaxy S9+, etc.) that provides stronger isolation than the standard TEE (Trusted Execution Environment).

This change requests StrongBox when creating the master key for encrypted shared preferences. The "request" is a preference, not a requirement - devices without StrongBox will automatically fall back to TEE.

**Backwards compatibility:** Existing users are unaffected. The MasterKey.Builder checks if a key already exists and reuses it regardless of builder settings. Only new installations will get StrongBox-backed keys on supported devices.

## Test plan
- [ ] Build the Android app
- [ ] Run on a device/emulator and verify the app launches without crashes
- [ ] Test creating a new wallet to ensure keychain operations still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Enabled hardware-backed storage for cryptographic keys on compatible devices, providing enhanced protection when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->