### PR TITLE
Restore scroll position when returning from transaction details

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -60,6 +60,9 @@ class WalletManager :
     // cached transaction details (observable for Compose)
     val transactionDetailsCache: SnapshotStateMap<TxId, TransactionDetails> = mutableStateMapOf()
 
+    // scroll position for transaction list (persists across navigation)
+    var scrolledTransactionId: String? by mutableStateOf(null)
+
     // computed properties
     val unit: String
         get() =

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionsCardView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionsCardView.kt
@@ -100,6 +100,33 @@ fun TransactionsCardView(
         }
     }
 
+    // scroll to saved transaction when returning from details
+    LaunchedEffect(manager?.scrolledTransactionId, hasTransactions) {
+        val targetId = manager?.scrolledTransactionId ?: return@LaunchedEffect
+        if (!hasTransactions) return@LaunchedEffect
+
+        // find the index of the transaction with the matching ID
+        val unsignedIndex = unsignedTransactions.indexOfFirst { it.id().toString() == targetId }
+        if (unsignedIndex >= 0) {
+            listState.animateScrollToItem(unsignedIndex)
+            manager.scrolledTransactionId = null
+            return@LaunchedEffect
+        }
+
+        val txIndex =
+            transactions.indexOfFirst {
+                when (it) {
+                    is Transaction.Confirmed -> it.v1.id().toString() == targetId
+                    is Transaction.Unconfirmed -> it.v1.id().toString() == targetId
+                }
+            }
+        if (txIndex >= 0) {
+            // offset by the number of unsigned transactions
+            listState.animateScrollToItem(unsignedTransactions.size + txIndex)
+            manager.scrolledTransactionId = null
+        }
+    }
+
     Column(
         modifier =
             modifier

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionsCardView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionsCardView.swift
@@ -56,13 +56,14 @@ struct TransactionsCardView: View {
 
                             Divider().opacity(0.7)
                         }
+                        .id(txn.id().description)
                     }
 
                     ForEach(transactions) { txn in
                         TransactionRow(txn: txn, metadata: metadata)
+                            .id(txn.id.description)
                     }
                 }
-                .scrollTargetLayout()
 
                 if transactions.isEmpty {
                     VStack {
@@ -151,6 +152,8 @@ struct ConfirmedTransactionView: View {
 
     private func goToTransactionDetails() {
         let txId = txn.id()
+        manager.scrolledTransactionId = txId.description
+
         if let details = manager.transactionDetails[txId] {
             return navigate(Route.transactionDetails(id: metadata.id, details: details))
         }
@@ -260,6 +263,8 @@ struct UnconfirmedTransactionView: View {
                     .foregroundStyle(amountColor(txn.sentAndReceived().direction()).opacity(0.65))
             }
         }.onTapGesture {
+            manager.scrolledTransactionId = txn.id().description
+
             Task {
                 await MiddlePopup(state: .loading).present()
                 do {
@@ -345,6 +350,8 @@ struct UnsignedTransactionView: View {
                 try? await manager.rust.amountInFiat(amount: txn.spendingAmount())
         }
         .onTapGesture {
+            manager.scrolledTransactionId = txn.id().description
+
             let hardwareExportRoute =
                 RouteFactory().sendHardwareExport(
                     id: metadata.id,

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -27,6 +27,9 @@ extension WeakReconciler: WalletManagerReconciler where Reconciler == WalletMana
     // cached transaction details
     var transactionDetails: [TxId: TransactionDetails] = [:]
 
+    // scroll position for transaction list (persists across navigation)
+    var scrolledTransactionId: String?
+
     init(id: WalletId) throws {
         self.id = id
         let rust = try RustWalletManager(id: id)


### PR DESCRIPTION
iOS: Use ScrollViewReader with proxy.scrollTo() to scroll back to the tapped transaction. Store transaction ID as String for reliable matching.

Android: Use LazyListState.animateScrollToItem() to scroll to the transaction index when returning from details view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic scroll-to-transaction: The app now remembers which transaction you were viewing and automatically scrolls back to it when you return from the details view on both Android and iOS platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->