### PR TITLE
Remove redundant `Address.string()` FFI, standardize on `unformatted()`

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -440,7 +440,7 @@ private fun GlobalAlertDialog(
                 text = { Text(state.message()) },
                 confirmButton = {
                     TextButton(onClick = {
-                        copyToClipboard(state.address.string())
+                        copyToClipboard(state.address.unformatted())
                         onDismiss()
                     }) { Text("Copy Address") }
                 },
@@ -469,7 +469,7 @@ private fun GlobalAlertDialog(
                             }) { Text("Send To Address") }
                         }
                         TextButton(onClick = {
-                            copyToClipboard(state.address.string())
+                            copyToClipboard(state.address.unformatted())
                             onDismiss()
                         }) { Text("Copy Address") }
                         TextButton(onClick = onDismiss) { Text("Cancel") }
@@ -485,7 +485,7 @@ private fun GlobalAlertDialog(
                 text = { Text(state.message()) },
                 confirmButton = {
                     TextButton(onClick = {
-                        copyToClipboard(state.address.string())
+                        copyToClipboard(state.address.unformatted())
                         onDismiss()
                     }) { Text("Copy Address") }
                 },

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
@@ -442,7 +442,7 @@ private fun UtxoItemRow(
             }
             Spacer(Modifier.height(4.dp))
             Text(
-                text = utxo.address.string(),
+                text = utxo.address.unformatted(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 12.sp,
                 maxLines = 1,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/ReceivedTransactionDetails.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/ReceivedTransactionDetails.kt
@@ -120,7 +120,7 @@ internal fun ReceivedTransactionDetails(
                 OutlinedButton(
                     onClick = {
                         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                        val clip = ClipData.newPlainText("address", address.string())
+                        val clip = ClipData.newPlainText("address", address.unformatted())
                         clipboard.setPrimaryClip(clip)
                         isCopied = true
                     },

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlCustomAmountSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlCustomAmountSheet.kt
@@ -375,7 +375,7 @@ private fun UtxoDetailRow(
             }
             Spacer(Modifier.height(4.dp))
             Text(
-                text = utxo.address.string(),
+                text = utxo.address.unformatted(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 12.sp,
                 maxLines = 1,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlSetAmountScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlSetAmountScreen.kt
@@ -231,7 +231,7 @@ fun CoinControlSetAmountScreen(
                             presenter.sheetState = null
                             when (multiFormat) {
                                 is MultiFormat.Address -> {
-                                    sendFlowManager.enteringAddress = multiFormat.v1.address().string()
+                                    sendFlowManager.enteringAddress = multiFormat.v1.address().unformatted()
                                     // clear focus to show formatted address
                                     presenter.focusField = null
                                 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -289,7 +289,7 @@ private fun SendFlowRouteToScreen(
                                     when (multiFormat) {
                                         is MultiFormat.Address -> {
                                             val addressWithNetwork = multiFormat.v1
-                                            sendFlowManager.enteringAddress = addressWithNetwork.address().string()
+                                            sendFlowManager.enteringAddress = addressWithNetwork.address().unformatted()
                                             // if QR contains an amount (BIP21), set it
                                             addressWithNetwork.amount()?.let { amount ->
                                                 sendFlowManager.updateAmount(amount)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -152,7 +152,7 @@ class SendFlowManager(
 
     fun updateAddress(address: Address) {
         if (isClosed.get()) return
-        _enteringAddress = address.string()
+        _enteringAddress = address.unformatted()
         this.address = address
         dispatch(SendFlowManagerAction.NotifyAddressChanged(address))
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -678,8 +678,6 @@ external fun uniffi_cove_types_checksum_method_address_hashtouint(
 ): Short
 external fun uniffi_cove_types_checksum_method_address_spaced_out(
 ): Short
-external fun uniffi_cove_types_checksum_method_address_string(
-): Short
 external fun uniffi_cove_types_checksum_method_address_unformatted(
 ): Short
 external fun uniffi_cove_types_checksum_method_addressinfo_address(
@@ -927,8 +925,6 @@ external fun uniffi_cove_types_fn_constructor_address_random(uniffi_out_err: Uni
 external fun uniffi_cove_types_fn_method_address_hashtouint(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
 external fun uniffi_cove_types_fn_method_address_spaced_out(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
-): RustBuffer.ByValue
-external fun uniffi_cove_types_fn_method_address_string(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_cove_types_fn_method_address_unformatted(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1468,9 +1464,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_address_spaced_out() != 7307.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_types_checksum_method_address_string() != 24375.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_address_unformatted() != 36743.toShort()) {
@@ -2334,8 +2327,6 @@ public interface AddressInterface {
     
     fun `spacedOut`(): kotlin.String
     
-    fun `string`(): kotlin.String
-    
     fun `unformatted`(): kotlin.String
     
     companion object
@@ -2455,19 +2446,6 @@ open class Address: Disposable, AutoCloseable, AddressInterface
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_types_fn_method_address_spaced_out(
-        it,
-        _status)
-}
-    }
-    )
-    }
-    
-
-    override fun `string`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_types_fn_method_address_string(
         it,
         _status)
 }

--- a/ios/Cove/Extention/String+Ext.swift
+++ b/ios/Cove/Extention/String+Ext.swift
@@ -19,7 +19,7 @@ extension String {
     }
 
     init(_ address: Address) {
-        self = address.string()
+        self = address.unformatted()
     }
 
     init(_ walletType: WalletType) {

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -52,7 +52,7 @@ struct UtxoListScreen: View {
                         .listRowBackground(Color.secondarySystemGroupedBackground)
                         .contextMenu {
                             Button(action: {
-                                UIPasteboard.general.string = utxo.address.string()
+                                UIPasteboard.general.string = utxo.address.unformatted()
                             }) {
                                 Text("Copy Address")
                             }

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/ReceivedDetailsExpandedView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/ReceivedDetailsExpandedView.swift
@@ -74,7 +74,7 @@ struct ReceivedDetailsExpandedView: View {
 
                 if let address = transactionDetails.address() {
                     Button(action: {
-                        UIPasteboard.general.string = address.string()
+                        UIPasteboard.general.string = address.unformatted()
                         withAnimation {
                             isCopied = true
                         }

--- a/ios/Cove/Flows/SendFlow/Common/SendFlowUtxoCustomAmountSheetView.swift
+++ b/ios/Cove/Flows/SendFlow/Common/SendFlowUtxoCustomAmountSheetView.swift
@@ -308,7 +308,7 @@ private struct UtxoRow: View {
         .cornerRadius(10)
         .contextMenu {
             Button(action: {
-                UIPasteboard.general.string = utxo.address.string()
+                UIPasteboard.general.string = utxo.address.unformatted()
             }) {
                 Text("Copy Address")
             }

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -89,7 +89,7 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
     }
 
     public func setAddress(_ address: Address) {
-        self._enteringAddress = address.string()
+        self._enteringAddress = address.unformatted()
         self.address = address
         self.dispatch(action: .notifyAddressChanged(address))
     }

--- a/ios/Cove/Flows/SendFlow/SetAmountScreen/QrCodeAddressView.swift
+++ b/ios/Cove/Flows/SendFlow/SetAmountScreen/QrCodeAddressView.swift
@@ -100,7 +100,7 @@ struct QrCodeAddressView: View {
                 case let .complete(data, haptic):
                     haptic.trigger()
                     if case let .address(addr) = data {
-                        scannedCode = TaggedString(addr.address().string())
+                        scannedCode = TaggedString(addr.address().unformatted())
                         scanComplete = true
                     } else {
                         // not an address - show error and allow retry

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -632,8 +632,6 @@ public protocol AddressProtocol: AnyObject, Sendable {
     
     func spacedOut()  -> String
     
-    func string()  -> String
-    
     func unformatted()  -> String
     
 }
@@ -747,14 +745,6 @@ open func hashToUint() -> UInt64  {
 open func spacedOut() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_cove_types_fn_method_address_spaced_out(
-            self.uniffiCloneHandle(),$0
-    )
-})
-}
-    
-open func string() -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_cove_types_fn_method_address_string(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -6185,9 +6175,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_address_spaced_out() != 7307) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_types_checksum_method_address_string() != 24375) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_address_unformatted() != 36743) {

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -314,10 +314,6 @@ impl Address {
         address_string_spaced_out(self.to_string())
     }
 
-    fn string(&self) -> String {
-        self.to_string()
-    }
-
     #[uniffi::method]
     fn unformatted(&self) -> String {
         self.to_string()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction details now display "Address unavailable" when address information is not present instead of showing blank text.
  * Copy address button visibility is now conditional, appearing only when an address exists.

* **Chores**
  * Enhanced error logging and warning notifications for transaction parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->