### PR TITLE
Allow pasting all words at once during hot wallet import

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletImportCard.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletImportCard.kt
@@ -56,6 +56,7 @@ internal fun WordInputGrid(
     tabIndex: Int,
     onWordsChanged: (List<List<String>>) -> Unit,
     onFocusChanged: (Int) -> Unit,
+    onPasteMnemonic: ((String) -> Unit)? = null,
 ) {
     val wordCount =
         when (numberOfWords) {
@@ -116,6 +117,7 @@ internal fun WordInputGrid(
                                 onFocusChanged(index + 1)
                             }
                         },
+                        onPasteMnemonic = onPasteMnemonic,
                     )
                 }
             }
@@ -149,6 +151,7 @@ internal fun WordInputGrid(
                                 onFocusChanged(index + 1)
                             }
                         },
+                        onPasteMnemonic = onPasteMnemonic,
                     )
                 }
             }
@@ -167,6 +170,7 @@ private fun WordInputField(
     onWordChanged: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
     onNext: () -> Unit,
+    onPasteMnemonic: ((String) -> Unit)? = null,
 ) {
     val focusManager = LocalFocusManager.current
     val autocomplete =
@@ -255,6 +259,13 @@ private fun WordInputField(
                 BasicTextField(
                     value = word,
                     onValueChange = { newValue ->
+                        // detect paste of full mnemonic (12+ words)
+                        val pastedWords = newValue.split(Regex("\\s+")).filter { it.isNotEmpty() }
+                        if (pastedWords.size >= 12 && onPasteMnemonic != null) {
+                            onPasteMnemonic(newValue)
+                            return@BasicTextField
+                        }
+
                         val trimmed = newValue.trim().lowercase()
                         val oldWord = previousWord
                         previousWord = trimmed


### PR DESCRIPTION
Closes #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now paste a complete mnemonic (12 or 24 words) directly into the wallet import screen on both Android and iOS. The system automatically detects valid mnemonics, validates the word count, and populates the input fields accordingly, streamlining the wallet import process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->