### PR TITLE
Android: Fix dark mode navigation flash (#510)

### DIFF
--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Cove" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">@color/cove_bg_dark</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="cove_bg_dark">#FF191919</color>
 </resources>


### PR DESCRIPTION
## Summary
- Create `values-night/themes.xml` with dark window background (`#191919`)
- Add `cove_bg_dark` color to `colors.xml`
- Prevents white flash during navigation transitions in dark mode

## Problem
Brief white flash (~0.2s) when navigating between screens in dark mode because:
- `themes.xml` uses light theme (white background)
- No `values-night/themes.xml` exists for dark mode
- Activity window background is white, but Compose content renders dark
- During navigation transitions, the white window background shows briefly

## Test plan
- [ ] Enable dark mode on device
- [ ] Navigate through settings menus
- [ ] Verify no white flash between screens

Fixes #510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android night (dark) theme visuals with a dedicated deep background color (#191919) for improved contrast in night mode.
  * Applies automatically to Android devices using the system night/dark appearance; no other UI elements were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->