### PR TITLE
Extract magic number constants

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -94,16 +94,6 @@ class AppManager private constructor() : FfiReconcile {
         wallets = runCatching { Database().wallets().all() }.getOrElse { emptyList() }
     }
 
-    companion object {
-        @Volatile
-        private var instance: AppManager? = null
-
-        fun getInstance(): AppManager =
-            instance ?: synchronized(this) {
-                instance ?: AppManager().also { instance = it }
-            }
-    }
-
     /**
      * set the cached wallet manager instance
      */
@@ -192,7 +182,8 @@ class AppManager private constructor() : FfiReconcile {
 
     fun getTapSignerBackup(ts: TapSigner): ByteArray? = rust.getTapSignerBackup(ts)
 
-    fun saveTapSignerBackup(ts: TapSigner, backup: ByteArray): Boolean = rust.saveTapSignerBackup(ts, backup)
+    fun saveTapSignerBackup(ts: TapSigner, backup: ByteArray): Boolean =
+        rust.saveTapSignerBackup(ts, backup)
 
     /**
      * reset the manager state
@@ -243,7 +234,7 @@ class AppManager private constructor() : FfiReconcile {
     fun closeSidebarAndNavigate(action: suspend () -> Unit) {
         isSidebarVisible = false
         mainScope.launch {
-            kotlinx.coroutines.delay(300)
+            kotlinx.coroutines.delay(SIDEBAR_NAVIGATION_DELAY_MS)
             action()
         }
     }
@@ -315,21 +306,27 @@ class AppManager private constructor() : FfiReconcile {
                         importHotWallet(mnemonic.words())
                     }
                 }
+
                 is MultiFormat.HardwareExport -> {
                     importColdWallet(multiFormat.v1)
                 }
+
                 is MultiFormat.Address -> {
                     handleAddress(multiFormat.v1)
                 }
+
                 is MultiFormat.Transaction -> {
                     handleTransaction(multiFormat.v1)
                 }
+
                 is MultiFormat.SignedPsbt -> {
                     handleSignedPsbt(multiFormat.v1)
                 }
+
                 is MultiFormat.TapSignerUnused -> {
                     alertState = TaggedItem(AppAlertState.UninitializedTapSigner(multiFormat.v1))
                 }
+
                 is MultiFormat.TapSignerReady -> {
                     val wallet = findTapSignerWallet(multiFormat.v1)
                     if (wallet != null) {
@@ -338,6 +335,7 @@ class AppManager private constructor() : FfiReconcile {
                         alertState = TaggedItem(AppAlertState.InitializedTapSigner(multiFormat.v1))
                     }
                 }
+
                 is MultiFormat.Bip329Labels -> {
                     val selectedWallet = database.globalConfig().selectedWallet()
                     if (selectedWallet == null) {
@@ -621,7 +619,7 @@ class AppManager private constructor() : FfiReconcile {
                     isLoading = true
                     loadWallets()
                     launch {
-                        kotlinx.coroutines.delay(200)
+                        kotlinx.coroutines.delay(MIN_LOADING_VISIBILITY_MS)
                         isLoading = false
                     }
                 }
@@ -650,6 +648,30 @@ class AppManager private constructor() : FfiReconcile {
     fun dispatch(action: AppAction) {
         Log.d(tag, "dispatch $action")
         rust.dispatch(action)
+    }
+
+    companion object {
+        @Volatile
+        private var instance: AppManager? = null
+
+        /**
+         * delay after closing sidebar before navigation action executes
+         *
+         * allows sidebar dismiss animation to complete to avoid visual jump
+         */
+        private const val SIDEBAR_NAVIGATION_DELAY_MS = 300L
+
+        /**
+         * minimum loading indicator visibility duration
+         *
+         * prevents loading flicker when wallet mode switches quickly
+         */
+        private const val MIN_LOADING_VISIBILITY_MS = 200L
+
+        fun getInstance(): AppManager =
+            instance ?: synchronized(this) {
+                instance ?: AppManager().also { instance = it }
+            }
     }
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -138,7 +138,7 @@ class CoinControlManager(
         updateSendFlowManagerTask?.cancel()
         updateSendFlowManagerTask =
             mainScope.launch {
-                delay(100)
+                delay(SEND_FLOW_UPDATE_DELAY_MS)
                 if (!isActive) return@launch
                 val selectedUtxos = utxos.filter { selected.contains(it.outpoint.hashToUint()) }
                 sfm.dispatch(SendFlowManagerAction.SetCoinControlMode(selectedUtxos))
@@ -210,5 +210,16 @@ class CoinControlManager(
         updateSendFlowManagerTask?.cancel()
         mainScope.cancel()
         rust.close()
+    }
+
+    companion object {
+
+        /**
+         * delay before propagating coin control selection to SendFlowManager
+         *
+         * batches rapid UTXO selection changes into a single update
+         * prevents excessive dispatch and recomputation during multi-select
+         */
+        private const val SEND_FLOW_UPDATE_DELAY_MS = 100L
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -140,8 +140,8 @@ class SendFlowManager(
     fun validate(displayAlert: Boolean = false): Boolean {
         if (isClosed.get()) return false
         return validateAmount(displayAlert) &&
-            validateAddress(displayAlert) &&
-            validateFeePercentage(displayAlert)
+                validateAddress(displayAlert) &&
+                validateFeePercentage(displayAlert)
     }
 
     fun validateAddress(displayAlert: Boolean = false): Boolean = rust.validateAddress(displayAlert)
@@ -230,7 +230,7 @@ class SendFlowManager(
                     presenter.alertState = null
                     presenter.sheetState = null
                     mainScope.launch {
-                        delay(600)
+                        delay(ALERT_PRESENTATION_DELAY_MS)
                         presenter.alertState = TaggedItem(message.v1)
                     }
                 }
@@ -275,7 +275,7 @@ class SendFlowManager(
      */
     fun debouncedDispatch(
         action: SendFlowManagerAction,
-        debounceDelayMs: Long = 66,
+        debounceDelayMs: Long = DEFAULT_DEBOUNCE_MS,
     ) {
         debouncedTask?.cancel()
         debouncedTask = null
@@ -300,5 +300,23 @@ class SendFlowManager(
         debouncedTask = null
         mainScope.cancel()
         rust.close()
+    }
+
+    companion object {
+
+        /**
+         * delay before showing alert when another modal (sheet/alert) was visible
+         *
+         * allows previous modal dismiss animation to complete before presenting a new alert
+         * material3 bottom sheet dismiss animation ≈ 500ms → extra buffer prevents flicker
+         */
+        private const val ALERT_PRESENTATION_DELAY_MS = 600L
+
+        /**
+         * default debounce for amount input
+         * ~60fps target = 16.67ms per frame, 66ms = ~4 frames
+         * balances responsiveness vs rust bridge overhead
+         */
+        private const val DEFAULT_DEBOUNCE_MS = 66L
     }
 }


### PR DESCRIPTION
Extract the constants of the magic numbers and cover them with documentation.

If this commit is applied, it will cause all the magic numbers in the AppManager, CoinControlManager, and SendFlowManager files to be converted to constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability by introducing configurable timing constants across app flow management and initialization systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->