### PR TITLE
Add build info and contact to settings screen

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         applicationId = "org.bitcoinppl.cove"
         minSdk = 33
         targetSdk = 36
-        versionCode = 7
+        versionCode = 9
         versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -174,7 +174,7 @@ class AppManager private constructor() : FfiReconcile {
             if (appVersion != rust.version()) {
                 return "MISMATCH ${rust.version()} || $appVersion (${rust.gitShortHash()})"
             }
-            return "v$appVersion (${rust.gitShortHash()})"
+            return "v$appVersion (${rust.gitShortHash()}-${BuildConfig.VERSION_CODE})"
         }
 
     fun findTapSignerWallet(ts: TapSigner): WalletMetadata? = rust.findTapSignerWallet(ts)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/MainSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/MainSettingsScreen.kt
@@ -5,10 +5,12 @@ import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
@@ -40,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -161,6 +164,35 @@ fun MainSettingsScreen(
                 WalletSettingsSection(app = app)
 
                 SecuritySection(app = app)
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    val debugOrRelease = app.rust.debugOrRelease()
+                    if (debugOrRelease.isNotEmpty()) {
+                        Text(
+                            text = debugOrRelease,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+                        )
+                    }
+                    Text(
+                        text = app.fullVersionId,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+                    )
+                    Text(
+                        text = "feedback@covebitcoinwallet.com",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+                    )
+                }
             }
         },
     )

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -109,7 +109,8 @@ private let walletModeChangeDelayMs = 250
 
     public var fullVersionId: String {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-        return "v\(appVersion) (\(rust.gitShortHash()))"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        return "v\(appVersion) (\(rust.gitShortHash())-\(buildNumber))"
     }
 
     public func updateWalletVm(_ vm: WalletManager) {


### PR DESCRIPTION
Display debug/release status, full version ID, build number, and feedback email at the bottom of the main settings screen. Also update versionCode to 8 in build.gradle.kts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings screen now displays detailed version and build info: full version identifier (includes git hash plus build number/version code), a release-type indicator (debug/release when applicable), and a support contact email.

* **Chores**
  * Incremented the app version code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->