### PR TITLE
Fix duplicated logic in SelectedWalletScreen and DRY balance display

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
@@ -338,12 +338,14 @@ fun SelectedWalletScreen(
                             .weight(1f)
                             .background(listBg),
                 ) {
-                    val hasTransactions =
-                        when (val loadState = manager?.loadState) {
-                            is WalletLoadState.SCANNING -> loadState.txns.isNotEmpty() || unsignedTransactions.isNotEmpty()
-                            is WalletLoadState.LOADED -> loadState.txns.isNotEmpty() || unsignedTransactions.isNotEmpty()
-                            else -> false
+                    val loadState = manager?.loadState
+                    val transactions =
+                        when (loadState) {
+                            is WalletLoadState.SCANNING -> loadState.txns
+                            is WalletLoadState.LOADED -> loadState.txns
+                            else -> emptyList()
                         }
+                    val hasTransactions = transactions.isNotEmpty() || unsignedTransactions.isNotEmpty()
 
                     val content: @Composable () -> Unit = {
                         Column(modifier = Modifier.fillMaxSize()) {
@@ -353,7 +355,7 @@ fun SelectedWalletScreen(
                                 app = app,
                             )
 
-                            when (val loadState = manager?.loadState) {
+                            when (loadState) {
                                 is WalletLoadState.LOADING, null -> {
                                     TransactionsLoadingView(
                                         secondaryText = secondaryText,
@@ -362,9 +364,8 @@ fun SelectedWalletScreen(
                                     )
                                 }
                                 is WalletLoadState.SCANNING -> {
-                                    val txns = loadState.txns
                                     val isFirstScan = manager.walletMetadata?.internal?.lastScanFinished == null
-                                    if (isFirstScan && txns.isEmpty() && unsignedTransactions.isEmpty()) {
+                                    if (isFirstScan && transactions.isEmpty() && unsignedTransactions.isEmpty()) {
                                         TransactionsLoadingView(
                                             secondaryText = secondaryText,
                                             primaryText = primaryText,
@@ -372,7 +373,7 @@ fun SelectedWalletScreen(
                                         )
                                     } else {
                                         TransactionsCardView(
-                                            transactions = txns,
+                                            transactions = transactions,
                                             unsignedTransactions = unsignedTransactions,
                                             isScanning = true,
                                             isFirstScan = isFirstScan,
@@ -388,7 +389,7 @@ fun SelectedWalletScreen(
                                 }
                                 is WalletLoadState.LOADED -> {
                                     TransactionsCardView(
-                                        transactions = loadState.txns,
+                                        transactions = transactions,
                                         unsignedTransactions = unsignedTransactions,
                                         isScanning = false,
                                         isFirstScan = false,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/WalletBalanceHeaderView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/WalletBalanceHeaderView.kt
@@ -83,56 +83,51 @@ internal fun BalanceWidget(
         modifier = Modifier.clickable { onToggleUnit() },
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        if (isHidden) {
-            Text(
-                text = "••••••",
-                color = Color.White.copy(alpha = 0.7f),
-                fontSize = 13.sp,
-            )
-        } else if (secondaryAmount != null) {
-            Text(
-                text = secondaryAmount,
-                color = Color.White.copy(alpha = 0.7f),
-                fontSize = 13.sp,
-            )
-        } else {
-            CircularProgressIndicator(
-                modifier = Modifier.size(12.dp),
-                color = Color.White.copy(alpha = 0.7f),
-                strokeWidth = 1.5.dp,
-            )
-        }
+        AmountDisplay(
+            amount = secondaryAmount,
+            isHidden = isHidden,
+            textContent = { text ->
+                Text(
+                    text = text,
+                    color = Color.White.copy(alpha = 0.7f),
+                    fontSize = 13.sp,
+                )
+            },
+            loadingContent = {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(12.dp),
+                    color = Color.White.copy(alpha = 0.7f),
+                    strokeWidth = 1.5.dp,
+                )
+            },
+        )
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(modifier = Modifier.weight(1f)) {
-                if (isHidden) {
-                    BalanceAutoSizeText(
-                        text = "••••••",
-                        modifier = Modifier.padding(end = 12.dp),
-                        color = Color.White,
-                        baseFontSize = 34.sp,
-                        minimumScaleFactor = 0.5f,
-                        fontWeight = FontWeight.Bold,
-                    )
-                } else if (primaryAmount != null) {
-                    BalanceAutoSizeText(
-                        text = primaryAmount,
-                        modifier = Modifier.padding(end = 12.dp),
-                        color = Color.White,
-                        baseFontSize = 34.sp,
-                        minimumScaleFactor = 0.5f,
-                        fontWeight = FontWeight.Bold,
-                    )
-                } else {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(28.dp),
-                        color = Color.White,
-                        strokeWidth = 2.dp,
-                    )
-                }
+                AmountDisplay(
+                    amount = primaryAmount,
+                    isHidden = isHidden,
+                    textContent = { text ->
+                        BalanceAutoSizeText(
+                            text = text,
+                            modifier = Modifier.padding(end = 12.dp),
+                            color = Color.White,
+                            baseFontSize = 34.sp,
+                            minimumScaleFactor = 0.5f,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    },
+                    loadingContent = {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(28.dp),
+                            color = Color.White,
+                            strokeWidth = 2.dp,
+                        )
+                    },
+                )
             }
             Icon(
                 imageVector = if (isHidden) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
@@ -144,6 +139,21 @@ internal fun BalanceWidget(
                         .clickable { onToggleSensitive() },
             )
         }
+    }
+}
+
+@Composable
+private fun AmountDisplay(
+    amount: String?,
+    isHidden: Boolean,
+    hiddenText: String = "••••••",
+    textContent: @Composable (String) -> Unit,
+    loadingContent: @Composable () -> Unit,
+) {
+    when {
+        isHidden -> textContent(hiddenText)
+        amount != null -> textContent(amount)
+        else -> loadingContent()
     }
 }
 


### PR DESCRIPTION
- Extract loadState and transactions once to avoid evaluating the when expression twice for overscroll handling
- Add AmountDisplay helper composable to eliminate repeated if/else-if/else pattern for hidden/amount/loading states in WalletBalanceHeaderView

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in how wallet balances and transaction lists are computed and displayed.
  * Streamlined loading state handling across balance and transaction views for more predictable UI behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->