### PR TITLE
Add Android product flavors for dev and store distribution

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,6 +48,17 @@ android {
             }
         }
     }
+
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("dev") {
+            dimension = "distribution"
+            applicationIdSuffix = ".dev"
+        }
+        create("store") {
+            dimension = "distribution"
+        }
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/android/app/src/dev/res/values/strings.xml
+++ b/android/app/src/dev/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Cove Dev</string>
+</resources>

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -54,7 +54,7 @@ enum Commands {
         profile: String,
     },
 
-    /// Build Android App Bundle (AAB) and copy to Downloads
+    /// Build Android App Bundle (AAB) and APK for Play Store, copy to Downloads
     #[command(name = "bundle-android")]
     BundleAndroid,
 


### PR DESCRIPTION
Add dev environment strings.xml with app name

Introduces a new strings.xml file for the dev environment, setting the app name to 'Cove Dev'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured build system to support separate development and production app variants
  * Development builds now clearly identified as "Cove Dev"

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->