### PR TITLE
Android send flow clean up fix

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
@@ -133,9 +133,7 @@ fun SelectedWalletScreen(
         } ?: usdAmount
     val unsignedTransactions = manager?.unsignedTransactions ?: emptyList()
 
-    // clear SendFlowManager when returning to wallet screen (matches iOS SelectedWalletScreen)
     LaunchedEffect(manager) {
-        app?.clearSendFlowManager()
         manager?.validateMetadata()
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -104,6 +104,7 @@ fun SendFlowContainer(
     DisposableEffect(walletId) {
         onDispose {
             sendFlowManager?.presenter?.setDisappearing()
+            app.clearSendFlowManager()
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send flow state management by preserving state when returning to the wallet screen and ensuring proper cleanup at the appropriate lifecycle stage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->