### PR TITLE
Make QR viewfinder size responsive on Android and iOS

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/QrCodeScanView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/QrCodeScanView.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -349,11 +350,17 @@ private fun QrScannerContent(
                 }
             }
 
-            // viewfinder overlay - centered
+            // viewfinder overlay - centered (65% of smaller screen dimension, capped 200-320dp)
+            val configuration = LocalConfiguration.current
+            val screenWidth = configuration.screenWidthDp.dp
+            val screenHeight = configuration.screenHeightDp.dp
+            val smallerDimension = minOf(screenWidth, screenHeight)
+            val viewfinderSize = (smallerDimension * 0.65f).coerceIn(200.dp, 320.dp)
+
             Canvas(
                 modifier =
                     Modifier
-                        .size(200.dp)
+                        .size(viewfinderSize)
                         .align(Alignment.Center),
             ) {
                 val strokeWidth = 4.dp.toPx()

--- a/ios/CodeScanner/ScannerViewController.swift
+++ b/ios/CodeScanner/ScannerViewController.swift
@@ -299,11 +299,16 @@
 
                     view.addSubview(imageView)
 
+                    // 65% of smaller view dimension, capped between 200-320pt
+                    let viewBounds = view.bounds
+                    let smallerDimension = min(viewBounds.width, viewBounds.height)
+                    let viewfinderSize = min(max(smallerDimension * 0.65, 200), 320)
+
                     NSLayoutConstraint.activate([
                         imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
                         imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                        imageView.widthAnchor.constraint(equalToConstant: 200),
-                        imageView.heightAnchor.constraint(equalToConstant: 200),
+                        imageView.widthAnchor.constraint(equalToConstant: viewfinderSize),
+                        imageView.heightAnchor.constraint(equalToConstant: viewfinderSize),
                     ])
                 }
 


### PR DESCRIPTION
The QR code viewfinder overlay now scales to 65% of the smaller screen dimension, with a minimum of 200 and maximum of 320 dp/pt, improving usability across different device sizes on both Android and iOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QR scanner viewfinder now scales to 65% of the smaller screen dimension and is clamped between 200 and 320 units for more consistent framing across device sizes (applies to Android and iOS).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->