### PR TITLE
 Track mutable cloud backup sync state and dirty wallet uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,6 @@ The role of this file is to describe common mistakes and confusion points that a
 - Use `cove_util::ResultExt::map_err_str` instead of `.map_err(|e| Error::Variant(e.to_string()))` — it's cleaner and equivalent
 - Use `cove_util::ResultExt::map_err_prefix` instead of `.map_err(|e| Error::Variant(format!("context: {e}")))` when the prefix is a static string — produces `"context: error_message"`
 - For long-lived UI-facing managers, prefer `dispatch(action:)` for user intents and keep named methods for reads, bootstrap/lifecycle hooks, and special service-style operations.
+- never use `pub(in ...)` or `pub(super)`; if non-private visibility is needed, use `pub(crate)` or `pub`
 - never manually edit generated files
 - no mod.rs files use the other format module_name.rs module_name/new_module.rs

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoveApplication.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoveApplication.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import org.bitcoinppl.cove_core.AuthType
+import org.bitcoinppl.cove_core.RustCloudBackupManager
 import org.bitcoinppl.cove_core.device.Device
 import org.bitcoinppl.cove_core.device.Keychain
 import org.bitcoinppl.cove_core.setRootDataDir
@@ -57,6 +58,9 @@ class CoveApplication : Application() {
         bootstrapCompleted = true
 
         AppManager.getInstance()
+        RustCloudBackupManager().use { rustCloudBackupManager ->
+            rustCloudBackupManager.resumePendingCloudUploadVerification()
+        }
         setupLifecycleObserver()
         setupMemoryCallbacks()
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -78,6 +78,7 @@ import org.bitcoinppl.cove.nfc.TapCardNfcManager
 import org.bitcoinppl.cove.sidebar.SidebarContainer
 import org.bitcoinppl.cove.ui.theme.CoveTheme
 import org.bitcoinppl.cove.views.LockView
+import org.bitcoinppl.cove_core.RustCloudBackupManager
 import org.bitcoinppl.cove.views.TermsAndConditionsSheet
 import org.bitcoinppl.cove_core.bootstrap
 import org.bitcoinppl.cove_core.activeMigration

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -98,6 +98,7 @@ import org.bitcoinppl.cove_core.NewWalletRoute
 import org.bitcoinppl.cove_core.NumberOfBip39Words
 import org.bitcoinppl.cove_core.Route
 import org.bitcoinppl.cove_core.RouteFactory
+import org.bitcoinppl.cove_core.SettingsRoute
 import org.bitcoinppl.cove_core.TapSignerRoute
 import org.bitcoinppl.cove_core.Wallet
 import org.bitcoinppl.cove_core.WalletType
@@ -539,12 +540,21 @@ private fun GlobalAlertDialog(
 
         is AppAlertState.HotWalletKeyMissing -> {
             val walletId = state.walletId
+            val cloudBackupEnabled =
+                runCatching { RustCloudBackupManager().use { it.isCloudBackupEnabled() } }
+                    .getOrDefault(false)
             AlertDialog(
                 onDismissRequest = onDismiss,
                 title = { Text(state.title()) },
                 text = { Text(state.message()) },
                 confirmButton = {
                     Column(horizontalAlignment = Alignment.End) {
+                        if (cloudBackupEnabled) {
+                            TextButton(onClick = {
+                                onDismiss()
+                                app.loadAndReset(Route.Settings(SettingsRoute.CloudBackup))
+                            }) { Text("Open Cloud Backup") }
+                        }
                         TextButton(onClick = {
                             onDismiss()
                             app.loadAndReset(Route.NewWallet(NewWalletRoute.HotWallet(HotWalletRoute.Import(NumberOfBip39Words.TWELVE, ImportType.MANUAL))))

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1385,9 +1385,13 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_backup_wallet_count(
     ): Short
+    external fun uniffi_cove_checksum_method_rustcloudbackupmanager_clear_sync_error_if_no_failed_wallet_uploads(
+    ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_current_status(
     ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_debug_reset_cloud_backup_state(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustcloudbackupmanager_has_failed_wallet_uploads(
     ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_has_pending_cloud_upload_verification(
     ): Short
@@ -1400,6 +1404,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_listen_for_updates(
     ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_resume_pending_cloud_upload_verification(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustcloudbackupmanager_schedule_wallet_upload_follow_up(
     ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_state(
     ): Short
@@ -2389,10 +2395,14 @@ internal object UniffiLib {
     ): Unit
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_backup_wallet_count(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_rustcloudbackupmanager_clear_sync_error_if_no_failed_wallet_uploads(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_current_status(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_debug_reset_cloud_backup_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    external fun uniffi_cove_fn_method_rustcloudbackupmanager_has_failed_wallet_uploads(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_has_pending_cloud_upload_verification(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_is_cloud_backup_enabled(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -2404,6 +2414,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_listen_for_updates(`ptr`: Long,`reconciler`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_resume_pending_cloud_upload_verification(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_fn_method_rustcloudbackupmanager_schedule_wallet_upload_follow_up(`ptr`: Long,`walletId`: RustBufferWalletId.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -3982,10 +3994,16 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_backup_wallet_count() != 17456.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_clear_sync_error_if_no_failed_wallet_uploads() != 7150.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_current_status() != 9796.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_debug_reset_cloud_backup_state() != 45375.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_has_failed_wallet_uploads() != 28193.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_has_pending_cloud_upload_verification() != 4437.toShort()) {
@@ -4004,6 +4022,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_resume_pending_cloud_upload_verification() != 24590.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_schedule_wallet_upload_follow_up() != 63751.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_state() != 8780.toShort()) {
@@ -17662,6 +17683,8 @@ public interface RustCloudBackupManagerInterface {
      */
     fun `backupWalletCount`(): kotlin.UInt?
     
+    fun `clearSyncErrorIfNoFailedWalletUploads`()
+    
     fun `currentStatus`(): CloudBackupStatus
     
     /**
@@ -17670,6 +17693,8 @@ public interface RustCloudBackupManagerInterface {
      * Debug-only: pair with Swift-side iCloud wipe for full reset
      */
     fun `debugResetCloudBackupState`()
+    
+    fun `hasFailedWalletUploads`(): kotlin.Boolean
     
     fun `hasPendingCloudUploadVerification`(): kotlin.Boolean
     
@@ -17691,6 +17716,8 @@ public interface RustCloudBackupManagerInterface {
     fun `listenForUpdates`(`reconciler`: CloudBackupManagerReconciler)
     
     fun `resumePendingCloudUploadVerification`()
+    
+    fun `scheduleWalletUploadFollowUp`(`walletId`: WalletId)
     
     fun `state`(): CloudBackupState
     
@@ -17864,6 +17891,18 @@ open class RustCloudBackupManager: Disposable, AutoCloseable, RustCloudBackupMan
     }
     
 
+    override fun `clearSyncErrorIfNoFailedWalletUploads`()
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustcloudbackupmanager_clear_sync_error_if_no_failed_wallet_uploads(
+        it,
+        _status)
+}
+    }
+    
+    
+
     override fun `currentStatus`(): CloudBackupStatus {
             return FfiConverterTypeCloudBackupStatus.lift(
     callWithHandle {
@@ -17892,6 +17931,19 @@ open class RustCloudBackupManager: Disposable, AutoCloseable, RustCloudBackupMan
 }
     }
     
+    
+
+    override fun `hasFailedWalletUploads`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustcloudbackupmanager_has_failed_wallet_uploads(
+        it,
+        _status)
+}
+    }
+    )
+    }
     
 
     override fun `hasPendingCloudUploadVerification`(): kotlin.Boolean {
@@ -17974,6 +18026,18 @@ open class RustCloudBackupManager: Disposable, AutoCloseable, RustCloudBackupMan
     UniffiLib.uniffi_cove_fn_method_rustcloudbackupmanager_resume_pending_cloud_upload_verification(
         it,
         _status)
+}
+    }
+    
+    
+
+    override fun `scheduleWalletUploadFollowUp`(`walletId`: WalletId)
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustcloudbackupmanager_schedule_wallet_upload_follow_up(
+        it,
+        FfiConverterTypeWalletId.lower(`walletId`),_status)
 }
     }
     
@@ -27143,9 +27207,9 @@ public object FfiConverterTypeBackupWalletSummary: FfiConverterRustBuffer<Backup
 data class CloudBackupDetail (
     var `lastSync`: kotlin.ULong?
     , 
-    var `backedUp`: List<CloudBackupWalletItem>
+    var `upToDate`: List<CloudBackupWalletItem>
     , 
-    var `notBackedUp`: List<CloudBackupWalletItem>
+    var `needsSync`: List<CloudBackupWalletItem>
     , 
     /**
      * Number of wallets in the cloud that aren't on this device
@@ -27176,15 +27240,15 @@ public object FfiConverterTypeCloudBackupDetail: FfiConverterRustBuffer<CloudBac
 
     override fun allocationSize(value: CloudBackupDetail) = (
             FfiConverterOptionalULong.allocationSize(value.`lastSync`) +
-            FfiConverterSequenceTypeCloudBackupWalletItem.allocationSize(value.`backedUp`) +
-            FfiConverterSequenceTypeCloudBackupWalletItem.allocationSize(value.`notBackedUp`) +
+            FfiConverterSequenceTypeCloudBackupWalletItem.allocationSize(value.`upToDate`) +
+            FfiConverterSequenceTypeCloudBackupWalletItem.allocationSize(value.`needsSync`) +
             FfiConverterUInt.allocationSize(value.`cloudOnlyCount`)
     )
 
     override fun write(value: CloudBackupDetail, buf: ByteBuffer) {
             FfiConverterOptionalULong.write(value.`lastSync`, buf)
-            FfiConverterSequenceTypeCloudBackupWalletItem.write(value.`backedUp`, buf)
-            FfiConverterSequenceTypeCloudBackupWalletItem.write(value.`notBackedUp`, buf)
+            FfiConverterSequenceTypeCloudBackupWalletItem.write(value.`upToDate`, buf)
+            FfiConverterSequenceTypeCloudBackupWalletItem.write(value.`needsSync`, buf)
             FfiConverterUInt.write(value.`cloudOnlyCount`, buf)
     }
 }
@@ -27278,6 +27342,10 @@ data class CloudBackupRestoreReport (
     var `walletsFailed`: kotlin.UInt
     , 
     var `failedWalletErrors`: List<kotlin.String>
+    , 
+    var `labelsFailedWalletNames`: List<kotlin.String>
+    , 
+    var `labelsFailedErrors`: List<kotlin.String>
     
 ){
     
@@ -27297,19 +27365,25 @@ public object FfiConverterTypeCloudBackupRestoreReport: FfiConverterRustBuffer<C
             FfiConverterUInt.read(buf),
             FfiConverterUInt.read(buf),
             FfiConverterSequenceString.read(buf),
+            FfiConverterSequenceString.read(buf),
+            FfiConverterSequenceString.read(buf),
         )
     }
 
     override fun allocationSize(value: CloudBackupRestoreReport) = (
             FfiConverterUInt.allocationSize(value.`walletsRestored`) +
             FfiConverterUInt.allocationSize(value.`walletsFailed`) +
-            FfiConverterSequenceString.allocationSize(value.`failedWalletErrors`)
+            FfiConverterSequenceString.allocationSize(value.`failedWalletErrors`) +
+            FfiConverterSequenceString.allocationSize(value.`labelsFailedWalletNames`) +
+            FfiConverterSequenceString.allocationSize(value.`labelsFailedErrors`)
     )
 
     override fun write(value: CloudBackupRestoreReport, buf: ByteBuffer) {
             FfiConverterUInt.write(value.`walletsRestored`, buf)
             FfiConverterUInt.write(value.`walletsFailed`, buf)
             FfiConverterSequenceString.write(value.`failedWalletErrors`, buf)
+            FfiConverterSequenceString.write(value.`labelsFailedWalletNames`, buf)
+            FfiConverterSequenceString.write(value.`labelsFailedErrors`, buf)
     }
 }
 
@@ -27416,15 +27490,19 @@ public object FfiConverterTypeCloudBackupState: FfiConverterRustBuffer<CloudBack
 data class CloudBackupWalletItem (
     var `name`: kotlin.String
     , 
-    var `network`: Network
+    var `network`: Network?
     , 
-    var `walletMode`: WalletMode
+    var `walletMode`: WalletMode?
     , 
-    var `walletType`: WalletType
+    var `walletType`: WalletType?
     , 
     var `fingerprint`: kotlin.String?
     , 
-    var `status`: CloudBackupWalletStatus
+    var `labelCount`: kotlin.UInt?
+    , 
+    var `backupUpdatedAt`: kotlin.ULong?
+    , 
+    var `syncStatus`: CloudBackupWalletStatus
     , 
     /**
      * Deterministic cloud record ID for the wallet backup represented by this item
@@ -27447,10 +27525,12 @@ public object FfiConverterTypeCloudBackupWalletItem: FfiConverterRustBuffer<Clou
     override fun read(buf: ByteBuffer): CloudBackupWalletItem {
         return CloudBackupWalletItem(
             FfiConverterString.read(buf),
-            FfiConverterTypeNetwork.read(buf),
-            FfiConverterTypeWalletMode.read(buf),
-            FfiConverterTypeWalletType.read(buf),
+            FfiConverterOptionalTypeNetwork.read(buf),
+            FfiConverterOptionalTypeWalletMode.read(buf),
+            FfiConverterOptionalTypeWalletType.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalUInt.read(buf),
+            FfiConverterOptionalULong.read(buf),
             FfiConverterTypeCloudBackupWalletStatus.read(buf),
             FfiConverterString.read(buf),
         )
@@ -27458,21 +27538,25 @@ public object FfiConverterTypeCloudBackupWalletItem: FfiConverterRustBuffer<Clou
 
     override fun allocationSize(value: CloudBackupWalletItem) = (
             FfiConverterString.allocationSize(value.`name`) +
-            FfiConverterTypeNetwork.allocationSize(value.`network`) +
-            FfiConverterTypeWalletMode.allocationSize(value.`walletMode`) +
-            FfiConverterTypeWalletType.allocationSize(value.`walletType`) +
+            FfiConverterOptionalTypeNetwork.allocationSize(value.`network`) +
+            FfiConverterOptionalTypeWalletMode.allocationSize(value.`walletMode`) +
+            FfiConverterOptionalTypeWalletType.allocationSize(value.`walletType`) +
             FfiConverterOptionalString.allocationSize(value.`fingerprint`) +
-            FfiConverterTypeCloudBackupWalletStatus.allocationSize(value.`status`) +
+            FfiConverterOptionalUInt.allocationSize(value.`labelCount`) +
+            FfiConverterOptionalULong.allocationSize(value.`backupUpdatedAt`) +
+            FfiConverterTypeCloudBackupWalletStatus.allocationSize(value.`syncStatus`) +
             FfiConverterString.allocationSize(value.`recordId`)
     )
 
     override fun write(value: CloudBackupWalletItem, buf: ByteBuffer) {
             FfiConverterString.write(value.`name`, buf)
-            FfiConverterTypeNetwork.write(value.`network`, buf)
-            FfiConverterTypeWalletMode.write(value.`walletMode`, buf)
-            FfiConverterTypeWalletType.write(value.`walletType`, buf)
+            FfiConverterOptionalTypeNetwork.write(value.`network`, buf)
+            FfiConverterOptionalTypeWalletMode.write(value.`walletMode`, buf)
+            FfiConverterOptionalTypeWalletType.write(value.`walletType`, buf)
             FfiConverterOptionalString.write(value.`fingerprint`, buf)
-            FfiConverterTypeCloudBackupWalletStatus.write(value.`status`, buf)
+            FfiConverterOptionalUInt.write(value.`labelCount`, buf)
+            FfiConverterOptionalULong.write(value.`backupUpdatedAt`, buf)
+            FfiConverterTypeCloudBackupWalletStatus.write(value.`syncStatus`, buf)
             FfiConverterString.write(value.`recordId`, buf)
     }
 }
@@ -33991,9 +34075,14 @@ public object FfiConverterTypeCloudBackupVerificationMetadata : FfiConverterRust
 
 enum class CloudBackupWalletStatus {
     
-    BACKED_UP,
-    NOT_BACKED_UP,
-    DELETED_FROM_DEVICE;
+    DIRTY,
+    UPLOADING,
+    UPLOADED_PENDING_CONFIRMATION,
+    CONFIRMED,
+    FAILED,
+    DELETED_FROM_DEVICE,
+    UNSUPPORTED_VERSION,
+    REMOTE_STATE_UNKNOWN;
 
     
 
@@ -34037,6 +34126,16 @@ sealed class CloudOnlyOperation {
         companion object
     }
     
+    data class Warning(
+        val `message`: kotlin.String, 
+        val `error`: kotlin.String) : CloudOnlyOperation()
+        
+    {
+        
+
+        companion object
+    }
+    
     data class Failed(
         val `error`: kotlin.String) : CloudOnlyOperation()
         
@@ -34066,7 +34165,11 @@ public object FfiConverterTypeCloudOnlyOperation : FfiConverterRustBuffer<CloudO
             2 -> CloudOnlyOperation.Operating(
                 FfiConverterString.read(buf),
                 )
-            3 -> CloudOnlyOperation.Failed(
+            3 -> CloudOnlyOperation.Warning(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            4 -> CloudOnlyOperation.Failed(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -34085,6 +34188,14 @@ public object FfiConverterTypeCloudOnlyOperation : FfiConverterRustBuffer<CloudO
             (
                 4UL
                 + FfiConverterString.allocationSize(value.`recordId`)
+            )
+        }
+        is CloudOnlyOperation.Warning -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`message`)
+                + FfiConverterString.allocationSize(value.`error`)
             )
         }
         is CloudOnlyOperation.Failed -> {
@@ -34107,8 +34218,14 @@ public object FfiConverterTypeCloudOnlyOperation : FfiConverterRustBuffer<CloudO
                 FfiConverterString.write(value.`recordId`, buf)
                 Unit
             }
-            is CloudOnlyOperation.Failed -> {
+            is CloudOnlyOperation.Warning -> {
                 buf.putInt(3)
+                FfiConverterString.write(value.`message`, buf)
+                FfiConverterString.write(value.`error`, buf)
+                Unit
+            }
+            is CloudOnlyOperation.Failed -> {
+                buf.putInt(4)
                 FfiConverterString.write(value.`error`, buf)
                 Unit
             }
@@ -52003,6 +52120,102 @@ public object FfiConverterOptionalTypeTapSignerResponse: FfiConverterRustBuffer<
         } else {
             buf.put(1)
             FfiConverterTypeTapSignerResponse.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeWalletMode: FfiConverterRustBuffer<WalletMode?> {
+    override fun read(buf: ByteBuffer): WalletMode? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeWalletMode.read(buf)
+    }
+
+    override fun allocationSize(value: WalletMode?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeWalletMode.allocationSize(value)
+        }
+    }
+
+    override fun write(value: WalletMode?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeWalletMode.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeWalletType: FfiConverterRustBuffer<WalletType?> {
+    override fun read(buf: ByteBuffer): WalletType? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeWalletType.read(buf)
+    }
+
+    override fun allocationSize(value: WalletType?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeWalletType.allocationSize(value)
+        }
+    }
+
+    override fun write(value: WalletType?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeWalletType.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeNetwork: FfiConverterRustBuffer<Network?> {
+    override fun read(buf: ByteBuffer): Network? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeNetwork.read(buf)
+    }
+
+    override fun allocationSize(value: Network?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeNetwork.allocationSize(value)
+        }
+    }
+
+    override fun write(value: Network?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeNetwork.write(value, buf)
         }
     }
 }

--- a/ios/Cove/CloudBackupManager.swift
+++ b/ios/Cove/CloudBackupManager.swift
@@ -81,6 +81,10 @@ final class CloudBackupManager: AnyReconciler, CloudBackupManagerReconciler, @un
         }
     }
 
+    var isCloudBackupEnabled: Bool {
+        rust.isCloudBackupEnabled()
+    }
+
     var lastVerifiedAt: Date? {
         guard case let .verified(lastVerifiedAt) = state.verificationMetadata else { return nil }
         return Date(timeIntervalSince1970: TimeInterval(lastVerifiedAt))

--- a/ios/Cove/CoveMainView.swift
+++ b/ios/Cove/CoveMainView.swift
@@ -47,6 +47,13 @@ struct CoveMainView: View {
                 try? app.rust.selectWallet(id: walletId)
             }
         case let .hotWalletKeyMissing(walletId: walletId):
+            if CloudBackupManager.shared.isCloudBackupEnabled {
+                Button("Open Cloud Backup") {
+                    app.alertState = .none
+                    app.loadAndReset(to: .settings(.cloudBackup))
+                }
+            }
+
             Button("Import 12 Words") {
                 app.alertState = .none
                 app.loadAndReset(to: .newWallet(.hotWallet(.import(.twelve, .manual))))

--- a/ios/Cove/Flows/Onboarding/StartupRecovery/DeviceRestoreView.swift
+++ b/ios/Cove/Flows/Onboarding/StartupRecovery/DeviceRestoreView.swift
@@ -274,6 +274,11 @@ private struct DeviceRestoreContent: View {
                 if report.walletsFailed > 0 {
                     warningCard(message: "\(report.walletsFailed) wallet(s) could not be restored")
                 }
+                if !report.labelsFailedWalletNames.isEmpty {
+                    warningCard(
+                        message: "\(report.labelsFailedWalletNames.count) restored wallet(s) had labels that could not be imported"
+                    )
+                }
 
                 Button(action: onDone) {
                     Text("Done")
@@ -334,7 +339,9 @@ private struct DeviceRestoreContent: View {
             CloudBackupRestoreReport(
                 walletsRestored: 4,
                 walletsFailed: 0,
-                failedWalletErrors: []
+                failedWalletErrors: [],
+                labelsFailedWalletNames: [],
+                labelsFailedErrors: []
             )
         ),
         combinedProgress: 1,
@@ -349,7 +356,9 @@ private struct DeviceRestoreContent: View {
             CloudBackupRestoreReport(
                 walletsRestored: 3,
                 walletsFailed: 1,
-                failedWalletErrors: ["Wallet 4 failed to restore"]
+                failedWalletErrors: ["Wallet 4 failed to restore"],
+                labelsFailedWalletNames: ["Wallet 2"],
+                labelsFailedErrors: ["Failed to parse labels: invalid type"]
             )
         ),
         combinedProgress: 1,

--- a/ios/Cove/Flows/SettingsFlow/CloudBackupDetailSections.swift
+++ b/ios/Cove/Flows/SettingsFlow/CloudBackupDetailSections.swift
@@ -25,11 +25,11 @@ struct DetailFormContent: View {
 
     var body: some View {
         HeaderSection(lastSync: detail.lastSync, syncHealth: syncHealth)
-        if !detail.backedUp.isEmpty {
-            WalletSections(wallets: detail.backedUp)
+        if !detail.upToDate.isEmpty {
+            WalletSections(wallets: detail.upToDate)
         }
-        if !detail.notBackedUp.isEmpty {
-            WalletSections(wallets: detail.notBackedUp, showNotBackedUpBadge: true)
+        if !detail.needsSync.isEmpty {
+            WalletSections(wallets: detail.needsSync)
         }
         if showCloudOnlySection {
             CloudOnlySection(manager: manager)
@@ -183,6 +183,7 @@ struct CloudOnlySection: View {
     let manager: CloudBackupManager
     @State private var selectedWallet: CloudBackupWalletItem?
     @State private var walletToDelete: CloudBackupWalletItem?
+    @State private var unsupportedRestoreWallet: CloudBackupWalletItem?
 
     private var isOperating: Bool {
         manager.cloudOnlyOperation.operatingRecordId != nil
@@ -200,7 +201,8 @@ struct CloudOnlySection: View {
             CloudOnlyActionDialogs(
                 manager: manager,
                 selectedWallet: $selectedWallet,
-                walletToDelete: $walletToDelete
+                walletToDelete: $walletToDelete,
+                unsupportedRestoreWallet: $unsupportedRestoreWallet
             )
         )
     }
@@ -236,6 +238,10 @@ private struct CloudOnlySectionContent: View {
                 Text(error)
                     .font(.caption)
                     .foregroundStyle(.red)
+            } else if case let .warning(message: message, error: _) = manager.cloudOnlyOperation {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
             }
 
         case let .failed(error):
@@ -275,6 +281,7 @@ private struct CloudOnlyActionDialogs: ViewModifier {
     let manager: CloudBackupManager
     @Binding var selectedWallet: CloudBackupWalletItem?
     @Binding var walletToDelete: CloudBackupWalletItem?
+    @Binding var unsupportedRestoreWallet: CloudBackupWalletItem?
 
     func body(content: Content) -> some View {
         content
@@ -288,6 +295,11 @@ private struct CloudOnlyActionDialogs: ViewModifier {
             ) {
                 if let item = selectedWallet {
                     Button("Restore to This Device") {
+                        if item.syncStatus == .unsupportedVersion {
+                            unsupportedRestoreWallet = item
+                            return
+                        }
+
                         manager.dispatch(action: .restoreCloudWallet(recordId: item.recordId))
                     }
                     Button("Delete from iCloud", role: .destructive) {
@@ -312,18 +324,29 @@ private struct CloudOnlyActionDialogs: ViewModifier {
             } message: {
                 Text("This wallet backup will be permanently removed from iCloud")
             }
+            .alert(
+                "Can't Restore \(unsupportedRestoreWallet?.name ?? "Wallet")",
+                isPresented: Binding(
+                    get: { unsupportedRestoreWallet != nil },
+                    set: { if !$0 { unsupportedRestoreWallet = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(
+                    "This backup uses a newer version of Cove and can't be restored on this device yet"
+                )
+            }
     }
 }
 
 struct WalletSections: View {
     let wallets: [CloudBackupWalletItem]
-    var showNotBackedUpBadge = false
 
     private let groupedWallets: GroupedWalletSections
 
-    init(wallets: [CloudBackupWalletItem], showNotBackedUpBadge: Bool = false) {
+    init(wallets: [CloudBackupWalletItem]) {
         self.wallets = wallets
-        self.showNotBackedUpBadge = showNotBackedUpBadge
         groupedWallets = GroupedWalletSections(wallets: wallets)
     }
 
@@ -337,22 +360,8 @@ struct WalletSections: View {
         }
     }
 
-    @ViewBuilder
     private func sectionHeader(for key: GroupKey) -> some View {
-        if showNotBackedUpBadge {
-            HStack {
-                Text(key.title)
-                Text("NOT BACKED UP")
-                    .font(.caption2)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.red, in: Capsule())
-            }
-        } else {
-            Text(key.title)
-        }
+        Text(key.title)
     }
 }
 
@@ -388,20 +397,40 @@ struct WalletItemRow: View {
                 Text(item.name)
                     .fontWeight(.medium)
                 Spacer()
-                StatusBadge(status: item.status)
+                StatusBadge(status: item.syncStatus)
             }
 
             HStack(spacing: 12) {
-                IconLabel("globe", item.network.displayName())
-                IconLabel("wallet.bifold", item.walletType.displayName())
+                if let network = item.network {
+                    IconLabel("globe", network.displayName())
+                }
+                if let walletType = item.walletType {
+                    IconLabel("wallet.bifold", walletType.displayName())
+                }
                 if let fingerprint = item.fingerprint {
                     IconLabel("touchid", fingerprint)
                 }
             }
             .font(.caption)
             .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                if let labelCount = item.labelCount {
+                    IconLabel("tag", "\(labelCount) labels")
+                }
+                if let backupUpdatedAt = item.backupUpdatedAt {
+                    IconLabel("clock", formatDate(backupUpdatedAt))
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
         .padding(.vertical, 2)
+    }
+
+    private func formatDate(_ timestamp: UInt64) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        return date.formatted(date: .abbreviated, time: .shortened)
     }
 }
 
@@ -410,17 +439,25 @@ private struct StatusBadge: View {
 
     private var label: String {
         switch status {
-        case .backedUp: "Backed up"
-        case .notBackedUp: "Not backed up"
+        case .dirty: "Dirty"
+        case .uploading: "Uploading"
+        case .uploadedPendingConfirmation: "Uploaded, confirming"
+        case .confirmed: "Confirmed"
+        case .failed: "Failed"
         case .deletedFromDevice: "Not on device"
+        case .unsupportedVersion: "Unsupported"
+        case .remoteStateUnknown: "Unknown"
         }
     }
 
     private var color: Color {
         switch status {
-        case .backedUp: .green
-        case .notBackedUp: .red
-        case .deletedFromDevice: .orange
+        case .dirty: .orange
+        case .uploading, .uploadedPendingConfirmation: .blue
+        case .confirmed: .green
+        case .failed: .red
+        case .deletedFromDevice, .unsupportedVersion: .orange
+        case .remoteStateUnknown: .secondary
         }
     }
 
@@ -436,19 +473,32 @@ private struct StatusBadge: View {
 }
 
 private struct GroupKey: Hashable, Comparable {
-    let network: Network
-    let walletMode: WalletMode
+    let network: Network?
+    let walletMode: WalletMode?
 
     var title: String {
-        switch walletMode {
+        guard let network, let walletMode else {
+            return "Unsupported"
+        }
+
+        return switch walletMode {
         case .decoy: "\(network.displayName()) · Decoy"
         default: network.displayName()
         }
     }
 
     static func < (lhs: GroupKey, rhs: GroupKey) -> Bool {
-        if lhs.network != rhs.network {
-            return lhs.network.displayName() < rhs.network.displayName()
+        if lhs.network == nil || lhs.walletMode == nil {
+            return rhs.network != nil && rhs.walletMode != nil
+        }
+        if rhs.network == nil || rhs.walletMode == nil {
+            return false
+        }
+
+        let lhsNetwork = lhs.network!
+        let rhsNetwork = rhs.network!
+        if lhsNetwork != rhsNetwork {
+            return lhsNetwork.displayName() < rhsNetwork.displayName()
         }
         return lhs.walletMode == .main && rhs.walletMode != .main
     }

--- a/ios/Cove/Flows/SettingsFlow/CloudBackupVerificationSection.swift
+++ b/ios/Cove/Flows/SettingsFlow/CloudBackupVerificationSection.swift
@@ -268,7 +268,7 @@ struct VerificationSection: View {
 
     private var actionButtons: some View {
         Section {
-            if manager.detail?.notBackedUp.isEmpty == false {
+            if manager.detail?.needsSync.isEmpty == false {
                 syncButton
             }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -7057,6 +7057,8 @@ public protocol RustCloudBackupManagerProtocol: AnyObject, Sendable {
      */
     func backupWalletCount()  -> UInt32?
     
+    func clearSyncErrorIfNoFailedWalletUploads() 
+    
     func currentStatus()  -> CloudBackupStatus
     
     /**
@@ -7065,6 +7067,8 @@ public protocol RustCloudBackupManagerProtocol: AnyObject, Sendable {
      * Debug-only: pair with Swift-side iCloud wipe for full reset
      */
     func debugResetCloudBackupState() 
+    
+    func hasFailedWalletUploads()  -> Bool
     
     func hasPendingCloudUploadVerification()  -> Bool
     
@@ -7086,6 +7090,8 @@ public protocol RustCloudBackupManagerProtocol: AnyObject, Sendable {
     func listenForUpdates(reconciler: CloudBackupManagerReconciler) 
     
     func resumePendingCloudUploadVerification() 
+    
+    func scheduleWalletUploadFollowUp(walletId: WalletId) 
     
     func state()  -> CloudBackupState
     
@@ -7195,6 +7201,13 @@ open func backupWalletCount() -> UInt32?  {
 })
 }
     
+open func clearSyncErrorIfNoFailedWalletUploads()  {try! rustCall() {
+    uniffi_cove_fn_method_rustcloudbackupmanager_clear_sync_error_if_no_failed_wallet_uploads(
+            self.uniffiCloneHandle(),$0
+    )
+}
+}
+    
 open func currentStatus() -> CloudBackupStatus  {
     return try!  FfiConverterTypeCloudBackupStatus_lift(try! rustCall() {
     uniffi_cove_fn_method_rustcloudbackupmanager_current_status(
@@ -7213,6 +7226,14 @@ open func debugResetCloudBackupState()  {try! rustCall() {
             self.uniffiCloneHandle(),$0
     )
 }
+}
+    
+open func hasFailedWalletUploads() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_cove_fn_method_rustcloudbackupmanager_has_failed_wallet_uploads(
+            self.uniffiCloneHandle(),$0
+    )
+})
 }
     
 open func hasPendingCloudUploadVerification() -> Bool  {
@@ -7267,6 +7288,14 @@ open func listenForUpdates(reconciler: CloudBackupManagerReconciler)  {try! rust
 open func resumePendingCloudUploadVerification()  {try! rustCall() {
     uniffi_cove_fn_method_rustcloudbackupmanager_resume_pending_cloud_upload_verification(
             self.uniffiCloneHandle(),$0
+    )
+}
+}
+    
+open func scheduleWalletUploadFollowUp(walletId: WalletId)  {try! rustCall() {
+    uniffi_cove_fn_method_rustcloudbackupmanager_schedule_wallet_upload_follow_up(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeWalletId_lower(walletId),$0
     )
 }
 }
@@ -12734,8 +12763,8 @@ public func FfiConverterTypeBackupWalletSummary_lower(_ value: BackupWalletSumma
 
 public struct CloudBackupDetail: Equatable, Hashable {
     public var lastSync: UInt64?
-    public var backedUp: [CloudBackupWalletItem]
-    public var notBackedUp: [CloudBackupWalletItem]
+    public var upToDate: [CloudBackupWalletItem]
+    public var needsSync: [CloudBackupWalletItem]
     /**
      * Number of wallets in the cloud that aren't on this device
      */
@@ -12743,13 +12772,13 @@ public struct CloudBackupDetail: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(lastSync: UInt64?, backedUp: [CloudBackupWalletItem], notBackedUp: [CloudBackupWalletItem], 
+    public init(lastSync: UInt64?, upToDate: [CloudBackupWalletItem], needsSync: [CloudBackupWalletItem], 
         /**
          * Number of wallets in the cloud that aren't on this device
          */cloudOnlyCount: UInt32) {
         self.lastSync = lastSync
-        self.backedUp = backedUp
-        self.notBackedUp = notBackedUp
+        self.upToDate = upToDate
+        self.needsSync = needsSync
         self.cloudOnlyCount = cloudOnlyCount
     }
 
@@ -12770,16 +12799,16 @@ public struct FfiConverterTypeCloudBackupDetail: FfiConverterRustBuffer {
         return
             try CloudBackupDetail(
                 lastSync: FfiConverterOptionUInt64.read(from: &buf), 
-                backedUp: FfiConverterSequenceTypeCloudBackupWalletItem.read(from: &buf), 
-                notBackedUp: FfiConverterSequenceTypeCloudBackupWalletItem.read(from: &buf), 
+                upToDate: FfiConverterSequenceTypeCloudBackupWalletItem.read(from: &buf), 
+                needsSync: FfiConverterSequenceTypeCloudBackupWalletItem.read(from: &buf), 
                 cloudOnlyCount: FfiConverterUInt32.read(from: &buf)
         )
     }
 
     public static func write(_ value: CloudBackupDetail, into buf: inout [UInt8]) {
         FfiConverterOptionUInt64.write(value.lastSync, into: &buf)
-        FfiConverterSequenceTypeCloudBackupWalletItem.write(value.backedUp, into: &buf)
-        FfiConverterSequenceTypeCloudBackupWalletItem.write(value.notBackedUp, into: &buf)
+        FfiConverterSequenceTypeCloudBackupWalletItem.write(value.upToDate, into: &buf)
+        FfiConverterSequenceTypeCloudBackupWalletItem.write(value.needsSync, into: &buf)
         FfiConverterUInt32.write(value.cloudOnlyCount, into: &buf)
     }
 }
@@ -12916,13 +12945,17 @@ public struct CloudBackupRestoreReport: Equatable, Hashable {
     public var walletsRestored: UInt32
     public var walletsFailed: UInt32
     public var failedWalletErrors: [String]
+    public var labelsFailedWalletNames: [String]
+    public var labelsFailedErrors: [String]
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(walletsRestored: UInt32, walletsFailed: UInt32, failedWalletErrors: [String]) {
+    public init(walletsRestored: UInt32, walletsFailed: UInt32, failedWalletErrors: [String], labelsFailedWalletNames: [String], labelsFailedErrors: [String]) {
         self.walletsRestored = walletsRestored
         self.walletsFailed = walletsFailed
         self.failedWalletErrors = failedWalletErrors
+        self.labelsFailedWalletNames = labelsFailedWalletNames
+        self.labelsFailedErrors = labelsFailedErrors
     }
 
     
@@ -12943,7 +12976,9 @@ public struct FfiConverterTypeCloudBackupRestoreReport: FfiConverterRustBuffer {
             try CloudBackupRestoreReport(
                 walletsRestored: FfiConverterUInt32.read(from: &buf), 
                 walletsFailed: FfiConverterUInt32.read(from: &buf), 
-                failedWalletErrors: FfiConverterSequenceString.read(from: &buf)
+                failedWalletErrors: FfiConverterSequenceString.read(from: &buf), 
+                labelsFailedWalletNames: FfiConverterSequenceString.read(from: &buf), 
+                labelsFailedErrors: FfiConverterSequenceString.read(from: &buf)
         )
     }
 
@@ -12951,6 +12986,8 @@ public struct FfiConverterTypeCloudBackupRestoreReport: FfiConverterRustBuffer {
         FfiConverterUInt32.write(value.walletsRestored, into: &buf)
         FfiConverterUInt32.write(value.walletsFailed, into: &buf)
         FfiConverterSequenceString.write(value.failedWalletErrors, into: &buf)
+        FfiConverterSequenceString.write(value.labelsFailedWalletNames, into: &buf)
+        FfiConverterSequenceString.write(value.labelsFailedErrors, into: &buf)
     }
 }
 
@@ -13074,11 +13111,13 @@ public func FfiConverterTypeCloudBackupState_lower(_ value: CloudBackupState) ->
 
 public struct CloudBackupWalletItem: Equatable, Hashable {
     public var name: String
-    public var network: Network
-    public var walletMode: WalletMode
-    public var walletType: WalletType
+    public var network: Network?
+    public var walletMode: WalletMode?
+    public var walletType: WalletType?
     public var fingerprint: String?
-    public var status: CloudBackupWalletStatus
+    public var labelCount: UInt32?
+    public var backupUpdatedAt: UInt64?
+    public var syncStatus: CloudBackupWalletStatus
     /**
      * Deterministic cloud record ID for the wallet backup represented by this item
      */
@@ -13086,7 +13125,7 @@ public struct CloudBackupWalletItem: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(name: String, network: Network, walletMode: WalletMode, walletType: WalletType, fingerprint: String?, status: CloudBackupWalletStatus, 
+    public init(name: String, network: Network?, walletMode: WalletMode?, walletType: WalletType?, fingerprint: String?, labelCount: UInt32?, backupUpdatedAt: UInt64?, syncStatus: CloudBackupWalletStatus, 
         /**
          * Deterministic cloud record ID for the wallet backup represented by this item
          */recordId: String) {
@@ -13095,7 +13134,9 @@ public struct CloudBackupWalletItem: Equatable, Hashable {
         self.walletMode = walletMode
         self.walletType = walletType
         self.fingerprint = fingerprint
-        self.status = status
+        self.labelCount = labelCount
+        self.backupUpdatedAt = backupUpdatedAt
+        self.syncStatus = syncStatus
         self.recordId = recordId
     }
 
@@ -13116,22 +13157,26 @@ public struct FfiConverterTypeCloudBackupWalletItem: FfiConverterRustBuffer {
         return
             try CloudBackupWalletItem(
                 name: FfiConverterString.read(from: &buf), 
-                network: FfiConverterTypeNetwork.read(from: &buf), 
-                walletMode: FfiConverterTypeWalletMode.read(from: &buf), 
-                walletType: FfiConverterTypeWalletType.read(from: &buf), 
+                network: FfiConverterOptionTypeNetwork.read(from: &buf), 
+                walletMode: FfiConverterOptionTypeWalletMode.read(from: &buf), 
+                walletType: FfiConverterOptionTypeWalletType.read(from: &buf), 
                 fingerprint: FfiConverterOptionString.read(from: &buf), 
-                status: FfiConverterTypeCloudBackupWalletStatus.read(from: &buf), 
+                labelCount: FfiConverterOptionUInt32.read(from: &buf), 
+                backupUpdatedAt: FfiConverterOptionUInt64.read(from: &buf), 
+                syncStatus: FfiConverterTypeCloudBackupWalletStatus.read(from: &buf), 
                 recordId: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: CloudBackupWalletItem, into buf: inout [UInt8]) {
         FfiConverterString.write(value.name, into: &buf)
-        FfiConverterTypeNetwork.write(value.network, into: &buf)
-        FfiConverterTypeWalletMode.write(value.walletMode, into: &buf)
-        FfiConverterTypeWalletType.write(value.walletType, into: &buf)
+        FfiConverterOptionTypeNetwork.write(value.network, into: &buf)
+        FfiConverterOptionTypeWalletMode.write(value.walletMode, into: &buf)
+        FfiConverterOptionTypeWalletType.write(value.walletType, into: &buf)
         FfiConverterOptionString.write(value.fingerprint, into: &buf)
-        FfiConverterTypeCloudBackupWalletStatus.write(value.status, into: &buf)
+        FfiConverterOptionUInt32.write(value.labelCount, into: &buf)
+        FfiConverterOptionUInt64.write(value.backupUpdatedAt, into: &buf)
+        FfiConverterTypeCloudBackupWalletStatus.write(value.syncStatus, into: &buf)
         FfiConverterString.write(value.recordId, into: &buf)
     }
 }
@@ -18607,9 +18652,14 @@ public func FfiConverterTypeCloudBackupVerificationMetadata_lower(_ value: Cloud
 
 public enum CloudBackupWalletStatus: Equatable, Hashable {
     
-    case backedUp
-    case notBackedUp
+    case dirty
+    case uploading
+    case uploadedPendingConfirmation
+    case confirmed
+    case failed
     case deletedFromDevice
+    case unsupportedVersion
+    case remoteStateUnknown
 
 
 
@@ -18631,11 +18681,21 @@ public struct FfiConverterTypeCloudBackupWalletStatus: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
         
-        case 1: return .backedUp
+        case 1: return .dirty
         
-        case 2: return .notBackedUp
+        case 2: return .uploading
         
-        case 3: return .deletedFromDevice
+        case 3: return .uploadedPendingConfirmation
+        
+        case 4: return .confirmed
+        
+        case 5: return .failed
+        
+        case 6: return .deletedFromDevice
+        
+        case 7: return .unsupportedVersion
+        
+        case 8: return .remoteStateUnknown
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -18645,16 +18705,36 @@ public struct FfiConverterTypeCloudBackupWalletStatus: FfiConverterRustBuffer {
         switch value {
         
         
-        case .backedUp:
+        case .dirty:
             writeInt(&buf, Int32(1))
         
         
-        case .notBackedUp:
+        case .uploading:
             writeInt(&buf, Int32(2))
         
         
-        case .deletedFromDevice:
+        case .uploadedPendingConfirmation:
             writeInt(&buf, Int32(3))
+        
+        
+        case .confirmed:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .failed:
+            writeInt(&buf, Int32(5))
+        
+        
+        case .deletedFromDevice:
+            writeInt(&buf, Int32(6))
+        
+        
+        case .unsupportedVersion:
+            writeInt(&buf, Int32(7))
+        
+        
+        case .remoteStateUnknown:
+            writeInt(&buf, Int32(8))
         
         }
     }
@@ -18682,6 +18762,8 @@ public enum CloudOnlyOperation: Equatable, Hashable {
     
     case idle
     case operating(recordId: String
+    )
+    case warning(message: String, error: String
     )
     case failed(error: String
     )
@@ -18711,7 +18793,10 @@ public struct FfiConverterTypeCloudOnlyOperation: FfiConverterRustBuffer {
         case 2: return .operating(recordId: try FfiConverterString.read(from: &buf)
         )
         
-        case 3: return .failed(error: try FfiConverterString.read(from: &buf)
+        case 3: return .warning(message: try FfiConverterString.read(from: &buf), error: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 4: return .failed(error: try FfiConverterString.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -18731,8 +18816,14 @@ public struct FfiConverterTypeCloudOnlyOperation: FfiConverterRustBuffer {
             FfiConverterString.write(recordId, into: &buf)
             
         
-        case let .failed(error):
+        case let .warning(message,error):
             writeInt(&buf, Int32(3))
+            FfiConverterString.write(message, into: &buf)
+            FfiConverterString.write(error, into: &buf)
+            
+        
+        case let .failed(error):
+            writeInt(&buf, Int32(4))
             FfiConverterString.write(error, into: &buf)
             
         }
@@ -33237,6 +33328,78 @@ fileprivate struct FfiConverterOptionTypeTapSignerResponse: FfiConverterRustBuff
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeWalletMode: FfiConverterRustBuffer {
+    typealias SwiftType = WalletMode?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWalletMode.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWalletMode.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWalletType: FfiConverterRustBuffer {
+    typealias SwiftType = WalletType?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWalletType.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWalletType.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeNetwork: FfiConverterRustBuffer {
+    typealias SwiftType = Network?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeNetwork.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeNetwork.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionSequenceTypeUtxo: FfiConverterRustBuffer {
     typealias SwiftType = [Utxo]?
 
@@ -34987,10 +35150,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_backup_wallet_count() != 17456) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_rustcloudbackupmanager_clear_sync_error_if_no_failed_wallet_uploads() != 7150) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_current_status() != 9796) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_debug_reset_cloud_backup_state() != 45375) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustcloudbackupmanager_has_failed_wallet_uploads() != 28193) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_has_pending_cloud_upload_verification() != 4437) {
@@ -35009,6 +35178,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_resume_pending_cloud_upload_verification() != 24590) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustcloudbackupmanager_schedule_wallet_upload_follow_up() != 63751) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_state() != 8780) {

--- a/rust/crates/cove-cspp/src/backup_data.rs
+++ b/rust/crates/cove-cspp/src/backup_data.rs
@@ -56,6 +56,13 @@ pub struct WalletEntry {
     pub xpub: Option<String>,
     #[zeroize(skip)]
     pub wallet_mode: WalletMode,
+    #[serde(with = "base64_serde::option")]
+    pub labels_zstd_jsonl: Option<Vec<u8>>,
+    pub labels_count: u32,
+    pub labels_hash: Option<String>,
+    pub labels_uncompressed_size: Option<u32>,
+    pub content_revision_hash: String,
+    pub updated_at: u64,
 }
 
 /// Secret material for a wallet
@@ -153,6 +160,12 @@ mod tests {
             }),
             xpub: Some("xpub661MyMwAqRbcF...".to_string()),
             wallet_mode: WalletMode::Main,
+            labels_zstd_jsonl: Some(vec![1, 2, 3]),
+            labels_count: 2,
+            labels_hash: Some("labels-hash".to_string()),
+            labels_uncompressed_size: Some(123),
+            content_revision_hash: "content-hash".to_string(),
+            updated_at: 42,
         };
 
         let json = serde_json::to_string(&entry).unwrap();
@@ -164,6 +177,28 @@ mod tests {
         );
         assert!(decoded.descriptors.is_some());
         assert_eq!(decoded.wallet_mode, WalletMode::Main);
+        assert_eq!(decoded.labels_zstd_jsonl, Some(vec![1, 2, 3]));
+        assert_eq!(decoded.labels_count, 2);
+        assert_eq!(decoded.labels_hash.as_deref(), Some("labels-hash"));
+        assert_eq!(decoded.labels_uncompressed_size, Some(123));
+        assert_eq!(decoded.content_revision_hash, "content-hash");
+        assert_eq!(decoded.updated_at, 42);
+    }
+
+    #[test]
+    fn wallet_entry_json_rejects_missing_new_fields() {
+        let json = serde_json::json!({
+            "wallet_id": "test-wallet",
+            "secret": "WatchOnly",
+            "metadata": {"name": "Test Wallet"},
+            "descriptors": null,
+            "xpub": null,
+            "wallet_mode": "Main"
+        });
+
+        let error = serde_json::from_value::<WalletEntry>(json).unwrap_err();
+
+        assert!(error.to_string().contains("labels_zstd_jsonl"));
     }
 
     #[test]

--- a/rust/crates/cove-cspp/src/serde_helpers.rs
+++ b/rust/crates/cove-cspp/src/serde_helpers.rs
@@ -37,4 +37,29 @@ pub mod base64_serde {
         let s = String::deserialize(deserializer)?;
         BASE64_STANDARD.decode(&s).map_err(serde::de::Error::custom)
     }
+
+    pub mod option {
+        use base64::Engine as _;
+        use base64::prelude::BASE64_STANDARD;
+        use serde::{Deserialize, Deserializer, Serializer};
+
+        pub fn serialize<S>(bytes: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match bytes {
+                Some(bytes) => serializer.serialize_some(&BASE64_STANDARD.encode(bytes)),
+                None => serializer.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Option::<String>::deserialize(deserializer)?
+                .map(|encoded| BASE64_STANDARD.decode(&encoded).map_err(serde::de::Error::custom))
+                .transpose()
+        }
+    }
 }

--- a/rust/crates/cove-cspp/src/wallet_crypto.rs
+++ b/rust/crates/cove-cspp/src/wallet_crypto.rs
@@ -64,6 +64,12 @@ mod tests {
             }),
             xpub: Some("xpub661MyMwAqRbcF...".to_string()),
             wallet_mode: WalletMode::Main,
+            labels_zstd_jsonl: None,
+            labels_count: 0,
+            labels_hash: None,
+            labels_uncompressed_size: None,
+            content_revision_hash: "test-content-hash".to_string(),
+            updated_at: 42,
         }
     }
 
@@ -151,6 +157,12 @@ mod tests {
                 descriptors: None,
                 xpub: None,
                 wallet_mode: WalletMode::Decoy,
+                labels_zstd_jsonl: None,
+                labels_count: 0,
+                labels_hash: None,
+                labels_uncompressed_size: None,
+                content_revision_hash: "test-content-hash".to_string(),
+                updated_at: 42,
             };
 
             let encrypted = encrypt_wallet_entry(&entry, &critical_key).unwrap();

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -17,6 +17,7 @@ use crate::{
         client::{FIAT_CLIENT, PriceResponse},
     },
     keychain::{Keychain, KeychainError},
+    manager::cloud_backup_manager::CLOUD_BACKUP_MANAGER,
     manager::deferred_dispatch::{DeferredDispatch, Dispatchable},
     network::Network,
     node::Node,
@@ -365,7 +366,10 @@ impl FfiApp {
 
         let keychain = Keychain::global();
         match keychain.save_tap_signer_backup(&metadata.id, backup) {
-            Ok(()) => true,
+            Ok(()) => {
+                CLOUD_BACKUP_MANAGER.handle_wallet_backup_change(metadata.id.clone());
+                true
+            }
             Err(e) => {
                 error!("Failed to save tap signer backup for {}: {e}", metadata.id);
                 false

--- a/rust/src/app/alert_state.rs
+++ b/rust/src/app/alert_state.rs
@@ -111,7 +111,7 @@ impl AppAlertState {
                 "This wallet has already been imported! Taking you there now...".to_string()
             }
             Self::HotWalletKeyMissing { .. } => {
-                let base = "This wallet's private key is no longer available on this device. It has been converted to watch-only. To restore full access, import your seed words.";
+                let base = "This wallet's private key is no longer available on this device. It has been converted to watch-only. To restore full access, recover it from Cloud Backup or import your seed words.";
 
                 cfg_if::cfg_if! {
                     if #[cfg(target_os = "ios")] {

--- a/rust/src/backup.rs
+++ b/rust/src/backup.rs
@@ -1,7 +1,7 @@
 use rand::RngExt as _;
 use zeroize::Zeroizing;
 
-mod crypto;
+pub(crate) mod crypto;
 mod error;
 mod export;
 pub(crate) mod import;

--- a/rust/src/backup/import.rs
+++ b/rust/src/backup/import.rs
@@ -13,7 +13,7 @@ use crate::database::global_config::GlobalConfigKey;
 use crate::label_manager::LabelManager;
 use crate::mnemonic::MnemonicExt as _;
 use crate::wallet::fingerprint::Fingerprint;
-use crate::wallet::metadata::{WalletMetadata, WalletMode, WalletType};
+use crate::wallet::metadata::{WalletId, WalletMetadata, WalletMode, WalletType};
 
 use super::crypto;
 use super::error::BackupError;
@@ -228,6 +228,24 @@ enum RestoreSaveBehavior {
     SkipCloudBackup,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum LabelRestoreBehavior {
+    MarkCloudBackupDirty,
+    PreserveCloudBackupClean,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LabelRestoreWarning {
+    pub wallet_name: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct LabelRestoreOutcome {
+    pub imported: bool,
+    pub warning: Option<LabelRestoreWarning>,
+}
+
 async fn restore_wallet(
     backup: &WalletBackup,
     existing_fingerprints: &[(Fingerprint, Network, WalletMode)],
@@ -247,7 +265,6 @@ async fn restore_wallet(
         return Ok(RestoreResult::Skipped { name });
     }
 
-    let mut labels_imported = false;
     let mut labels_failure: Option<(String, String)> = None;
     let mut degraded = cold_missing_backup;
     let fingerprint = metadata
@@ -279,16 +296,16 @@ async fn restore_wallet(
         }
     }
 
-    if let Some(jsonl) = &backup.labels_jsonl
-        && !jsonl.is_empty()
-    {
-        match import_labels(&wallet_id, jsonl) {
-            Ok(()) => labels_imported = true,
-            Err(e) => {
-                warn!("Failed to import labels for wallet {name}: {e}");
-                labels_failure = Some((name.clone(), e.to_string()));
-            }
-        }
+    let labels_outcome = restore_wallet_labels(
+        &wallet_id,
+        &name,
+        backup.labels_jsonl.as_deref(),
+        LabelRestoreBehavior::MarkCloudBackupDirty,
+    );
+    let labels_imported = labels_outcome.imported;
+    if let Some(warning) = labels_outcome.warning {
+        warn!("Failed to import labels for wallet {name}: {}", warning.error);
+        labels_failure = Some((warning.wallet_name, warning.error));
     }
 
     Ok(RestoreResult::Imported { name, labels_imported, labels_failure, fingerprint, degraded })
@@ -505,9 +522,39 @@ pub(crate) fn cleanup_failed_wallet(metadata: &WalletMetadata) -> Vec<String> {
     failures
 }
 
-fn import_labels(id: &cove_types::WalletId, jsonl: &str) -> Result<(), BackupError> {
+fn import_labels(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
     let manager = LabelManager::new(id.clone());
     manager.import(jsonl).map_err(|e| BackupError::Restore(e.to_string()))
+}
+
+pub(crate) fn restore_wallet_labels(
+    wallet_id: &WalletId,
+    wallet_name: &str,
+    labels_jsonl: Option<&str>,
+    behavior: LabelRestoreBehavior,
+) -> LabelRestoreOutcome {
+    let Some(jsonl) = labels_jsonl.filter(|jsonl| !jsonl.is_empty()) else {
+        return LabelRestoreOutcome::default();
+    };
+
+    let manager = LabelManager::new(wallet_id.clone());
+    let import_result = match behavior {
+        LabelRestoreBehavior::MarkCloudBackupDirty => import_labels(wallet_id, jsonl),
+        LabelRestoreBehavior::PreserveCloudBackupClean => manager
+            .import_without_cloud_backup_dirty(jsonl)
+            .map_err(|error| BackupError::Restore(error.to_string())),
+    };
+
+    match import_result {
+        Ok(()) => LabelRestoreOutcome { imported: true, warning: None },
+        Err(error) => LabelRestoreOutcome {
+            imported: false,
+            warning: Some(LabelRestoreWarning {
+                wallet_name: wallet_name.to_string(),
+                error: error.to_string(),
+            }),
+        },
+    }
 }
 
 fn restore_settings(settings: &super::model::AppSettings) -> Result<(), BackupError> {

--- a/rust/src/database.rs
+++ b/rust/src/database.rs
@@ -21,7 +21,7 @@ use cove_util::result_ext::ResultExt as _;
 use std::{path::PathBuf, sync::Arc};
 
 use arc_swap::ArcSwap;
-use cloud_backup::{CloudBackupStateTable, CloudUploadQueueTable};
+use cloud_backup::{CloudBackupStateTable, CloudBlobSyncStateTable};
 use global_cache::GlobalCacheTable;
 use global_config::GlobalConfigTable;
 use global_flag::GlobalFlagTable;
@@ -46,7 +46,7 @@ pub struct Database {
     pub global_config: GlobalConfigTable,
     pub global_cache: GlobalCacheTable,
     pub cloud_backup_state: CloudBackupStateTable,
-    pub cloud_upload_queue: CloudUploadQueueTable,
+    pub cloud_blob_sync_states: CloudBlobSyncStateTable,
     pub wallets: WalletsTable,
     pub unsigned_transactions: UnsignedTransactionsTable,
     pub historical_prices: HistoricalPriceTable,
@@ -132,7 +132,7 @@ impl Database {
         let global_config = GlobalConfigTable::new(main_db_arc.clone(), &write_txn);
         let global_cache = GlobalCacheTable::new(main_db_arc.clone(), &write_txn);
         let cloud_backup_state = CloudBackupStateTable::new(main_db_arc.clone(), &write_txn);
-        let cloud_upload_queue = CloudUploadQueueTable::new(main_db_arc.clone(), &write_txn);
+        let cloud_blob_sync_states = CloudBlobSyncStateTable::new(main_db_arc.clone(), &write_txn);
         let unsigned_transactions = UnsignedTransactionsTable::new(main_db_arc.clone(), &write_txn);
         let historical_prices = HistoricalPriceTable::new(main_db_arc.clone(), &write_txn);
 
@@ -143,7 +143,7 @@ impl Database {
             global_config,
             global_cache,
             cloud_backup_state,
-            cloud_upload_queue,
+            cloud_blob_sync_states,
             wallets,
             unsigned_transactions,
             historical_prices,

--- a/rust/src/database/cloud_backup.rs
+++ b/rust/src/database/cloud_backup.rs
@@ -1,19 +1,22 @@
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
-use redb::TableDefinition;
+use redb::{ReadableTable as _, TableDefinition};
 use serde::{Deserialize, Serialize};
 
 use cove_types::redb::Json;
 use cove_util::result_ext::ResultExt as _;
 
 use super::Error;
+use crate::wallet::metadata::WalletId;
 
 const CURRENT_KEY: &str = "current";
 
-pub const CLOUD_BACKUP_STATE_TABLE: TableDefinition<&'static str, Json<PersistedCloudBackupState>> =
+const CLOUD_BACKUP_STATE_TABLE: TableDefinition<&'static str, Json<PersistedCloudBackupState>> =
     TableDefinition::new("cloud_backup_state");
-pub const CLOUD_UPLOAD_QUEUE_TABLE: TableDefinition<&'static str, Json<PendingCloudUploadQueue>> =
-    TableDefinition::new("cloud_upload_queue");
+const CLOUD_BLOB_SYNC_STATE_TABLE: TableDefinition<
+    &'static str,
+    Json<PersistedCloudBlobSyncState>,
+> = TableDefinition::new("cloud_blob_sync_state");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PersistedCloudBackupStatus {
@@ -36,6 +39,8 @@ pub struct PersistedCloudBackupState {
     pub last_verification_requested_at: Option<u64>,
     #[serde(default)]
     pub last_verification_dismissed_at: Option<u64>,
+    #[serde(default)]
+    pub pending_verification_completion: Option<PersistedPendingVerificationCompletion>,
 }
 
 impl Default for PersistedCloudBackupState {
@@ -47,6 +52,7 @@ impl Default for PersistedCloudBackupState {
             last_verified_at: None,
             last_verification_requested_at: None,
             last_verification_dismissed_at: None,
+            pending_verification_completion: None,
         }
     }
 }
@@ -92,95 +98,94 @@ impl PersistedCloudBackupState {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedPendingVerificationCompletion {
+    pub report: PersistedDeepVerificationReport,
+    pub namespace_id: String,
+    pub uploads: Vec<PersistedPendingVerificationUpload>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedDeepVerificationReport {
+    pub master_key_wrapper_repaired: bool,
+    pub local_master_key_repaired: bool,
+    pub credential_recovered: bool,
+    pub wallets_verified: u32,
+    pub wallets_failed: u32,
+    pub wallets_unsupported: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedPendingVerificationUpload {
+    pub record_id: String,
+    pub expected_revision: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CloudUploadKind {
     BackupBlob,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CloudUploadVerificationState {
-    Pending {
-        attempt_count: u32,
-        #[serde(default)]
-        last_checked_at: Option<u64>,
-    },
-    Confirmed(u64),
+pub struct PersistedCloudBlobSyncState {
+    pub kind: CloudUploadKind,
+    pub namespace_id: String,
+    pub wallet_id: Option<WalletId>,
+    pub record_id: String,
+    pub state: PersistedCloudBlobState,
+}
+
+impl PersistedCloudBlobSyncState {
+    pub fn is_dirty(&self) -> bool {
+        matches!(self.state, PersistedCloudBlobState::Dirty(_))
+    }
+
+    pub fn is_uploaded_pending_confirmation(&self) -> bool {
+        matches!(self.state, PersistedCloudBlobState::UploadedPendingConfirmation(_))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PendingCloudUploadItem {
-    pub kind: CloudUploadKind,
-    pub namespace_id: String,
-    pub record_id: String,
-    pub enqueued_at: u64,
-    /// Keeps confirmed blobs until the cloud listing catches up
-    pub verification: CloudUploadVerificationState,
+pub enum PersistedCloudBlobState {
+    Dirty(CloudBlobDirtyState),
+    Uploading(CloudBlobUploadingState),
+    UploadedPendingConfirmation(CloudBlobUploadedPendingConfirmationState),
+    Confirmed(CloudBlobConfirmedState),
+    Failed(CloudBlobFailedState),
 }
 
-impl PendingCloudUploadItem {
-    pub fn is_confirmed(&self) -> bool {
-        matches!(self.verification, CloudUploadVerificationState::Confirmed(_))
-    }
-
-    pub fn confirmed_at(&self) -> Option<u64> {
-        match self.verification {
-            CloudUploadVerificationState::Confirmed(confirmed_at) => Some(confirmed_at),
-            CloudUploadVerificationState::Pending { .. } => None,
-        }
-    }
-
-    pub fn last_checked_at(&self) -> Option<u64> {
-        match self.verification {
-            CloudUploadVerificationState::Pending { last_checked_at, .. } => last_checked_at,
-            CloudUploadVerificationState::Confirmed(_) => None,
-        }
-    }
-
-    pub fn attempt_count(&self) -> u32 {
-        match self.verification {
-            CloudUploadVerificationState::Pending { attempt_count, .. } => attempt_count,
-            CloudUploadVerificationState::Confirmed(_) => 0,
-        }
-    }
-
-    pub fn confirm(&mut self, confirmed_at: u64) {
-        self.verification = CloudUploadVerificationState::Confirmed(confirmed_at);
-    }
-
-    pub fn mark_checked(&mut self, checked_at: u64) {
-        if let CloudUploadVerificationState::Pending { attempt_count, last_checked_at } =
-            &mut self.verification
-        {
-            *attempt_count += 1;
-            *last_checked_at = Some(checked_at);
-        }
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudBlobDirtyState {
+    pub changed_at: u64,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PendingCloudUploadQueue {
-    pub items: Vec<PendingCloudUploadItem>,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudBlobUploadingState {
+    pub revision_hash: String,
+    pub started_at: u64,
 }
 
-impl PendingCloudUploadQueue {
-    pub fn has_unconfirmed(&self) -> bool {
-        self.items.iter().any(|item| !item.is_confirmed())
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudBlobUploadedPendingConfirmationState {
+    pub revision_hash: String,
+    pub uploaded_at: u64,
+    pub attempt_count: u32,
+    pub last_checked_at: Option<u64>,
+}
 
-    pub fn cleanup_listed(
-        &mut self,
-        kind: CloudUploadKind,
-        namespace_id: &str,
-        listed_ids: &HashSet<String>,
-    ) {
-        self.items.retain(|item| {
-            if item.kind != kind || item.namespace_id != namespace_id {
-                return true;
-            }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudBlobConfirmedState {
+    pub revision_hash: String,
+    pub confirmed_at: u64,
+}
 
-            !item.is_confirmed() || !listed_ids.contains(&item.record_id)
-        });
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudBlobFailedState {
+    pub revision_hash: Option<String>,
+    #[serde(default)]
+    pub retryable: bool,
+    pub error: String,
+    pub failed_at: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -239,34 +244,50 @@ impl CloudBackupStateTable {
 }
 
 #[derive(Debug, Clone)]
-pub struct CloudUploadQueueTable {
+pub struct CloudBlobSyncStateTable {
     db: Arc<redb::Database>,
 }
 
-impl CloudUploadQueueTable {
+impl CloudBlobSyncStateTable {
     pub fn new(db: Arc<redb::Database>, write_txn: &redb::WriteTransaction) -> Self {
         write_txn
-            .open_table(CLOUD_UPLOAD_QUEUE_TABLE)
-            .expect("failed to create cloud upload queue table");
+            .open_table(CLOUD_BLOB_SYNC_STATE_TABLE)
+            .expect("failed to create cloud blob sync state table");
 
         Self { db }
     }
 
-    pub fn get(&self) -> Result<Option<PendingCloudUploadQueue>, Error> {
+    pub fn get(&self, record_id: &str) -> Result<Option<PersistedCloudBlobSyncState>, Error> {
         let read_txn = self.db.begin_read().map_err_str(Error::DatabaseAccess)?;
         let table =
-            read_txn.open_table(CLOUD_UPLOAD_QUEUE_TABLE).map_err_str(Error::TableAccess)?;
+            read_txn.open_table(CLOUD_BLOB_SYNC_STATE_TABLE).map_err_str(Error::TableAccess)?;
 
-        Ok(table.get(CURRENT_KEY).map_err_str(Error::TableAccess)?.map(|value| value.value()))
+        Ok(table.get(record_id).map_err_str(Error::TableAccess)?.map(|value| value.value()))
     }
 
-    pub fn set(&self, value: &PendingCloudUploadQueue) -> Result<(), Error> {
+    pub fn list(&self) -> Result<Vec<PersistedCloudBlobSyncState>, Error> {
+        let read_txn = self.db.begin_read().map_err_str(Error::DatabaseAccess)?;
+        let table =
+            read_txn.open_table(CLOUD_BLOB_SYNC_STATE_TABLE).map_err_str(Error::TableAccess)?;
+
+        let mut states = Vec::new();
+        let iter = table.iter().map_err_str(Error::TableAccess)?;
+        for entry in iter {
+            let (_, value) = entry.map_err_str(Error::TableAccess)?;
+            states.push(value.value());
+        }
+
+        Ok(states)
+    }
+
+    pub fn set(&self, value: &PersistedCloudBlobSyncState) -> Result<(), Error> {
         let write_txn = self.db.begin_write().map_err_str(Error::DatabaseAccess)?;
 
         {
-            let mut table =
-                write_txn.open_table(CLOUD_UPLOAD_QUEUE_TABLE).map_err_str(Error::TableAccess)?;
-            table.insert(CURRENT_KEY, value).map_err_str(Error::TableAccess)?;
+            let mut table = write_txn
+                .open_table(CLOUD_BLOB_SYNC_STATE_TABLE)
+                .map_err_str(Error::TableAccess)?;
+            table.insert(value.record_id.as_str(), value).map_err_str(Error::TableAccess)?;
         }
 
         write_txn.commit().map_err_str(Error::DatabaseAccess)?;
@@ -274,13 +295,73 @@ impl CloudUploadQueueTable {
         Ok(())
     }
 
-    pub fn delete(&self) -> Result<(), Error> {
+    pub fn set_if_current(
+        &self,
+        current: &PersistedCloudBlobSyncState,
+        next: &PersistedCloudBlobSyncState,
+    ) -> Result<bool, Error> {
+        debug_assert_eq!(current.record_id, next.record_id);
+
         let write_txn = self.db.begin_write().map_err_str(Error::DatabaseAccess)?;
 
         {
-            let mut table =
-                write_txn.open_table(CLOUD_UPLOAD_QUEUE_TABLE).map_err_str(Error::TableAccess)?;
-            table.remove(CURRENT_KEY).map_err_str(Error::TableAccess)?;
+            let mut table = write_txn
+                .open_table(CLOUD_BLOB_SYNC_STATE_TABLE)
+                .map_err_str(Error::TableAccess)?;
+
+            let matches_current = table
+                .get(current.record_id.as_str())
+                .map_err_str(Error::TableAccess)?
+                .map(|stored| stored.value() == *current)
+                .unwrap_or(false);
+
+            if !matches_current {
+                return Ok(false);
+            }
+
+            table.insert(next.record_id.as_str(), next).map_err_str(Error::TableAccess)?;
+        }
+        write_txn.commit().map_err_str(Error::DatabaseAccess)?;
+
+        Ok(true)
+    }
+
+    pub fn delete(&self, record_id: &str) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err_str(Error::DatabaseAccess)?;
+
+        {
+            let mut table = write_txn
+                .open_table(CLOUD_BLOB_SYNC_STATE_TABLE)
+                .map_err_str(Error::TableAccess)?;
+            table.remove(record_id).map_err_str(Error::TableAccess)?;
+        }
+
+        write_txn.commit().map_err_str(Error::DatabaseAccess)?;
+
+        Ok(())
+    }
+
+    pub fn delete_all(&self) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err_str(Error::DatabaseAccess)?;
+
+        {
+            let mut table = write_txn
+                .open_table(CLOUD_BLOB_SYNC_STATE_TABLE)
+                .map_err_str(Error::TableAccess)?;
+            // collect keys before removal because redb iterators borrow table from write_txn,
+            // so CLOUD_BLOB_SYNC_STATE_TABLE cannot be mutated while iterating
+            let keys = table
+                .iter()
+                .map_err_str(Error::TableAccess)?
+                .map(|entry| {
+                    let (key, _) = entry.map_err_str(Error::TableAccess)?;
+                    Ok(key.value().to_string())
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            for key in keys {
+                table.remove(key.as_str()).map_err_str(Error::TableAccess)?;
+            }
         }
 
         write_txn.commit().map_err_str(Error::DatabaseAccess)?;
@@ -318,82 +399,57 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_listed_only_removes_confirmed_matching_items() {
-        let mut queue = PendingCloudUploadQueue {
-            items: vec![
-                PendingCloudUploadItem {
-                    kind: CloudUploadKind::BackupBlob,
-                    namespace_id: "ns-1".into(),
-                    record_id: "wallet-a".into(),
-                    enqueued_at: 10,
-                    verification: CloudUploadVerificationState::Confirmed(12),
-                },
-                PendingCloudUploadItem {
-                    kind: CloudUploadKind::BackupBlob,
-                    namespace_id: "ns-1".into(),
-                    record_id: "wallet-b".into(),
-                    enqueued_at: 11,
-                    verification: CloudUploadVerificationState::Pending {
-                        attempt_count: 0,
-                        last_checked_at: None,
-                    },
-                },
-            ],
+    fn blob_sync_state_helpers_reflect_state() {
+        let confirmed = PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id: "ns-1".into(),
+            wallet_id: None,
+            record_id: "wallet-a".into(),
+            state: PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
+                revision_hash: "rev-1".into(),
+                confirmed_at: 42,
+            }),
         };
 
-        queue.cleanup_listed(
-            CloudUploadKind::BackupBlob,
-            "ns-1",
-            &HashSet::from([String::from("wallet-a")]),
-        );
+        assert!(!confirmed.is_dirty());
 
-        assert_eq!(queue.items.len(), 1);
-        assert_eq!(queue.items[0].record_id, "wallet-b");
+        let dirty = PersistedCloudBlobSyncState {
+            state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at: 10 }),
+            ..confirmed.clone()
+        };
+
+        assert!(dirty.is_dirty());
     }
 
     #[test]
-    fn pending_upload_item_helpers_reflect_pending_state() {
-        let mut item = PendingCloudUploadItem {
+    fn uploaded_pending_confirmation_tracks_attempts() {
+        let state = PersistedCloudBlobSyncState {
             kind: CloudUploadKind::BackupBlob,
             namespace_id: "ns-1".into(),
+            wallet_id: None,
             record_id: "wallet-a".into(),
-            enqueued_at: 10,
-            verification: CloudUploadVerificationState::Pending {
-                attempt_count: 1,
-                last_checked_at: Some(12),
-            },
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: 3,
+                    last_checked_at: Some(12),
+                },
+            ),
         };
 
-        assert!(!item.is_confirmed());
-        assert_eq!(item.confirmed_at(), None);
-        assert_eq!(item.last_checked_at(), Some(12));
-        assert_eq!(item.attempt_count(), 1);
-
-        item.mark_checked(20);
-
-        assert_eq!(item.last_checked_at(), Some(20));
-        assert_eq!(item.attempt_count(), 2);
+        assert!(state.is_uploaded_pending_confirmation());
     }
 
     #[test]
-    fn pending_upload_item_helpers_reflect_confirmed_state() {
-        let mut item = PendingCloudUploadItem {
-            kind: CloudUploadKind::BackupBlob,
-            namespace_id: "ns-1".into(),
-            record_id: "wallet-a".into(),
-            enqueued_at: 10,
-            verification: CloudUploadVerificationState::Confirmed(12),
-        };
+    fn failed_blob_state_defaults_retryable_to_false() {
+        let failed_state: CloudBlobFailedState = serde_json::from_value(serde_json::json!({
+            "revision_hash": "rev-1",
+            "error": "offline",
+            "failed_at": 42
+        }))
+        .unwrap();
 
-        assert!(item.is_confirmed());
-        assert_eq!(item.confirmed_at(), Some(12));
-        assert_eq!(item.last_checked_at(), None);
-        assert_eq!(item.attempt_count(), 0);
-
-        item.mark_checked(20);
-
-        assert_eq!(item.confirmed_at(), Some(12));
-        assert_eq!(item.last_checked_at(), None);
-        assert_eq!(item.attempt_count(), 0);
+        assert!(!failed_state.retryable);
     }
 }

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -4,6 +4,7 @@ use cove_util::result_ext::ResultExt as _;
 
 use crate::{
     database::{InsertOrUpdate, Record, record::Timestamps, wallet_data::WalletDataDb},
+    manager::cloud_backup_manager::CLOUD_BACKUP_MANAGER,
     multi_format::Bip329Labels,
     transaction::{TransactionDetails, TransactionDirection},
     wallet::{Address, metadata::WalletId},
@@ -165,11 +166,14 @@ impl LabelManager {
                 .insert_labels_with_timestamps(output_labels, timestamps)
                 .map_err_str(LabelManagerError::SaveOutputLabels)?;
 
+            self.mark_cloud_backup_dirty();
+
             return Ok(());
         }
 
         // UPDATE
         self.update_labels_for_txn(&tx_id, input_records_iter, output_records_iter)?;
+        self.mark_cloud_backup_dirty();
 
         Ok(())
     }
@@ -221,6 +225,8 @@ impl LabelManager {
             .delete_labels(labels_to_delete)
             .map_err_str(LabelManagerError::DeleteLabels)?;
 
+        self.mark_cloud_backup_dirty();
+
         Ok(())
     }
 
@@ -231,9 +237,7 @@ impl LabelManager {
     }
 
     pub fn import(&self, jsonl: &str) -> Result<(), LabelManagerError> {
-        let labels = Labels::try_from_str(jsonl).map_err_str(LabelManagerError::Parse)?;
-
-        self.import_labels(labels)
+        self.save_imported_labels(parse_labels(jsonl)?, true)
     }
 
     pub async fn export(&self) -> Result<String, LabelManagerError> {
@@ -298,11 +302,36 @@ impl LabelManager {
     }
 
     pub fn import_labels(&self, labels: impl Into<Labels>) -> Result<(), LabelManagerError> {
-        let labels = labels.into();
+        self.save_imported_labels(labels.into(), true)
+    }
 
+    pub(crate) fn export_blocking(&self) -> Result<String, LabelManagerError> {
+        let labels = self.db.labels.all_labels().map_err_str(LabelManagerError::Get)?;
+        labels.export().map_err_str(LabelManagerError::Export)
+    }
+
+    pub(crate) fn import_without_cloud_backup_dirty(
+        &self,
+        jsonl: &str,
+    ) -> Result<(), LabelManagerError> {
+        self.save_imported_labels(parse_labels(jsonl)?, false)
+    }
+
+    fn save_imported_labels(
+        &self,
+        labels: Labels,
+        mark_cloud_backup_dirty: bool,
+    ) -> Result<(), LabelManagerError> {
         self.db.labels.insert_labels(labels).map_err_str(LabelManagerError::Save)?;
+        if mark_cloud_backup_dirty {
+            self.mark_cloud_backup_dirty();
+        }
 
         Ok(())
+    }
+
+    fn mark_cloud_backup_dirty(&self) {
+        CLOUD_BACKUP_MANAGER.handle_wallet_backup_change(self.db.id.clone());
     }
 
     fn update_labels_for_txn(
@@ -500,4 +529,8 @@ impl LabelManager {
             })
             .collect()
     }
+}
+
+fn parse_labels(jsonl: &str) -> Result<Labels, LabelManagerError> {
+    Labels::try_from_str(jsonl).map_err_str(LabelManagerError::Parse)
 }

--- a/rust/src/manager/cloud_backup_detail_manager.rs
+++ b/rust/src/manager/cloud_backup_detail_manager.rs
@@ -1,9 +1,10 @@
+use act_zero::send;
 use tracing::error;
 
 use super::cloud_backup_manager::{
     CLOUD_BACKUP_MANAGER, CloudBackupError, CloudBackupManagerAction, CloudBackupReconcileMessage,
     CloudBackupWalletItem, DeepVerificationFailure, DeepVerificationReport, DeepVerificationResult,
-    RustCloudBackupManager,
+    RustCloudBackupManager, runtime_actor::CloudBackupOperation,
 };
 
 type Action = CloudBackupManagerAction;
@@ -118,40 +119,43 @@ impl RustCloudBackupManager {
     }
 
     fn spawn_verification(self: std::sync::Arc<Self>, force_discoverable: bool) {
-        cove_tokio::task::spawn_blocking(move || {
-            self.handle_start_verification(force_discoverable)
-        });
+        let operation = CloudBackupOperation::Verification { force_discoverable };
+        send!(self.runtime.start_operation(operation, None));
     }
 
     fn spawn_recovery(self: std::sync::Arc<Self>, action: RecoveryAction) {
-        cove_tokio::task::spawn_blocking(move || self.handle_recovery(action));
+        let operation = CloudBackupOperation::Recovery { action };
+        send!(self.runtime.start_operation(operation, None));
     }
 
     fn spawn_repair_passkey(self: std::sync::Arc<Self>, no_discovery: bool) {
-        cove_tokio::task::spawn_blocking(move || self.handle_repair_passkey(no_discovery));
+        let operation = CloudBackupOperation::RepairPasskey { no_discovery };
+        send!(self.runtime.start_operation(operation, None));
     }
 
     fn spawn_sync(self: std::sync::Arc<Self>) {
-        cove_tokio::task::spawn_blocking(move || self.handle_sync());
+        send!(self.runtime.start_operation(CloudBackupOperation::Sync, None));
     }
 
     fn spawn_fetch_cloud_only(self: std::sync::Arc<Self>) {
-        cove_tokio::task::spawn_blocking(move || self.handle_fetch_cloud_only());
+        send!(self.runtime.start_operation(CloudBackupOperation::FetchCloudOnly, None));
     }
 
     fn spawn_restore_cloud_wallet(self: std::sync::Arc<Self>, record_id: String) {
-        cove_tokio::task::spawn_blocking(move || self.handle_restore_cloud_wallet(&record_id));
+        let operation = CloudBackupOperation::RestoreCloudWallet;
+        send!(self.runtime.start_operation(operation, Some(record_id)));
     }
 
     fn spawn_delete_cloud_wallet(self: std::sync::Arc<Self>, record_id: String) {
-        cove_tokio::task::spawn_blocking(move || self.handle_delete_cloud_wallet(&record_id));
+        let operation = CloudBackupOperation::DeleteCloudWallet;
+        send!(self.runtime.start_operation(operation, Some(record_id)));
     }
 
     fn spawn_refresh_detail(self: std::sync::Arc<Self>) {
-        cove_tokio::task::spawn_blocking(move || self.handle_refresh_detail());
+        send!(self.runtime.start_operation(CloudBackupOperation::RefreshDetail, None));
     }
 
-    fn handle_start_verification(&self, force_discoverable: bool) {
+    pub(crate) fn handle_start_verification(&self, force_discoverable: bool) {
         self.clear_pending_verification_completion();
         self.set_verification(VerificationState::Verifying);
 
@@ -195,7 +199,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_recovery(&self, action: RecoveryAction) {
+    pub(crate) fn handle_recovery(&self, action: RecoveryAction) {
         self.set_recovery(RecoveryState::Recovering(action.clone()));
 
         let result = match &action {
@@ -221,7 +225,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_repair_passkey(&self, no_discovery: bool) {
+    pub(crate) fn handle_repair_passkey(&self, no_discovery: bool) {
         self.set_recovery(RecoveryState::Recovering(RecoveryAction::RepairPasskey));
 
         let result = if no_discovery {
@@ -262,7 +266,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_sync(&self) {
+    pub(crate) fn handle_sync(&self) {
         self.set_sync(SyncState::Syncing);
 
         match self.do_sync_unsynced_wallets() {
@@ -276,7 +280,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_fetch_cloud_only(&self) {
+    pub(crate) fn handle_fetch_cloud_only(&self) {
         self.set_cloud_only(CloudOnlyState::Loading);
         self.set_cloud_only_operation(CloudOnlyOperation::Idle);
 
@@ -291,7 +295,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_restore_cloud_wallet(&self, record_id: &str) {
+    pub(crate) fn handle_restore_cloud_wallet(&self, record_id: &str) {
         self.set_cloud_only_operation(CloudOnlyOperation::Operating {
             record_id: record_id.to_string(),
         });
@@ -325,7 +329,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_delete_cloud_wallet(&self, record_id: &str) {
+    pub(crate) fn handle_delete_cloud_wallet(&self, record_id: &str) {
         self.set_cloud_only_operation(CloudOnlyOperation::Operating {
             record_id: record_id.to_string(),
         });
@@ -349,7 +353,7 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn handle_refresh_detail(&self) {
+    pub(crate) fn handle_refresh_detail(&self) {
         if let Some(result) = self.refresh_cloud_backup_detail() {
             match result {
                 super::cloud_backup_manager::CloudBackupDetailResult::Success(detail) => {

--- a/rust/src/manager/cloud_backup_detail_manager.rs
+++ b/rust/src/manager/cloud_backup_detail_manager.rs
@@ -51,6 +51,7 @@ pub enum CloudOnlyState {
 pub enum CloudOnlyOperation {
     Idle,
     Operating { record_id: String },
+    Warning { message: String, error: String },
     Failed { error: String },
 }
 
@@ -296,8 +297,18 @@ impl RustCloudBackupManager {
         });
 
         match self.do_restore_cloud_wallet(record_id) {
-            Ok(()) => {
-                self.set_cloud_only_operation(CloudOnlyOperation::Idle);
+            Ok(outcome) => {
+                if let Some(warning) = outcome.labels_warning {
+                    self.set_cloud_only_operation(CloudOnlyOperation::Warning {
+                        message: format!(
+                            "{} was restored, but its labels could not be imported",
+                            warning.wallet_name
+                        ),
+                        error: warning.error,
+                    });
+                } else {
+                    self.set_cloud_only_operation(CloudOnlyOperation::Idle);
+                }
 
                 let mut cloud_only = self.state.read().cloud_only.clone();
                 if let CloudOnlyState::Loaded { wallets } = &mut cloud_only {

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -9,9 +9,15 @@ use std::sync::{
     Arc, LazyLock,
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use cove_cspp::CsppStore as _;
-use cove_cspp::backup_data::MASTER_KEY_RECORD_ID;
+use cove_cspp::backup_data::{MASTER_KEY_RECORD_ID, wallet_record_id};
+use cove_device::cloud_storage::CloudStorage;
+use cove_tokio::DebouncedTask;
 use cove_util::ResultExt as _;
 use flume::{Receiver, Sender};
 use parking_lot::{Mutex, RwLock};
@@ -24,12 +30,21 @@ use cove_device::keychain::{
 };
 use cove_types::network::Network;
 
-use crate::backup::model::DescriptorPair as LocalDescriptorPair;
 use crate::database::Database;
-use crate::database::cloud_backup::{PersistedCloudBackupState, PersistedCloudBackupStatus};
-use crate::wallet::metadata::{WalletId, WalletMode as LocalWalletMode, WalletType};
+use crate::database::cloud_backup::{
+    CloudBlobDirtyState, CloudUploadKind, PersistedCloudBackupState, PersistedCloudBackupStatus,
+    PersistedCloudBlobState, PersistedCloudBlobSyncState, PersistedDeepVerificationReport,
+    PersistedPendingVerificationCompletion, PersistedPendingVerificationUpload,
+};
+use crate::wallet::metadata::{
+    WalletId, WalletMetadata, WalletMode as LocalWalletMode, WalletType,
+};
 
-use self::wallets::{UnpersistedPrfKey, all_local_wallets, count_all_wallets};
+use self::cloud_inventory::RemoteWalletTruth;
+use self::wallets::wallet_metadata_change_requires_upload;
+use self::wallets::{
+    UnpersistedPrfKey, WalletBackupLookup, WalletBackupReader, all_local_wallets, count_all_wallets,
+};
 use super::cloud_backup_detail_manager::{
     CloudOnlyOperation, CloudOnlyState, RecoveryState, SyncState, VerificationState,
 };
@@ -100,6 +115,8 @@ pub struct CloudBackupRestoreReport {
     pub wallets_restored: u32,
     pub wallets_failed: u32,
     pub failed_wallet_errors: Vec<String>,
+    pub labels_failed_wallet_names: Vec<String>,
+    pub labels_failed_errors: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, uniffi::Record)]
@@ -124,19 +141,26 @@ pub struct CloudBackupRestoreProgress {
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
 pub enum CloudBackupWalletStatus {
-    BackedUp,
-    NotBackedUp,
+    Dirty,
+    Uploading,
+    UploadedPendingConfirmation,
+    Confirmed,
+    Failed,
     DeletedFromDevice,
+    UnsupportedVersion,
+    RemoteStateUnknown,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Record)]
 pub struct CloudBackupWalletItem {
     pub name: String,
-    pub network: Network,
-    pub wallet_mode: LocalWalletMode,
-    pub wallet_type: WalletType,
+    pub network: Option<Network>,
+    pub wallet_mode: Option<LocalWalletMode>,
+    pub wallet_type: Option<WalletType>,
     pub fingerprint: Option<String>,
-    pub status: CloudBackupWalletStatus,
+    pub label_count: Option<u32>,
+    pub backup_updated_at: Option<u64>,
+    pub sync_status: CloudBackupWalletStatus,
     /// Deterministic cloud record ID for the wallet backup represented by this item
     pub record_id: String,
 }
@@ -150,8 +174,8 @@ pub enum CloudBackupDetailResult {
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
 pub struct CloudBackupDetail {
     pub last_sync: Option<u64>,
-    pub backed_up: Vec<CloudBackupWalletItem>,
-    pub not_backed_up: Vec<CloudBackupWalletItem>,
+    pub up_to_date: Vec<CloudBackupWalletItem>,
+    pub needs_sync: Vec<CloudBackupWalletItem>,
     /// Number of wallets in the cloud that aren't on this device
     pub cloud_only_count: u32,
 }
@@ -258,7 +282,13 @@ pub(crate) struct PendingEnableSession {
 pub(crate) struct PendingVerificationCompletion {
     report: DeepVerificationReport,
     namespace_id: String,
-    record_ids: Vec<String>,
+    uploads: Vec<PendingVerificationUpload>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PendingVerificationUpload {
+    record_id: String,
+    expected_revision: String,
 }
 
 impl std::fmt::Debug for PendingEnableSession {
@@ -280,8 +310,12 @@ impl PendingEnableSession {
 }
 
 impl PendingVerificationCompletion {
-    fn new(report: DeepVerificationReport, namespace_id: String, record_ids: Vec<String>) -> Self {
-        Self { report, namespace_id, record_ids }
+    fn new(
+        report: DeepVerificationReport,
+        namespace_id: String,
+        uploads: Vec<PendingVerificationUpload>,
+    ) -> Self {
+        Self { report, namespace_id, uploads }
     }
 
     pub(crate) fn report(&self) -> &DeepVerificationReport {
@@ -292,8 +326,82 @@ impl PendingVerificationCompletion {
         &self.namespace_id
     }
 
-    pub(crate) fn record_ids(&self) -> &[String] {
-        &self.record_ids
+    pub(crate) fn uploads(&self) -> &[PendingVerificationUpload] {
+        &self.uploads
+    }
+
+    fn persisted(&self) -> PersistedPendingVerificationCompletion {
+        PersistedPendingVerificationCompletion {
+            report: PersistedDeepVerificationReport::from(&self.report),
+            namespace_id: self.namespace_id.clone(),
+            uploads: self.uploads.iter().map(PersistedPendingVerificationUpload::from).collect(),
+        }
+    }
+
+    fn from_persisted(completion: PersistedPendingVerificationCompletion) -> Self {
+        Self {
+            report: DeepVerificationReport::from(completion.report),
+            namespace_id: completion.namespace_id,
+            uploads: completion
+                .uploads
+                .into_iter()
+                .map(PendingVerificationUpload::from_persisted)
+                .collect(),
+        }
+    }
+}
+
+impl PendingVerificationUpload {
+    pub(crate) fn new(record_id: String, expected_revision: String) -> Self {
+        Self { record_id, expected_revision }
+    }
+
+    pub(crate) fn record_id(&self) -> &str {
+        &self.record_id
+    }
+
+    pub(crate) fn expected_revision(&self) -> &str {
+        &self.expected_revision
+    }
+
+    fn from_persisted(upload: PersistedPendingVerificationUpload) -> Self {
+        Self { record_id: upload.record_id, expected_revision: upload.expected_revision }
+    }
+}
+
+impl DeepVerificationReport {
+    fn from(report: PersistedDeepVerificationReport) -> Self {
+        Self {
+            master_key_wrapper_repaired: report.master_key_wrapper_repaired,
+            local_master_key_repaired: report.local_master_key_repaired,
+            credential_recovered: report.credential_recovered,
+            wallets_verified: report.wallets_verified,
+            wallets_failed: report.wallets_failed,
+            wallets_unsupported: report.wallets_unsupported,
+            detail: None,
+        }
+    }
+}
+
+impl From<&DeepVerificationReport> for PersistedDeepVerificationReport {
+    fn from(report: &DeepVerificationReport) -> Self {
+        Self {
+            master_key_wrapper_repaired: report.master_key_wrapper_repaired,
+            local_master_key_repaired: report.local_master_key_repaired,
+            credential_recovered: report.credential_recovered,
+            wallets_verified: report.wallets_verified,
+            wallets_failed: report.wallets_failed,
+            wallets_unsupported: report.wallets_unsupported,
+        }
+    }
+}
+
+impl From<&PendingVerificationUpload> for PersistedPendingVerificationUpload {
+    fn from(upload: &PendingVerificationUpload) -> Self {
+        Self {
+            record_id: upload.record_id.clone(),
+            expected_revision: upload.expected_revision.clone(),
+        }
     }
 }
 
@@ -351,6 +459,9 @@ pub struct RustCloudBackupManager {
     pending_verification_completion: Arc<Mutex<Option<PendingVerificationCompletion>>>,
     pending_upload_verifier_running: Arc<AtomicBool>,
     pending_upload_verifier_wakeup: Arc<Notify>,
+    wallet_upload_debouncers: Arc<Mutex<HashMap<WalletId, DebouncedTask<()>>>>,
+    wallet_upload_retry_counts: Arc<Mutex<HashMap<WalletId, u32>>>,
+    active_wallet_uploads: Arc<Mutex<HashSet<WalletId>>>,
     restore_operation_id: Arc<AtomicU64>,
     restore_operation_gate: Arc<Mutex<()>>,
 }
@@ -393,6 +504,9 @@ impl RustCloudBackupManager {
             pending_verification_completion: Arc::new(Mutex::new(None)),
             pending_upload_verifier_running: Arc::new(AtomicBool::new(false)),
             pending_upload_verifier_wakeup: Arc::new(Notify::new()),
+            wallet_upload_debouncers: Arc::new(Mutex::new(HashMap::new())),
+            wallet_upload_retry_counts: Arc::new(Mutex::new(HashMap::new())),
+            active_wallet_uploads: Arc::new(Mutex::new(HashSet::new())),
             restore_operation_id: Arc::new(AtomicU64::new(0)),
             restore_operation_gate: Arc::new(Mutex::new(())),
         }
@@ -661,6 +775,18 @@ impl RustCloudBackupManager {
         })
     }
 
+    pub(crate) fn build_cloud_backup_detail_with_remote_truth(
+        &self,
+        wallet_record_ids: &[String],
+        remote_wallet_truth: RemoteWalletTruth,
+    ) -> Result<CloudBackupDetail, CloudBackupError> {
+        Ok(self::cloud_inventory::CloudWalletInventory::load_with_remote_truth(
+            wallet_record_ids,
+            remote_wallet_truth,
+        )?
+        .build_detail())
+    }
+
     pub(crate) fn dismiss_verification_prompt_impl(&self) -> Result<(), CloudBackupError> {
         let mut state = Self::load_persisted_state();
         if state.last_verification_requested_at.is_none() {
@@ -680,6 +806,175 @@ impl RustCloudBackupManager {
             .ok_or_else(|| CloudBackupError::Internal("namespace_id not found in keychain".into()))
     }
 
+    pub(crate) fn mark_wallet_blob_dirty(&self, wallet_id: WalletId) {
+        if !Self::load_persisted_state().is_configured() {
+            return;
+        }
+
+        let Ok(namespace_id) = self.current_namespace_id() else {
+            warn!("Cloud backup dirty mark skipped, namespace is unavailable");
+            return;
+        };
+
+        let changed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+        let record_id = wallet_record_id(wallet_id.as_ref());
+        let sync_state = PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id,
+            wallet_id: Some(wallet_id.clone()),
+            record_id,
+            state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at }),
+        };
+
+        if let Err(error) = Database::global().cloud_blob_sync_states.set(&sync_state) {
+            error!("Failed to persist dirty cloud backup state: {error}");
+            return;
+        }
+
+        self.reset_wallet_upload_retry_count(&wallet_id);
+        self.schedule_wallet_upload(wallet_id, false);
+    }
+
+    pub(crate) fn handle_wallet_metadata_update(
+        &self,
+        before: &WalletMetadata,
+        after: &WalletMetadata,
+    ) {
+        if wallet_metadata_change_requires_upload(before, after) {
+            self.mark_wallet_blob_dirty(after.id.clone());
+        }
+    }
+
+    pub(crate) fn handle_wallet_backup_change(&self, wallet_id: WalletId) {
+        self.mark_wallet_blob_dirty(wallet_id);
+    }
+
+    pub(crate) fn handle_wallet_backup_change_and_reverify(&self, wallet_id: WalletId) {
+        self.mark_wallet_blob_dirty(wallet_id);
+        self.mark_verification_required_after_wallet_change();
+    }
+
+    pub(crate) fn handle_wallet_set_change(&self) {
+        self.mark_verification_required_after_wallet_change();
+    }
+
+    fn schedule_wallet_upload(&self, wallet_id: WalletId, immediate: bool) {
+        if immediate {
+            self.spawn_wallet_upload(wallet_id);
+            return;
+        }
+
+        self.schedule_wallet_upload_after(wallet_id, LIVE_UPLOAD_DEBOUNCE);
+    }
+
+    fn schedule_wallet_upload_after(&self, wallet_id: WalletId, delay: Duration) {
+        let task = DebouncedTask::new("cloud_wallet_backup_upload", delay);
+        self.wallet_upload_debouncers.lock().insert(wallet_id.clone(), task.clone());
+
+        let this = CLOUD_BACKUP_MANAGER.clone();
+        task.replace(async move {
+            this.spawn_wallet_upload(wallet_id);
+        });
+    }
+
+    fn next_wallet_upload_retry_delay(&self, wallet_id: &WalletId) -> Duration {
+        let mut retry_counts = self.wallet_upload_retry_counts.lock();
+        let retry_count = retry_counts.entry(wallet_id.clone()).or_default();
+        let delay = live_upload_retry_delay_for_attempt(*retry_count);
+        *retry_count = retry_count.saturating_add(1);
+        delay
+    }
+
+    fn reset_wallet_upload_retry_count(&self, wallet_id: &WalletId) {
+        self.wallet_upload_retry_counts.lock().remove(wallet_id);
+    }
+
+    fn spawn_wallet_upload(&self, wallet_id: WalletId) {
+        let this = CLOUD_BACKUP_MANAGER.clone();
+        cove_tokio::task::spawn_blocking(move || this.run_wallet_upload(wallet_id));
+    }
+
+    fn run_wallet_upload(&self, wallet_id: WalletId) {
+        {
+            let mut active_uploads = self.active_wallet_uploads.lock();
+            if !active_uploads.insert(wallet_id.clone()) {
+                return;
+            }
+        }
+
+        let upload_result = self.do_upload_wallet_if_dirty(&wallet_id);
+        if let Err(error) = &upload_result {
+            error!("Cloud backup upload failed for wallet_id={wallet_id}: {error}");
+            self.set_sync_error(Some(error.to_string()));
+        }
+
+        {
+            let mut active_uploads = self.active_wallet_uploads.lock();
+            active_uploads.remove(&wallet_id);
+        }
+
+        if upload_result.is_ok() {
+            self.reset_wallet_upload_retry_count(&wallet_id);
+            self.clear_sync_error_if_no_failed_wallet_uploads();
+        }
+
+        self.schedule_wallet_upload_follow_up(wallet_id);
+    }
+
+    fn resume_wallet_uploads_from_persisted_state(&self) {
+        let states = match Database::global().cloud_blob_sync_states.list() {
+            Ok(states) => states,
+            Err(error) => {
+                error!("Failed to load cloud blob sync states on startup: {error}");
+                return;
+            }
+        };
+
+        for sync_state in states {
+            let Some(wallet_id) = sync_state.wallet_id.clone() else {
+                continue;
+            };
+
+            match &sync_state.state {
+                PersistedCloudBlobState::Dirty(_) => {
+                    self.schedule_wallet_upload(wallet_id, true);
+                }
+                PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
+                    self.schedule_wallet_upload(wallet_id, true);
+                }
+                PersistedCloudBlobState::Uploading(_) => {
+                    if !self.downgrade_interrupted_upload_to_dirty(&sync_state) {
+                        continue;
+                    }
+
+                    self.schedule_wallet_upload(wallet_id, true);
+                }
+                PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                | PersistedCloudBlobState::Confirmed(_) => {}
+                PersistedCloudBlobState::Failed(_) => {}
+            }
+        }
+    }
+
+    fn downgrade_interrupted_upload_to_dirty(
+        &self,
+        sync_state: &PersistedCloudBlobSyncState,
+    ) -> bool {
+        let changed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+        match self.replace_blob_state_if_current(
+            sync_state,
+            PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at }),
+            "persist interrupted upload dirty state",
+        ) {
+            Ok(wrote_dirty) => wrote_dirty,
+            Err(error) => {
+                error!("Failed to downgrade interrupted upload state: {error}");
+                false
+            }
+        }
+    }
+
     pub(crate) fn replace_pending_enable_session(&self, session: PendingEnableSession) {
         *self.pending_enable_session.lock() = Some(session);
     }
@@ -696,17 +991,98 @@ impl RustCloudBackupManager {
         &self,
         completion: PendingVerificationCompletion,
     ) {
+        let persisted_completion = completion.persisted();
         *self.pending_verification_completion.lock() = Some(completion);
+
+        let mut state = Self::load_persisted_state();
+        state.pending_verification_completion = Some(persisted_completion);
+        if let Err(error) =
+            self.persist_cloud_backup_state(&state, "persist pending verification completion")
+        {
+            error!("Failed to persist pending verification completion: {error}");
+        }
     }
 
     pub(crate) fn pending_verification_completion(&self) -> Option<PendingVerificationCompletion> {
-        self.pending_verification_completion.lock().clone()
+        if let Some(completion) = self.pending_verification_completion.lock().clone() {
+            return Some(completion);
+        }
+
+        let completion = Self::load_persisted_state()
+            .pending_verification_completion
+            .map(PendingVerificationCompletion::from_persisted);
+        if let Some(completion) = &completion {
+            *self.pending_verification_completion.lock() = Some(completion.clone());
+        }
+
+        completion
     }
 
     pub(crate) fn clear_pending_verification_completion(&self) {
         self.pending_verification_completion.lock().take();
+
+        let mut state = Self::load_persisted_state();
+        if state.pending_verification_completion.is_none() {
+            return;
+        }
+
+        state.pending_verification_completion = None;
+        if let Err(error) =
+            self.persist_cloud_backup_state(&state, "clear pending verification completion")
+        {
+            error!("Failed to clear pending verification completion: {error}");
+        }
     }
 
+    fn load_remote_wallet_truth(
+        &self,
+        wallet_record_ids: &[String],
+    ) -> Result<RemoteWalletTruth, CloudBackupError> {
+        let namespace = self.current_namespace_id()?;
+        let db = Database::global();
+        let local_wallets = all_local_wallets(&db)?;
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        let Some(master_key) = cspp
+            .load_master_key_from_store()
+            .map_err_prefix("load local master key", CloudBackupError::Internal)?
+        else {
+            return Ok(RemoteWalletTruth {
+                unknown_record_ids: wallet_record_ids.iter().cloned().collect(),
+                ..RemoteWalletTruth::default()
+            });
+        };
+
+        let cloud = CloudStorage::global();
+        let reader = WalletBackupReader::new(
+            cloud.clone(),
+            namespace.clone(),
+            Zeroizing::new(master_key.critical_data_key()),
+        );
+        let mut remote_wallet_truth = RemoteWalletTruth::default();
+
+        for wallet in local_wallets {
+            let record_id = wallet_record_id(wallet.id.as_ref());
+
+            match reader.summary(&record_id) {
+                Ok(WalletBackupLookup::Found(summary)) => {
+                    remote_wallet_truth.summaries_by_record_id.insert(record_id, summary);
+                }
+                Ok(WalletBackupLookup::NotFound) => {}
+                Ok(WalletBackupLookup::UnsupportedVersion(version)) => {
+                    warn!(
+                        "Cloud backup remote truth found unsupported wallet backup version {version} for record_id={record_id}"
+                    );
+                    remote_wallet_truth.unsupported_record_ids.insert(record_id);
+                }
+                Err(error) => {
+                    warn!("Cloud backup remote truth failed for record_id={record_id}: {error}");
+                    remote_wallet_truth.unknown_record_ids.insert(record_id);
+                }
+            }
+        }
+
+        Ok(remote_wallet_truth)
+    }
     fn start_background_operation<F>(
         self: Arc<Self>,
         operation_name: &str,
@@ -855,15 +1231,75 @@ impl RustCloudBackupManager {
     }
 
     pub fn has_pending_cloud_upload_verification(&self) -> bool {
-        Database::global()
-            .cloud_upload_queue
-            .get()
-            .ok()
-            .flatten()
-            .is_some_and(|queue| queue.has_unconfirmed())
+        if self.pending_verification_completion().is_some() {
+            return true;
+        }
+
+        Database::global().cloud_blob_sync_states.list().ok().is_some_and(|states| {
+            states.into_iter().any(|state| state.is_uploaded_pending_confirmation())
+        })
+    }
+
+    fn clear_sync_error_if_no_failed_wallet_uploads(&self) {
+        if self.has_failed_wallet_uploads() {
+            return;
+        }
+
+        self.set_sync_error(None);
+    }
+
+    fn has_failed_wallet_uploads(&self) -> bool {
+        match Database::global().cloud_blob_sync_states.list() {
+            Ok(states) => states
+                .into_iter()
+                .any(|state| matches!(state.state, PersistedCloudBlobState::Failed(_))),
+            Err(error) => {
+                error!("Failed to read cloud blob sync states while clearing sync error: {error}");
+                true
+            }
+        }
+    }
+
+    fn schedule_wallet_upload_follow_up(&self, wallet_id: WalletId) {
+        let record_id = wallet_record_id(wallet_id.as_ref());
+        let sync_state = match Database::global().cloud_blob_sync_states.get(&record_id) {
+            Ok(sync_state) => sync_state,
+            Err(error) => {
+                error!(
+                    "Failed to read wallet upload follow-up state for record_id={record_id}: {error}"
+                );
+                return;
+            }
+        };
+
+        let Some(sync_state) = sync_state else {
+            return;
+        };
+
+        if sync_state.is_dirty() {
+            self.reset_wallet_upload_retry_count(&wallet_id);
+            self.schedule_wallet_upload(wallet_id, true);
+            return;
+        }
+
+        match sync_state.state {
+            PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
+                let delay = self.next_wallet_upload_retry_delay(&wallet_id);
+                self.schedule_wallet_upload_after(wallet_id, delay);
+            }
+            PersistedCloudBlobState::Uploading(_)
+            | PersistedCloudBlobState::UploadedPendingConfirmation(_)
+            | PersistedCloudBlobState::Confirmed(_) => {}
+            PersistedCloudBlobState::Failed(_) => {
+                self.reset_wallet_upload_retry_count(&wallet_id);
+            }
+            PersistedCloudBlobState::Dirty(_) => unreachable!("dirty state handled above"),
+        }
     }
 
     pub fn resume_pending_cloud_upload_verification(&self) {
+        self.sync_persisted_state();
+        self.resume_wallet_uploads_from_persisted_state();
         self.start_pending_upload_verification_loop();
     }
 
@@ -883,7 +1319,7 @@ impl RustCloudBackupManager {
 
         let db = Database::global();
         let _ = db.cloud_backup_state.delete();
-        let _ = db.cloud_upload_queue.delete();
+        let _ = db.cloud_blob_sync_states.delete_all();
 
         self.clear_pending_verification_completion();
         self.set_progress(None);
@@ -911,21 +1347,11 @@ impl RustCloudBackupManager {
     ///
     /// Returns immediately if cloud backup isn't enabled (e.g. during restore)
     pub fn backup_new_wallet(&self, metadata: crate::wallet::metadata::WalletMetadata) {
-        let status = self.state.read().status.clone();
-        if !matches!(status, CloudBackupStatus::Enabled | CloudBackupStatus::PasskeyMissing) {
+        if !Self::load_persisted_state().is_configured() {
             return;
         }
 
-        let this = CLOUD_BACKUP_MANAGER.clone();
-        cove_tokio::task::spawn_blocking(move || {
-            if let Err(error) = this.do_backup_wallets(&[metadata]) {
-                warn!("Failed to backup new wallet, retrying full sync: {error}");
-                if let Err(error) = this.do_sync_unsynced_wallets() {
-                    error!("Retry sync also failed: {error}");
-                    this.set_sync_error(Some(error.to_string()));
-                }
-            }
-        });
+        self.handle_wallet_backup_change_and_reverify(metadata.id);
     }
 }
 
@@ -1074,6 +1500,18 @@ pub fn cspp_namespaces_subdirectory() -> String {
     cove_cspp::backup_data::NAMESPACES_SUBDIRECTORY.to_string()
 }
 
+pub(super) const LIVE_UPLOAD_DEBOUNCE: Duration = Duration::from_secs(5);
+const MAX_LIVE_UPLOAD_RETRY_DELAY: Duration = Duration::from_secs(60);
+
+fn live_upload_retry_delay_for_attempt(retry_count: u32) -> Duration {
+    let backoff_multiplier = 1u64 << retry_count.min(4);
+    let delay_secs = LIVE_UPLOAD_DEBOUNCE
+        .as_secs()
+        .saturating_mul(backoff_multiplier)
+        .min(MAX_LIVE_UPLOAD_RETRY_DELAY.as_secs());
+    Duration::from_secs(delay_secs)
+}
+
 fn wipe_wallet_keychain_items_for_catastrophic_recovery() -> Result<(), CatastrophicRecoveryError> {
     let keychain = Keychain::global();
     let wallet_ids = catastrophic_wipe_wallet_ids(
@@ -1161,6 +1599,19 @@ fn wallet_ids_from_wallet_data_dir(wallet_data_dir: &Path) -> Vec<WalletId> {
 pub(crate) fn cloud_backup_test_lock() -> &'static parking_lot::Mutex<()> {
     static LOCK: std::sync::OnceLock<parking_lot::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(parking_lot::Mutex::default)
+}
+
+#[cfg(test)]
+impl RustCloudBackupManager {
+    pub(crate) fn run_wallet_upload_for_test(&self, wallet_id: WalletId) {
+        self.run_wallet_upload(wallet_id);
+    }
+
+    pub(crate) fn clear_wallet_upload_debouncers_for_test(&self) {
+        self.wallet_upload_debouncers.lock().clear();
+        self.wallet_upload_retry_counts.lock().clear();
+        self.active_wallet_uploads.lock().clear();
+    }
 }
 
 #[cfg(test)]
@@ -1267,6 +1718,20 @@ mod tests {
     }
 
     #[test]
+    fn live_upload_retry_delay_increases_with_attempts() {
+        assert_eq!(live_upload_retry_delay_for_attempt(0), Duration::from_secs(5));
+        assert_eq!(live_upload_retry_delay_for_attempt(1), Duration::from_secs(10));
+        assert_eq!(live_upload_retry_delay_for_attempt(2), Duration::from_secs(20));
+        assert_eq!(live_upload_retry_delay_for_attempt(3), Duration::from_secs(40));
+    }
+
+    #[test]
+    fn live_upload_retry_delay_caps_at_maximum() {
+        assert_eq!(live_upload_retry_delay_for_attempt(4), MAX_LIVE_UPLOAD_RETRY_DELAY);
+        assert_eq!(live_upload_retry_delay_for_attempt(10), MAX_LIVE_UPLOAD_RETRY_DELAY);
+    }
+
+    #[test]
     fn restore_complete_clears_restore_progress() {
         let _guard = test_lock().lock();
         let manager = RustCloudBackupManager::init();
@@ -1280,6 +1745,8 @@ mod tests {
             wallets_restored: 1,
             wallets_failed: 0,
             failed_wallet_errors: Vec::new(),
+            labels_failed_wallet_names: Vec::new(),
+            labels_failed_errors: Vec::new(),
         }));
 
         assert!(manager.state.read().restore_progress.is_none());
@@ -1293,6 +1760,8 @@ mod tests {
             wallets_restored: 0,
             wallets_failed: 2,
             failed_wallet_errors: vec!["download failed".into()],
+            labels_failed_wallet_names: Vec::new(),
+            labels_failed_errors: Vec::new(),
         };
 
         manager.set_restore_progress(Some(CloudBackupRestoreProgress {
@@ -1379,6 +1848,8 @@ mod tests {
             wallets_restored: 1,
             wallets_failed: 0,
             failed_wallet_errors: Vec::new(),
+            labels_failed_wallet_names: Vec::new(),
+            labels_failed_errors: Vec::new(),
         };
 
         let error = manager
@@ -1470,7 +1941,10 @@ mod tests {
         let _guard = test_lock().lock();
         cove_tokio::init();
         let manager = RustCloudBackupManager::init();
-        manager.debug_reset_cloud_backup_state();
+        manager.set_status(CloudBackupStatus::Disabled);
+        manager.set_progress(None);
+        manager.set_restore_progress(None);
+        manager.set_restore_report(None);
 
         manager.clone().start_background_operation(
             "first_enable",
@@ -1479,7 +1953,7 @@ mod tests {
         );
 
         assert_eq!(manager.state.read().status, CloudBackupStatus::Enabling);
-        manager.debug_reset_cloud_backup_state();
+        manager.set_status(CloudBackupStatus::Disabled);
     }
 
     #[test]

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -364,8 +364,27 @@ impl PendingVerificationUpload {
         &self.expected_revision
     }
 
+    pub(crate) fn target_revision(&self, sync_state: Option<&PersistedCloudBlobState>) -> String {
+        sync_state
+            .and_then(PersistedCloudBlobState::revision_hash)
+            .unwrap_or(&self.expected_revision)
+            .to_owned()
+    }
+
     fn from_persisted(upload: PersistedPendingVerificationUpload) -> Self {
         Self { record_id: upload.record_id, expected_revision: upload.expected_revision }
+    }
+}
+
+impl PersistedCloudBlobState {
+    pub(crate) fn revision_hash(&self) -> Option<&str> {
+        match self {
+            Self::Uploading(state) => Some(&state.revision_hash),
+            Self::UploadedPendingConfirmation(state) => Some(&state.revision_hash),
+            Self::Confirmed(state) => Some(&state.revision_hash),
+            Self::Failed(state) => state.revision_hash.as_deref(),
+            Self::Dirty(_) => None,
+        }
     }
 }
 

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -513,6 +513,9 @@ impl RustCloudBackupManager {
     }
 
     fn init() -> Arc<Self> {
+        #[cfg(test)]
+        ensure_cloud_backup_test_tokio_runtime();
+
         let (sender, receiver) = flume::bounded(1000);
 
         Self {
@@ -1621,6 +1624,30 @@ pub(crate) fn cloud_backup_test_lock() -> &'static parking_lot::Mutex<()> {
 }
 
 #[cfg(test)]
+pub(crate) fn ensure_cloud_backup_test_tokio_runtime() {
+    static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INIT.get_or_init(|| {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("cloud-backup-test-tokio".into())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("create cloud backup test tokio runtime");
+
+                runtime.block_on(async move {
+                    cove_tokio::init();
+                    sender.send(()).expect("signal cloud backup test tokio runtime");
+                    std::future::pending::<()>().await;
+                });
+            })
+            .expect("spawn cloud backup test tokio runtime thread");
+        receiver.recv().expect("wait for cloud backup test tokio runtime");
+    });
+}
+
+#[cfg(test)]
 impl RustCloudBackupManager {
     pub(crate) fn run_wallet_upload_for_test(&self, wallet_id: WalletId) {
         self.run_wallet_upload(wallet_id);
@@ -1630,6 +1657,16 @@ impl RustCloudBackupManager {
         self.wallet_upload_debouncers.lock().clear();
         self.wallet_upload_retry_counts.lock().clear();
         self.active_wallet_uploads.lock().clear();
+    }
+
+    pub(crate) fn has_wallet_upload_debouncer_for_test(&self, wallet_id: WalletId) -> bool {
+        let runtime = self.runtime.clone();
+        std::thread::spawn(move || {
+            cove_tokio::task::block_on(call!(runtime.has_upload_debouncer_for_test(wallet_id)))
+                .expect("check upload debouncer")
+        })
+        .join()
+        .expect("check upload debouncer thread")
     }
 }
 

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -1,27 +1,22 @@
 mod cloud_inventory;
 mod ops;
 mod pending;
+pub(crate) mod runtime_actor;
 mod verify;
 mod wallets;
 
 use std::path::Path;
-use std::sync::{
-    Arc, LazyLock,
-    atomic::{AtomicBool, AtomicU64, Ordering},
-};
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 
+use act_zero::{Addr, call, send};
 use cove_cspp::CsppStore as _;
 use cove_cspp::backup_data::{MASTER_KEY_RECORD_ID, wallet_record_id};
 use cove_device::cloud_storage::CloudStorage;
-use cove_tokio::DebouncedTask;
+use cove_tokio::task::spawn_actor;
 use cove_util::ResultExt as _;
 use flume::{Receiver, Sender};
-use parking_lot::{Mutex, RwLock};
-use tokio::sync::Notify;
+use parking_lot::RwLock;
 use tracing::{error, info, warn};
 use zeroize::Zeroizing;
 
@@ -41,6 +36,7 @@ use crate::wallet::metadata::{
 };
 
 use self::cloud_inventory::RemoteWalletTruth;
+use self::runtime_actor::{CloudBackupOperation, CloudBackupRuntimeActor, RestoreOperation};
 use self::wallets::wallet_metadata_change_requires_upload;
 use self::wallets::{
     UnpersistedPrfKey, WalletBackupLookup, WalletBackupReader, all_local_wallets, count_all_wallets,
@@ -474,15 +470,7 @@ pub struct RustCloudBackupManager {
     pub state: Arc<RwLock<CloudBackupState>>,
     pub reconciler: Sender<Message>,
     pub reconcile_receiver: Arc<Receiver<Message>>,
-    pending_enable_session: Arc<Mutex<Option<PendingEnableSession>>>,
-    pending_verification_completion: Arc<Mutex<Option<PendingVerificationCompletion>>>,
-    pending_upload_verifier_running: Arc<AtomicBool>,
-    pending_upload_verifier_wakeup: Arc<Notify>,
-    wallet_upload_debouncers: Arc<Mutex<HashMap<WalletId, DebouncedTask<()>>>>,
-    wallet_upload_retry_counts: Arc<Mutex<HashMap<WalletId, u32>>>,
-    active_wallet_uploads: Arc<Mutex<HashSet<WalletId>>>,
-    restore_operation_id: Arc<AtomicU64>,
-    restore_operation_gate: Arc<Mutex<()>>,
+    pub(crate) runtime: Addr<CloudBackupRuntimeActor>,
 }
 
 impl RustCloudBackupManager {
@@ -518,21 +506,12 @@ impl RustCloudBackupManager {
 
         let (sender, receiver) = flume::bounded(1000);
 
-        Self {
+        Arc::new_cyclic(|manager| Self {
             state: Arc::new(RwLock::new(CloudBackupState::default())),
             reconciler: sender,
             reconcile_receiver: Arc::new(receiver),
-            pending_enable_session: Arc::new(Mutex::new(None)),
-            pending_verification_completion: Arc::new(Mutex::new(None)),
-            pending_upload_verifier_running: Arc::new(AtomicBool::new(false)),
-            pending_upload_verifier_wakeup: Arc::new(Notify::new()),
-            wallet_upload_debouncers: Arc::new(Mutex::new(HashMap::new())),
-            wallet_upload_retry_counts: Arc::new(Mutex::new(HashMap::new())),
-            active_wallet_uploads: Arc::new(Mutex::new(HashSet::new())),
-            restore_operation_id: Arc::new(AtomicU64::new(0)),
-            restore_operation_gate: Arc::new(Mutex::new(())),
-        }
-        .into()
+            runtime: spawn_actor(CloudBackupRuntimeActor::new(manager.clone())),
+        })
     }
 
     fn verification_metadata_for(
@@ -688,82 +667,6 @@ impl RustCloudBackupManager {
         );
     }
 
-    fn next_restore_operation_id(&self) -> u64 {
-        let _gate = self.restore_operation_gate.lock();
-        self.restore_operation_id.fetch_add(1, Ordering::AcqRel) + 1
-    }
-
-    fn invalidate_restore_operation(&self) {
-        let _gate = self.restore_operation_gate.lock();
-        self.restore_operation_id.fetch_add(1, Ordering::AcqRel);
-    }
-
-    pub(crate) fn ensure_current_restore_operation(
-        &self,
-        operation_id: u64,
-    ) -> Result<(), CloudBackupError> {
-        // only use this as a preflight read
-        // side-effecting restore work must use the locked helpers below so
-        // cancellation can't race between the check and the write
-        if self.restore_operation_id.load(Ordering::Acquire) == operation_id {
-            return Ok(());
-        }
-
-        Err(CloudBackupError::Cancelled)
-    }
-
-    pub(crate) fn set_status_for_restore_operation(
-        &self,
-        operation_id: u64,
-        status: CloudBackupStatus,
-    ) -> Result<(), CloudBackupError> {
-        self.with_current_restore_operation(operation_id, |this| this.set_status(status))
-    }
-
-    pub(crate) fn set_restore_progress_for_restore_operation(
-        &self,
-        operation_id: u64,
-        progress: Option<CloudBackupRestoreProgress>,
-    ) -> Result<(), CloudBackupError> {
-        self.with_current_restore_operation(operation_id, |this| {
-            this.set_restore_progress(progress)
-        })
-    }
-
-    pub(crate) fn set_restore_report_for_restore_operation(
-        &self,
-        operation_id: u64,
-        report: Option<CloudBackupRestoreReport>,
-    ) -> Result<(), CloudBackupError> {
-        self.with_current_restore_operation(operation_id, |this| this.set_restore_report(report))
-    }
-
-    fn with_current_restore_operation<T>(
-        &self,
-        operation_id: u64,
-        update: impl FnOnce(&Self) -> T,
-    ) -> Result<T, CloudBackupError> {
-        let _gate = self.restore_operation_gate.lock();
-        if self.restore_operation_id.load(Ordering::Acquire) != operation_id {
-            return Err(CloudBackupError::Cancelled);
-        }
-
-        Ok(update(self))
-    }
-
-    fn with_current_restore_operation_result<T>(
-        &self,
-        operation_id: u64,
-        update: impl FnOnce(&Self) -> Result<T, CloudBackupError>,
-    ) -> Result<T, CloudBackupError> {
-        let _gate = self.restore_operation_gate.lock();
-        if self.restore_operation_id.load(Ordering::Acquire) != operation_id {
-            return Err(CloudBackupError::Cancelled);
-        }
-
-        update(self)
-    }
-
     pub(crate) fn persist_cloud_backup_state(
         &self,
         state: &PersistedCloudBackupState,
@@ -782,19 +685,50 @@ impl RustCloudBackupManager {
 
     pub(crate) fn persist_cloud_backup_state_for_restore_operation(
         &self,
-        operation_id: u64,
+        operation: &RestoreOperation,
         state: &PersistedCloudBackupState,
         context: &str,
     ) -> Result<(), CloudBackupError> {
-        self.with_current_restore_operation_result(operation_id, |this| {
+        operation.run_result(|| {
             Database::global()
                 .cloud_backup_state
                 .set(state)
                 .map_err(|error| CloudBackupError::Internal(format!("{context}: {error}")))?;
-            this.set_status(Self::runtime_status_for(state));
-            this.refresh_persisted_flags();
+            self.set_status(Self::runtime_status_for(state));
+            self.refresh_persisted_flags();
             Ok(())
         })
+    }
+
+    pub(crate) fn ensure_current_restore_operation(
+        &self,
+        operation: &RestoreOperation,
+    ) -> Result<(), CloudBackupError> {
+        operation.ensure_current()
+    }
+
+    pub(crate) fn set_status_for_restore_operation(
+        &self,
+        operation: &RestoreOperation,
+        status: CloudBackupStatus,
+    ) -> Result<(), CloudBackupError> {
+        operation.run(|| self.set_status(status)).map(|_| ())
+    }
+
+    pub(crate) fn set_restore_progress_for_restore_operation(
+        &self,
+        operation: &RestoreOperation,
+        progress: Option<CloudBackupRestoreProgress>,
+    ) -> Result<(), CloudBackupError> {
+        operation.run(|| self.set_restore_progress(progress)).map(|_| ())
+    }
+
+    pub(crate) fn set_restore_report_for_restore_operation(
+        &self,
+        operation: &RestoreOperation,
+        report: Option<CloudBackupRestoreReport>,
+    ) -> Result<(), CloudBackupError> {
+        operation.run(|| self.set_restore_report(report)).map(|_| ())
     }
 
     pub(crate) fn build_cloud_backup_detail_with_remote_truth(
@@ -853,7 +787,6 @@ impl RustCloudBackupManager {
             return;
         }
 
-        self.reset_wallet_upload_retry_count(&wallet_id);
         self.schedule_wallet_upload(wallet_id, false);
     }
 
@@ -881,101 +814,7 @@ impl RustCloudBackupManager {
     }
 
     fn schedule_wallet_upload(&self, wallet_id: WalletId, immediate: bool) {
-        if immediate {
-            self.spawn_wallet_upload(wallet_id);
-            return;
-        }
-
-        self.schedule_wallet_upload_after(wallet_id, LIVE_UPLOAD_DEBOUNCE);
-    }
-
-    fn schedule_wallet_upload_after(&self, wallet_id: WalletId, delay: Duration) {
-        let task = DebouncedTask::new("cloud_wallet_backup_upload", delay);
-        self.wallet_upload_debouncers.lock().insert(wallet_id.clone(), task.clone());
-
-        let this = CLOUD_BACKUP_MANAGER.clone();
-        task.replace(async move {
-            this.spawn_wallet_upload(wallet_id);
-        });
-    }
-
-    fn next_wallet_upload_retry_delay(&self, wallet_id: &WalletId) -> Duration {
-        let mut retry_counts = self.wallet_upload_retry_counts.lock();
-        let retry_count = retry_counts.entry(wallet_id.clone()).or_default();
-        let delay = live_upload_retry_delay_for_attempt(*retry_count);
-        *retry_count = retry_count.saturating_add(1);
-        delay
-    }
-
-    fn reset_wallet_upload_retry_count(&self, wallet_id: &WalletId) {
-        self.wallet_upload_retry_counts.lock().remove(wallet_id);
-    }
-
-    fn spawn_wallet_upload(&self, wallet_id: WalletId) {
-        let this = CLOUD_BACKUP_MANAGER.clone();
-        cove_tokio::task::spawn_blocking(move || this.run_wallet_upload(wallet_id));
-    }
-
-    fn run_wallet_upload(&self, wallet_id: WalletId) {
-        {
-            let mut active_uploads = self.active_wallet_uploads.lock();
-            if !active_uploads.insert(wallet_id.clone()) {
-                return;
-            }
-        }
-
-        let upload_result = self.do_upload_wallet_if_dirty(&wallet_id);
-        if let Err(error) = &upload_result {
-            error!("Cloud backup upload failed for wallet_id={wallet_id}: {error}");
-            self.set_sync_error(Some(error.to_string()));
-        }
-
-        {
-            let mut active_uploads = self.active_wallet_uploads.lock();
-            active_uploads.remove(&wallet_id);
-        }
-
-        if upload_result.is_ok() {
-            self.reset_wallet_upload_retry_count(&wallet_id);
-            self.clear_sync_error_if_no_failed_wallet_uploads();
-        }
-
-        self.schedule_wallet_upload_follow_up(wallet_id);
-    }
-
-    fn resume_wallet_uploads_from_persisted_state(&self) {
-        let states = match Database::global().cloud_blob_sync_states.list() {
-            Ok(states) => states,
-            Err(error) => {
-                error!("Failed to load cloud blob sync states on startup: {error}");
-                return;
-            }
-        };
-
-        for sync_state in states {
-            let Some(wallet_id) = sync_state.wallet_id.clone() else {
-                continue;
-            };
-
-            match &sync_state.state {
-                PersistedCloudBlobState::Dirty(_) => {
-                    self.schedule_wallet_upload(wallet_id, true);
-                }
-                PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
-                    self.schedule_wallet_upload(wallet_id, true);
-                }
-                PersistedCloudBlobState::Uploading(_) => {
-                    if !self.downgrade_interrupted_upload_to_dirty(&sync_state) {
-                        continue;
-                    }
-
-                    self.schedule_wallet_upload(wallet_id, true);
-                }
-                PersistedCloudBlobState::UploadedPendingConfirmation(_)
-                | PersistedCloudBlobState::Confirmed(_) => {}
-                PersistedCloudBlobState::Failed(_) => {}
-            }
-        }
+        send!(self.runtime.schedule_wallet_upload(wallet_id, immediate));
     }
 
     fn downgrade_interrupted_upload_to_dirty(
@@ -998,15 +837,25 @@ impl RustCloudBackupManager {
     }
 
     pub(crate) fn replace_pending_enable_session(&self, session: PendingEnableSession) {
-        *self.pending_enable_session.lock() = Some(session);
+        cove_tokio::task::block_on(call!(self.runtime.replace_pending_enable_session(session)))
+            .unwrap_or_else(|error| {
+                error!("Failed to cache pending enable session: {error}");
+            });
     }
 
     pub(crate) fn take_pending_enable_session(&self) -> Option<PendingEnableSession> {
-        self.pending_enable_session.lock().take()
+        cove_tokio::task::block_on(call!(self.runtime.take_pending_enable_session()))
+            .unwrap_or_else(|error| {
+                error!("Failed to take pending enable session: {error}");
+                None
+            })
     }
 
     pub(crate) fn clear_pending_enable_session(&self) {
-        self.pending_enable_session.lock().take();
+        cove_tokio::task::block_on(call!(self.runtime.clear_pending_enable_session()))
+            .unwrap_or_else(|error| {
+                error!("Failed to clear pending enable session: {error}");
+            });
     }
 
     pub(crate) fn replace_pending_verification_completion(
@@ -1014,7 +863,6 @@ impl RustCloudBackupManager {
         completion: PendingVerificationCompletion,
     ) {
         let persisted_completion = completion.persisted();
-        *self.pending_verification_completion.lock() = Some(completion);
 
         let mut state = Self::load_persisted_state();
         state.pending_verification_completion = Some(persisted_completion);
@@ -1022,29 +870,22 @@ impl RustCloudBackupManager {
             self.persist_cloud_backup_state(&state, "persist pending verification completion")
         {
             error!("Failed to persist pending verification completion: {error}");
+            return;
         }
+
+        send!(self.runtime.cache_pending_verification_completion(completion));
     }
 
     pub(crate) fn pending_verification_completion(&self) -> Option<PendingVerificationCompletion> {
-        if let Some(completion) = self.pending_verification_completion.lock().clone() {
-            return Some(completion);
-        }
-
-        let completion = Self::load_persisted_state()
+        Self::load_persisted_state()
             .pending_verification_completion
-            .map(PendingVerificationCompletion::from_persisted);
-        if let Some(completion) = &completion {
-            *self.pending_verification_completion.lock() = Some(completion.clone());
-        }
-
-        completion
+            .map(PendingVerificationCompletion::from_persisted)
     }
 
     pub(crate) fn clear_pending_verification_completion(&self) {
-        self.pending_verification_completion.lock().take();
-
         let mut state = Self::load_persisted_state();
         if state.pending_verification_completion.is_none() {
+            send!(self.runtime.clear_pending_verification_completion());
             return;
         }
 
@@ -1053,7 +894,10 @@ impl RustCloudBackupManager {
             self.persist_cloud_backup_state(&state, "clear pending verification completion")
         {
             error!("Failed to clear pending verification completion: {error}");
+            return;
         }
+
+        send!(self.runtime.clear_pending_verification_completion());
     }
 
     fn load_remote_wallet_truth(
@@ -1105,14 +949,12 @@ impl RustCloudBackupManager {
 
         Ok(remote_wallet_truth)
     }
-    fn start_background_operation<F>(
-        self: Arc<Self>,
+
+    pub(super) fn begin_background_operation(
+        &self,
         operation_name: &str,
         entering_status: Option<CloudBackupStatus>,
-        work: F,
-    ) where
-        F: FnOnce(Arc<Self>) -> Result<(), CloudBackupError> + Send + 'static,
-    {
+    ) -> bool {
         if let Some(status) = entering_status.clone() {
             let (
                 progress_changed,
@@ -1127,7 +969,7 @@ impl RustCloudBackupManager {
                     CloudBackupStatus::Enabling | CloudBackupStatus::Restoring
                 ) {
                     warn!("{operation_name} called while {current_status:?}, ignoring");
-                    return;
+                    return false;
                 }
 
                 let progress_changed = state.progress.take().is_some();
@@ -1159,19 +1001,17 @@ impl RustCloudBackupManager {
             let status = self.state.read().status.clone();
             if matches!(status, CloudBackupStatus::Enabling | CloudBackupStatus::Restoring) {
                 warn!("{operation_name} called while {status:?}, ignoring");
-                return;
+                return false;
             }
         }
 
-        let operation_name = operation_name.to_owned();
-        cove_tokio::task::spawn_blocking(move || {
-            if let Err(error) = work(self.clone()) {
-                error!("{operation_name} failed: {error}");
-                self.set_progress(None);
-                self.set_restore_progress(None);
-                self.set_status(Self::status_for_operation_error(&error));
-            }
-        });
+        true
+    }
+
+    pub(super) fn finish_background_operation_error(&self, error: &CloudBackupError) {
+        self.set_progress(None);
+        self.set_restore_progress(None);
+        self.set_status(Self::status_for_operation_error(error));
     }
 }
 
@@ -1253,7 +1093,7 @@ impl RustCloudBackupManager {
     }
 
     pub fn has_pending_cloud_upload_verification(&self) -> bool {
-        if self.pending_verification_completion().is_some() {
+        if Self::load_persisted_state().pending_verification_completion.is_some() {
             return true;
         }
 
@@ -1262,7 +1102,7 @@ impl RustCloudBackupManager {
         })
     }
 
-    fn clear_sync_error_if_no_failed_wallet_uploads(&self) {
+    pub(super) fn clear_sync_error_if_no_failed_wallet_uploads(&self) {
         if self.has_failed_wallet_uploads() {
             return;
         }
@@ -1282,46 +1122,9 @@ impl RustCloudBackupManager {
         }
     }
 
-    fn schedule_wallet_upload_follow_up(&self, wallet_id: WalletId) {
-        let record_id = wallet_record_id(wallet_id.as_ref());
-        let sync_state = match Database::global().cloud_blob_sync_states.get(&record_id) {
-            Ok(sync_state) => sync_state,
-            Err(error) => {
-                error!(
-                    "Failed to read wallet upload follow-up state for record_id={record_id}: {error}"
-                );
-                return;
-            }
-        };
-
-        let Some(sync_state) = sync_state else {
-            return;
-        };
-
-        if sync_state.is_dirty() {
-            self.reset_wallet_upload_retry_count(&wallet_id);
-            self.schedule_wallet_upload(wallet_id, true);
-            return;
-        }
-
-        match sync_state.state {
-            PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
-                let delay = self.next_wallet_upload_retry_delay(&wallet_id);
-                self.schedule_wallet_upload_after(wallet_id, delay);
-            }
-            PersistedCloudBlobState::Uploading(_)
-            | PersistedCloudBlobState::UploadedPendingConfirmation(_)
-            | PersistedCloudBlobState::Confirmed(_) => {}
-            PersistedCloudBlobState::Failed(_) => {
-                self.reset_wallet_upload_retry_count(&wallet_id);
-            }
-            PersistedCloudBlobState::Dirty(_) => unreachable!("dirty state handled above"),
-        }
-    }
-
     pub fn resume_pending_cloud_upload_verification(&self) {
         self.sync_persisted_state();
-        self.resume_wallet_uploads_from_persisted_state();
+        send!(self.runtime.resume_wallet_uploads_from_persisted_state());
         self.start_pending_upload_verification_loop();
     }
 
@@ -1357,6 +1160,10 @@ impl RustCloudBackupManager {
         self.set_cloud_only(CloudOnlyState::NotFetched);
         self.set_cloud_only_operation(CloudOnlyOperation::Idle);
         self.set_status(CloudBackupStatus::Disabled);
+        cove_tokio::task::block_on(call!(self.runtime.clear_upload_runtime_state()))
+            .unwrap_or_else(|error| {
+                error!("Failed to clear cloud backup runtime upload state: {error}");
+            });
         info!("Debug: reset cloud backup local state (including master key)");
     }
 
@@ -1379,76 +1186,31 @@ impl RustCloudBackupManager {
 
 impl RustCloudBackupManager {
     pub(crate) fn enable_cloud_backup(&self) {
-        CLOUD_BACKUP_MANAGER.clone().start_background_operation(
-            "enable_cloud_backup",
-            Some(CloudBackupStatus::Enabling),
-            |this| this.do_enable_cloud_backup(),
-        );
+        send!(self.runtime.start_operation(CloudBackupOperation::Enable, None));
     }
 
     pub(crate) fn enable_cloud_backup_force_new(&self) {
-        CLOUD_BACKUP_MANAGER.clone().start_background_operation(
-            "enable_cloud_backup_force_new",
-            Some(CloudBackupStatus::Enabling),
-            |this| this.do_enable_cloud_backup_force_new(),
-        );
+        send!(self.runtime.start_operation(CloudBackupOperation::EnableForceNew, None));
     }
 
     pub(crate) fn enable_cloud_backup_no_discovery(&self) {
-        CLOUD_BACKUP_MANAGER.clone().start_background_operation(
-            "enable_cloud_backup_no_discovery",
-            Some(CloudBackupStatus::Enabling),
-            |this| this.do_enable_cloud_backup_no_discovery(),
-        );
+        send!(self.runtime.start_operation(CloudBackupOperation::EnableNoDiscovery, None));
     }
 
     pub(crate) fn discard_pending_enable_cloud_backup(&self) {
-        if self.take_pending_enable_session().is_some() {
-            cove_cspp::Cspp::new(Keychain::global().clone()).delete_master_key();
-        }
+        cove_tokio::task::block_on(call!(self.runtime.discard_pending_enable_session()))
+            .unwrap_or_else(|error| {
+                error!("Failed to discard pending enable session: {error}");
+            });
     }
 
     pub(crate) fn cancel_restore(&self) {
-        let status = self.state.read().status.clone();
-        if !matches!(status, CloudBackupStatus::Restoring) {
-            return;
-        }
-
-        self.invalidate_restore_operation();
-        self.set_progress(None);
-        self.set_restore_progress(None);
-        self.set_restore_report(None);
-        self.set_status(Self::runtime_status_for(&Self::load_persisted_state()));
-        info!("restore_from_cloud_backup: cancelled active restore");
+        send!(self.runtime.cancel_restore());
     }
 
     pub(crate) fn restore_from_cloud_backup(&self) {
-        info!("restore_from_cloud_backup: spawning restore task");
-        let this = CLOUD_BACKUP_MANAGER.clone();
-        {
-            let status = this.state.read().status.clone();
-            if matches!(status, CloudBackupStatus::Enabling | CloudBackupStatus::Restoring) {
-                warn!("restore_from_cloud_backup called while {status:?}, ignoring");
-                return;
-            }
-        }
-
-        let operation_id = this.next_restore_operation_id();
-        cove_tokio::task::spawn_blocking(move || {
-            info!("restore_from_cloud_backup: task started");
-            match this.do_restore_from_cloud_backup(operation_id) {
-                Ok(()) => {}
-                Err(CloudBackupError::Cancelled) => {
-                    info!("restore_from_cloud_backup: task cancelled");
-                }
-                Err(error) => {
-                    error!("restore_from_cloud_backup failed: {error}");
-                    this.set_progress(None);
-                    this.set_restore_progress(None);
-                    this.set_status(Self::status_for_operation_error(&error));
-                }
-            }
-        });
+        info!("restore_from_cloud_backup: enqueueing restore task");
+        send!(self.runtime.start_restore_from_cloud_backup());
     }
 }
 
@@ -1650,13 +1412,27 @@ pub(crate) fn ensure_cloud_backup_test_tokio_runtime() {
 #[cfg(test)]
 impl RustCloudBackupManager {
     pub(crate) fn run_wallet_upload_for_test(&self, wallet_id: WalletId) {
-        self.run_wallet_upload(wallet_id);
+        let runtime = self.runtime.clone();
+        std::thread::spawn(move || {
+            cove_tokio::task::block_on(call!(runtime.run_wallet_upload_inline_for_test(wallet_id)))
+                .expect("run wallet upload");
+        })
+        .join()
+        .expect("wallet upload test thread");
     }
 
     pub(crate) fn clear_wallet_upload_debouncers_for_test(&self) {
-        self.wallet_upload_debouncers.lock().clear();
-        self.wallet_upload_retry_counts.lock().clear();
-        self.active_wallet_uploads.lock().clear();
+        let runtime = self.runtime.clone();
+        std::thread::spawn(move || {
+            cove_tokio::task::block_on(call!(runtime.clear_upload_runtime_state()))
+                .expect("clear upload runtime state");
+        })
+        .join()
+        .expect("clear upload runtime state thread");
+    }
+
+    pub(crate) fn verify_pending_uploads_once_for_test(&self) -> bool {
+        self.verify_pending_uploads_once()
     }
 
     pub(crate) fn has_wallet_upload_debouncer_for_test(&self, wallet_id: WalletId) -> bool {
@@ -1677,6 +1453,21 @@ mod tests {
 
     fn test_lock() -> &'static parking_lot::Mutex<()> {
         super::cloud_backup_test_lock()
+    }
+
+    fn init_manager() -> Arc<RustCloudBackupManager> {
+        cove_tokio::init();
+        RustCloudBackupManager::init()
+    }
+
+    fn new_restore_operation(manager: &RustCloudBackupManager) -> RestoreOperation {
+        cove_tokio::task::block_on(call!(manager.runtime.new_restore_operation()))
+            .expect("create restore operation")
+    }
+
+    fn invalidate_restore_operation(manager: &RustCloudBackupManager) {
+        cove_tokio::task::block_on(call!(manager.runtime.invalidate_restore_operation()))
+            .expect("invalidate restore operation");
     }
 
     #[test]
@@ -1710,7 +1501,7 @@ mod tests {
     #[test]
     fn restore_progress_updates_state() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
+        let manager = init_manager();
         let progress = CloudBackupRestoreProgress {
             stage: CloudBackupRestoreStage::Downloading,
             completed: 1,
@@ -1790,7 +1581,7 @@ mod tests {
     #[test]
     fn restore_complete_clears_restore_progress() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
+        let manager = init_manager();
         manager.set_restore_progress(Some(CloudBackupRestoreProgress {
             stage: CloudBackupRestoreStage::Restoring,
             completed: 1,
@@ -1811,7 +1602,7 @@ mod tests {
     #[test]
     fn terminal_status_clears_restore_progress_and_keeps_report() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
+        let manager = init_manager();
         let report = CloudBackupRestoreReport {
             wallets_restored: 0,
             wallets_failed: 2,
@@ -1847,9 +1638,9 @@ mod tests {
     #[test]
     fn stale_restore_operation_cannot_update_restore_progress() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
-        let stale_operation_id = manager.next_restore_operation_id();
-        let current_operation_id = manager.next_restore_operation_id();
+        let manager = init_manager();
+        let stale_operation = new_restore_operation(&manager);
+        let current_operation = new_restore_operation(&manager);
         let progress = CloudBackupRestoreProgress {
             stage: CloudBackupRestoreStage::Downloading,
             completed: 1,
@@ -1857,17 +1648,14 @@ mod tests {
         };
 
         let error = manager
-            .set_restore_progress_for_restore_operation(stale_operation_id, Some(progress.clone()))
+            .set_restore_progress_for_restore_operation(&stale_operation, Some(progress.clone()))
             .unwrap_err();
 
         assert!(matches!(error, CloudBackupError::Cancelled));
         assert_eq!(manager.state.read().restore_progress, None);
 
         manager
-            .set_restore_progress_for_restore_operation(
-                current_operation_id,
-                Some(progress.clone()),
-            )
+            .set_restore_progress_for_restore_operation(&current_operation, Some(progress.clone()))
             .unwrap();
 
         assert_eq!(manager.state.read().restore_progress, Some(progress));
@@ -1876,19 +1664,19 @@ mod tests {
     #[test]
     fn stale_restore_operation_cannot_update_status() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
-        let stale_operation_id = manager.next_restore_operation_id();
-        let current_operation_id = manager.next_restore_operation_id();
+        let manager = init_manager();
+        let stale_operation = new_restore_operation(&manager);
+        let current_operation = new_restore_operation(&manager);
 
         let error = manager
-            .set_status_for_restore_operation(stale_operation_id, CloudBackupStatus::Restoring)
+            .set_status_for_restore_operation(&stale_operation, CloudBackupStatus::Restoring)
             .unwrap_err();
 
         assert!(matches!(error, CloudBackupError::Cancelled));
         assert_eq!(manager.state.read().status, CloudBackupStatus::Disabled);
 
         manager
-            .set_status_for_restore_operation(current_operation_id, CloudBackupStatus::Restoring)
+            .set_status_for_restore_operation(&current_operation, CloudBackupStatus::Restoring)
             .unwrap();
 
         assert_eq!(manager.state.read().status, CloudBackupStatus::Restoring);
@@ -1897,9 +1685,9 @@ mod tests {
     #[test]
     fn stale_restore_operation_cannot_update_restore_report() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
-        let stale_operation_id = manager.next_restore_operation_id();
-        let current_operation_id = manager.next_restore_operation_id();
+        let manager = init_manager();
+        let stale_operation = new_restore_operation(&manager);
+        let current_operation = new_restore_operation(&manager);
         let report = CloudBackupRestoreReport {
             wallets_restored: 1,
             wallets_failed: 0,
@@ -1909,14 +1697,14 @@ mod tests {
         };
 
         let error = manager
-            .set_restore_report_for_restore_operation(stale_operation_id, Some(report.clone()))
+            .set_restore_report_for_restore_operation(&stale_operation, Some(report.clone()))
             .unwrap_err();
 
         assert!(matches!(error, CloudBackupError::Cancelled));
         assert_eq!(manager.state.read().restore_report, None);
 
         manager
-            .set_restore_report_for_restore_operation(current_operation_id, Some(report.clone()))
+            .set_restore_report_for_restore_operation(&current_operation, Some(report.clone()))
             .unwrap();
 
         assert_eq!(manager.state.read().restore_report, Some(report));
@@ -1925,13 +1713,13 @@ mod tests {
     #[test]
     fn stale_restore_operation_cannot_persist_cloud_backup_state() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
+        let manager = init_manager();
         let db = Database::global();
         db.cloud_backup_state.set(&PersistedCloudBackupState::default()).unwrap();
         manager.set_status(CloudBackupStatus::Disabled);
 
-        let stale_operation_id = manager.next_restore_operation_id();
-        let current_operation_id = manager.next_restore_operation_id();
+        let stale_operation = new_restore_operation(&manager);
+        let current_operation = new_restore_operation(&manager);
         let persisted_state = PersistedCloudBackupState {
             status: PersistedCloudBackupStatus::Enabled,
             ..PersistedCloudBackupState::default()
@@ -1939,7 +1727,7 @@ mod tests {
 
         let error = manager
             .persist_cloud_backup_state_for_restore_operation(
-                stale_operation_id,
+                &stale_operation,
                 &persisted_state,
                 "test stale restore persist",
             )
@@ -1951,7 +1739,7 @@ mod tests {
 
         manager
             .persist_cloud_backup_state_for_restore_operation(
-                current_operation_id,
+                &current_operation,
                 &persisted_state,
                 "test current restore persist",
             )
@@ -1964,25 +1752,25 @@ mod tests {
     #[test]
     fn invalidated_restore_operation_becomes_cancelled() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
-        let operation_id = manager.next_restore_operation_id();
+        let manager = init_manager();
+        let operation = new_restore_operation(&manager);
 
-        manager.invalidate_restore_operation();
+        invalidate_restore_operation(&manager);
 
-        let error = manager.ensure_current_restore_operation(operation_id).unwrap_err();
+        let error = manager.ensure_current_restore_operation(&operation).unwrap_err();
         assert!(matches!(error, CloudBackupError::Cancelled));
     }
 
     #[test]
     fn stale_restore_operation_does_not_run_locked_update() {
         let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
-        let stale_operation_id = manager.next_restore_operation_id();
-        manager.next_restore_operation_id();
+        let manager = init_manager();
+        let stale_operation = new_restore_operation(&manager);
+        let _current_operation = new_restore_operation(&manager);
         let mut ran = false;
 
-        let error = manager
-            .with_current_restore_operation_result(stale_operation_id, |_| {
+        let error = stale_operation
+            .run_result(|| {
                 ran = true;
                 Ok(())
             })
@@ -1995,17 +1783,14 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn start_background_operation_claims_enabling_synchronously() {
         let _guard = test_lock().lock();
-        cove_tokio::init();
-        let manager = RustCloudBackupManager::init();
+        let manager = init_manager();
         manager.set_status(CloudBackupStatus::Disabled);
         manager.set_progress(None);
         manager.set_restore_progress(None);
         manager.set_restore_report(None);
 
-        manager.clone().start_background_operation(
-            "first_enable",
-            Some(CloudBackupStatus::Enabling),
-            |_| Ok(()),
+        assert!(
+            manager.begin_background_operation("first_enable", Some(CloudBackupStatus::Enabling),)
         );
 
         assert_eq!(manager.state.read().status, CloudBackupStatus::Enabling);

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -1411,16 +1411,6 @@ pub(crate) fn ensure_cloud_backup_test_tokio_runtime() {
 
 #[cfg(test)]
 impl RustCloudBackupManager {
-    pub(crate) fn run_wallet_upload_for_test(&self, wallet_id: WalletId) {
-        let runtime = self.runtime.clone();
-        std::thread::spawn(move || {
-            cove_tokio::task::block_on(call!(runtime.run_wallet_upload_inline_for_test(wallet_id)))
-                .expect("run wallet upload");
-        })
-        .join()
-        .expect("wallet upload test thread");
-    }
-
     pub(crate) fn clear_wallet_upload_debouncers_for_test(&self) {
         let runtime = self.runtime.clone();
         std::thread::spawn(move || {
@@ -1456,18 +1446,28 @@ mod tests {
     }
 
     fn init_manager() -> Arc<RustCloudBackupManager> {
-        cove_tokio::init();
+        super::ensure_cloud_backup_test_tokio_runtime();
         RustCloudBackupManager::init()
     }
 
     fn new_restore_operation(manager: &RustCloudBackupManager) -> RestoreOperation {
-        cove_tokio::task::block_on(call!(manager.runtime.new_restore_operation()))
-            .expect("create restore operation")
+        let runtime = manager.runtime.clone();
+        std::thread::spawn(move || {
+            cove_tokio::task::block_on(call!(runtime.new_restore_operation()))
+                .expect("create restore operation")
+        })
+        .join()
+        .expect("create restore operation thread")
     }
 
     fn invalidate_restore_operation(manager: &RustCloudBackupManager) {
-        cove_tokio::task::block_on(call!(manager.runtime.invalidate_restore_operation()))
-            .expect("invalidate restore operation");
+        let runtime = manager.runtime.clone();
+        std::thread::spawn(move || {
+            cove_tokio::task::block_on(call!(runtime.invalidate_restore_operation()))
+                .expect("invalidate restore operation");
+        })
+        .join()
+        .expect("invalidate restore operation thread");
     }
 
     #[test]

--- a/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
+++ b/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
@@ -31,12 +31,12 @@ enum WalletItemBucket {
     NeedsSync,
 }
 
-enum RemoteWalletState<'a> {
+enum RemoteWalletState {
     Unknown,
     Unsupported,
     Missing,
-    Matching(&'a RemoteWalletBackupSummary),
-    Stale(&'a RemoteWalletBackupSummary),
+    Matching(RemoteWalletBackupSummary),
+    Stale(RemoteWalletBackupSummary),
 }
 
 pub(super) struct CloudWalletInventory {
@@ -184,19 +184,15 @@ impl CloudWalletInventory {
         let sync_state = self.sync_states_by_record_id.get(&wallet.record_id)?;
 
         match &sync_state.state {
-            crate::database::cloud_backup::PersistedCloudBlobState::UploadedPendingConfirmation(
-                state,
-            ) => Some(state.uploaded_at),
-            crate::database::cloud_backup::PersistedCloudBlobState::Confirmed(state) => {
-                Some(state.confirmed_at)
-            }
-            crate::database::cloud_backup::PersistedCloudBlobState::Dirty(_)
-            | crate::database::cloud_backup::PersistedCloudBlobState::Uploading(_)
-            | crate::database::cloud_backup::PersistedCloudBlobState::Failed(_) => None,
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => Some(state.uploaded_at),
+            PersistedCloudBlobState::Confirmed(state) => Some(state.confirmed_at),
+            PersistedCloudBlobState::Dirty(_)
+            | PersistedCloudBlobState::Uploading(_)
+            | PersistedCloudBlobState::Failed(_) => None,
         }
     }
 
-    fn remote_wallet_state<'a>(&'a self, wallet: &LocalWalletSnapshot) -> RemoteWalletState<'a> {
+    fn remote_wallet_state(&self, wallet: &LocalWalletSnapshot) -> RemoteWalletState {
         if self.remote_wallet_truth.unsupported_record_ids.contains(&wallet.record_id) {
             return RemoteWalletState::Unsupported;
         }
@@ -212,10 +208,10 @@ impl CloudWalletInventory {
         };
 
         if remote_summary.revision_hash == wallet.revision_hash {
-            return RemoteWalletState::Matching(remote_summary);
+            return RemoteWalletState::Matching(remote_summary.clone());
         }
 
-        RemoteWalletState::Stale(remote_summary)
+        RemoteWalletState::Stale(remote_summary.clone())
     }
 }
 
@@ -253,17 +249,13 @@ fn sync_status_from_state(
     fallback_status: CloudBackupWalletStatus,
 ) -> CloudBackupWalletStatus {
     match sync_state.map(|state| &state.state) {
-        Some(crate::database::cloud_backup::PersistedCloudBlobState::Uploading(_)) => {
-            CloudBackupWalletStatus::Uploading
+        Some(PersistedCloudBlobState::Uploading(_)) => CloudBackupWalletStatus::Uploading,
+        Some(PersistedCloudBlobState::UploadedPendingConfirmation(_)) => {
+            CloudBackupWalletStatus::UploadedPendingConfirmation
         }
-        Some(
-            crate::database::cloud_backup::PersistedCloudBlobState::UploadedPendingConfirmation(_),
-        ) => CloudBackupWalletStatus::UploadedPendingConfirmation,
-        Some(crate::database::cloud_backup::PersistedCloudBlobState::Failed(_)) => {
-            CloudBackupWalletStatus::Failed
-        }
-        Some(crate::database::cloud_backup::PersistedCloudBlobState::Dirty(_))
-        | Some(crate::database::cloud_backup::PersistedCloudBlobState::Confirmed(_))
+        Some(PersistedCloudBlobState::Failed(_)) => CloudBackupWalletStatus::Failed,
+        Some(PersistedCloudBlobState::Dirty(_))
+        | Some(PersistedCloudBlobState::Confirmed(_))
         | None => fallback_status,
     }
 }

--- a/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
+++ b/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
@@ -1,86 +1,108 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use cove_cspp::backup_data::wallet_record_id;
+use cove_util::ResultExt as _;
 
-use super::{
-    CloudBackupDetail, CloudBackupError, CloudBackupWalletItem, CloudBackupWalletStatus,
-    cspp_master_key_record_id,
-};
+use super::wallets::{RemoteWalletBackupSummary, all_local_wallets, prepare_wallet_backup};
+use super::{CloudBackupDetail, CloudBackupError, CloudBackupWalletItem, CloudBackupWalletStatus};
 use crate::database::Database;
 use crate::database::cloud_backup::{
-    CloudUploadKind, PendingCloudUploadItem, PersistedCloudBackupStatus,
+    CloudBlobFailedState, PersistedCloudBackupStatus, PersistedCloudBlobState,
+    PersistedCloudBlobSyncState,
 };
-use crate::manager::cloud_backup_manager::wallets::all_local_wallets;
 use crate::wallet::metadata::WalletMetadata;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RemoteWalletTruth {
+    pub(super) summaries_by_record_id: HashMap<String, RemoteWalletBackupSummary>,
+    pub(super) unsupported_record_ids: HashSet<String>,
+    pub(super) unknown_record_ids: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LocalWalletSnapshot {
+    metadata: WalletMetadata,
+    record_id: String,
+    revision_hash: String,
+    local_label_count: u32,
+}
+
+enum WalletItemBucket {
+    UpToDate,
+    NeedsSync,
+}
+
+enum RemoteWalletState<'a> {
+    Unknown,
+    Unsupported,
+    Missing,
+    Matching(&'a RemoteWalletBackupSummary),
+    Stale(&'a RemoteWalletBackupSummary),
+}
 
 pub(super) struct CloudWalletInventory {
     last_sync: Option<u64>,
-    local_wallets: Vec<WalletMetadata>,
+    local_wallets: Vec<LocalWalletSnapshot>,
     cloud_wallet_record_ids: HashSet<String>,
+    sync_states_by_record_id: HashMap<String, PersistedCloudBlobSyncState>,
+    remote_wallet_truth: RemoteWalletTruth,
+    strict_cloud_presence: bool,
 }
 
 impl CloudWalletInventory {
-    pub(super) fn load(wallet_record_ids: &[String]) -> Result<Self, CloudBackupError> {
+    pub(super) fn load_with_remote_truth(
+        wallet_record_ids: &[String],
+        remote_wallet_truth: RemoteWalletTruth,
+    ) -> Result<Self, CloudBackupError> {
         let db = Database::global();
-        let local_wallets = all_local_wallets(&db)?;
+        let local_wallets = all_local_wallet_snapshots(&db)?;
         let last_sync = last_sync(&db);
-        let cloud_wallet_record_ids = merged_cloud_wallet_record_ids(&db, wallet_record_ids);
+        let sync_states_by_record_id = sync_states_by_record_id(&db)?;
 
-        Ok(Self::new(last_sync, local_wallets, cloud_wallet_record_ids))
-    }
-
-    pub(super) fn load_strict(wallet_record_ids: &[String]) -> Result<Self, CloudBackupError> {
-        let db = Database::global();
-        let local_wallets = all_local_wallets(&db)?;
-        let last_sync = last_sync(&db);
-        let cloud_wallet_record_ids = listed_cloud_wallet_record_ids(wallet_record_ids, &[], false);
-
-        Ok(Self::new(last_sync, local_wallets, cloud_wallet_record_ids))
-    }
-
-    fn new(
-        last_sync: Option<u64>,
-        local_wallets: Vec<WalletMetadata>,
-        cloud_wallet_record_ids: HashSet<String>,
-    ) -> Self {
-        Self { last_sync, local_wallets, cloud_wallet_record_ids }
+        Ok(Self {
+            last_sync,
+            local_wallets,
+            cloud_wallet_record_ids: wallet_record_ids.iter().cloned().collect(),
+            sync_states_by_record_id,
+            remote_wallet_truth,
+            strict_cloud_presence: false,
+        })
     }
 
     pub(super) fn cloud_wallet_count(&self) -> usize {
         self.cloud_wallet_record_ids.len()
     }
 
-    pub(super) fn unsynced_local_wallets(&self) -> Vec<WalletMetadata> {
+    pub(super) fn upload_candidate_wallets(&self) -> Vec<WalletMetadata> {
+        if self.strict_cloud_presence {
+            return self
+                .local_wallets
+                .iter()
+                .filter(|wallet| !self.cloud_wallet_record_ids.contains(&wallet.record_id))
+                .map(|wallet| wallet.metadata.clone())
+                .collect();
+        }
+
         self.local_wallets
             .iter()
-            .filter(|wallet| {
-                !self.cloud_wallet_record_ids.contains(&wallet_record_id(wallet.id.as_ref()))
-            })
-            .cloned()
+            .filter(|wallet| self.is_upload_candidate_wallet(wallet))
+            .map(|wallet| wallet.metadata.clone())
             .collect()
     }
 
     pub(super) fn build_detail(&self) -> CloudBackupDetail {
         let local_record_ids: HashSet<_> =
-            self.local_wallets.iter().map(|wallet| wallet_record_id(wallet.id.as_ref())).collect();
+            self.local_wallets.iter().map(|wallet| wallet.record_id.clone()).collect();
 
-        let mut backed_up = Vec::new();
-        let mut not_backed_up = Vec::new();
+        let mut up_to_date = Vec::new();
+        let mut needs_sync = Vec::new();
 
         for wallet in &self.local_wallets {
-            let record_id = wallet_record_id(wallet.id.as_ref());
-            let status = if self.cloud_wallet_record_ids.contains(&record_id) {
-                CloudBackupWalletStatus::BackedUp
-            } else {
-                CloudBackupWalletStatus::NotBackedUp
-            };
+            let item = self.local_wallet_item(wallet);
 
-            let item = local_wallet_item(wallet, status);
-
-            match item.status {
-                CloudBackupWalletStatus::BackedUp => backed_up.push(item),
-                CloudBackupWalletStatus::NotBackedUp => not_backed_up.push(item),
-                CloudBackupWalletStatus::DeletedFromDevice => {}
+            match wallet_item_bucket(&item) {
+                Some(WalletItemBucket::UpToDate) => up_to_date.push(item),
+                Some(WalletItemBucket::NeedsSync) => needs_sync.push(item),
+                None => {}
             }
         }
 
@@ -90,7 +112,186 @@ impl CloudWalletInventory {
             .filter(|record_id| !local_record_ids.contains(*record_id))
             .count() as u32;
 
-        CloudBackupDetail { last_sync: self.last_sync, backed_up, not_backed_up, cloud_only_count }
+        CloudBackupDetail { last_sync: self.last_sync, up_to_date, needs_sync, cloud_only_count }
+    }
+
+    pub(super) fn has_unknown_remote_wallets(&self) -> bool {
+        self.local_wallets.iter().any(|wallet| {
+            matches!(
+                self.sync_status_for_wallet(wallet),
+                CloudBackupWalletStatus::RemoteStateUnknown
+            )
+        })
+    }
+
+    fn local_wallet_item(&self, wallet: &LocalWalletSnapshot) -> CloudBackupWalletItem {
+        let remote_summary = self.remote_wallet_truth.summaries_by_record_id.get(&wallet.record_id);
+
+        CloudBackupWalletItem {
+            name: wallet.metadata.name.clone(),
+            network: Some(wallet.metadata.network),
+            wallet_mode: Some(wallet.metadata.wallet_mode),
+            wallet_type: Some(wallet.metadata.wallet_type),
+            fingerprint: wallet.metadata.master_fingerprint.as_ref().map(|fp| fp.as_uppercase()),
+            label_count: remote_summary
+                .map(|summary| summary.label_count)
+                .or(Some(wallet.local_label_count)),
+            backup_updated_at: self.backup_updated_at_for_wallet(wallet),
+            sync_status: self.sync_status_for_wallet(wallet),
+            record_id: wallet.record_id.clone(),
+        }
+    }
+
+    fn is_upload_candidate_wallet(&self, wallet: &LocalWalletSnapshot) -> bool {
+        let sync_state = self.sync_states_by_record_id.get(&wallet.record_id);
+
+        match self.remote_wallet_state(wallet) {
+            RemoteWalletState::Unsupported | RemoteWalletState::Matching(_) => false,
+            RemoteWalletState::Unknown => has_local_upload_candidate(sync_state),
+            RemoteWalletState::Missing | RemoteWalletState::Stale(_) => !matches!(
+                sync_state.map(|state| &state.state),
+                Some(PersistedCloudBlobState::Uploading(_))
+                    | Some(PersistedCloudBlobState::UploadedPendingConfirmation(_))
+            ),
+        }
+    }
+
+    fn sync_status_for_wallet(&self, wallet: &LocalWalletSnapshot) -> CloudBackupWalletStatus {
+        let sync_state = self.sync_states_by_record_id.get(&wallet.record_id);
+        match self.remote_wallet_state(wallet) {
+            RemoteWalletState::Matching(_) => CloudBackupWalletStatus::Confirmed,
+            RemoteWalletState::Unsupported => {
+                sync_status_from_state(sync_state, CloudBackupWalletStatus::RemoteStateUnknown)
+            }
+            RemoteWalletState::Unknown => sync_status_for_unknown_remote(sync_state),
+            RemoteWalletState::Missing | RemoteWalletState::Stale(_) => {
+                sync_status_from_state(sync_state, CloudBackupWalletStatus::Dirty)
+            }
+        }
+    }
+
+    fn backup_updated_at_for_wallet(&self, wallet: &LocalWalletSnapshot) -> Option<u64> {
+        match self.remote_wallet_state(wallet) {
+            RemoteWalletState::Matching(remote_summary)
+            | RemoteWalletState::Stale(remote_summary) => {
+                return Some(remote_summary.updated_at);
+            }
+            RemoteWalletState::Unknown
+            | RemoteWalletState::Unsupported
+            | RemoteWalletState::Missing => {}
+        }
+
+        let sync_state = self.sync_states_by_record_id.get(&wallet.record_id)?;
+
+        match &sync_state.state {
+            crate::database::cloud_backup::PersistedCloudBlobState::UploadedPendingConfirmation(
+                state,
+            ) => Some(state.uploaded_at),
+            crate::database::cloud_backup::PersistedCloudBlobState::Confirmed(state) => {
+                Some(state.confirmed_at)
+            }
+            crate::database::cloud_backup::PersistedCloudBlobState::Dirty(_)
+            | crate::database::cloud_backup::PersistedCloudBlobState::Uploading(_)
+            | crate::database::cloud_backup::PersistedCloudBlobState::Failed(_) => None,
+        }
+    }
+
+    fn remote_wallet_state<'a>(&'a self, wallet: &LocalWalletSnapshot) -> RemoteWalletState<'a> {
+        if self.remote_wallet_truth.unsupported_record_ids.contains(&wallet.record_id) {
+            return RemoteWalletState::Unsupported;
+        }
+
+        if self.remote_wallet_truth.unknown_record_ids.contains(&wallet.record_id) {
+            return RemoteWalletState::Unknown;
+        }
+
+        let Some(remote_summary) =
+            self.remote_wallet_truth.summaries_by_record_id.get(&wallet.record_id)
+        else {
+            return RemoteWalletState::Missing;
+        };
+
+        if remote_summary.revision_hash == wallet.revision_hash {
+            return RemoteWalletState::Matching(remote_summary);
+        }
+
+        RemoteWalletState::Stale(remote_summary)
+    }
+}
+
+fn wallet_item_bucket(item: &CloudBackupWalletItem) -> Option<WalletItemBucket> {
+    match item.sync_status {
+        CloudBackupWalletStatus::Confirmed => Some(WalletItemBucket::UpToDate),
+        CloudBackupWalletStatus::DeletedFromDevice => None,
+        CloudBackupWalletStatus::Dirty
+        | CloudBackupWalletStatus::Uploading
+        | CloudBackupWalletStatus::UploadedPendingConfirmation
+        | CloudBackupWalletStatus::Failed
+        | CloudBackupWalletStatus::UnsupportedVersion
+        | CloudBackupWalletStatus::RemoteStateUnknown => Some(WalletItemBucket::NeedsSync),
+    }
+}
+
+fn all_local_wallet_snapshots(db: &Database) -> Result<Vec<LocalWalletSnapshot>, CloudBackupError> {
+    all_local_wallets(db)?
+        .into_iter()
+        .map(|wallet| {
+            let prepared = prepare_wallet_backup(&wallet, wallet.wallet_mode)?;
+
+            Ok(LocalWalletSnapshot {
+                metadata: wallet,
+                record_id: prepared.record_id,
+                revision_hash: prepared.revision_hash,
+                local_label_count: prepared.entry.labels_count,
+            })
+        })
+        .collect()
+}
+
+fn sync_status_from_state(
+    sync_state: Option<&PersistedCloudBlobSyncState>,
+    fallback_status: CloudBackupWalletStatus,
+) -> CloudBackupWalletStatus {
+    match sync_state.map(|state| &state.state) {
+        Some(crate::database::cloud_backup::PersistedCloudBlobState::Uploading(_)) => {
+            CloudBackupWalletStatus::Uploading
+        }
+        Some(
+            crate::database::cloud_backup::PersistedCloudBlobState::UploadedPendingConfirmation(_),
+        ) => CloudBackupWalletStatus::UploadedPendingConfirmation,
+        Some(crate::database::cloud_backup::PersistedCloudBlobState::Failed(_)) => {
+            CloudBackupWalletStatus::Failed
+        }
+        Some(crate::database::cloud_backup::PersistedCloudBlobState::Dirty(_))
+        | Some(crate::database::cloud_backup::PersistedCloudBlobState::Confirmed(_))
+        | None => fallback_status,
+    }
+}
+
+fn sync_status_for_unknown_remote(
+    sync_state: Option<&PersistedCloudBlobSyncState>,
+) -> CloudBackupWalletStatus {
+    match sync_state.map(|state| &state.state) {
+        Some(PersistedCloudBlobState::Dirty(_)) => CloudBackupWalletStatus::Dirty,
+        Some(PersistedCloudBlobState::Uploading(_)) => CloudBackupWalletStatus::Uploading,
+        Some(PersistedCloudBlobState::UploadedPendingConfirmation(_)) => {
+            CloudBackupWalletStatus::UploadedPendingConfirmation
+        }
+        Some(PersistedCloudBlobState::Failed(_)) => CloudBackupWalletStatus::Failed,
+        Some(PersistedCloudBlobState::Confirmed(_)) | None => {
+            CloudBackupWalletStatus::RemoteStateUnknown
+        }
+    }
+}
+
+fn has_local_upload_candidate(sync_state: Option<&PersistedCloudBlobSyncState>) -> bool {
+    match sync_state.map(|state| &state.state) {
+        Some(PersistedCloudBlobState::Dirty(_)) => true,
+        Some(PersistedCloudBlobState::Failed(CloudBlobFailedState { retryable, .. })) => *retryable,
+        Some(PersistedCloudBlobState::Uploading(_))
+        | Some(PersistedCloudBlobState::UploadedPendingConfirmation(_))
+        | Some(PersistedCloudBlobState::Confirmed(_))
+        | None => false,
     }
 }
 
@@ -104,158 +305,360 @@ fn last_sync(db: &Database) -> Option<u64> {
     }
 }
 
-pub(super) fn merged_cloud_wallet_record_ids(
+fn sync_states_by_record_id(
     db: &Database,
-    wallet_record_ids: &[String],
-) -> HashSet<String> {
-    let pending_items =
-        db.cloud_upload_queue.get().ok().flatten().map(|queue| queue.items).unwrap_or_default();
-
-    listed_cloud_wallet_record_ids(wallet_record_ids, &pending_items, true)
-}
-
-fn listed_cloud_wallet_record_ids(
-    wallet_record_ids: &[String],
-    pending_items: &[PendingCloudUploadItem],
-    include_pending_uploads: bool,
-) -> HashSet<String> {
-    let mut cloud_wallet_record_ids: HashSet<_> = wallet_record_ids.iter().cloned().collect();
-
-    if include_pending_uploads {
-        merge_pending_wallet_record_ids(&mut cloud_wallet_record_ids, pending_items);
-    }
-
-    cloud_wallet_record_ids
-}
-
-fn merge_pending_wallet_record_ids(
-    cloud_wallet_record_ids: &mut HashSet<String>,
-    pending_items: &[PendingCloudUploadItem],
-) {
-    let master_key_id = cspp_master_key_record_id();
-    for item in pending_items {
-        if item.kind == CloudUploadKind::BackupBlob && item.record_id != master_key_id {
-            cloud_wallet_record_ids.insert(item.record_id.clone());
-        }
-    }
-}
-
-fn local_wallet_item(
-    wallet: &WalletMetadata,
-    status: CloudBackupWalletStatus,
-) -> CloudBackupWalletItem {
-    CloudBackupWalletItem {
-        name: wallet.name.clone(),
-        network: wallet.network,
-        wallet_mode: wallet.wallet_mode,
-        wallet_type: wallet.wallet_type,
-        fingerprint: wallet.master_fingerprint.as_ref().map(|fp| fp.as_uppercase()),
-        status,
-        record_id: wallet_record_id(wallet.id.as_ref()),
-    }
+) -> Result<HashMap<String, PersistedCloudBlobSyncState>, CloudBackupError> {
+    db.cloud_blob_sync_states
+        .list()
+        .map_err_prefix("list cloud blob sync states", CloudBackupError::Internal)
+        .map(|states| {
+            states
+                .into_iter()
+                .map(|state| (state.record_id.clone(), state))
+                .collect::<HashMap<_, _>>()
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::cloud_backup::CloudUploadVerificationState;
+    use crate::database::cloud_backup::{
+        CloudBlobConfirmedState, CloudBlobDirtyState, CloudBlobFailedState,
+        CloudBlobUploadedPendingConfirmationState, CloudBlobUploadingState, CloudUploadKind,
+        PersistedCloudBlobState,
+    };
 
-    #[test]
-    fn merge_pending_wallet_record_ids_skips_master_key() {
-        let mut cloud_wallet_record_ids = HashSet::from(["wallet-a".to_string()]);
-        let pending_blobs = vec![
-            PendingCloudUploadItem {
-                kind: CloudUploadKind::BackupBlob,
-                namespace_id: "ns-1".into(),
-                record_id: cspp_master_key_record_id(),
-                enqueued_at: 0,
-                verification: CloudUploadVerificationState::Pending {
-                    attempt_count: 0,
-                    last_checked_at: None,
-                },
-            },
-            PendingCloudUploadItem {
-                kind: CloudUploadKind::BackupBlob,
-                namespace_id: "ns-1".into(),
-                record_id: "wallet-b".to_string(),
-                enqueued_at: 0,
-                verification: CloudUploadVerificationState::Pending {
-                    attempt_count: 0,
-                    last_checked_at: None,
-                },
-            },
-        ];
-
-        merge_pending_wallet_record_ids(&mut cloud_wallet_record_ids, &pending_blobs);
-
-        assert!(cloud_wallet_record_ids.contains("wallet-a"));
-        assert!(cloud_wallet_record_ids.contains("wallet-b"));
-        assert!(!cloud_wallet_record_ids.contains(&cspp_master_key_record_id()));
-    }
-
-    #[test]
-    fn inventory_build_detail_preserves_wallet_statuses() {
-        let wallet_a = WalletMetadata::preview_new();
-        let mut wallet_b = WalletMetadata::preview_new();
-        wallet_b.name = "Wallet B".into();
-
-        let cloud_wallet_record_ids = HashSet::from([wallet_record_id(wallet_a.id.as_ref())]);
-        let inventory = CloudWalletInventory::new(
-            Some(42),
-            vec![wallet_a.clone(), wallet_b.clone()],
-            cloud_wallet_record_ids,
-        );
-
-        let detail = inventory.build_detail();
-
-        assert_eq!(detail.last_sync, Some(42));
-        assert_eq!(detail.backed_up.len(), 1);
-        assert_eq!(detail.not_backed_up.len(), 1);
-        assert_eq!(detail.backed_up[0].record_id, wallet_record_id(wallet_a.id.as_ref()));
-        assert_eq!(detail.not_backed_up[0].record_id, wallet_record_id(wallet_b.id.as_ref()));
-    }
-
-    #[test]
-    fn inventory_unsynced_local_wallets_uses_merged_cloud_ids() {
-        let wallet_a = WalletMetadata::preview_new();
-        let mut wallet_b = WalletMetadata::preview_new();
-        wallet_b.name = "Wallet B".into();
-
-        let cloud_wallet_record_ids = HashSet::from([wallet_record_id(wallet_a.id.as_ref())]);
-        let inventory = CloudWalletInventory::new(
-            None,
-            vec![wallet_a, wallet_b.clone()],
-            cloud_wallet_record_ids,
-        );
-
-        let unsynced = inventory.unsynced_local_wallets();
-
-        assert_eq!(unsynced.len(), 1);
-        assert_eq!(unsynced[0].id, wallet_b.id);
-    }
-
-    #[test]
-    fn listed_cloud_wallet_record_ids_can_ignore_pending_uploads() {
-        let wallet_a = WalletMetadata::preview_new();
-        let wallet_b = WalletMetadata::preview_new();
-        let pending_items = vec![PendingCloudUploadItem {
+    fn sync_state(state: PersistedCloudBlobState) -> PersistedCloudBlobSyncState {
+        PersistedCloudBlobSyncState {
             kind: CloudUploadKind::BackupBlob,
             namespace_id: "ns-1".into(),
-            record_id: wallet_record_id(wallet_b.id.as_ref()),
-            enqueued_at: 0,
-            verification: CloudUploadVerificationState::Pending {
+            wallet_id: None,
+            record_id: "record-1".into(),
+            state,
+        }
+    }
+
+    #[test]
+    fn status_is_confirmed_when_remote_revision_matches() {
+        let state = sync_state(PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
+            revision_hash: "old".into(),
+            confirmed_at: 10,
+        }));
+        let wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-1".into(),
+            revision_hash: "rev-1".into(),
+            local_label_count: 3,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet.clone()],
+            cloud_wallet_record_ids: HashSet::new(),
+            sync_states_by_record_id: HashMap::from([(wallet.record_id.clone(), state)]),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::from([(
+                    wallet.record_id.clone(),
+                    RemoteWalletBackupSummary {
+                        revision_hash: "rev-1".into(),
+                        label_count: 2,
+                        updated_at: 50,
+                    },
+                )]),
+                unsupported_record_ids: HashSet::new(),
+                unknown_record_ids: HashSet::new(),
+            },
+            strict_cloud_presence: false,
+        };
+
+        assert_eq!(inventory.sync_status_for_wallet(&wallet), CloudBackupWalletStatus::Confirmed);
+        assert_eq!(inventory.backup_updated_at_for_wallet(&wallet), Some(50));
+    }
+
+    #[test]
+    fn status_stays_uploaded_pending_confirmation_when_remote_is_stale() {
+        let state = sync_state(PersistedCloudBlobState::UploadedPendingConfirmation(
+            CloudBlobUploadedPendingConfirmationState {
+                revision_hash: "rev-2".into(),
+                uploaded_at: 20,
                 attempt_count: 0,
                 last_checked_at: None,
             },
-        }];
+        ));
+        let wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-1".into(),
+            revision_hash: "rev-2".into(),
+            local_label_count: 1,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet.clone()],
+            cloud_wallet_record_ids: HashSet::new(),
+            sync_states_by_record_id: HashMap::from([(wallet.record_id.clone(), state)]),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::from([(
+                    wallet.record_id.clone(),
+                    RemoteWalletBackupSummary {
+                        revision_hash: "rev-1".into(),
+                        label_count: 1,
+                        updated_at: 10,
+                    },
+                )]),
+                unsupported_record_ids: HashSet::new(),
+                unknown_record_ids: HashSet::new(),
+            },
+            strict_cloud_presence: false,
+        };
 
-        let strict_ids = listed_cloud_wallet_record_ids(
-            &[wallet_record_id(wallet_a.id.as_ref())],
-            &pending_items,
-            false,
+        assert_eq!(
+            inventory.sync_status_for_wallet(&wallet),
+            CloudBackupWalletStatus::UploadedPendingConfirmation
         );
+    }
 
-        assert!(strict_ids.contains(&wallet_record_id(wallet_a.id.as_ref())));
-        assert!(!strict_ids.contains(&wallet_record_id(wallet_b.id.as_ref())));
+    #[test]
+    fn status_is_unknown_when_remote_truth_failed_without_active_upload() {
+        let wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-1".into(),
+            revision_hash: "rev-1".into(),
+            local_label_count: 0,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet.clone()],
+            cloud_wallet_record_ids: HashSet::new(),
+            sync_states_by_record_id: HashMap::new(),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::new(),
+                unsupported_record_ids: HashSet::new(),
+                unknown_record_ids: HashSet::from([wallet.record_id.clone()]),
+            },
+            strict_cloud_presence: false,
+        };
+
+        assert_eq!(
+            inventory.sync_status_for_wallet(&wallet),
+            CloudBackupWalletStatus::RemoteStateUnknown
+        );
+        assert!(inventory.has_unknown_remote_wallets());
+        assert!(inventory.upload_candidate_wallets().is_empty());
+    }
+
+    #[test]
+    fn status_stays_dirty_when_remote_truth_failed_for_dirty_wallet() {
+        let wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-1".into(),
+            revision_hash: "rev-1".into(),
+            local_label_count: 0,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet.clone()],
+            cloud_wallet_record_ids: HashSet::new(),
+            sync_states_by_record_id: HashMap::from([(
+                wallet.record_id.clone(),
+                sync_state(PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at: 10 })),
+            )]),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::new(),
+                unsupported_record_ids: HashSet::new(),
+                unknown_record_ids: HashSet::from([wallet.record_id.clone()]),
+            },
+            strict_cloud_presence: false,
+        };
+
+        assert_eq!(inventory.sync_status_for_wallet(&wallet), CloudBackupWalletStatus::Dirty);
+        assert!(!inventory.has_unknown_remote_wallets());
+        assert_eq!(inventory.upload_candidate_wallets(), vec![wallet.metadata.clone()]);
+    }
+
+    #[test]
+    fn retryable_failed_unknown_wallet_stays_upload_candidate() {
+        let wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-1".into(),
+            revision_hash: "rev-1".into(),
+            local_label_count: 0,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet.clone()],
+            cloud_wallet_record_ids: HashSet::new(),
+            sync_states_by_record_id: HashMap::from([(
+                wallet.record_id.clone(),
+                sync_state(PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    revision_hash: Some("rev-1".into()),
+                    retryable: true,
+                    error: "offline".into(),
+                    failed_at: 10,
+                })),
+            )]),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::new(),
+                unsupported_record_ids: HashSet::new(),
+                unknown_record_ids: HashSet::from([wallet.record_id.clone()]),
+            },
+            strict_cloud_presence: false,
+        };
+
+        assert_eq!(inventory.sync_status_for_wallet(&wallet), CloudBackupWalletStatus::Failed);
+        assert_eq!(inventory.upload_candidate_wallets(), vec![wallet.metadata.clone()]);
+    }
+
+    #[test]
+    fn strict_inventory_only_treats_listed_wallets_as_synced() {
+        let wallet_a = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-a".into(),
+            revision_hash: "rev-a".into(),
+            local_label_count: 0,
+        };
+        let wallet_b = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-b".into(),
+            revision_hash: "rev-b".into(),
+            local_label_count: 0,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet_a.clone(), wallet_b.clone()],
+            cloud_wallet_record_ids: HashSet::from([wallet_a.record_id.clone()]),
+            sync_states_by_record_id: HashMap::new(),
+            remote_wallet_truth: RemoteWalletTruth::default(),
+            strict_cloud_presence: true,
+        };
+
+        let unsynced = inventory.upload_candidate_wallets();
+
+        assert_eq!(unsynced.len(), 1);
+        assert_eq!(unsynced[0].id, wallet_b.metadata.id);
+    }
+
+    #[test]
+    fn upload_candidates_exclude_pending_states_but_detail_keeps_them_visible() {
+        let uploading_wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-uploading".into(),
+            revision_hash: "rev-uploading".into(),
+            local_label_count: 0,
+        };
+        let pending_wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-pending".into(),
+            revision_hash: "rev-pending".into(),
+            local_label_count: 0,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![uploading_wallet.clone(), pending_wallet.clone()],
+            cloud_wallet_record_ids: HashSet::new(),
+            sync_states_by_record_id: HashMap::from([
+                (
+                    uploading_wallet.record_id.clone(),
+                    PersistedCloudBlobSyncState {
+                        kind: CloudUploadKind::BackupBlob,
+                        namespace_id: "ns-1".into(),
+                        wallet_id: None,
+                        record_id: uploading_wallet.record_id.clone(),
+                        state: PersistedCloudBlobState::Uploading(CloudBlobUploadingState {
+                            revision_hash: "rev-uploading".into(),
+                            started_at: 10,
+                        }),
+                    },
+                ),
+                (
+                    pending_wallet.record_id.clone(),
+                    PersistedCloudBlobSyncState {
+                        kind: CloudUploadKind::BackupBlob,
+                        namespace_id: "ns-1".into(),
+                        wallet_id: None,
+                        record_id: pending_wallet.record_id.clone(),
+                        state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                            CloudBlobUploadedPendingConfirmationState {
+                                revision_hash: "rev-pending".into(),
+                                uploaded_at: 20,
+                                attempt_count: 0,
+                                last_checked_at: None,
+                            },
+                        ),
+                    },
+                ),
+            ]),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::from([
+                    (
+                        uploading_wallet.record_id.clone(),
+                        RemoteWalletBackupSummary {
+                            revision_hash: "stale-uploading".into(),
+                            label_count: 0,
+                            updated_at: 5,
+                        },
+                    ),
+                    (
+                        pending_wallet.record_id.clone(),
+                        RemoteWalletBackupSummary {
+                            revision_hash: "stale-pending".into(),
+                            label_count: 0,
+                            updated_at: 6,
+                        },
+                    ),
+                ]),
+                unsupported_record_ids: HashSet::new(),
+                unknown_record_ids: HashSet::new(),
+            },
+            strict_cloud_presence: false,
+        };
+
+        let upload_candidates = inventory.upload_candidate_wallets();
+
+        assert!(upload_candidates.is_empty());
+
+        let detail = inventory.build_detail();
+
+        assert_eq!(detail.needs_sync.len(), 2);
+        assert!(detail.needs_sync.iter().any(|item| {
+            item.record_id == uploading_wallet.record_id
+                && item.sync_status == CloudBackupWalletStatus::Uploading
+        }));
+        assert!(detail.needs_sync.iter().any(|item| {
+            item.record_id == pending_wallet.record_id
+                && item.sync_status == CloudBackupWalletStatus::UploadedPendingConfirmation
+        }));
+    }
+
+    #[test]
+    fn unsupported_remote_backups_are_visible_but_not_upload_candidates() {
+        let wallet = LocalWalletSnapshot {
+            metadata: WalletMetadata::preview_new(),
+            record_id: "record-1".into(),
+            revision_hash: "rev-1".into(),
+            local_label_count: 3,
+        };
+        let inventory = CloudWalletInventory {
+            last_sync: None,
+            local_wallets: vec![wallet.clone()],
+            cloud_wallet_record_ids: HashSet::from([wallet.record_id.clone()]),
+            sync_states_by_record_id: HashMap::new(),
+            remote_wallet_truth: RemoteWalletTruth {
+                summaries_by_record_id: HashMap::new(),
+                unsupported_record_ids: HashSet::from([wallet.record_id.clone()]),
+                unknown_record_ids: HashSet::new(),
+            },
+            strict_cloud_presence: false,
+        };
+
+        assert_eq!(
+            inventory.sync_status_for_wallet(&wallet),
+            CloudBackupWalletStatus::RemoteStateUnknown
+        );
+        assert!(inventory.upload_candidate_wallets().is_empty());
+
+        let detail = inventory.build_detail();
+
+        assert_eq!(detail.needs_sync.len(), 1);
+        assert_eq!(detail.needs_sync[0].record_id, wallet.record_id);
+        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::RemoteStateUnknown);
     }
 }

--- a/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
+++ b/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
@@ -161,7 +161,7 @@ impl CloudWalletInventory {
         match self.remote_wallet_state(wallet) {
             RemoteWalletState::Matching(_) => CloudBackupWalletStatus::Confirmed,
             RemoteWalletState::Unsupported => {
-                sync_status_from_state(sync_state, CloudBackupWalletStatus::RemoteStateUnknown)
+                sync_status_from_state(sync_state, CloudBackupWalletStatus::UnsupportedVersion)
             }
             RemoteWalletState::Unknown => sync_status_for_unknown_remote(sync_state),
             RemoteWalletState::Missing | RemoteWalletState::Stale(_) => {
@@ -643,7 +643,7 @@ mod tests {
 
         assert_eq!(
             inventory.sync_status_for_wallet(&wallet),
-            CloudBackupWalletStatus::RemoteStateUnknown
+            CloudBackupWalletStatus::UnsupportedVersion
         );
         assert!(inventory.upload_candidate_wallets().is_empty());
 
@@ -651,6 +651,6 @@ mod tests {
 
         assert_eq!(detail.needs_sync.len(), 1);
         assert_eq!(detail.needs_sync[0].record_id, wallet.record_id);
-        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::RemoteStateUnknown);
+        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::UnsupportedVersion);
     }
 }

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -18,7 +18,7 @@ use super::wallets::{
 use super::{
     CloudBackupError, CloudBackupReconcileMessage as Message, CloudBackupRestoreProgress,
     CloudBackupRestoreReport, CloudBackupRestoreStage, CloudBackupStatus, CloudBackupWalletItem,
-    CloudBackupWalletStatus, PendingEnableSession, RustCloudBackupManager,
+    CloudBackupWalletStatus, PendingEnableSession, RestoreOperation, RustCloudBackupManager,
 };
 use crate::database::Database;
 use crate::database::cloud_backup::{PersistedCloudBackupState, PersistedCloudBackupStatus};
@@ -59,13 +59,13 @@ impl RustCloudBackupManager {
 
     fn send_restore_progress(
         &self,
-        operation_id: u64,
+        operation: &RestoreOperation,
         stage: CloudBackupRestoreStage,
         completed: u32,
         total: Option<u32>,
     ) -> Result<(), CloudBackupError> {
         self.set_restore_progress_for_restore_operation(
-            operation_id,
+            operation,
             Some(CloudBackupRestoreProgress { stage, completed, total }),
         )
     }
@@ -548,13 +548,13 @@ impl RustCloudBackupManager {
 
     pub(super) fn do_restore_from_cloud_backup(
         &self,
-        operation_id: u64,
+        operation: &RestoreOperation,
     ) -> Result<(), CloudBackupError> {
         self.set_progress(None);
         self.set_restore_progress(None);
         self.set_restore_report(None);
-        self.set_status_for_restore_operation(operation_id, CloudBackupStatus::Restoring)?;
-        self.send_restore_progress(operation_id, CloudBackupRestoreStage::Finding, 0, None)?;
+        self.set_status_for_restore_operation(operation, CloudBackupStatus::Restoring)?;
+        self.send_restore_progress(operation, CloudBackupRestoreStage::Finding, 0, None)?;
 
         let cloud = CloudStorage::global();
         let keychain = Keychain::global();
@@ -564,12 +564,12 @@ impl RustCloudBackupManager {
         let passkey = PasskeyAccess::global();
         let (master_key, namespace_id) = match self.restore_via_passkey_matching(cloud, passkey) {
             Ok(matched) => {
-                self.with_current_restore_operation_result(operation_id, |_| {
+                operation.run_result(|| {
                     cspp.save_master_key(&matched.master_key)
                         .map_err_prefix("save master key", CloudBackupError::Internal)?;
                     Ok(())
                 })?;
-                self.with_current_restore_operation_result(operation_id, |_| {
+                operation.run_result(|| {
                     keychain
                         .save_cspp_passkey_and_namespace(
                             &matched.credential_id,
@@ -590,7 +590,7 @@ impl RustCloudBackupManager {
                 info!("Restore: passkey didn't match, trying local master key fallback");
                 let (master_key, namespace_id) = try_restore_from_local_master_key(cloud, &cspp)
                     .ok_or(CloudBackupError::PasskeyMismatch)?;
-                self.with_current_restore_operation_result(operation_id, |_| {
+                operation.run_result(|| {
                     persist_namespace_id(keychain, &namespace_id)?;
                     Ok(())
                 })?;
@@ -600,7 +600,7 @@ impl RustCloudBackupManager {
         };
 
         // download and restore wallets
-        self.ensure_current_restore_operation(operation_id)?;
+        self.ensure_current_restore_operation(operation)?;
         let wallet_record_ids =
             cloud.list_wallet_backups(namespace_id.clone()).map_err_str(CloudBackupError::Cloud)?;
 
@@ -621,25 +621,19 @@ impl RustCloudBackupManager {
             .map_err_prefix("collect fingerprints", CloudBackupError::Internal)?;
         let mut restore_session = WalletRestoreSession::new(existing_fingerprints);
 
-        let downloaded_wallets = self.download_wallets_for_restore(
-            operation_id,
-            &reader,
-            &wallet_record_ids,
-            &mut report,
-        )?;
+        let downloaded_wallets =
+            self.download_wallets_for_restore(operation, &reader, &wallet_record_ids, &mut report)?;
         let restore_total = downloaded_wallets.len() as u32;
 
         self.send_restore_progress(
-            operation_id,
+            operation,
             CloudBackupRestoreStage::Restoring,
             0,
             Some(restore_total),
         )?;
 
         for (index, (record_id, wallet)) in downloaded_wallets.iter().enumerate() {
-            match self.with_current_restore_operation_result(operation_id, |_| {
-                restore_session.restore_downloaded(wallet)
-            }) {
+            match operation.run_result(|| restore_session.restore_downloaded(wallet)) {
                 Ok(outcome) => {
                     report.wallets_restored += 1;
                     if let Some(warning) = outcome.labels_warning {
@@ -656,7 +650,7 @@ impl RustCloudBackupManager {
             }
 
             self.send_restore_progress(
-                operation_id,
+                operation,
                 CloudBackupRestoreStage::Restoring,
                 (index + 1) as u32,
                 Some(restore_total),
@@ -664,8 +658,8 @@ impl RustCloudBackupManager {
         }
 
         if report.wallets_restored == 0 && report.wallets_failed > 0 {
-            self.set_restore_progress_for_restore_operation(operation_id, None)?;
-            self.set_restore_report_for_restore_operation(operation_id, Some(report))?;
+            self.set_restore_progress_for_restore_operation(operation, None)?;
+            self.set_restore_report_for_restore_operation(operation, Some(report))?;
             return Err(CloudBackupError::Internal("all wallets failed to restore".into()));
         }
 
@@ -684,14 +678,14 @@ impl RustCloudBackupManager {
             pending_verification_completion: None,
         };
         self.persist_cloud_backup_state_for_restore_operation(
-            operation_id,
+            operation,
             &state,
             "persist restored cloud backup state",
         )?;
 
-        self.set_restore_progress_for_restore_operation(operation_id, None)?;
-        self.set_restore_report_for_restore_operation(operation_id, Some(report))?;
-        self.set_status_for_restore_operation(operation_id, CloudBackupStatus::Enabled)?;
+        self.set_restore_progress_for_restore_operation(operation, None)?;
+        self.set_restore_report_for_restore_operation(operation, Some(report))?;
+        self.set_status_for_restore_operation(operation, CloudBackupStatus::Enabled)?;
 
         info!("Cloud backup restore complete");
         Ok(())
@@ -699,7 +693,7 @@ impl RustCloudBackupManager {
 
     fn download_wallets_for_restore(
         &self,
-        operation_id: u64,
+        operation: &RestoreOperation,
         reader: &WalletBackupReader,
         wallet_record_ids: &[String],
         report: &mut CloudBackupRestoreReport,
@@ -707,7 +701,7 @@ impl RustCloudBackupManager {
         let total = wallet_record_ids.len() as u32;
 
         self.send_restore_progress(
-            operation_id,
+            operation,
             CloudBackupRestoreStage::Downloading,
             0,
             Some(total),
@@ -716,7 +710,7 @@ impl RustCloudBackupManager {
         let mut downloaded_wallets = Vec::with_capacity(wallet_record_ids.len());
 
         for (index, record_id) in wallet_record_ids.iter().enumerate() {
-            self.ensure_current_restore_operation(operation_id)?;
+            self.ensure_current_restore_operation(operation)?;
             match reader.lookup(record_id) {
                 Ok(WalletBackupLookup::Found(wallet)) => {
                     downloaded_wallets.push((record_id.clone(), wallet));
@@ -744,7 +738,7 @@ impl RustCloudBackupManager {
             }
 
             self.send_restore_progress(
-                operation_id,
+                operation,
                 CloudBackupRestoreStage::Downloading,
                 (index + 1) as u32,
                 Some(total),
@@ -903,6 +897,9 @@ mod test_support;
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use cove_cspp::CsppStore;
     use cove_cspp::backup_data::{
         WalletEntry, WalletMode as CloudWalletMode, WalletSecret, wallet_filename_from_record_id,
@@ -919,8 +916,8 @@ mod tests {
     use crate::database::Database;
     use crate::database::cloud_backup::{
         CloudBlobDirtyState, CloudBlobFailedState, CloudBlobUploadedPendingConfirmationState,
-        CloudUploadKind, PersistedCloudBackupState, PersistedCloudBackupStatus,
-        PersistedCloudBlobState, PersistedCloudBlobSyncState,
+        CloudBlobUploadingState, CloudUploadKind, PersistedCloudBackupState,
+        PersistedCloudBackupStatus, PersistedCloudBlobState, PersistedCloudBlobSyncState,
     };
     use crate::label_manager::LabelManager;
     use crate::manager::cloud_backup_manager::{
@@ -931,7 +928,7 @@ mod tests {
     use crate::network::Network;
     use crate::wallet::{
         Wallet,
-        metadata::{WalletMode, WalletType},
+        metadata::{WalletMetadata, WalletMode, WalletType},
     };
     use bip39::Mnemonic;
 
@@ -1140,7 +1137,7 @@ mod tests {
         assert_eq!(state.status, PersistedCloudBackupStatus::Unverified);
         assert!(state.last_verification_requested_at.is_some());
 
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1375,7 +1372,7 @@ mod tests {
         manager.do_reupload_all_wallets().unwrap();
 
         assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(2));
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
     }
 
     #[test]
@@ -1500,7 +1497,7 @@ mod tests {
         cove_tokio::init();
         let globals = test_globals();
         let manager = CLOUD_BACKUP_MANAGER.clone();
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
         configure_enabled_cloud_backup(&manager, globals, 0);
 
         let metadata = xpub_only_wallet_metadata();
@@ -1509,7 +1506,7 @@ mod tests {
         persist_dirty_blob_state(metadata.id.clone());
         globals.cloud.fail_next_wallet_backup_upload("offline");
 
-        manager.run_wallet_upload_for_test(metadata.id.clone());
+        run_wallet_upload_for_test_async(&manager, metadata.id.clone()).await;
 
         assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
         assert!(manager.state().sync_error.is_some());
@@ -1525,8 +1522,8 @@ mod tests {
         ));
         assert!(manager.has_wallet_upload_debouncer_for_test(metadata.id.clone()));
 
-        manager.clear_wallet_upload_debouncers_for_test();
-        manager.run_wallet_upload_for_test(metadata.id.clone());
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
+        run_wallet_upload_for_test_async(&manager, metadata.id.clone()).await;
 
         assert!(globals.cloud.uploaded_wallet_backup_count() >= 1);
         assert!(manager.state().sync_error.is_none());
@@ -1539,7 +1536,7 @@ mod tests {
             })
         ));
 
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
     }
 
     #[expect(
@@ -1560,7 +1557,7 @@ mod tests {
         persist_dirty_blob_state(metadata.id.clone());
         globals.cloud.fail_wallet_backup_upload_quota_exceeded();
 
-        manager.run_wallet_upload_for_test(metadata.id.clone());
+        run_wallet_upload_for_test_async(&manager, metadata.id.clone()).await;
 
         assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 1);
         assert!(matches!(
@@ -1583,7 +1580,7 @@ mod tests {
 
         assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 1);
 
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
         globals.cloud.clear_wallet_backup_upload_failure();
     }
 
@@ -1609,8 +1606,8 @@ mod tests {
         persist_dirty_blob_state(second_wallet.id.clone());
         globals.cloud.fail_wallet_backup_upload("offline");
 
-        manager.run_wallet_upload_for_test(first_wallet.id.clone());
-        manager.run_wallet_upload_for_test(second_wallet.id.clone());
+        run_wallet_upload_for_test_async(&manager, first_wallet.id.clone()).await;
+        run_wallet_upload_for_test_async(&manager, second_wallet.id.clone()).await;
 
         assert!(manager.state().sync_error.is_some());
         assert!(matches!(
@@ -1624,7 +1621,7 @@ mod tests {
 
         globals.cloud.clear_wallet_backup_upload_failure();
 
-        manager.run_wallet_upload_for_test(first_wallet.id.clone());
+        run_wallet_upload_for_test_async(&manager, first_wallet.id.clone()).await;
 
         assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
         assert!(manager.state().sync_error.is_some());
@@ -1641,7 +1638,7 @@ mod tests {
             Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Failed(_), .. })
         ));
 
-        manager.run_wallet_upload_for_test(second_wallet.id.clone());
+        run_wallet_upload_for_test_async(&manager, second_wallet.id.clone()).await;
 
         assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 2);
         assert!(manager.state().sync_error.is_none());
@@ -1654,7 +1651,7 @@ mod tests {
             })
         ));
 
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
     }
 
     #[expect(
@@ -1685,7 +1682,7 @@ mod tests {
 
         assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 0);
 
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
         globals.cloud.clear_wallet_backup_upload_failure();
     }
 
@@ -1699,7 +1696,7 @@ mod tests {
         cove_tokio::init();
         let globals = test_globals();
         let manager = CLOUD_BACKUP_MANAGER.clone();
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
         configure_enabled_cloud_backup(&manager, globals, 0);
 
         let metadata = xpub_only_wallet_metadata();
@@ -1726,7 +1723,7 @@ mod tests {
         )
         .await;
 
-        manager.clear_wallet_upload_debouncers_for_test();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -2791,8 +2788,8 @@ mod tests {
         globals.cloud.set_wallet_files(remote_namespace_id, vec!["wallet-remote.json".into()]);
         globals.passkey.set_discover_result(Err(PasskeyError::UserCancelled));
 
-        let operation_id = manager.next_restore_operation_id();
-        let error = manager.do_restore_from_cloud_backup(operation_id).unwrap_err();
+        let operation = new_restore_operation_for_test(&manager);
+        let error = manager.do_restore_from_cloud_backup(&operation).unwrap_err();
 
         assert!(matches!(error, CloudBackupError::PasskeyDiscoveryCancelled));
         assert_eq!(Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()), None);
@@ -2856,8 +2853,8 @@ mod tests {
             ],
         );
 
-        let operation_id = manager.next_restore_operation_id();
-        manager.do_restore_from_cloud_backup(operation_id).unwrap();
+        let operation = new_restore_operation_for_test(&manager);
+        manager.do_restore_from_cloud_backup(&operation).unwrap();
 
         let report = manager.state().restore_report.expect("expected restore report");
         assert_eq!(report.wallets_restored, 1);
@@ -2926,8 +2923,8 @@ mod tests {
             ],
         );
 
-        let operation_id = manager.next_restore_operation_id();
-        manager.do_restore_from_cloud_backup(operation_id).unwrap();
+        let operation = new_restore_operation_for_test(&manager);
+        manager.do_restore_from_cloud_backup(&operation).unwrap();
 
         let report = manager.state().restore_report.expect("expected restore report");
         assert_eq!(report.wallets_restored, 1);
@@ -2967,8 +2964,8 @@ mod tests {
         );
         globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
 
-        let operation_id = manager.next_restore_operation_id();
-        manager.do_restore_from_cloud_backup(operation_id).unwrap();
+        let operation = new_restore_operation_for_test(&manager);
+        manager.do_restore_from_cloud_backup(&operation).unwrap();
 
         let report = manager.state().restore_report.expect("expected restore report");
         assert_eq!(report.wallets_restored, 1);
@@ -3068,8 +3065,8 @@ mod tests {
         );
         globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
 
-        let operation_id = manager.next_restore_operation_id();
-        let error = manager.do_restore_from_cloud_backup(operation_id).unwrap_err();
+        let operation = new_restore_operation_for_test(&manager);
+        let error = manager.do_restore_from_cloud_backup(&operation).unwrap_err();
 
         assert!(matches!(
             error,
@@ -3112,8 +3109,8 @@ mod tests {
             .cloud
             .set_wallet_files(namespace, vec![wallet_filename_from_record_id(&missing_record_id)]);
 
-        let operation_id = manager.next_restore_operation_id();
-        let error = manager.do_restore_from_cloud_backup(operation_id).unwrap_err();
+        let operation = new_restore_operation_for_test(&manager);
+        let error = manager.do_restore_from_cloud_backup(&operation).unwrap_err();
 
         assert!(matches!(
             error,

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -31,6 +31,11 @@ const RECREATE_MANIFEST_RECOVERY_MESSAGE: &str =
     "Cloud backup needs verification before the backup index can be recreated";
 const UNSUPPORTED_CLOUD_ONLY_WALLET_NAME: &str = "Unsupported wallet backup";
 
+enum FinalizeUploadStateMode {
+    PreserveVerification,
+    ResetVerification,
+}
+
 impl RustCloudBackupManager {
     fn clear_enable_progress(&self, status: CloudBackupStatus) {
         self.set_progress(None);
@@ -70,14 +75,21 @@ impl RustCloudBackupManager {
         cloud: &CloudStorage,
         namespace_id: &str,
         uploaded_wallets: Vec<super::wallets::PreparedWalletBackup>,
-        persist_state: impl FnOnce(&Database, u32) -> Result<(), CloudBackupError>,
+        state_mode: FinalizeUploadStateMode,
     ) -> Result<(), CloudBackupError> {
         let db = Database::global();
         let wallet_count = cloud
             .list_wallet_backups(namespace_id.to_owned())
             .map(|ids| ids.len() as u32)
             .unwrap_or(uploaded_wallets.len() as u32);
-        persist_state(&db, wallet_count)?;
+        match state_mode {
+            FinalizeUploadStateMode::PreserveVerification => {
+                persist_enabled_cloud_backup_state(&db, wallet_count)?;
+            }
+            FinalizeUploadStateMode::ResetVerification => {
+                persist_enabled_cloud_backup_state_reset_verification(&db, wallet_count)?;
+            }
+        }
 
         let uploaded_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
         for wallet in uploaded_wallets {
@@ -284,9 +296,12 @@ impl RustCloudBackupManager {
         let uploaded_wallets =
             upload_all_wallets(cloud, &namespace, &critical_key, &Database::global())?;
 
-        self.finalize_uploaded_wallets(cloud, &namespace, uploaded_wallets, |db, wallet_count| {
-            persist_enabled_cloud_backup_state(db, wallet_count)
-        })?;
+        self.finalize_uploaded_wallets(
+            cloud,
+            &namespace,
+            uploaded_wallets,
+            FinalizeUploadStateMode::PreserveVerification,
+        )?;
 
         Ok(())
     }
@@ -388,9 +403,7 @@ impl RustCloudBackupManager {
             cloud,
             &matched.namespace_id,
             uploaded_wallets,
-            |db, wallet_count| {
-                persist_enabled_cloud_backup_state_reset_verification(db, wallet_count)
-            },
+            FinalizeUploadStateMode::ResetVerification,
         )?;
 
         self.clear_enable_progress(CloudBackupStatus::Enabled);
@@ -788,9 +801,7 @@ impl RustCloudBackupManager {
             cloud,
             &namespace_id,
             uploaded_wallets,
-            |db, wallet_count| {
-                persist_enabled_cloud_backup_state_reset_verification(db, wallet_count)
-            },
+            FinalizeUploadStateMode::ResetVerification,
         )?;
 
         self.clear_enable_progress(CloudBackupStatus::Enabled);
@@ -869,22 +880,6 @@ where
     }
 }
 
-#[cfg(test)]
-fn restore_from_local_master_key_fallback<S>(
-    cloud: &CloudStorage,
-    store: &S,
-    cspp: &cove_cspp::Cspp<S>,
-) -> Result<(cove_cspp::master_key::MasterKey, String), CloudBackupError>
-where
-    S: cove_cspp::CsppStore,
-    S::Error: std::fmt::Display,
-{
-    let (master_key, namespace_id) =
-        try_restore_from_local_master_key(cloud, cspp).ok_or(CloudBackupError::PasskeyMismatch)?;
-    persist_namespace_id(store, &namespace_id)?;
-    Ok((master_key, namespace_id))
-}
-
 pub(super) fn load_master_key_for_cloud_action<S, F>(
     cspp: &cove_cspp::Cspp<S>,
     recover_missing: F,
@@ -903,35 +898,29 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-    use std::sync::{Arc, OnceLock};
-    use std::time::Duration;
+#[path = "ops/test_support.rs"]
+mod test_support;
 
-    use bip39::Mnemonic;
+#[cfg(test)]
+mod tests {
     use cove_cspp::CsppStore;
     use cove_cspp::backup_data::{
         WalletEntry, WalletMode as CloudWalletMode, WalletSecret, wallet_filename_from_record_id,
         wallet_record_id,
     };
-    use cove_device::cloud_storage::{CloudStorage, CloudStorageAccess, CloudStorageError};
+    use cove_device::cloud_storage::{CloudStorage, CloudStorageAccess};
     use cove_device::keychain::{
-        CSPP_CREDENTIAL_ID_KEY, CSPP_NAMESPACE_ID_KEY, CSPP_PRF_SALT_KEY, Keychain, KeychainAccess,
+        CSPP_CREDENTIAL_ID_KEY, CSPP_NAMESPACE_ID_KEY, CSPP_PRF_SALT_KEY, Keychain,
     };
-    use cove_device::passkey::{
-        DiscoveredPasskeyResult, PasskeyAccess, PasskeyCredentialPresence, PasskeyError,
-        PasskeyProvider,
-    };
-    use parking_lot::Mutex;
-    use sha2::Digest as _;
-    use strum::IntoEnumIterator as _;
+    use cove_device::passkey::{DiscoveredPasskeyResult, PasskeyAccess, PasskeyError};
 
+    use super::test_support::*;
     use super::*;
     use crate::database::Database;
     use crate::database::cloud_backup::{
         CloudBlobDirtyState, CloudBlobFailedState, CloudBlobUploadedPendingConfirmationState,
-        CloudBlobUploadingState, CloudUploadKind, PersistedCloudBackupState,
-        PersistedCloudBackupStatus, PersistedCloudBlobState, PersistedCloudBlobSyncState,
+        CloudUploadKind, PersistedCloudBackupState, PersistedCloudBackupStatus,
+        PersistedCloudBlobState, PersistedCloudBlobSyncState,
     };
     use crate::label_manager::LabelManager;
     use crate::manager::cloud_backup_manager::{
@@ -939,717 +928,17 @@ mod tests {
         VerificationFailureKind, VerificationState,
     };
     use crate::manager::wallet_manager::RustWalletManager;
-    use crate::mnemonic::MnemonicExt as _;
     use crate::network::Network;
     use crate::wallet::{
         Wallet,
-        metadata::{WalletId, WalletMetadata, WalletMode, WalletType},
+        metadata::{WalletMode, WalletType},
     };
+    use bip39::Mnemonic;
 
-    #[derive(Debug, Default)]
-    struct MockStore {
-        entries: Mutex<HashMap<String, String>>,
-        save_count: Mutex<usize>,
-    }
-
-    #[derive(Debug, Clone)]
-    struct MockStoreHandle(Arc<MockStore>);
-
-    impl cove_cspp::CsppStore for MockStoreHandle {
-        type Error = String;
-
-        fn save(&self, key: String, value: String) -> Result<(), Self::Error> {
-            *self.0.save_count.lock() += 1;
-            self.0.entries.lock().insert(key, value);
-            Ok(())
+    mod cove_tokio {
+        pub(super) fn init() {
+            super::init_test_runtime();
         }
-
-        fn get(&self, key: String) -> Option<String> {
-            self.0.entries.lock().get(&key).cloned()
-        }
-
-        fn delete(&self, key: String) -> bool {
-            self.0.entries.lock().remove(&key).is_some()
-        }
-    }
-
-    type MockDiscoverResult = Result<(Vec<u8>, Vec<u8>), PasskeyError>;
-
-    #[derive(Debug, Clone, Default)]
-    struct MockKeychain {
-        entries: Arc<Mutex<HashMap<String, String>>>,
-    }
-
-    impl MockKeychain {
-        fn reset(&self) {
-            self.entries.lock().clear();
-        }
-    }
-
-    impl KeychainAccess for MockKeychain {
-        fn save(
-            &self,
-            key: String,
-            value: String,
-        ) -> Result<(), cove_device::keychain::KeychainError> {
-            self.entries.lock().insert(key, value);
-            Ok(())
-        }
-
-        fn get(&self, key: String) -> Option<String> {
-            self.entries.lock().get(&key).cloned()
-        }
-
-        fn delete(&self, key: String) -> bool {
-            self.entries.lock().remove(&key).is_some()
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct MockCloudState {
-        wallet_files: HashMap<String, Vec<String>>,
-        master_key_backups: HashMap<String, Vec<u8>>,
-        wallet_backups: HashMap<(String, String), Vec<u8>>,
-        wallet_backup_download_overrides: HashMap<(String, String), Vec<u8>>,
-        list_wallet_files_error: Option<CloudStorageError>,
-        upload_master_key_error: Option<CloudStorageError>,
-        next_upload_wallet_backup_error: Option<CloudStorageError>,
-        upload_wallet_backup_error: Option<CloudStorageError>,
-        reflect_uploaded_wallets_in_listing: bool,
-        uploaded_wallet_backups: Vec<(String, String)>,
-        wallet_backup_upload_attempts: usize,
-        dirty_wallet_on_next_upload: Option<WalletId>,
-        changed_wallet_on_next_upload: Option<WalletId>,
-        dirty_wallet_on_next_backup_check: Option<WalletId>,
-    }
-
-    #[derive(Debug, Clone, Default)]
-    struct MockCloudStorage {
-        state: Arc<Mutex<MockCloudState>>,
-    }
-
-    impl MockCloudStorage {
-        fn reset(&self) {
-            *self.state.lock() = MockCloudState::default();
-        }
-
-        fn set_wallet_files(&self, namespace: String, wallet_files: Vec<String>) {
-            self.state.lock().wallet_files.insert(namespace, wallet_files);
-        }
-
-        fn set_master_key_backup(&self, namespace: String, backup: Vec<u8>) {
-            self.state.lock().master_key_backups.insert(namespace, backup);
-        }
-
-        fn set_wallet_backup(&self, namespace: String, record_id: String, backup: Vec<u8>) {
-            self.state.lock().wallet_backups.insert((namespace, record_id), backup);
-        }
-
-        fn set_wallet_backup_download_override(
-            &self,
-            namespace: String,
-            record_id: String,
-            backup: Vec<u8>,
-        ) {
-            self.state
-                .lock()
-                .wallet_backup_download_overrides
-                .insert((namespace, record_id), backup);
-        }
-
-        fn fail_list_wallet_files(&self, message: &str) {
-            self.state.lock().list_wallet_files_error =
-                Some(CloudStorageError::DownloadFailed(message.into()));
-        }
-
-        fn clear_list_wallet_files_failure(&self) {
-            self.state.lock().list_wallet_files_error = None;
-        }
-
-        fn fail_master_key_upload(&self, message: &str) {
-            self.state.lock().upload_master_key_error =
-                Some(CloudStorageError::UploadFailed(message.into()));
-        }
-
-        fn fail_wallet_backup_upload(&self, message: &str) {
-            self.state.lock().upload_wallet_backup_error =
-                Some(CloudStorageError::UploadFailed(message.into()));
-        }
-
-        fn fail_wallet_backup_upload_quota_exceeded(&self) {
-            self.state.lock().upload_wallet_backup_error = Some(CloudStorageError::QuotaExceeded);
-        }
-
-        fn fail_next_wallet_backup_upload(&self, message: &str) {
-            self.state.lock().next_upload_wallet_backup_error =
-                Some(CloudStorageError::UploadFailed(message.into()));
-        }
-
-        fn clear_wallet_backup_upload_failure(&self) {
-            let mut state = self.state.lock();
-            state.next_upload_wallet_backup_error = None;
-            state.upload_wallet_backup_error = None;
-        }
-
-        fn set_reflect_uploaded_wallets_in_listing(&self, enabled: bool) {
-            self.state.lock().reflect_uploaded_wallets_in_listing = enabled;
-        }
-
-        fn uploaded_wallet_backup_count(&self) -> usize {
-            self.state.lock().uploaded_wallet_backups.len()
-        }
-
-        fn wallet_backup_upload_attempt_count(&self) -> usize {
-            self.state.lock().wallet_backup_upload_attempts
-        }
-
-        fn dirty_wallet_on_next_upload(&self, wallet_id: WalletId) {
-            self.state.lock().dirty_wallet_on_next_upload = Some(wallet_id);
-        }
-
-        fn change_wallet_on_next_upload(&self, wallet_id: WalletId) {
-            self.state.lock().changed_wallet_on_next_upload = Some(wallet_id);
-        }
-
-        fn dirty_wallet_on_next_backup_check(&self, wallet_id: WalletId) {
-            self.state.lock().dirty_wallet_on_next_backup_check = Some(wallet_id);
-        }
-    }
-
-    impl CloudStorageAccess for MockCloudStorage {
-        fn upload_master_key_backup(
-            &self,
-            _namespace: String,
-            _data: Vec<u8>,
-        ) -> Result<(), CloudStorageError> {
-            if let Some(error) = self.state.lock().upload_master_key_error.clone() {
-                return Err(error);
-            }
-
-            Ok(())
-        }
-
-        fn upload_wallet_backup(
-            &self,
-            namespace: String,
-            record_id: String,
-            data: Vec<u8>,
-        ) -> Result<(), CloudStorageError> {
-            let (dirty_wallet, changed_wallet) = {
-                let mut state = self.state.lock();
-                state.wallet_backup_upload_attempts += 1;
-                if let Some(error) = state.next_upload_wallet_backup_error.take() {
-                    return Err(error);
-                }
-
-                if let Some(error) = state.upload_wallet_backup_error.clone() {
-                    return Err(error);
-                }
-
-                let dirty_wallet = state.dirty_wallet_on_next_upload.take();
-                let changed_wallet = state.changed_wallet_on_next_upload.take();
-                state.wallet_backups.insert((namespace.clone(), record_id.clone()), data);
-                state.uploaded_wallet_backups.push((namespace, record_id));
-                (dirty_wallet, changed_wallet)
-            };
-            if let Some(wallet_id) = dirty_wallet {
-                persist_dirty_blob_state(wallet_id);
-            }
-            if let Some(wallet_id) = changed_wallet {
-                mutate_wallet_and_persist_dirty(wallet_id);
-            }
-            Ok(())
-        }
-
-        fn download_master_key_backup(
-            &self,
-            namespace: String,
-        ) -> Result<Vec<u8>, CloudStorageError> {
-            self.state
-                .lock()
-                .master_key_backups
-                .get(&namespace)
-                .cloned()
-                .ok_or(CloudStorageError::NotFound(namespace))
-        }
-
-        fn download_wallet_backup(
-            &self,
-            namespace: String,
-            record_id: String,
-        ) -> Result<Vec<u8>, CloudStorageError> {
-            let dirty_wallet = self.state.lock().dirty_wallet_on_next_backup_check.take();
-            if let Some(wallet_id) = dirty_wallet {
-                persist_dirty_blob_state(wallet_id);
-            }
-
-            let override_key = (namespace.clone(), record_id.clone());
-            if let Some(backup) =
-                self.state.lock().wallet_backup_download_overrides.get(&override_key).cloned()
-            {
-                return Ok(backup);
-            }
-
-            self.state
-                .lock()
-                .wallet_backups
-                .get(&(namespace.clone(), record_id.clone()))
-                .cloned()
-                .ok_or(CloudStorageError::NotFound(format!("{namespace}/{record_id}")))
-        }
-
-        fn delete_wallet_backup(
-            &self,
-            _namespace: String,
-            _record_id: String,
-        ) -> Result<(), CloudStorageError> {
-            Ok(())
-        }
-
-        fn list_namespaces(&self) -> Result<Vec<String>, CloudStorageError> {
-            Ok(self.state.lock().wallet_files.keys().cloned().collect())
-        }
-
-        fn list_wallet_files(&self, namespace: String) -> Result<Vec<String>, CloudStorageError> {
-            let state = self.state.lock();
-            if let Some(error) = state.list_wallet_files_error.clone() {
-                return Err(error);
-            }
-            let mut wallet_files = state.wallet_files.get(&namespace).cloned().unwrap_or_default();
-
-            if state.reflect_uploaded_wallets_in_listing {
-                for (uploaded_namespace, record_id) in &state.uploaded_wallet_backups {
-                    if uploaded_namespace == &namespace {
-                        let filename = wallet_filename_from_record_id(record_id);
-                        if !wallet_files.contains(&filename) {
-                            wallet_files.push(filename);
-                        }
-                    }
-                }
-            }
-
-            Ok(wallet_files)
-        }
-
-        fn is_backup_uploaded(
-            &self,
-            _namespace: String,
-            _record_id: String,
-        ) -> Result<bool, CloudStorageError> {
-            Ok(true)
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct MockPasskeyProviderImpl {
-        discover_result: Arc<Mutex<MockDiscoverResult>>,
-    }
-
-    impl Default for MockPasskeyProviderImpl {
-        fn default() -> Self {
-            Self { discover_result: Arc::new(Mutex::new(Err(PasskeyError::NoCredentialFound))) }
-        }
-    }
-
-    impl MockPasskeyProviderImpl {
-        fn reset(&self) {
-            *self.discover_result.lock() = Err(PasskeyError::NoCredentialFound);
-        }
-
-        fn set_discover_result(&self, result: Result<DiscoveredPasskeyResult, PasskeyError>) {
-            *self.discover_result.lock() =
-                result.map(|value| (value.prf_output, value.credential_id));
-        }
-    }
-
-    impl PasskeyProvider for MockPasskeyProviderImpl {
-        fn create_passkey(
-            &self,
-            _rp_id: String,
-            _user_id: Vec<u8>,
-            _challenge: Vec<u8>,
-        ) -> Result<Vec<u8>, PasskeyError> {
-            Err(PasskeyError::CreationFailed("unexpected create_passkey call".into()))
-        }
-
-        fn authenticate_with_prf(
-            &self,
-            _rp_id: String,
-            _credential_id: Vec<u8>,
-            _prf_salt: Vec<u8>,
-            _challenge: Vec<u8>,
-        ) -> Result<Vec<u8>, PasskeyError> {
-            Err(PasskeyError::AuthenticationFailed("unexpected authenticate_with_prf call".into()))
-        }
-
-        fn discover_and_authenticate_with_prf(
-            &self,
-            _rp_id: String,
-            _prf_salt: Vec<u8>,
-            _challenge: Vec<u8>,
-        ) -> Result<DiscoveredPasskeyResult, PasskeyError> {
-            self.discover_result.lock().clone().map(|(prf_output, credential_id)| {
-                DiscoveredPasskeyResult { prf_output, credential_id }
-            })
-        }
-
-        fn is_prf_supported(&self) -> bool {
-            true
-        }
-
-        fn check_passkey_presence(
-            &self,
-            _rp_id: String,
-            _credential_id: Vec<u8>,
-        ) -> PasskeyCredentialPresence {
-            PasskeyCredentialPresence::Present
-        }
-    }
-
-    struct TestGlobals {
-        keychain: MockKeychain,
-        cloud: MockCloudStorage,
-        passkey: MockPasskeyProviderImpl,
-    }
-
-    impl TestGlobals {
-        fn init() -> Self {
-            let keychain = MockKeychain::default();
-            let cloud = MockCloudStorage::default();
-            let passkey = MockPasskeyProviderImpl::default();
-
-            let _ = Keychain::new(Box::new(keychain.clone()));
-            let _ = CloudStorage::new(Box::new(cloud.clone()));
-            let _ = PasskeyAccess::new(Box::new(passkey.clone()));
-
-            Self { keychain, cloud, passkey }
-        }
-
-        fn reset(&self) {
-            self.keychain.reset();
-            self.cloud.reset();
-            self.passkey.reset();
-            cove_cspp::Cspp::<Keychain>::clear_cached_master_key();
-        }
-    }
-
-    fn test_globals() -> &'static TestGlobals {
-        static GLOBALS: OnceLock<TestGlobals> = OnceLock::new();
-        GLOBALS.get_or_init(TestGlobals::init)
-    }
-
-    fn test_lock() -> &'static parking_lot::Mutex<()> {
-        super::super::cloud_backup_test_lock()
-    }
-
-    fn clear_local_wallets() {
-        let wallets = Database::global().wallets();
-        for network in Network::iter() {
-            for mode in WalletMode::iter() {
-                wallets.save_all_wallets(network, mode, Vec::new()).unwrap();
-            }
-        }
-    }
-
-    fn persist_dirty_blob_state(wallet_id: WalletId) {
-        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
-        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
-        let changed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
-
-        Database::global()
-            .cloud_blob_sync_states
-            .set(&PersistedCloudBlobSyncState {
-                kind: CloudUploadKind::BackupBlob,
-                namespace_id,
-                wallet_id: Some(wallet_id),
-                record_id,
-                state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at }),
-            })
-            .unwrap();
-    }
-
-    fn mutate_wallet_and_persist_dirty(wallet_id: WalletId) {
-        let mut wallet = all_local_wallets(&Database::global())
-            .unwrap()
-            .into_iter()
-            .find(|wallet| wallet.id == wallet_id)
-            .unwrap();
-        wallet.name.push_str(" updated");
-        Database::global()
-            .wallets()
-            .save_all_wallets(wallet.network, wallet.wallet_mode, vec![wallet.clone()])
-            .unwrap();
-        persist_dirty_blob_state(wallet.id);
-    }
-
-    fn persist_failed_blob_state(wallet_id: WalletId, retryable: bool) {
-        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
-        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
-        let failed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
-
-        Database::global()
-            .cloud_blob_sync_states
-            .set(&PersistedCloudBlobSyncState {
-                kind: CloudUploadKind::BackupBlob,
-                namespace_id,
-                wallet_id: Some(wallet_id),
-                record_id,
-                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
-                    revision_hash: Some("rev-1".into()),
-                    retryable,
-                    error: "failed".into(),
-                    failed_at,
-                }),
-            })
-            .unwrap();
-    }
-
-    fn persist_uploading_blob_state(wallet_id: WalletId, started_at: u64) {
-        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
-        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
-
-        Database::global()
-            .cloud_blob_sync_states
-            .set(&PersistedCloudBlobSyncState {
-                kind: CloudUploadKind::BackupBlob,
-                namespace_id,
-                wallet_id: Some(wallet_id),
-                record_id,
-                state: PersistedCloudBlobState::Uploading(CloudBlobUploadingState {
-                    revision_hash: "rev-1".into(),
-                    started_at,
-                }),
-            })
-            .unwrap();
-    }
-
-    fn reset_cloud_backup_test_state(manager: &RustCloudBackupManager, globals: &TestGlobals) {
-        globals.reset();
-        clear_local_wallets();
-        manager.debug_reset_cloud_backup_state();
-        manager.clear_wallet_upload_debouncers_for_test();
-    }
-
-    async fn wait_for_test_condition(
-        timeout: Duration,
-        message: &str,
-        mut condition: impl FnMut() -> bool,
-    ) {
-        tokio::time::timeout(timeout, async {
-            loop {
-                if condition() {
-                    break;
-                }
-
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            }
-        })
-        .await
-        .expect(message);
-    }
-
-    async fn assert_test_condition_stays_true(
-        duration: Duration,
-        message: &str,
-        mut condition: impl FnMut() -> bool,
-    ) {
-        let deadline = tokio::time::Instant::now() + duration;
-        while tokio::time::Instant::now() < deadline {
-            assert!(condition(), "{message}");
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-    }
-
-    fn configure_enabled_cloud_backup(
-        manager: &RustCloudBackupManager,
-        globals: &TestGlobals,
-        wallet_count: u32,
-    ) {
-        reset_cloud_backup_test_state(manager, globals);
-
-        let master_key = cove_cspp::master_key::MasterKey::generate();
-        let namespace = master_key.namespace_id();
-        let keychain = Keychain::global();
-        keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
-        cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
-
-        manager
-            .persist_cloud_backup_state(
-                &PersistedCloudBackupState {
-                    status: PersistedCloudBackupStatus::Enabled,
-                    wallet_count: Some(wallet_count),
-                    ..PersistedCloudBackupState::default()
-                },
-                "set cloud backup enabled for test",
-            )
-            .unwrap();
-        manager.sync_persisted_state();
-    }
-
-    fn enable_cloud_backup_without_reset(manager: &RustCloudBackupManager, wallet_count: u32) {
-        let master_key = cove_cspp::master_key::MasterKey::generate();
-        let namespace = master_key.namespace_id();
-        let keychain = Keychain::global();
-        keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
-        cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
-
-        manager
-            .persist_cloud_backup_state(
-                &PersistedCloudBackupState {
-                    status: PersistedCloudBackupStatus::Enabled,
-                    wallet_count: Some(wallet_count),
-                    ..PersistedCloudBackupState::default()
-                },
-                "set cloud backup enabled for test",
-            )
-            .unwrap();
-        manager.sync_persisted_state();
-    }
-
-    fn xpub_only_wallet_metadata() -> WalletMetadata {
-        let mut metadata = WalletMetadata::preview_new();
-        metadata.wallet_type = WalletType::XpubOnly;
-        metadata
-    }
-
-    fn sample_xpub(metadata: &WalletMetadata) -> String {
-        let mnemonic = Mnemonic::parse(
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-        )
-        .unwrap();
-        mnemonic.xpub(metadata.network.into()).to_string()
-    }
-
-    fn persist_xpub_wallets(wallets: Vec<WalletMetadata>) {
-        for wallet in &wallets {
-            let xpub = sample_xpub(wallet);
-            Keychain::global().save_wallet_xpub(&wallet.id, xpub.parse().unwrap()).unwrap();
-        }
-
-        let Some(first_wallet) = wallets.first() else {
-            return;
-        };
-
-        Database::global()
-            .wallets()
-            .save_all_wallets(first_wallet.network, first_wallet.wallet_mode, wallets)
-            .unwrap();
-    }
-
-    fn encrypted_wallet_backup_bytes(
-        metadata: &WalletMetadata,
-        master_key: &cove_cspp::master_key::MasterKey,
-        revision_hash: &str,
-        version: u32,
-    ) -> Vec<u8> {
-        let mut prepared = crate::manager::cloud_backup_manager::wallets::prepare_wallet_backup(
-            metadata,
-            metadata.wallet_mode,
-        )
-        .unwrap();
-        prepared.entry.content_revision_hash = revision_hash.to_string();
-
-        let critical_key = zeroize::Zeroizing::new(master_key.critical_data_key());
-        let mut encrypted =
-            cove_cspp::wallet_crypto::encrypt_wallet_entry(&prepared.entry, &critical_key).unwrap();
-        encrypted.version = version;
-        serde_json::to_vec(&encrypted).unwrap()
-    }
-
-    fn wallet_entry_with_labels(
-        metadata: &WalletMetadata,
-        labels_jsonl: Option<&str>,
-    ) -> WalletEntry {
-        let labels_count = labels_jsonl
-            .map(|jsonl| jsonl.lines().filter(|line| !line.trim().is_empty()).count() as u32)
-            .unwrap_or_default();
-        let labels_zstd_jsonl =
-            labels_jsonl.map(|jsonl| crate::backup::crypto::compress(jsonl.as_bytes()).unwrap());
-        let labels_hash = labels_jsonl
-            .filter(|jsonl| !jsonl.is_empty())
-            .map(|jsonl| hex::encode(sha2::Sha256::digest(jsonl.as_bytes())));
-        let labels_uncompressed_size =
-            labels_jsonl.map(|jsonl| jsonl.len().try_into().unwrap_or(u32::MAX));
-
-        WalletEntry {
-            wallet_id: metadata.id.to_string(),
-            secret: WalletSecret::WatchOnly,
-            metadata: serde_json::to_value(metadata).unwrap(),
-            descriptors: None,
-            xpub: Some(sample_xpub(metadata)),
-            wallet_mode: CloudWalletMode::Main,
-            labels_zstd_jsonl,
-            labels_count,
-            labels_hash,
-            labels_uncompressed_size,
-            content_revision_hash: "test-content-hash".to_string(),
-            updated_at: 42,
-        }
-    }
-
-    fn encrypted_wallet_backup_bytes_for_entry(
-        entry: &WalletEntry,
-        master_key: &cove_cspp::master_key::MasterKey,
-        version: u32,
-    ) -> Vec<u8> {
-        let critical_key = zeroize::Zeroizing::new(master_key.critical_data_key());
-        let mut encrypted =
-            cove_cspp::wallet_crypto::encrypt_wallet_entry(entry, &critical_key).unwrap();
-        encrypted.version = version;
-        serde_json::to_vec(&encrypted).unwrap()
-    }
-
-    fn sample_labels_jsonl() -> &'static str {
-        r#"{"type":"tx","ref":"d97bf8892657980426c879e4ab2001f09342f1ab61cfa602741a7715a3d60290","label":"last txn received","origin":"pkh([73c5da0a/44h/0h/0h])"}"#
-    }
-
-    fn prepare_deep_verify_with_unsynced_wallet(
-        manager: &RustCloudBackupManager,
-        globals: &TestGlobals,
-    ) -> crate::wallet::metadata::WalletMetadata {
-        reset_cloud_backup_test_state(manager, globals);
-
-        let master_key = cove_cspp::master_key::MasterKey::generate();
-        let namespace = master_key.namespace_id();
-        let prf_key = [7u8; 32];
-        let prf_salt = [9u8; 32];
-        let credential_id = vec![1, 2, 3, 4];
-        let encrypted_master =
-            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &prf_key, &prf_salt)
-                .unwrap();
-
-        globals.cloud.set_master_key_backup(
-            namespace.clone(),
-            serde_json::to_vec(&encrypted_master).unwrap(),
-        );
-        globals.cloud.set_reflect_uploaded_wallets_in_listing(false);
-        globals.passkey.set_discover_result(Ok(DiscoveredPasskeyResult {
-            prf_output: prf_key.to_vec(),
-            credential_id,
-        }));
-
-        let keychain = Keychain::global();
-        keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
-        cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
-
-        manager
-            .persist_cloud_backup_state(
-                &PersistedCloudBackupState {
-                    status: PersistedCloudBackupStatus::Enabled,
-                    ..PersistedCloudBackupState::default()
-                },
-                "set cloud backup enabled for test",
-            )
-            .unwrap();
-
-        let mut metadata = crate::wallet::metadata::WalletMetadata::preview_new();
-        metadata.wallet_type = crate::wallet::metadata::WalletType::WatchOnly;
-        Database::global()
-            .wallets()
-            .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata.clone()])
-            .unwrap();
-
-        metadata
     }
 
     #[test]
@@ -1833,6 +1122,10 @@ mod tests {
         ));
     }
 
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
     #[tokio::test(flavor = "current_thread")]
     async fn backup_new_wallet_marks_verification_required() {
         let _guard = test_lock().lock();
@@ -1887,7 +1180,7 @@ mod tests {
             Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Dirty(_), .. })
         ));
 
-        clear_wallet_upload_runtime_for_test_async(&manager).await;
+        manager.clear_wallet_upload_debouncers_for_test();
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -2058,6 +1351,10 @@ mod tests {
         assert!(cspp.load_master_key_from_store().unwrap().is_none());
     }
 
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
     #[tokio::test(flavor = "current_thread")]
     async fn reupload_all_wallets_persists_full_cloud_wallet_count() {
         let _guard = test_lock().lock();
@@ -2193,6 +1490,10 @@ mod tests {
         ));
     }
 
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
     #[tokio::test(flavor = "current_thread")]
     async fn failed_live_wallet_upload_retries_without_restart() {
         let _guard = test_lock().lock();
@@ -2222,8 +1523,7 @@ mod tests {
                 ..
             })
         ));
-
-        assert!(manager.wallet_upload_debouncers.lock().contains_key(&metadata.id));
+        assert!(manager.has_wallet_upload_debouncer_for_test(metadata.id.clone()));
 
         manager.clear_wallet_upload_debouncers_for_test();
         manager.run_wallet_upload_for_test(metadata.id.clone());
@@ -2287,6 +1587,10 @@ mod tests {
         globals.cloud.clear_wallet_backup_upload_failure();
     }
 
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
     #[tokio::test(flavor = "current_thread")]
     async fn sync_error_clears_only_after_last_failed_wallet_upload_recovers() {
         let _guard = test_lock().lock();
@@ -2385,6 +1689,10 @@ mod tests {
         globals.cloud.clear_wallet_backup_upload_failure();
     }
 
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
     #[tokio::test(flavor = "current_thread")]
     async fn startup_resume_retries_interrupted_uploading_wallets() {
         let _guard = test_lock().lock();

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -8,10 +8,10 @@ use zeroize::Zeroizing;
 
 use super::cloud_inventory::CloudWalletInventory;
 use super::wallets::{
-    DownloadedWalletBackup, NamespaceMatchOutcome, UnpersistedPrfKey, all_local_wallets,
-    create_new_prf_key, discover_or_create_prf_key_without_persisting, download_wallet_backup,
-    persist_enabled_cloud_backup_state, persist_enabled_cloud_backup_state_reset_verification,
-    restore_downloaded_wallet_for_restore, restore_single_wallet, try_match_namespace_with_passkey,
+    DownloadedWalletBackup, NamespaceMatchOutcome, UnpersistedPrfKey, WalletBackupLookup,
+    WalletBackupReader, WalletRestoreSession, all_local_wallets, create_new_prf_key,
+    discover_or_create_prf_key_without_persisting, persist_enabled_cloud_backup_state,
+    persist_enabled_cloud_backup_state_reset_verification, try_match_namespace_with_passkey,
     upload_all_wallets,
 };
 
@@ -22,7 +22,6 @@ use super::{
 };
 use crate::database::Database;
 use crate::database::cloud_backup::{PersistedCloudBackupState, PersistedCloudBackupStatus};
-use crate::wallet::metadata::WalletMetadata;
 
 const CLOUD_ONLY_FETCH_RECOVERY_MESSAGE: &str =
     "Cloud backup needs verification before wallets not on this device can be loaded";
@@ -30,8 +29,15 @@ const CLOUD_ONLY_RESTORE_RECOVERY_MESSAGE: &str =
     "Cloud backup needs verification before this wallet can be restored";
 const RECREATE_MANIFEST_RECOVERY_MESSAGE: &str =
     "Cloud backup needs verification before the backup index can be recreated";
+const UNSUPPORTED_CLOUD_ONLY_WALLET_NAME: &str = "Unsupported wallet backup";
 
 impl RustCloudBackupManager {
+    fn clear_enable_progress(&self, status: CloudBackupStatus) {
+        self.set_progress(None);
+        self.set_restore_progress(None);
+        self.set_status(status);
+    }
+
     fn rollback_new_local_master_key(
         &self,
         cspp: &cove_cspp::Cspp<Keychain>,
@@ -59,19 +65,46 @@ impl RustCloudBackupManager {
         )
     }
 
+    fn finalize_uploaded_wallets(
+        &self,
+        cloud: &CloudStorage,
+        namespace_id: &str,
+        uploaded_wallets: Vec<super::wallets::PreparedWalletBackup>,
+        persist_state: impl FnOnce(&Database, u32) -> Result<(), CloudBackupError>,
+    ) -> Result<(), CloudBackupError> {
+        let db = Database::global();
+        let wallet_count = cloud
+            .list_wallet_backups(namespace_id.to_owned())
+            .map(|ids| ids.len() as u32)
+            .unwrap_or(uploaded_wallets.len() as u32);
+        persist_state(&db, wallet_count)?;
+
+        let uploaded_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+        for wallet in uploaded_wallets {
+            self.mark_blob_uploaded_pending_confirmation(
+                namespace_id,
+                Some(wallet.metadata.id),
+                wallet.record_id,
+                wallet.revision_hash,
+                uploaded_at,
+            )?;
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn do_sync_unsynced_wallets(&self) -> Result<(), CloudBackupError> {
         let namespace = self.current_namespace_id()?;
         info!("Sync: listing cloud wallet backups for namespace {namespace}");
         let cloud = CloudStorage::global();
         let wallet_record_ids =
             cloud.list_wallet_backups(namespace).map_err_str(CloudBackupError::Cloud)?;
-        let inventory = CloudWalletInventory::load(&wallet_record_ids)?;
+        let remote_wallet_truth = self.load_remote_wallet_truth(&wallet_record_ids)?;
+        let inventory =
+            CloudWalletInventory::load_with_remote_truth(&wallet_record_ids, remote_wallet_truth)?;
 
-        info!(
-            "Sync: found {} wallet(s) in cloud (including pending)",
-            inventory.cloud_wallet_count()
-        );
-        let unsynced = inventory.unsynced_local_wallets();
+        info!("Sync: found {} wallet(s) in cloud", inventory.cloud_wallet_count());
+        let unsynced = inventory.upload_candidate_wallets();
 
         if unsynced.is_empty() {
             info!("Sync: all wallets already synced");
@@ -113,26 +146,56 @@ impl RustCloudBackupManager {
             )
         })?;
 
-        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let reader = WalletBackupReader::new(
+            cloud.clone(),
+            namespace.clone(),
+            Zeroizing::new(master_key.critical_data_key()),
+        );
         let mut items = Vec::new();
 
         for record_id in orphan_ids {
-            let metadata: WalletMetadata =
-                match download_wallet_backup(cloud, &namespace, record_id, &critical_key) {
-                    Ok(wallet) => wallet.metadata,
-                    Err(error) => {
-                        warn!("Failed to load cloud-only wallet {record_id}: {error}");
-                        continue;
-                    }
-                };
+            let wallet = match reader.lookup(record_id) {
+                Ok(WalletBackupLookup::Found(wallet)) => wallet,
+                Ok(WalletBackupLookup::UnsupportedVersion(version)) => {
+                    warn!(
+                        "Cloud-only wallet {record_id} uses unsupported wallet backup version {version}"
+                    );
+                    items.push(CloudBackupWalletItem {
+                        name: UNSUPPORTED_CLOUD_ONLY_WALLET_NAME.into(),
+                        network: None,
+                        wallet_mode: None,
+                        wallet_type: None,
+                        fingerprint: None,
+                        label_count: None,
+                        backup_updated_at: None,
+                        sync_status: CloudBackupWalletStatus::UnsupportedVersion,
+                        record_id: record_id.clone(),
+                    });
+                    continue;
+                }
+                Ok(WalletBackupLookup::NotFound) => {
+                    warn!("Failed to load cloud-only wallet {record_id}: not found");
+                    continue;
+                }
+                Err(error) => {
+                    warn!("Failed to load cloud-only wallet {record_id}: {error}");
+                    continue;
+                }
+            };
+            let metadata = wallet.metadata;
 
             items.push(CloudBackupWalletItem {
                 name: metadata.name,
-                network: metadata.network,
-                wallet_mode: metadata.wallet_mode,
-                wallet_type: metadata.wallet_type,
-                fingerprint: metadata.master_fingerprint.as_ref().map(|fp| fp.as_uppercase()),
-                status: CloudBackupWalletStatus::DeletedFromDevice,
+                network: Some(metadata.network),
+                wallet_mode: Some(metadata.wallet_mode),
+                wallet_type: Some(metadata.wallet_type),
+                fingerprint: metadata
+                    .master_fingerprint
+                    .as_ref()
+                    .map(|fingerprint| fingerprint.as_ref().as_uppercase()),
+                label_count: Some(wallet.entry.labels_count),
+                backup_updated_at: Some(wallet.entry.updated_at),
+                sync_status: CloudBackupWalletStatus::DeletedFromDevice,
                 record_id: record_id.clone(),
             });
         }
@@ -140,7 +203,10 @@ impl RustCloudBackupManager {
         Ok(items)
     }
 
-    pub(crate) fn do_restore_cloud_wallet(&self, record_id: &str) -> Result<(), CloudBackupError> {
+    pub(crate) fn do_restore_cloud_wallet(
+        &self,
+        record_id: &str,
+    ) -> Result<super::wallets::WalletRestoreOutcome, CloudBackupError> {
         let namespace = self.current_namespace_id()?;
         let cloud = CloudStorage::global();
         let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
@@ -150,10 +216,14 @@ impl RustCloudBackupManager {
                 CLOUD_ONLY_RESTORE_RECOVERY_MESSAGE,
             )
         })?;
-        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let reader = WalletBackupReader::new(
+            cloud.clone(),
+            namespace.clone(),
+            Zeroizing::new(master_key.critical_data_key()),
+        );
 
         let db = Database::global();
-        let mut existing_fingerprints: Vec<_> = all_local_wallets(&db)?
+        let existing_fingerprints: Vec<_> = all_local_wallets(&db)?
             .iter()
             .filter_map(|wallet| {
                 wallet
@@ -162,16 +232,11 @@ impl RustCloudBackupManager {
                     .map(|fp| (**fp, wallet.network, wallet.wallet_mode))
             })
             .collect();
+        let mut restore_session = WalletRestoreSession::new(existing_fingerprints);
 
-        restore_single_wallet(
-            cloud,
-            &namespace,
-            record_id,
-            &critical_key,
-            &mut existing_fingerprints,
-        )?;
+        let outcome = restore_session.restore_record(&reader, record_id)?;
         info!("Restored cloud wallet {record_id}");
-        Ok(())
+        Ok(outcome)
     }
 
     pub(crate) fn do_delete_cloud_wallet(&self, record_id: &str) -> Result<(), CloudBackupError> {
@@ -181,7 +246,7 @@ impl RustCloudBackupManager {
         cloud
             .delete_wallet_backup(namespace.clone(), record_id.to_string())
             .map_err_str(CloudBackupError::Cloud)?;
-        self.remove_pending_uploads(&namespace, std::iter::once(record_id.to_string()))?;
+        self.remove_blob_sync_states(std::iter::once(record_id.to_string()))?;
 
         let wallet_record_ids =
             cloud.list_wallet_backups(namespace).map_err_str(CloudBackupError::Cloud)?;
@@ -216,11 +281,12 @@ impl RustCloudBackupManager {
 
         let critical_key = Zeroizing::new(master_key.critical_data_key());
         let cloud = CloudStorage::global();
-        let db = Database::global();
+        let uploaded_wallets =
+            upload_all_wallets(cloud, &namespace, &critical_key, &Database::global())?;
 
-        let uploaded_record_ids = upload_all_wallets(cloud, &namespace, &critical_key, &db)?;
-        persist_enabled_cloud_backup_state(&db, uploaded_record_ids.len() as u32)?;
-        self.enqueue_pending_uploads(&namespace, uploaded_record_ids)?;
+        self.finalize_uploaded_wallets(cloud, &namespace, uploaded_wallets, |db, wallet_count| {
+            persist_enabled_cloud_backup_state(db, wallet_count)
+        })?;
 
         Ok(())
     }
@@ -269,18 +335,14 @@ impl RustCloudBackupManager {
             NamespaceMatchOutcome::UserDeclined => {
                 info!("Enable: user cancelled passkey picker during namespace matching");
                 self.send(Message::PasskeyDiscoveryCancelled);
-                self.set_progress(None);
-                self.set_restore_progress(None);
-                self.set_status(CloudBackupStatus::Disabled);
+                self.clear_enable_progress(CloudBackupStatus::Disabled);
                 Ok(())
             }
 
             NamespaceMatchOutcome::NoMatch => {
                 info!("Enable: passkey didn't match existing backups, asking user to confirm");
                 self.send(Message::ExistingBackupFound);
-                self.set_progress(None);
-                self.set_restore_progress(None);
-                self.set_status(CloudBackupStatus::Disabled);
+                self.clear_enable_progress(CloudBackupStatus::Disabled);
                 Ok(())
             }
 
@@ -310,15 +372,8 @@ impl RustCloudBackupManager {
             .map_err_prefix("save recovered master key", CloudBackupError::Internal)?;
 
         let critical_key = Zeroizing::new(matched.master_key.critical_data_key());
-        let db = Database::global();
-        let uploaded_wallet_record_ids =
-            upload_all_wallets(cloud, &matched.namespace_id, &critical_key, &db)?;
-
-        // get accurate wallet count from cloud (includes pre-existing + uploaded)
-        let wallet_count = cloud
-            .list_wallet_backups(matched.namespace_id.clone())
-            .map(|ids| ids.len() as u32)
-            .unwrap_or(uploaded_wallet_record_ids.len() as u32);
+        let uploaded_wallets =
+            upload_all_wallets(cloud, &matched.namespace_id, &critical_key, &Database::global())?;
 
         // persist credentials AFTER uploads succeed
         keychain
@@ -329,12 +384,16 @@ impl RustCloudBackupManager {
             )
             .map_err_prefix("save cspp credentials", CloudBackupError::Internal)?;
 
-        persist_enabled_cloud_backup_state_reset_verification(&db, wallet_count)?;
-        self.enqueue_pending_uploads(&matched.namespace_id, uploaded_wallet_record_ids)?;
+        self.finalize_uploaded_wallets(
+            cloud,
+            &matched.namespace_id,
+            uploaded_wallets,
+            |db, wallet_count| {
+                persist_enabled_cloud_backup_state_reset_verification(db, wallet_count)
+            },
+        )?;
 
-        self.set_progress(None);
-        self.set_restore_progress(None);
-        self.set_status(CloudBackupStatus::Enabled);
+        self.clear_enable_progress(CloudBackupStatus::Enabled);
         info!("Cloud backup enabled (recovered existing namespace)");
         Ok(())
     }
@@ -370,9 +429,7 @@ impl RustCloudBackupManager {
                     "Enable cancelled before passkey setup finished",
                 );
                 self.send(Message::PasskeyDiscoveryCancelled);
-                self.set_progress(None);
-                self.set_restore_progress(None);
-                self.set_status(CloudBackupStatus::Disabled);
+                self.clear_enable_progress(CloudBackupStatus::Disabled);
                 return Ok(());
             }
             Err(error) => {
@@ -444,9 +501,7 @@ impl RustCloudBackupManager {
                     "Enable (no discovery) cancelled before passkey setup finished",
                 );
                 self.send(Message::PasskeyDiscoveryCancelled);
-                self.set_progress(None);
-                self.set_restore_progress(None);
-                self.set_status(CloudBackupStatus::Disabled);
+                self.clear_enable_progress(CloudBackupStatus::Disabled);
                 return Ok(());
             }
             Err(error) => {
@@ -466,9 +521,7 @@ impl RustCloudBackupManager {
             );
             self.replace_pending_enable_session(PendingEnableSession::new(master_key, passkey));
             self.send(Message::ExistingBackupFound);
-            self.set_progress(None);
-            self.set_restore_progress(None);
-            self.set_status(CloudBackupStatus::Disabled);
+            self.clear_enable_progress(CloudBackupStatus::Disabled);
             return Ok(());
         }
 
@@ -538,22 +591,27 @@ impl RustCloudBackupManager {
         let wallet_record_ids =
             cloud.list_wallet_backups(namespace_id.clone()).map_err_str(CloudBackupError::Cloud)?;
 
-        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let reader = WalletBackupReader::new(
+            cloud.clone(),
+            namespace_id.clone(),
+            Zeroizing::new(master_key.critical_data_key()),
+        );
         let mut report = CloudBackupRestoreReport {
             wallets_restored: 0,
             wallets_failed: 0,
             failed_wallet_errors: Vec::new(),
+            labels_failed_wallet_names: Vec::new(),
+            labels_failed_errors: Vec::new(),
         };
 
-        let mut existing_fingerprints = crate::backup::import::collect_existing_fingerprints()
+        let existing_fingerprints = crate::backup::import::collect_existing_fingerprints()
             .map_err_prefix("collect fingerprints", CloudBackupError::Internal)?;
+        let mut restore_session = WalletRestoreSession::new(existing_fingerprints);
 
         let downloaded_wallets = self.download_wallets_for_restore(
             operation_id,
-            cloud,
-            &namespace_id,
+            &reader,
             &wallet_record_ids,
-            &critical_key,
             &mut report,
         )?;
         let restore_total = downloaded_wallets.len() as u32;
@@ -567,9 +625,15 @@ impl RustCloudBackupManager {
 
         for (index, (record_id, wallet)) in downloaded_wallets.iter().enumerate() {
             match self.with_current_restore_operation_result(operation_id, |_| {
-                restore_downloaded_wallet_for_restore(wallet, &mut existing_fingerprints)
+                restore_session.restore_downloaded(wallet)
             }) {
-                Ok(()) => report.wallets_restored += 1,
+                Ok(outcome) => {
+                    report.wallets_restored += 1;
+                    if let Some(warning) = outcome.labels_warning {
+                        report.labels_failed_wallet_names.push(warning.wallet_name);
+                        report.labels_failed_errors.push(warning.error);
+                    }
+                }
                 Err(CloudBackupError::Cancelled) => return Err(CloudBackupError::Cancelled),
                 Err(error) => {
                     warn!("Failed to restore wallet {record_id}: {error}");
@@ -592,7 +656,10 @@ impl RustCloudBackupManager {
             return Err(CloudBackupError::Internal("all wallets failed to restore".into()));
         }
 
-        let wallet_count = report.wallets_restored;
+        let wallet_count = cloud
+            .list_wallet_backups(namespace_id.clone())
+            .map(|record_ids| record_ids.len() as u32)
+            .unwrap_or(wallet_record_ids.len() as u32);
         let now = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
         let state = PersistedCloudBackupState {
             status: PersistedCloudBackupStatus::Enabled,
@@ -601,6 +668,7 @@ impl RustCloudBackupManager {
             last_verified_at: None,
             last_verification_requested_at: None,
             last_verification_dismissed_at: None,
+            pending_verification_completion: None,
         };
         self.persist_cloud_backup_state_for_restore_operation(
             operation_id,
@@ -619,10 +687,8 @@ impl RustCloudBackupManager {
     fn download_wallets_for_restore(
         &self,
         operation_id: u64,
-        cloud: &CloudStorage,
-        namespace_id: &str,
+        reader: &WalletBackupReader,
         wallet_record_ids: &[String],
-        critical_key: &[u8; 32],
         report: &mut CloudBackupRestoreReport,
     ) -> Result<Vec<(String, DownloadedWalletBackup)>, CloudBackupError> {
         let total = wallet_record_ids.len() as u32;
@@ -638,8 +704,25 @@ impl RustCloudBackupManager {
 
         for (index, record_id) in wallet_record_ids.iter().enumerate() {
             self.ensure_current_restore_operation(operation_id)?;
-            match download_wallet_backup(cloud, namespace_id, record_id, critical_key) {
-                Ok(wallet) => downloaded_wallets.push((record_id.clone(), wallet)),
+            match reader.lookup(record_id) {
+                Ok(WalletBackupLookup::Found(wallet)) => {
+                    downloaded_wallets.push((record_id.clone(), wallet));
+                }
+                Ok(WalletBackupLookup::NotFound) => {
+                    let error =
+                        format!("wallet {record_id} was listed but missing from cloud backup");
+                    warn!("Failed to download wallet {record_id}: {error}");
+                    report.wallets_failed += 1;
+                    report.failed_wallet_errors.push(error);
+                }
+                Ok(WalletBackupLookup::UnsupportedVersion(version)) => {
+                    let error = format!(
+                        "wallet {record_id} uses unsupported wallet backup version {version}"
+                    );
+                    warn!("Failed to download wallet {record_id}: {error}");
+                    report.wallets_failed += 1;
+                    report.failed_wallet_errors.push(error);
+                }
                 Err(error) => {
                     warn!("Failed to download wallet {record_id}: {error}");
                     report.wallets_failed += 1;
@@ -680,9 +763,8 @@ impl RustCloudBackupManager {
 
         info!("Enable: uploading wallets");
         let critical_key = Zeroizing::new(master_key.critical_data_key());
-        let db = Database::global();
-        let uploaded_wallet_record_ids =
-            upload_all_wallets(cloud, &namespace_id, &critical_key, &db)?;
+        let uploaded_wallets =
+            upload_all_wallets(cloud, &namespace_id, &critical_key, &Database::global())?;
 
         info!("Enable: persisting cloud backup state");
         keychain
@@ -692,18 +774,26 @@ impl RustCloudBackupManager {
                 &namespace_id,
             )
             .map_err_prefix("save cspp credentials", CloudBackupError::Internal)?;
-        persist_enabled_cloud_backup_state_reset_verification(
-            &db,
-            uploaded_wallet_record_ids.len() as u32,
-        )?;
-        self.enqueue_pending_uploads(
+
+        let uploaded_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+        self.mark_blob_uploaded_pending_confirmation(
             &namespace_id,
-            std::iter::once(super::cspp_master_key_record_id()).chain(uploaded_wallet_record_ids),
+            None,
+            super::cspp_master_key_record_id(),
+            "master-key-wrapper".into(),
+            uploaded_at,
         )?;
 
-        self.set_progress(None);
-        self.set_restore_progress(None);
-        self.set_status(CloudBackupStatus::Enabled);
+        self.finalize_uploaded_wallets(
+            cloud,
+            &namespace_id,
+            uploaded_wallets,
+            |db, wallet_count| {
+                persist_enabled_cloud_backup_state_reset_verification(db, wallet_count)
+            },
+        )?;
+
+        self.clear_enable_progress(CloudBackupStatus::Enabled);
         info!("Cloud backup enabled successfully");
         Ok(())
     }
@@ -795,7 +885,7 @@ where
     Ok((master_key, namespace_id))
 }
 
-fn load_master_key_for_cloud_action<S, F>(
+pub(super) fn load_master_key_for_cloud_action<S, F>(
     cspp: &cove_cspp::Cspp<S>,
     recover_missing: F,
 ) -> Result<cove_cspp::master_key::MasterKey, CloudBackupError>
@@ -816,11 +906,13 @@ where
 mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, OnceLock};
+    use std::time::Duration;
 
     use bip39::Mnemonic;
     use cove_cspp::CsppStore;
     use cove_cspp::backup_data::{
         WalletEntry, WalletMode as CloudWalletMode, WalletSecret, wallet_filename_from_record_id,
+        wallet_record_id,
     };
     use cove_device::cloud_storage::{CloudStorage, CloudStorageAccess, CloudStorageError};
     use cove_device::keychain::{
@@ -831,17 +923,28 @@ mod tests {
         PasskeyProvider,
     };
     use parking_lot::Mutex;
+    use sha2::Digest as _;
     use strum::IntoEnumIterator as _;
 
     use super::*;
     use crate::database::Database;
-    use crate::database::cloud_backup::{PersistedCloudBackupState, PersistedCloudBackupStatus};
-    use crate::manager::cloud_backup_manager::{
-        DeepVerificationResult, VerificationFailureKind, VerificationState,
+    use crate::database::cloud_backup::{
+        CloudBlobDirtyState, CloudBlobFailedState, CloudBlobUploadedPendingConfirmationState,
+        CloudBlobUploadingState, CloudUploadKind, PersistedCloudBackupState,
+        PersistedCloudBackupStatus, PersistedCloudBlobState, PersistedCloudBlobSyncState,
     };
+    use crate::label_manager::LabelManager;
+    use crate::manager::cloud_backup_manager::{
+        CLOUD_BACKUP_MANAGER, CloudBackupDetailResult, DeepVerificationResult,
+        VerificationFailureKind, VerificationState,
+    };
+    use crate::manager::wallet_manager::RustWalletManager;
     use crate::mnemonic::MnemonicExt as _;
     use crate::network::Network;
-    use crate::wallet::metadata::{WalletMode, WalletType};
+    use crate::wallet::{
+        Wallet,
+        metadata::{WalletId, WalletMetadata, WalletMode, WalletType},
+    };
 
     #[derive(Debug, Default)]
     struct MockStore {
@@ -907,10 +1010,17 @@ mod tests {
         wallet_files: HashMap<String, Vec<String>>,
         master_key_backups: HashMap<String, Vec<u8>>,
         wallet_backups: HashMap<(String, String), Vec<u8>>,
+        wallet_backup_download_overrides: HashMap<(String, String), Vec<u8>>,
+        list_wallet_files_error: Option<CloudStorageError>,
         upload_master_key_error: Option<CloudStorageError>,
+        next_upload_wallet_backup_error: Option<CloudStorageError>,
         upload_wallet_backup_error: Option<CloudStorageError>,
         reflect_uploaded_wallets_in_listing: bool,
         uploaded_wallet_backups: Vec<(String, String)>,
+        wallet_backup_upload_attempts: usize,
+        dirty_wallet_on_next_upload: Option<WalletId>,
+        changed_wallet_on_next_upload: Option<WalletId>,
+        dirty_wallet_on_next_backup_check: Option<WalletId>,
     }
 
     #[derive(Debug, Clone, Default)]
@@ -931,6 +1041,31 @@ mod tests {
             self.state.lock().master_key_backups.insert(namespace, backup);
         }
 
+        fn set_wallet_backup(&self, namespace: String, record_id: String, backup: Vec<u8>) {
+            self.state.lock().wallet_backups.insert((namespace, record_id), backup);
+        }
+
+        fn set_wallet_backup_download_override(
+            &self,
+            namespace: String,
+            record_id: String,
+            backup: Vec<u8>,
+        ) {
+            self.state
+                .lock()
+                .wallet_backup_download_overrides
+                .insert((namespace, record_id), backup);
+        }
+
+        fn fail_list_wallet_files(&self, message: &str) {
+            self.state.lock().list_wallet_files_error =
+                Some(CloudStorageError::DownloadFailed(message.into()));
+        }
+
+        fn clear_list_wallet_files_failure(&self) {
+            self.state.lock().list_wallet_files_error = None;
+        }
+
         fn fail_master_key_upload(&self, message: &str) {
             self.state.lock().upload_master_key_error =
                 Some(CloudStorageError::UploadFailed(message.into()));
@@ -941,12 +1076,43 @@ mod tests {
                 Some(CloudStorageError::UploadFailed(message.into()));
         }
 
+        fn fail_wallet_backup_upload_quota_exceeded(&self) {
+            self.state.lock().upload_wallet_backup_error = Some(CloudStorageError::QuotaExceeded);
+        }
+
+        fn fail_next_wallet_backup_upload(&self, message: &str) {
+            self.state.lock().next_upload_wallet_backup_error =
+                Some(CloudStorageError::UploadFailed(message.into()));
+        }
+
+        fn clear_wallet_backup_upload_failure(&self) {
+            let mut state = self.state.lock();
+            state.next_upload_wallet_backup_error = None;
+            state.upload_wallet_backup_error = None;
+        }
+
         fn set_reflect_uploaded_wallets_in_listing(&self, enabled: bool) {
             self.state.lock().reflect_uploaded_wallets_in_listing = enabled;
         }
 
         fn uploaded_wallet_backup_count(&self) -> usize {
             self.state.lock().uploaded_wallet_backups.len()
+        }
+
+        fn wallet_backup_upload_attempt_count(&self) -> usize {
+            self.state.lock().wallet_backup_upload_attempts
+        }
+
+        fn dirty_wallet_on_next_upload(&self, wallet_id: WalletId) {
+            self.state.lock().dirty_wallet_on_next_upload = Some(wallet_id);
+        }
+
+        fn change_wallet_on_next_upload(&self, wallet_id: WalletId) {
+            self.state.lock().changed_wallet_on_next_upload = Some(wallet_id);
+        }
+
+        fn dirty_wallet_on_next_backup_check(&self, wallet_id: WalletId) {
+            self.state.lock().dirty_wallet_on_next_backup_check = Some(wallet_id);
         }
     }
 
@@ -969,13 +1135,29 @@ mod tests {
             record_id: String,
             data: Vec<u8>,
         ) -> Result<(), CloudStorageError> {
-            if let Some(error) = self.state.lock().upload_wallet_backup_error.clone() {
-                return Err(error);
-            }
+            let (dirty_wallet, changed_wallet) = {
+                let mut state = self.state.lock();
+                state.wallet_backup_upload_attempts += 1;
+                if let Some(error) = state.next_upload_wallet_backup_error.take() {
+                    return Err(error);
+                }
 
-            let mut state = self.state.lock();
-            state.wallet_backups.insert((namespace.clone(), record_id.clone()), data);
-            state.uploaded_wallet_backups.push((namespace, record_id));
+                if let Some(error) = state.upload_wallet_backup_error.clone() {
+                    return Err(error);
+                }
+
+                let dirty_wallet = state.dirty_wallet_on_next_upload.take();
+                let changed_wallet = state.changed_wallet_on_next_upload.take();
+                state.wallet_backups.insert((namespace.clone(), record_id.clone()), data);
+                state.uploaded_wallet_backups.push((namespace, record_id));
+                (dirty_wallet, changed_wallet)
+            };
+            if let Some(wallet_id) = dirty_wallet {
+                persist_dirty_blob_state(wallet_id);
+            }
+            if let Some(wallet_id) = changed_wallet {
+                mutate_wallet_and_persist_dirty(wallet_id);
+            }
             Ok(())
         }
 
@@ -996,6 +1178,18 @@ mod tests {
             namespace: String,
             record_id: String,
         ) -> Result<Vec<u8>, CloudStorageError> {
+            let dirty_wallet = self.state.lock().dirty_wallet_on_next_backup_check.take();
+            if let Some(wallet_id) = dirty_wallet {
+                persist_dirty_blob_state(wallet_id);
+            }
+
+            let override_key = (namespace.clone(), record_id.clone());
+            if let Some(backup) =
+                self.state.lock().wallet_backup_download_overrides.get(&override_key).cloned()
+            {
+                return Ok(backup);
+            }
+
             self.state
                 .lock()
                 .wallet_backups
@@ -1018,6 +1212,9 @@ mod tests {
 
         fn list_wallet_files(&self, namespace: String) -> Result<Vec<String>, CloudStorageError> {
             let state = self.state.lock();
+            if let Some(error) = state.list_wallet_files_error.clone() {
+                return Err(error);
+            }
             let mut wallet_files = state.wallet_files.get(&namespace).cloned().unwrap_or_default();
 
             if state.reflect_uploaded_wallets_in_listing {
@@ -1154,10 +1351,113 @@ mod tests {
         }
     }
 
+    fn persist_dirty_blob_state(wallet_id: WalletId) {
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+        let changed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id,
+                wallet_id: Some(wallet_id),
+                record_id,
+                state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at }),
+            })
+            .unwrap();
+    }
+
+    fn mutate_wallet_and_persist_dirty(wallet_id: WalletId) {
+        let mut wallet = all_local_wallets(&Database::global())
+            .unwrap()
+            .into_iter()
+            .find(|wallet| wallet.id == wallet_id)
+            .unwrap();
+        wallet.name.push_str(" updated");
+        Database::global()
+            .wallets()
+            .save_all_wallets(wallet.network, wallet.wallet_mode, vec![wallet.clone()])
+            .unwrap();
+        persist_dirty_blob_state(wallet.id);
+    }
+
+    fn persist_failed_blob_state(wallet_id: WalletId, retryable: bool) {
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+        let failed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id,
+                wallet_id: Some(wallet_id),
+                record_id,
+                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    revision_hash: Some("rev-1".into()),
+                    retryable,
+                    error: "failed".into(),
+                    failed_at,
+                }),
+            })
+            .unwrap();
+    }
+
+    fn persist_uploading_blob_state(wallet_id: WalletId, started_at: u64) {
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id,
+                wallet_id: Some(wallet_id),
+                record_id,
+                state: PersistedCloudBlobState::Uploading(CloudBlobUploadingState {
+                    revision_hash: "rev-1".into(),
+                    started_at,
+                }),
+            })
+            .unwrap();
+    }
+
     fn reset_cloud_backup_test_state(manager: &RustCloudBackupManager, globals: &TestGlobals) {
         globals.reset();
         clear_local_wallets();
         manager.debug_reset_cloud_backup_state();
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    async fn wait_for_test_condition(
+        timeout: Duration,
+        message: &str,
+        mut condition: impl FnMut() -> bool,
+    ) {
+        tokio::time::timeout(timeout, async {
+            loop {
+                if condition() {
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect(message);
+    }
+
+    async fn assert_test_condition_stays_true(
+        duration: Duration,
+        message: &str,
+        mut condition: impl FnMut() -> bool,
+    ) {
+        let deadline = tokio::time::Instant::now() + duration;
+        while tokio::time::Instant::now() < deadline {
+            assert!(condition(), "{message}");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
 
     fn configure_enabled_cloud_backup(
@@ -1167,6 +1467,26 @@ mod tests {
     ) {
         reset_cloud_backup_test_state(manager, globals);
 
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let keychain = Keychain::global();
+        keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
+        cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
+
+        manager
+            .persist_cloud_backup_state(
+                &PersistedCloudBackupState {
+                    status: PersistedCloudBackupStatus::Enabled,
+                    wallet_count: Some(wallet_count),
+                    ..PersistedCloudBackupState::default()
+                },
+                "set cloud backup enabled for test",
+            )
+            .unwrap();
+        manager.sync_persisted_state();
+    }
+
+    fn enable_cloud_backup_without_reset(manager: &RustCloudBackupManager, wallet_count: u32) {
         let master_key = cove_cspp::master_key::MasterKey::generate();
         let namespace = master_key.namespace_id();
         let keychain = Keychain::global();
@@ -1198,6 +1518,89 @@ mod tests {
         )
         .unwrap();
         mnemonic.xpub(metadata.network.into()).to_string()
+    }
+
+    fn persist_xpub_wallets(wallets: Vec<WalletMetadata>) {
+        for wallet in &wallets {
+            let xpub = sample_xpub(wallet);
+            Keychain::global().save_wallet_xpub(&wallet.id, xpub.parse().unwrap()).unwrap();
+        }
+
+        let Some(first_wallet) = wallets.first() else {
+            return;
+        };
+
+        Database::global()
+            .wallets()
+            .save_all_wallets(first_wallet.network, first_wallet.wallet_mode, wallets)
+            .unwrap();
+    }
+
+    fn encrypted_wallet_backup_bytes(
+        metadata: &WalletMetadata,
+        master_key: &cove_cspp::master_key::MasterKey,
+        revision_hash: &str,
+        version: u32,
+    ) -> Vec<u8> {
+        let mut prepared = crate::manager::cloud_backup_manager::wallets::prepare_wallet_backup(
+            metadata,
+            metadata.wallet_mode,
+        )
+        .unwrap();
+        prepared.entry.content_revision_hash = revision_hash.to_string();
+
+        let critical_key = zeroize::Zeroizing::new(master_key.critical_data_key());
+        let mut encrypted =
+            cove_cspp::wallet_crypto::encrypt_wallet_entry(&prepared.entry, &critical_key).unwrap();
+        encrypted.version = version;
+        serde_json::to_vec(&encrypted).unwrap()
+    }
+
+    fn wallet_entry_with_labels(
+        metadata: &WalletMetadata,
+        labels_jsonl: Option<&str>,
+    ) -> WalletEntry {
+        let labels_count = labels_jsonl
+            .map(|jsonl| jsonl.lines().filter(|line| !line.trim().is_empty()).count() as u32)
+            .unwrap_or_default();
+        let labels_zstd_jsonl =
+            labels_jsonl.map(|jsonl| crate::backup::crypto::compress(jsonl.as_bytes()).unwrap());
+        let labels_hash = labels_jsonl
+            .filter(|jsonl| !jsonl.is_empty())
+            .map(|jsonl| hex::encode(sha2::Sha256::digest(jsonl.as_bytes())));
+        let labels_uncompressed_size =
+            labels_jsonl.map(|jsonl| jsonl.len().try_into().unwrap_or(u32::MAX));
+
+        WalletEntry {
+            wallet_id: metadata.id.to_string(),
+            secret: WalletSecret::WatchOnly,
+            metadata: serde_json::to_value(metadata).unwrap(),
+            descriptors: None,
+            xpub: Some(sample_xpub(metadata)),
+            wallet_mode: CloudWalletMode::Main,
+            labels_zstd_jsonl,
+            labels_count,
+            labels_hash,
+            labels_uncompressed_size,
+            content_revision_hash: "test-content-hash".to_string(),
+            updated_at: 42,
+        }
+    }
+
+    fn encrypted_wallet_backup_bytes_for_entry(
+        entry: &WalletEntry,
+        master_key: &cove_cspp::master_key::MasterKey,
+        version: u32,
+    ) -> Vec<u8> {
+        let critical_key = zeroize::Zeroizing::new(master_key.critical_data_key());
+        let mut encrypted =
+            cove_cspp::wallet_crypto::encrypt_wallet_entry(entry, &critical_key).unwrap();
+        encrypted.version = version;
+        serde_json::to_vec(&encrypted).unwrap()
+    }
+
+    fn sample_labels_jsonl() -> &'static str {
+        r#"{"type":"tx","ref":"d97bf8892657980426c879e4ab2001f09342f1ab61cfa602741a7715a3d60290","label":"last txn received","origin":"pkh([73c5da0a/44h/0h/0h])"}"#
     }
 
     fn prepare_deep_verify_with_unsynced_wallet(
@@ -1249,6 +1652,166 @@ mod tests {
         metadata
     }
 
+    #[test]
+    fn passkey_match_treats_missing_credential_as_no_match() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        globals.passkey.set_discover_result(Err(PasskeyError::NoCredentialFound));
+
+        let outcome = try_match_namespace_with_passkey(
+            CloudStorage::global(),
+            PasskeyAccess::global(),
+            &[namespace],
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, NamespaceMatchOutcome::NoMatch));
+    }
+
+    #[test]
+    fn passkey_match_treats_user_cancel_as_user_declined() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        globals.passkey.set_discover_result(Err(PasskeyError::UserCancelled));
+
+        let outcome = try_match_namespace_with_passkey(
+            CloudStorage::global(),
+            PasskeyAccess::global(),
+            &[namespace],
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, NamespaceMatchOutcome::UserDeclined));
+    }
+
+    #[test]
+    fn passkey_match_mixed_supported_and_unsupported_versions_returns_no_match() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let supported_namespace = format!("{}-supported", master_key.namespace_id());
+        let unsupported_namespace = format!("{}-unsupported", master_key.namespace_id());
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        let mut unsupported_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        unsupported_master.version = 2;
+
+        globals.cloud.set_master_key_backup(
+            supported_namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        globals.cloud.set_master_key_backup(
+            unsupported_namespace.clone(),
+            serde_json::to_vec(&unsupported_master).unwrap(),
+        );
+        globals.passkey.set_discover_result(Ok(DiscoveredPasskeyResult {
+            prf_output: vec![8; 32],
+            credential_id: vec![1, 2, 3],
+        }));
+
+        let outcome = try_match_namespace_with_passkey(
+            CloudStorage::global(),
+            PasskeyAccess::global(),
+            &[supported_namespace, unsupported_namespace],
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, NamespaceMatchOutcome::NoMatch));
+    }
+
+    #[test]
+    fn mock_master_key_upload_persists_uploaded_bytes() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+
+        let namespace = "namespace-1".to_string();
+        let uploaded = vec![1, 2, 3, 4];
+        globals.cloud.upload_master_key_backup(namespace.clone(), uploaded.clone()).unwrap();
+
+        assert_eq!(globals.cloud.download_master_key_backup(namespace).unwrap(), uploaded);
+    }
+
+    #[test]
+    fn persist_xpub_wallets_saves_each_wallet_in_its_own_scope() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+
+        let first_wallet = xpub_only_wallet_metadata();
+        let mut second_wallet = xpub_only_wallet_metadata();
+        second_wallet.network = Network::Testnet;
+        second_wallet.wallet_mode = WalletMode::Decoy;
+
+        Database::global()
+            .wallets()
+            .save_all_wallets(first_wallet.network, first_wallet.wallet_mode, Vec::new())
+            .unwrap();
+        Database::global()
+            .wallets()
+            .save_all_wallets(second_wallet.network, second_wallet.wallet_mode, Vec::new())
+            .unwrap();
+
+        persist_xpub_wallets(vec![first_wallet.clone(), second_wallet.clone()]);
+
+        assert!(
+            Database::global()
+                .wallets()
+                .get(&first_wallet.id, first_wallet.network, first_wallet.wallet_mode)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            Database::global()
+                .wallets()
+                .get(&second_wallet.id, second_wallet.network, second_wallet.wallet_mode)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn wrapper_repair_discovery_propagates_unsupported_provider() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+        globals.passkey.set_discover_result(Err(PasskeyError::PrfUnsupportedProvider));
+
+        let error = match discover_or_create_prf_key_without_persisting(PasskeyAccess::global()) {
+            Ok(_) => panic!("expected unsupported passkey provider error"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, CloudBackupError::UnsupportedPasskeyProvider));
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn backup_wallets_uploads_when_cloud_backup_is_enabled() {
         let _guard = test_lock().lock();
@@ -1265,13 +1828,66 @@ mod tests {
 
         assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
         assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(4));
-        assert!(
-            Database::global()
-                .cloud_upload_queue
-                .get()
-                .unwrap()
-                .is_some_and(|queue| queue.has_unconfirmed())
-        );
+        assert!(Database::global().cloud_blob_sync_states.list().unwrap().into_iter().any(
+            |state| matches!(state.state, PersistedCloudBlobState::UploadedPendingConfirmation(_))
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backup_new_wallet_marks_verification_required() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 3);
+
+        manager.backup_new_wallet(xpub_only_wallet_metadata());
+
+        let state = Database::global().cloud_backup_state.get().unwrap();
+        assert_eq!(state.status, PersistedCloudBackupStatus::Unverified);
+        assert!(state.last_verification_requested_at.is_some());
+
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backup_new_wallet_still_tracks_when_runtime_status_is_error() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        globals.reset();
+
+        let namespace = "test-namespace".to_string();
+        Keychain::global().save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
+        Database::global().cloud_blob_sync_states.delete_all().unwrap();
+        manager
+            .persist_cloud_backup_state(
+                &PersistedCloudBackupState {
+                    status: PersistedCloudBackupStatus::Enabled,
+                    wallet_count: Some(3),
+                    ..PersistedCloudBackupState::default()
+                },
+                "set cloud backup enabled for test",
+            )
+            .unwrap();
+        manager.sync_persisted_state();
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = wallet_record_id(metadata.id.as_ref());
+        manager.set_status(CloudBackupStatus::Error("offline".into()));
+
+        manager.backup_new_wallet(metadata);
+
+        let state = Database::global().cloud_backup_state.get().unwrap();
+        assert_eq!(state.status, PersistedCloudBackupStatus::Unverified);
+        assert!(state.last_verification_requested_at.is_some());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Dirty(_), .. })
+        ));
+
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1292,14 +1908,20 @@ mod tests {
                 descriptors: None,
                 xpub: Some(sample_xpub(&metadata)),
                 wallet_mode: CloudWalletMode::Main,
+                labels_zstd_jsonl: None,
+                labels_count: 0,
+                labels_hash: None,
+                labels_uncompressed_size: None,
+                content_revision_hash: "test-content-hash".to_string(),
+                updated_at: 42,
             },
         };
 
-        restore_downloaded_wallet_for_restore(&wallet, &mut Vec::new()).unwrap();
+        WalletRestoreSession::new(Vec::new()).restore_downloaded(&wallet).unwrap();
 
         assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
         assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(5));
-        assert_eq!(Database::global().cloud_upload_queue.get().unwrap(), None);
+        assert!(Database::global().cloud_blob_sync_states.list().unwrap().is_empty());
         assert!(
             Database::global()
                 .wallets()
@@ -1307,6 +1929,31 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn restore_downloaded_wallet_restores_labels_without_marking_cloud_backup_dirty() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 5);
+
+        let metadata = xpub_only_wallet_metadata();
+        let wallet = DownloadedWalletBackup {
+            metadata: metadata.clone(),
+            entry: wallet_entry_with_labels(&metadata, Some(sample_labels_jsonl())),
+        };
+
+        let outcome = WalletRestoreSession::new(Vec::new()).restore_downloaded(&wallet).unwrap();
+
+        assert!(outcome.labels_warning.is_none());
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(5));
+        assert!(Database::global().cloud_blob_sync_states.list().unwrap().is_empty());
+
+        let exported = LabelManager::new(metadata.id.clone()).export_blocking().unwrap();
+        assert!(exported.contains("\"label\":\"last txn received\""));
     }
 
     #[test]
@@ -1411,6 +2058,62 @@ mod tests {
         assert!(cspp.load_master_key_from_store().unwrap().is_none());
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn reupload_all_wallets_persists_full_cloud_wallet_count() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        persist_xpub_wallets(vec![metadata]);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        globals.cloud.set_reflect_uploaded_wallets_in_listing(true);
+        globals
+            .cloud
+            .set_wallet_files(namespace, vec![wallet_filename_from_record_id("cloud-only-record")]);
+
+        manager.do_reupload_all_wallets().unwrap();
+
+        assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(2));
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[test]
+    fn fetch_cloud_only_wallets_surfaces_unsupported_versions() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let keychain = Keychain::global();
+        let namespace = keychain.get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let master_key =
+            cove_cspp::Cspp::new(keychain.clone()).load_master_key_from_store().unwrap().unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&metadata, &master_key, "unsupported-revision", 2),
+        );
+        globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
+
+        let wallets = manager.do_fetch_cloud_only_wallets().unwrap();
+
+        assert_eq!(wallets.len(), 1);
+        assert_eq!(wallets[0].record_id, record_id);
+        assert_eq!(wallets[0].name, UNSUPPORTED_CLOUD_ONLY_WALLET_NAME);
+        assert_eq!(wallets[0].sync_status, CloudBackupWalletStatus::UnsupportedVersion);
+        assert_eq!(wallets[0].network, None);
+        assert_eq!(wallets[0].wallet_mode, None);
+        assert_eq!(wallets[0].wallet_type, None);
+        assert_eq!(wallets[0].label_count, None);
+        assert_eq!(wallets[0].backup_updated_at, None);
+    }
+
     #[test]
     fn backup_wallets_does_not_create_master_key_or_upload_when_missing() {
         let _guard = test_lock().lock();
@@ -1438,6 +2141,799 @@ mod tests {
     }
 
     #[test]
+    fn upload_wallet_if_dirty_does_not_create_master_key_for_existing_namespace() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        globals.reset();
+
+        let namespace = "existing-namespace";
+        Keychain::global().save(CSPP_NAMESPACE_ID_KEY.into(), namespace.into()).unwrap();
+
+        let manager = RustCloudBackupManager::init();
+        let metadata = xpub_only_wallet_metadata();
+        let xpub = sample_xpub(&metadata);
+        Keychain::global().save_wallet_xpub(&metadata.id, xpub.parse().unwrap()).unwrap();
+        Database::global()
+            .wallets()
+            .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata.clone()])
+            .unwrap();
+
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id: namespace.into(),
+                wallet_id: Some(metadata.id.clone()),
+                record_id: record_id.clone(),
+                state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at: 1 }),
+            })
+            .unwrap();
+
+        let error = manager.do_upload_wallet_if_dirty(&metadata.id).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CloudBackupError::RecoveryRequired(message)
+                if message == "Cloud backup needs verification before wallets can be uploaded"
+        ));
+
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        assert!(cspp.load_master_key_from_store().unwrap().is_none());
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    retryable: false,
+                    ..
+                }),
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn failed_live_wallet_upload_retries_without_restart() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = CLOUD_BACKUP_MANAGER.clone();
+        manager.clear_wallet_upload_debouncers_for_test();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata.clone()]);
+        persist_dirty_blob_state(metadata.id.clone());
+        globals.cloud.fail_next_wallet_backup_upload("offline");
+
+        manager.run_wallet_upload_for_test(metadata.id.clone());
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert!(manager.state().sync_error.is_some());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    retryable: true,
+                    ..
+                }),
+                ..
+            })
+        ));
+
+        assert!(manager.wallet_upload_debouncers.lock().contains_key(&metadata.id));
+
+        manager.clear_wallet_upload_debouncers_for_test();
+        manager.run_wallet_upload_for_test(metadata.id.clone());
+
+        assert!(globals.cloud.uploaded_wallet_backup_count() >= 1);
+        assert!(manager.state().sync_error.is_none());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                    | PersistedCloudBlobState::Confirmed(_),
+                ..
+            })
+        ));
+
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
+    #[tokio::test(flavor = "current_thread")]
+    async fn permanent_failed_wallet_upload_does_not_retry_without_restart() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = CLOUD_BACKUP_MANAGER.clone();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata.clone()]);
+        persist_dirty_blob_state(metadata.id.clone());
+        globals.cloud.fail_wallet_backup_upload_quota_exceeded();
+
+        manager.run_wallet_upload_for_test(metadata.id.clone());
+
+        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 1);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    retryable: false,
+                    ..
+                }),
+                ..
+            })
+        ));
+
+        assert_test_condition_stays_true(
+            super::super::LIVE_UPLOAD_DEBOUNCE + Duration::from_secs(1),
+            "non-retryable upload should not retry without restart",
+            || globals.cloud.wallet_backup_upload_attempt_count() == 1,
+        )
+        .await;
+
+        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 1);
+
+        manager.clear_wallet_upload_debouncers_for_test();
+        globals.cloud.clear_wallet_backup_upload_failure();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sync_error_clears_only_after_last_failed_wallet_upload_recovers() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = CLOUD_BACKUP_MANAGER.clone();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let first_wallet = xpub_only_wallet_metadata();
+        let second_wallet = xpub_only_wallet_metadata();
+        let first_record_id = cove_cspp::backup_data::wallet_record_id(first_wallet.id.as_ref());
+        let second_record_id = cove_cspp::backup_data::wallet_record_id(second_wallet.id.as_ref());
+
+        persist_xpub_wallets(vec![first_wallet.clone(), second_wallet.clone()]);
+        persist_dirty_blob_state(first_wallet.id.clone());
+        persist_dirty_blob_state(second_wallet.id.clone());
+        globals.cloud.fail_wallet_backup_upload("offline");
+
+        manager.run_wallet_upload_for_test(first_wallet.id.clone());
+        manager.run_wallet_upload_for_test(second_wallet.id.clone());
+
+        assert!(manager.state().sync_error.is_some());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&first_record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Failed(_), .. })
+        ));
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&second_record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Failed(_), .. })
+        ));
+
+        globals.cloud.clear_wallet_backup_upload_failure();
+
+        manager.run_wallet_upload_for_test(first_wallet.id.clone());
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
+        assert!(manager.state().sync_error.is_some());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&first_record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                    | PersistedCloudBlobState::Confirmed(_),
+                ..
+            })
+        ));
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&second_record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Failed(_), .. })
+        ));
+
+        manager.run_wallet_upload_for_test(second_wallet.id.clone());
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 2);
+        assert!(manager.state().sync_error.is_none());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&second_record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                    | PersistedCloudBlobState::Confirmed(_),
+                ..
+            })
+        ));
+
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "tests serialize shared cloud backup globals across awaits"
+    )]
+    #[tokio::test(flavor = "current_thread")]
+    async fn startup_resume_skips_non_retryable_failed_wallet_uploads() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = CLOUD_BACKUP_MANAGER.clone();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        persist_xpub_wallets(vec![metadata.clone()]);
+        persist_failed_blob_state(metadata.id.clone(), false);
+        globals.cloud.fail_wallet_backup_upload_quota_exceeded();
+
+        manager.resume_pending_cloud_upload_verification();
+
+        assert_test_condition_stays_true(
+            Duration::from_millis(250),
+            "startup resume should not retry non-retryable failed uploads",
+            || globals.cloud.wallet_backup_upload_attempt_count() == 0,
+        )
+        .await;
+
+        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 0);
+
+        manager.clear_wallet_upload_debouncers_for_test();
+        globals.cloud.clear_wallet_backup_upload_failure();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn startup_resume_retries_interrupted_uploading_wallets() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = CLOUD_BACKUP_MANAGER.clone();
+        manager.clear_wallet_upload_debouncers_for_test();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata.clone()]);
+        persist_uploading_blob_state(metadata.id, 1);
+
+        manager.resume_pending_cloud_upload_verification();
+
+        wait_for_test_condition(
+            Duration::from_secs(1),
+            "startup resume should retry interrupted uploads",
+            || {
+                matches!(
+                    Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+                    Some(PersistedCloudBlobSyncState {
+                        state: PersistedCloudBlobState::Dirty(_)
+                            | PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                            | PersistedCloudBlobState::Confirmed(_),
+                        ..
+                    })
+                )
+            },
+        )
+        .await;
+
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn validate_metadata_marks_generated_wallet_names_dirty() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = CLOUD_BACKUP_MANAGER.clone();
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let mut metadata = WalletMetadata::preview_new();
+        metadata.name.clear();
+
+        let wallet = Wallet::try_new_persisted_and_selected(
+            metadata,
+            Mnemonic::parse(
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            )
+            .unwrap(),
+            None,
+        )
+        .unwrap();
+        let wallet_id = wallet.id();
+        let stored_metadata = Database::global()
+            .wallets()
+            .get(&wallet_id, wallet.network, wallet.metadata.wallet_mode)
+            .unwrap()
+            .unwrap();
+        let expected_name = stored_metadata
+            .master_fingerprint
+            .as_deref()
+            .map_or_else(|| "Unnamed Wallet".to_string(), |fingerprint| fingerprint.as_uppercase());
+
+        enable_cloud_backup_without_reset(&manager, 1);
+
+        let wallet_manager = RustWalletManager::try_new(wallet_id.clone()).unwrap();
+        wallet_manager.validate_metadata();
+
+        let updated_metadata = Database::global()
+            .wallets()
+            .get(&wallet_id, wallet.network, wallet.metadata.wallet_mode)
+            .unwrap()
+            .unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+
+        assert_eq!(updated_metadata.name, expected_name);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Dirty(_), .. })
+        ));
+
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[test]
+    fn upload_wallet_if_dirty_removes_deleted_wallet_sync_state() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = WalletMetadata::preview_new();
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id: namespace.clone(),
+                wallet_id: Some(metadata.id.clone()),
+                record_id: record_id.clone(),
+                state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at: 1 }),
+            })
+            .unwrap();
+
+        manager.do_upload_wallet_if_dirty(&metadata.id).unwrap();
+
+        assert!(Database::global().cloud_blob_sync_states.get(&record_id).unwrap().is_none());
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert_eq!(Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()), Some(namespace));
+    }
+
+    #[test]
+    fn sync_and_integrity_skip_pending_upload_candidates() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 1);
+
+        let mut metadata = WalletMetadata::preview_new();
+        metadata.wallet_type = WalletType::WatchOnly;
+        Database::global()
+            .wallets()
+            .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata.clone()])
+            .unwrap();
+
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id,
+                wallet_id: Some(metadata.id.clone()),
+                record_id,
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                    CloudBlobUploadedPendingConfirmationState {
+                        revision_hash: "rev-1".into(),
+                        uploaded_at: 10,
+                        attempt_count: 0,
+                        last_checked_at: None,
+                    },
+                ),
+            })
+            .unwrap();
+
+        manager.do_sync_unsynced_wallets().unwrap();
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(1));
+
+        let warning = manager.verify_backup_integrity_impl().expect("expected passkey warning");
+
+        assert!(!warning.contains("some wallets are not backed up"));
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(1));
+    }
+
+    #[test]
+    fn integrity_does_not_retry_sync_after_auto_backup_failure() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 1);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        Keychain::global()
+            .save_cspp_passkey_and_namespace(&[1, 2, 3, 4], [9; 32], &namespace)
+            .unwrap();
+
+        let mut metadata = WalletMetadata::preview_new();
+        metadata.wallet_type = WalletType::WatchOnly;
+        Database::global()
+            .wallets()
+            .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata])
+            .unwrap();
+        globals.cloud.fail_wallet_backup_upload("offline");
+
+        let warning = manager.verify_backup_integrity_impl().expect("expected integrity warning");
+
+        assert!(warning.contains("some wallets are not backed up"));
+        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 1);
+    }
+
+    #[test]
+    fn integrity_warns_when_wallet_list_fails() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        Keychain::global()
+            .save_cspp_passkey_and_namespace(&[1, 2, 3, 4], [9; 32], &namespace)
+            .unwrap();
+        globals.cloud.fail_list_wallet_files("offline");
+
+        let warning = manager.verify_backup_integrity_impl().expect("expected integrity warning");
+
+        assert!(warning.contains("wallet backups could not be listed"));
+        globals.cloud.clear_list_wallet_files_failure();
+    }
+
+    #[test]
+    fn integrity_preserves_unsupported_remote_wallet_backups() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 1);
+
+        let metadata = xpub_only_wallet_metadata();
+        persist_xpub_wallets(vec![metadata.clone()]);
+
+        let keychain = Keychain::global();
+        let namespace = keychain.get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        keychain.save_cspp_passkey_and_namespace(&[1, 2, 3, 4], [9; 32], &namespace).unwrap();
+        let master_key =
+            cove_cspp::Cspp::new(keychain.clone()).load_master_key_from_store().unwrap().unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&metadata, &master_key, "unsupported-revision", 2),
+        );
+        globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
+
+        let warning = manager.verify_backup_integrity_impl();
+
+        assert!(warning.is_none());
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+
+        let detail = manager.state().detail.expect("expected cloud backup detail");
+        assert_eq!(detail.needs_sync.len(), 1);
+        assert_eq!(detail.needs_sync[0].record_id, record_id);
+        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::RemoteStateUnknown);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn refresh_cloud_backup_detail_marks_listed_wallet_unknown_when_master_key_is_missing() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        globals.reset();
+
+        let metadata = xpub_only_wallet_metadata();
+        Database::global()
+            .wallets()
+            .save_all_wallets(metadata.network, metadata.wallet_mode, Vec::new())
+            .unwrap();
+        Database::global().cloud_blob_sync_states.delete_all().unwrap();
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let keychain = Keychain::global();
+        keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace.clone()).unwrap();
+        cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
+        manager
+            .persist_cloud_backup_state(
+                &PersistedCloudBackupState {
+                    status: PersistedCloudBackupStatus::Enabled,
+                    wallet_count: Some(1),
+                    ..PersistedCloudBackupState::default()
+                },
+                "set cloud backup enabled for test",
+            )
+            .unwrap();
+        manager.sync_persisted_state();
+
+        persist_xpub_wallets(vec![metadata.clone()]);
+
+        let record_id = wallet_record_id(metadata.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&metadata, &master_key, "rev-1", 1),
+        );
+        globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
+
+        let cspp = cove_cspp::Cspp::new(keychain.clone());
+        cspp.delete_master_key();
+        cove_cspp::Cspp::<Keychain>::clear_cached_master_key();
+
+        let Some(CloudBackupDetailResult::Success(detail)) = manager.refresh_cloud_backup_detail()
+        else {
+            panic!("expected cloud backup detail");
+        };
+
+        assert_eq!(detail.needs_sync.len(), 1);
+        assert_eq!(detail.needs_sync[0].record_id, record_id);
+        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::RemoteStateUnknown);
+    }
+
+    #[test]
+    fn sync_skips_wallets_with_unknown_remote_truth() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 1);
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata]);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        globals
+            .cloud
+            .set_wallet_files(namespace.clone(), vec![wallet_filename_from_record_id(&record_id)]);
+        globals.cloud.set_wallet_backup(namespace, record_id, b"{".to_vec());
+
+        manager.do_sync_unsynced_wallets().unwrap();
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn integrity_refreshes_detail_after_auto_backup_success() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata]);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        Keychain::global()
+            .save_cspp_passkey_and_namespace(&[1, 2, 3, 4], [9; 32], &namespace)
+            .unwrap();
+        globals.cloud.set_reflect_uploaded_wallets_in_listing(true);
+
+        let warning = manager.verify_backup_integrity_impl();
+
+        assert!(warning.is_none());
+        let detail = manager.state().detail.expect("expected cloud backup detail");
+        assert_eq!(detail.up_to_date.len(), 1);
+        assert!(detail.needs_sync.is_empty());
+        assert_eq!(detail.up_to_date[0].record_id, record_id);
+        assert_eq!(detail.up_to_date[0].sync_status, CloudBackupWalletStatus::Confirmed);
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[test]
+    fn integrity_does_not_retry_sync_after_auto_backup_success_when_listing_stays_empty() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        persist_xpub_wallets(vec![metadata]);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        Keychain::global()
+            .save_cspp_passkey_and_namespace(&[1, 2, 3, 4], [9; 32], &namespace)
+            .unwrap();
+
+        let warning = manager.verify_backup_integrity_impl();
+
+        assert!(warning.is_none());
+        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 1);
+    }
+
+    #[test]
+    fn integrity_refreshes_detail_after_auto_backup_failure() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata]);
+
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        Keychain::global()
+            .save_cspp_passkey_and_namespace(&[1, 2, 3, 4], [9; 32], &namespace)
+            .unwrap();
+        globals.cloud.fail_wallet_backup_upload("offline");
+
+        let warning = manager.verify_backup_integrity_impl().expect("expected integrity warning");
+
+        assert!(warning.contains("some wallets are not backed up"));
+        let detail = manager.state().detail.expect("expected cloud backup detail");
+        assert_eq!(detail.needs_sync.len(), 1);
+        assert_eq!(detail.needs_sync[0].record_id, record_id);
+        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::Dirty);
+    }
+
+    #[test]
+    fn upload_wallet_if_dirty_preserves_newer_dirty_state() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let mut metadata = WalletMetadata::preview_new();
+        metadata.wallet_type = WalletType::WatchOnly;
+        Database::global()
+            .wallets()
+            .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata.clone()])
+            .unwrap();
+
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id,
+                wallet_id: Some(metadata.id.clone()),
+                record_id: record_id.clone(),
+                state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at: 1 }),
+            })
+            .unwrap();
+        globals.cloud.dirty_wallet_on_next_upload(metadata.id.clone());
+
+        manager.do_upload_wallet_if_dirty(&metadata.id).unwrap();
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Dirty(_), .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn upload_wallet_if_dirty_retries_stale_uploading_state() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        persist_xpub_wallets(vec![metadata.clone()]);
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_uploading_blob_state(metadata.id.clone(), 1);
+
+        manager.do_upload_wallet_if_dirty(&metadata.id).unwrap();
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_),
+                ..
+            })
+        ));
+        manager.clear_wallet_upload_debouncers_for_test();
+    }
+
+    #[test]
+    fn upload_wallet_if_dirty_skips_fresh_uploading_state() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        persist_xpub_wallets(vec![metadata.clone()]);
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_uploading_blob_state(
+            metadata.id.clone(),
+            jiff::Timestamp::now().as_second().try_into().unwrap_or(0),
+        );
+
+        manager.do_upload_wallet_if_dirty(&metadata.id).unwrap();
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Uploading(CloudBlobUploadingState { .. }),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn backup_wallets_preserves_newer_dirty_state() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let mut metadata = WalletMetadata::preview_new();
+        metadata.wallet_type = WalletType::WatchOnly;
+        Database::global()
+            .wallets()
+            .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata.clone()])
+            .unwrap();
+        globals.cloud.change_wallet_on_next_upload(metadata.id.clone());
+
+        manager.do_backup_wallets(&[metadata.clone()]).unwrap();
+
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Dirty(_), .. })
+        ));
+    }
+
+    #[test]
+    fn pending_upload_verification_preserves_newer_dirty_state() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = WalletMetadata::preview_new();
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id,
+                wallet_id: Some(metadata.id.clone()),
+                record_id: record_id.clone(),
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                    CloudBlobUploadedPendingConfirmationState {
+                        revision_hash: "rev-1".into(),
+                        uploaded_at: 10,
+                        attempt_count: 0,
+                        last_checked_at: None,
+                    },
+                ),
+            })
+            .unwrap();
+        globals.cloud.dirty_wallet_on_next_backup_check(metadata.id.clone());
+
+        let has_more_pending = manager.verify_pending_uploads_once_for_test();
+
+        assert!(!has_more_pending);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Dirty(_), .. })
+        ));
+    }
+
+    #[test]
     fn deep_verify_fails_when_auto_sync_upload_fails() {
         let _guard = test_lock().lock();
         let globals = test_globals();
@@ -1456,8 +2952,8 @@ mod tests {
                     "failed to auto-sync missing wallet backups: cloud storage error: upload failed: upload failed"
                 );
                 let detail = failure.detail.expect("expected detail on retry failure");
-                assert_eq!(detail.not_backed_up.len(), 1);
-                assert_eq!(detail.not_backed_up[0].record_id, record_id);
+                assert_eq!(detail.needs_sync.len(), 1);
+                assert_eq!(detail.needs_sync[0].record_id, record_id);
             }
             other => panic!("expected retry failure, got {other:?}"),
         }
@@ -1477,8 +2973,9 @@ mod tests {
         match result {
             DeepVerificationResult::AwaitingUploadConfirmation(report) => {
                 let detail = report.detail.expect("expected verification detail");
-                assert_eq!(detail.not_backed_up.len(), 1);
-                assert_eq!(detail.not_backed_up[0].record_id, record_id);
+                assert_eq!(detail.up_to_date.len(), 1);
+                assert!(detail.needs_sync.is_empty());
+                assert_eq!(detail.up_to_date[0].record_id, record_id);
             }
             other => panic!("expected awaiting upload confirmation, got {other:?}"),
         }
@@ -1507,7 +3004,6 @@ mod tests {
 
         assert!(!has_more_pending);
         assert!(manager.pending_verification_completion().is_none());
-        assert!(!manager.has_pending_cloud_upload_verification());
 
         match manager.state().verification {
             VerificationState::Verified(report) => {
@@ -1516,14 +3012,328 @@ mod tests {
                 assert_eq!(report.wallets_unsupported, 0);
 
                 let detail = report.detail.expect("expected verification detail");
-                assert_eq!(detail.backed_up.len(), 1);
-                assert!(detail.not_backed_up.is_empty());
-                assert_eq!(detail.backed_up[0].record_id, record_id);
+                assert_eq!(detail.up_to_date.len(), 1);
+                assert!(detail.needs_sync.is_empty());
+                assert_eq!(detail.up_to_date[0].record_id, record_id);
             }
             other => {
                 panic!("expected verified result after pending upload verification, got {other:?}")
             }
         }
+
+        assert!(!manager.has_pending_cloud_upload_verification());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_upload_verification_survives_restart() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        assert!(matches!(result, DeepVerificationResult::AwaitingUploadConfirmation(_)));
+        assert!(manager.pending_verification_completion().is_some());
+
+        let restarted_manager = RustCloudBackupManager::init();
+
+        assert!(restarted_manager.pending_verification_completion().is_some());
+        restarted_manager.sync_persisted_state();
+        let has_more_pending = restarted_manager.verify_pending_uploads_once_for_test();
+
+        assert!(!has_more_pending);
+        assert!(restarted_manager.pending_verification_completion().is_none());
+        match restarted_manager.state().verification {
+            VerificationState::Verified(report) => {
+                assert_eq!(report.wallets_verified, 1);
+                assert_eq!(report.wallets_failed, 0);
+                assert_eq!(report.wallets_unsupported, 0);
+
+                let detail = report.detail.expect("expected verification detail");
+                assert_eq!(detail.up_to_date.len(), 1);
+                assert!(detail.needs_sync.is_empty());
+                assert_eq!(detail.up_to_date[0].record_id, record_id);
+            }
+            other => {
+                panic!("expected verified result after restart, got {other:?}")
+            }
+        }
+        assert!(!restarted_manager.has_pending_cloud_upload_verification());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_upload_verification_retries_until_expected_revision_is_readable() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        let master_key = cove_cspp::Cspp::new(Keychain::global().clone())
+            .load_master_key_from_store()
+            .unwrap()
+            .unwrap();
+        let current_revision =
+            crate::manager::cloud_backup_manager::wallets::prepare_wallet_backup(
+                &metadata,
+                metadata.wallet_mode,
+            )
+            .unwrap()
+            .revision_hash;
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        assert!(matches!(result, DeepVerificationResult::AwaitingUploadConfirmation(_)));
+        globals.cloud.set_wallet_backup_download_override(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&metadata, &master_key, "stale-revision", 1),
+        );
+
+        let has_more_pending = manager.verify_pending_uploads_once_for_test();
+
+        assert!(has_more_pending);
+        assert!(manager.pending_verification_completion().is_some());
+        assert!(manager.has_pending_cloud_upload_verification());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                    | PersistedCloudBlobState::Confirmed(_),
+                ..
+            })
+        ));
+        assert!(!matches!(
+            manager.state().verification,
+            VerificationState::Verified(_) | VerificationState::Failed(_)
+        ));
+
+        globals.cloud.set_wallet_backup_download_override(
+            namespace,
+            record_id,
+            encrypted_wallet_backup_bytes(&metadata, &master_key, &current_revision, 1),
+        );
+
+        let has_more_pending = manager.verify_pending_uploads_once_for_test();
+
+        assert!(!has_more_pending);
+        assert!(manager.pending_verification_completion().is_none());
+        match manager.state().verification {
+            VerificationState::Verified(report) => {
+                assert_eq!(report.wallets_verified, 1);
+                assert_eq!(report.wallets_failed, 0);
+                assert_eq!(report.wallets_unsupported, 0);
+            }
+            other => panic!("expected verified result after retry, got {other:?}"),
+        }
+        assert!(!manager.has_pending_cloud_upload_verification());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_upload_verification_accepts_newer_revision_after_wallet_changes() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        globals.cloud.change_wallet_on_next_upload(metadata.id.clone());
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        assert!(matches!(result, DeepVerificationResult::AwaitingUploadConfirmation(_)));
+        assert!(manager.pending_verification_completion().is_some());
+        assert!(manager.has_pending_cloud_upload_verification());
+
+        manager.do_upload_wallet_if_dirty(&metadata.id).unwrap();
+
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_),
+                ..
+            })
+        ));
+
+        let has_more_pending = manager.verify_pending_uploads_once_for_test();
+
+        assert!(!has_more_pending);
+        assert!(manager.pending_verification_completion().is_none());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Confirmed(_), .. })
+        ));
+
+        match manager.state().verification {
+            VerificationState::Verified(report) => {
+                assert_eq!(report.wallets_verified, 1);
+                assert_eq!(report.wallets_failed, 0);
+                assert_eq!(report.wallets_unsupported, 0);
+
+                let detail = report.detail.expect("expected verification detail");
+                assert_eq!(detail.up_to_date.len(), 1);
+                assert!(detail.needs_sync.is_empty());
+                assert_eq!(detail.up_to_date[0].record_id, record_id);
+            }
+            other => panic!("expected verified result after newer upload, got {other:?}"),
+        }
+
+        assert!(!manager.has_pending_cloud_upload_verification());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_upload_verification_marks_invalid_wallet_json_failed() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        assert!(matches!(result, DeepVerificationResult::AwaitingUploadConfirmation(_)));
+        globals.cloud.set_wallet_backup(namespace, record_id.clone(), b"{".to_vec());
+
+        let has_more_pending = manager.verify_pending_uploads_once_for_test();
+
+        assert!(!has_more_pending);
+        assert!(manager.pending_verification_completion().is_none());
+
+        match manager.state().verification {
+            VerificationState::Verified(report) => {
+                assert_eq!(report.wallets_verified, 0);
+                assert_eq!(report.wallets_failed, 1);
+                assert_eq!(report.wallets_unsupported, 0);
+            }
+            other => {
+                panic!("expected verified result after pending upload verification, got {other:?}")
+            }
+        }
+
+        assert!(!manager.has_pending_cloud_upload_verification());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pending_upload_verification_marks_terminal_live_upload_failures_failed() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        configure_enabled_cloud_backup(&manager, globals, 0);
+
+        let metadata = xpub_only_wallet_metadata();
+        let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        persist_xpub_wallets(vec![metadata.clone()]);
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&PersistedCloudBlobSyncState {
+                kind: CloudUploadKind::BackupBlob,
+                namespace_id: namespace_id.clone(),
+                wallet_id: Some(metadata.id),
+                record_id: record_id.clone(),
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                    CloudBlobUploadedPendingConfirmationState {
+                        revision_hash: "rev-1".into(),
+                        uploaded_at: 10,
+                        attempt_count: 0,
+                        last_checked_at: None,
+                    },
+                ),
+            })
+            .unwrap();
+        globals.cloud.set_wallet_backup(namespace_id, record_id.clone(), b"{".to_vec());
+
+        let has_more_pending = manager.verify_pending_uploads_once_for_test();
+
+        assert!(!has_more_pending);
+        assert!(!manager.has_pending_cloud_upload_verification());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    retryable: false,
+                    ..
+                }),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn deep_verify_preserves_unsupported_remote_wallet_backups() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let keychain = Keychain::global();
+        let namespace = keychain.get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let master_key =
+            cove_cspp::Cspp::new(keychain.clone()).load_master_key_from_store().unwrap().unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&metadata, &master_key, "unsupported-revision", 2),
+        );
+        globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        match result {
+            DeepVerificationResult::Verified(report) => {
+                assert_eq!(report.wallets_verified, 0);
+                assert_eq!(report.wallets_failed, 0);
+                assert_eq!(report.wallets_unsupported, 1);
+            }
+            other => panic!("expected verified result, got {other:?}"),
+        }
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
+        assert!(manager.pending_verification_completion().is_none());
+    }
+
+    #[test]
+    fn deep_verify_retries_when_remote_wallet_truth_is_unknown() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        globals
+            .cloud
+            .set_wallet_files(namespace.clone(), vec![wallet_filename_from_record_id(&record_id)]);
+        globals.cloud.set_wallet_backup(namespace, record_id.clone(), b"{".to_vec());
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        match result {
+            DeepVerificationResult::Failed(failure) => {
+                assert_eq!(failure.kind, VerificationFailureKind::Retry);
+                assert_eq!(
+                    failure.message,
+                    "failed to refresh remote wallet truth for some wallets"
+                );
+
+                let detail = failure.detail.expect("expected verification detail");
+                assert_eq!(detail.needs_sync.len(), 1);
+                assert_eq!(detail.needs_sync[0].record_id, record_id);
+                assert_eq!(
+                    detail.needs_sync[0].sync_status,
+                    CloudBackupWalletStatus::RemoteStateUnknown
+                );
+            }
+            other => panic!("expected retry failure, got {other:?}"),
+        }
+
+        assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 0);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1540,10 +3350,10 @@ mod tests {
         match result {
             DeepVerificationResult::Verified(report) => {
                 let detail = report.detail.expect("expected verification detail");
-                assert_eq!(detail.backed_up.len(), 1);
-                assert!(detail.not_backed_up.is_empty());
+                assert_eq!(detail.up_to_date.len(), 1);
+                assert!(detail.needs_sync.is_empty());
                 assert_eq!(
-                    detail.backed_up[0].record_id,
+                    detail.up_to_date[0].record_id,
                     cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref())
                 );
             }
@@ -1551,6 +3361,55 @@ mod tests {
         }
 
         assert_eq!(globals.cloud.uploaded_wallet_backup_count(), 1);
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState { state: PersistedCloudBlobState::Confirmed(_), .. })
+        ));
+        assert!(!manager.has_pending_cloud_upload_verification());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deep_verify_awaits_upload_confirmation_when_remote_revision_is_stale() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+        let metadata = prepare_deep_verify_with_unsynced_wallet(&manager, globals);
+        let namespace = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+        let master_key = cove_cspp::Cspp::new(Keychain::global().clone())
+            .load_master_key_from_store()
+            .unwrap()
+            .unwrap();
+        globals.cloud.set_reflect_uploaded_wallets_in_listing(true);
+        globals.cloud.set_wallet_backup_download_override(
+            namespace,
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&metadata, &master_key, "stale-revision", 1),
+        );
+
+        let result = manager.deep_verify_cloud_backup(true);
+
+        match result {
+            DeepVerificationResult::AwaitingUploadConfirmation(report) => {
+                let detail = report.detail.expect("expected verification detail");
+                assert!(detail.up_to_date.is_empty());
+                assert_eq!(detail.needs_sync.len(), 1);
+                assert_eq!(detail.needs_sync[0].record_id, record_id);
+            }
+            other => panic!("expected awaiting upload confirmation, got {other:?}"),
+        }
+
+        assert!(manager.pending_verification_completion().is_some());
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::UploadedPendingConfirmation(_),
+                ..
+            })
+        ));
+        assert!(manager.has_pending_cloud_upload_verification());
     }
 
     #[test]
@@ -1629,5 +3488,335 @@ mod tests {
 
         assert!(matches!(error, CloudBackupError::PasskeyDiscoveryCancelled));
         assert_eq!(Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()), None);
+    }
+
+    #[test]
+    fn restore_counts_unsupported_wallet_versions_as_failures() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        cove_cspp::Cspp::new(Keychain::global().clone()).save_master_key(&master_key).unwrap();
+
+        let supported_wallet = xpub_only_wallet_metadata();
+        let unsupported_wallet = xpub_only_wallet_metadata();
+        Keychain::global()
+            .save_wallet_xpub(&supported_wallet.id, sample_xpub(&supported_wallet).parse().unwrap())
+            .unwrap();
+        Keychain::global()
+            .save_wallet_xpub(
+                &unsupported_wallet.id,
+                sample_xpub(&unsupported_wallet).parse().unwrap(),
+            )
+            .unwrap();
+
+        let supported_record_id =
+            cove_cspp::backup_data::wallet_record_id(supported_wallet.id.as_ref());
+        let unsupported_record_id =
+            cove_cspp::backup_data::wallet_record_id(unsupported_wallet.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            supported_record_id.clone(),
+            encrypted_wallet_backup_bytes(&supported_wallet, &master_key, "supported-revision", 1),
+        );
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            unsupported_record_id.clone(),
+            encrypted_wallet_backup_bytes(
+                &unsupported_wallet,
+                &master_key,
+                "unsupported-revision",
+                2,
+            ),
+        );
+        globals.cloud.set_wallet_files(
+            namespace,
+            vec![
+                wallet_filename_from_record_id(&supported_record_id),
+                wallet_filename_from_record_id(&unsupported_record_id),
+            ],
+        );
+
+        let operation_id = manager.next_restore_operation_id();
+        manager.do_restore_from_cloud_backup(operation_id).unwrap();
+
+        let report = manager.state().restore_report.expect("expected restore report");
+        assert_eq!(report.wallets_restored, 1);
+        assert_eq!(report.wallets_failed, 1);
+        assert_eq!(report.failed_wallet_errors.len(), 1);
+        assert!(report.failed_wallet_errors[0].contains("unsupported wallet backup version 2"));
+        assert_eq!(Database::global().cloud_backup_state.get().unwrap().wallet_count, Some(2));
+        assert!(
+            Database::global()
+                .wallets()
+                .get(&supported_wallet.id, supported_wallet.network, supported_wallet.wallet_mode,)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            Database::global()
+                .wallets()
+                .get(
+                    &unsupported_wallet.id,
+                    unsupported_wallet.network,
+                    unsupported_wallet.wallet_mode,
+                )
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn restore_counts_listed_missing_wallet_backups_as_failures() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        cove_cspp::Cspp::new(Keychain::global().clone()).save_master_key(&master_key).unwrap();
+
+        let supported_wallet = xpub_only_wallet_metadata();
+        let missing_wallet = xpub_only_wallet_metadata();
+        Keychain::global()
+            .save_wallet_xpub(&supported_wallet.id, sample_xpub(&supported_wallet).parse().unwrap())
+            .unwrap();
+        let supported_record_id =
+            cove_cspp::backup_data::wallet_record_id(supported_wallet.id.as_ref());
+        let missing_record_id =
+            cove_cspp::backup_data::wallet_record_id(missing_wallet.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            supported_record_id.clone(),
+            encrypted_wallet_backup_bytes(&supported_wallet, &master_key, "supported-revision", 1),
+        );
+        globals.cloud.set_wallet_files(
+            namespace,
+            vec![
+                wallet_filename_from_record_id(&supported_record_id),
+                wallet_filename_from_record_id(&missing_record_id),
+            ],
+        );
+
+        let operation_id = manager.next_restore_operation_id();
+        manager.do_restore_from_cloud_backup(operation_id).unwrap();
+
+        let report = manager.state().restore_report.expect("expected restore report");
+        assert_eq!(report.wallets_restored, 1);
+        assert_eq!(report.wallets_failed, 1);
+        assert!(
+            report.failed_wallet_errors[0].contains("was listed but missing from cloud backup")
+        );
+        assert!(report.labels_failed_wallet_names.is_empty());
+    }
+
+    #[test]
+    fn restore_reports_label_warning_without_failing_wallet_restore() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        cove_cspp::Cspp::new(Keychain::global().clone()).save_master_key(&master_key).unwrap();
+
+        let wallet = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet.id.as_ref());
+        let entry = wallet_entry_with_labels(&wallet, Some("{"));
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes_for_entry(&entry, &master_key, 1),
+        );
+        globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
+
+        let operation_id = manager.next_restore_operation_id();
+        manager.do_restore_from_cloud_backup(operation_id).unwrap();
+
+        let report = manager.state().restore_report.expect("expected restore report");
+        assert_eq!(report.wallets_restored, 1);
+        assert_eq!(report.wallets_failed, 0);
+        assert_eq!(report.labels_failed_wallet_names, vec![wallet.name.clone()]);
+        assert_eq!(report.labels_failed_errors.len(), 1);
+        assert!(
+            report.labels_failed_errors[0].contains("Failed to parse labels")
+                || report.labels_failed_errors[0].contains("failed to parse")
+        );
+        assert!(
+            Database::global()
+                .wallets()
+                .get(&wallet.id, wallet.network, wallet.wallet_mode)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn restore_cloud_wallet_returns_label_warning_without_failing_restore() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        Keychain::global().save(CSPP_NAMESPACE_ID_KEY.into(), namespace.clone()).unwrap();
+        cove_cspp::Cspp::new(Keychain::global().clone()).save_master_key(&master_key).unwrap();
+        manager
+            .persist_cloud_backup_state(
+                &PersistedCloudBackupState {
+                    status: PersistedCloudBackupStatus::Enabled,
+                    ..PersistedCloudBackupState::default()
+                },
+                "enable cloud backup for restore cloud wallet test",
+            )
+            .unwrap();
+
+        let wallet = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet.id.as_ref());
+        let entry = wallet_entry_with_labels(&wallet, Some("{"));
+        globals.cloud.set_wallet_backup(
+            namespace,
+            record_id.clone(),
+            encrypted_wallet_backup_bytes_for_entry(&entry, &master_key, 1),
+        );
+
+        let outcome = manager.do_restore_cloud_wallet(&record_id).unwrap();
+
+        let warning = outcome.labels_warning.expect("expected label warning");
+        assert_eq!(warning.wallet_name, wallet.name);
+        assert!(
+            warning.error.contains("Failed to parse labels")
+                || warning.error.contains("failed to parse")
+        );
+        assert!(
+            Database::global()
+                .wallets()
+                .get(&wallet.id, wallet.network, wallet.wallet_mode)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn restore_fails_when_all_wallet_backups_are_unsupported() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        cove_cspp::Cspp::new(Keychain::global().clone()).save_master_key(&master_key).unwrap();
+
+        let wallet = xpub_only_wallet_metadata();
+        Keychain::global()
+            .save_wallet_xpub(&wallet.id, sample_xpub(&wallet).parse().unwrap())
+            .unwrap();
+
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet.id.as_ref());
+        globals.cloud.set_wallet_backup(
+            namespace.clone(),
+            record_id.clone(),
+            encrypted_wallet_backup_bytes(&wallet, &master_key, "unsupported-revision", 2),
+        );
+        globals.cloud.set_wallet_files(namespace, vec![wallet_filename_from_record_id(&record_id)]);
+
+        let operation_id = manager.next_restore_operation_id();
+        let error = manager.do_restore_from_cloud_backup(operation_id).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CloudBackupError::Internal(message) if message == "all wallets failed to restore"
+        ));
+
+        let report = manager.state().restore_report.expect("expected restore report");
+        assert_eq!(report.wallets_restored, 0);
+        assert_eq!(report.wallets_failed, 1);
+        assert!(report.failed_wallet_errors[0].contains("unsupported wallet backup version 2"));
+        assert_eq!(
+            Database::global().cloud_backup_state.get().unwrap().status,
+            PersistedCloudBackupStatus::Disabled
+        );
+    }
+
+    #[test]
+    fn restore_fails_when_all_listed_wallet_backups_are_missing() {
+        let _guard = test_lock().lock();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let encrypted_master =
+            cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &[7; 32], &[9; 32])
+                .unwrap();
+        globals.cloud.set_master_key_backup(
+            namespace.clone(),
+            serde_json::to_vec(&encrypted_master).unwrap(),
+        );
+        cove_cspp::Cspp::new(Keychain::global().clone()).save_master_key(&master_key).unwrap();
+
+        let missing_wallet = xpub_only_wallet_metadata();
+        let missing_record_id =
+            cove_cspp::backup_data::wallet_record_id(missing_wallet.id.as_ref());
+        globals
+            .cloud
+            .set_wallet_files(namespace, vec![wallet_filename_from_record_id(&missing_record_id)]);
+
+        let operation_id = manager.next_restore_operation_id();
+        let error = manager.do_restore_from_cloud_backup(operation_id).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CloudBackupError::Internal(message) if message == "all wallets failed to restore"
+        ));
+
+        let report = manager.state().restore_report.expect("expected restore report");
+        assert_eq!(report.wallets_restored, 0);
+        assert_eq!(report.wallets_failed, 1);
+        assert!(
+            report.failed_wallet_errors[0].contains("was listed but missing from cloud backup")
+        );
     }
 }

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -1928,7 +1928,7 @@ mod tests {
         let detail = manager.state().detail.expect("expected cloud backup detail");
         assert_eq!(detail.needs_sync.len(), 1);
         assert_eq!(detail.needs_sync[0].record_id, record_id);
-        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::RemoteStateUnknown);
+        assert_eq!(detail.needs_sync[0].sync_status, CloudBackupWalletStatus::UnsupportedVersion);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1937,14 +1937,9 @@ mod tests {
         cove_tokio::init();
         let globals = test_globals();
         let manager = RustCloudBackupManager::init();
-        globals.reset();
+        reset_cloud_backup_test_state(&manager, globals);
 
         let metadata = xpub_only_wallet_metadata();
-        Database::global()
-            .wallets()
-            .save_all_wallets(metadata.network, metadata.wallet_mode, Vec::new())
-            .unwrap();
-        Database::global().cloud_blob_sync_states.delete_all().unwrap();
 
         let master_key = cove_cspp::master_key::MasterKey::generate();
         let namespace = master_key.namespace_id();

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+use act_zero::call;
 use bip39::Mnemonic;
+use cove_cspp::CsppStore;
 use cove_cspp::backup_data::{
     WalletEntry, WalletMode as CloudWalletMode, WalletSecret, wallet_filename_from_record_id,
 };

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -1,0 +1,782 @@
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use bip39::Mnemonic;
+use cove_cspp::backup_data::{
+    WalletEntry, WalletMode as CloudWalletMode, WalletSecret, wallet_filename_from_record_id,
+};
+use cove_device::cloud_storage::{CloudStorage, CloudStorageAccess, CloudStorageError};
+use cove_device::keychain::{CSPP_NAMESPACE_ID_KEY, Keychain, KeychainAccess};
+use cove_device::passkey::{
+    DiscoveredPasskeyResult, PasskeyAccess, PasskeyCredentialPresence, PasskeyError,
+    PasskeyProvider,
+};
+use parking_lot::Mutex;
+use sha2::Digest as _;
+use strum::IntoEnumIterator as _;
+
+use super::*;
+use crate::database::Database;
+use crate::database::cloud_backup::{
+    CloudBlobDirtyState, CloudBlobFailedState, CloudBlobUploadingState, CloudUploadKind,
+    PersistedCloudBackupState, PersistedCloudBackupStatus, PersistedCloudBlobState,
+    PersistedCloudBlobSyncState,
+};
+use crate::mnemonic::MnemonicExt as _;
+use crate::network::Network;
+use crate::wallet::metadata::{WalletId, WalletMetadata, WalletMode, WalletType};
+
+#[derive(Debug, Default)]
+pub(crate) struct MockStore {
+    pub(crate) entries: Mutex<HashMap<String, String>>,
+    pub(crate) save_count: Mutex<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MockStoreHandle(pub(crate) Arc<MockStore>);
+
+impl cove_cspp::CsppStore for MockStoreHandle {
+    type Error = String;
+
+    fn save(&self, key: String, value: String) -> Result<(), Self::Error> {
+        *self.0.save_count.lock() += 1;
+        self.0.entries.lock().insert(key, value);
+        Ok(())
+    }
+
+    fn get(&self, key: String) -> Option<String> {
+        self.0.entries.lock().get(&key).cloned()
+    }
+
+    fn delete(&self, key: String) -> bool {
+        self.0.entries.lock().remove(&key).is_some()
+    }
+}
+
+type MockDiscoverResult = Result<(Vec<u8>, Vec<u8>), PasskeyError>;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MockKeychain {
+    entries: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl MockKeychain {
+    fn reset(&self) {
+        self.entries.lock().clear();
+    }
+}
+
+impl KeychainAccess for MockKeychain {
+    fn save(&self, key: String, value: String) -> Result<(), cove_device::keychain::KeychainError> {
+        self.entries.lock().insert(key, value);
+        Ok(())
+    }
+
+    fn get(&self, key: String) -> Option<String> {
+        self.entries.lock().get(&key).cloned()
+    }
+
+    fn delete(&self, key: String) -> bool {
+        self.entries.lock().remove(&key).is_some()
+    }
+}
+
+#[derive(Debug, Default)]
+struct MockCloudState {
+    wallet_files: HashMap<String, Vec<String>>,
+    master_key_backups: HashMap<String, Vec<u8>>,
+    wallet_backups: HashMap<(String, String), Vec<u8>>,
+    wallet_backup_download_overrides: HashMap<(String, String), Vec<u8>>,
+    list_wallet_files_error: Option<CloudStorageError>,
+    upload_master_key_error: Option<CloudStorageError>,
+    next_upload_wallet_backup_error: Option<CloudStorageError>,
+    upload_wallet_backup_error: Option<CloudStorageError>,
+    reflect_uploaded_wallets_in_listing: bool,
+    uploaded_wallet_backups: Vec<(String, String)>,
+    wallet_backup_upload_attempts: usize,
+    dirty_wallet_on_next_upload: Option<WalletId>,
+    changed_wallet_on_next_upload: Option<WalletId>,
+    dirty_wallet_on_next_backup_check: Option<WalletId>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MockCloudStorage {
+    state: Arc<Mutex<MockCloudState>>,
+}
+
+impl MockCloudStorage {
+    pub(crate) fn reset(&self) {
+        *self.state.lock() = MockCloudState::default();
+    }
+
+    pub(crate) fn set_wallet_files(&self, namespace: String, wallet_files: Vec<String>) {
+        self.state.lock().wallet_files.insert(namespace, wallet_files);
+    }
+
+    pub(crate) fn set_master_key_backup(&self, namespace: String, backup: Vec<u8>) {
+        self.state.lock().master_key_backups.insert(namespace, backup);
+    }
+
+    pub(crate) fn set_wallet_backup(&self, namespace: String, record_id: String, backup: Vec<u8>) {
+        self.state.lock().wallet_backups.insert((namespace, record_id), backup);
+    }
+
+    pub(crate) fn set_wallet_backup_download_override(
+        &self,
+        namespace: String,
+        record_id: String,
+        backup: Vec<u8>,
+    ) {
+        self.state.lock().wallet_backup_download_overrides.insert((namespace, record_id), backup);
+    }
+
+    pub(crate) fn fail_list_wallet_files(&self, message: &str) {
+        self.state.lock().list_wallet_files_error =
+            Some(CloudStorageError::DownloadFailed(message.into()));
+    }
+
+    pub(crate) fn clear_list_wallet_files_failure(&self) {
+        self.state.lock().list_wallet_files_error = None;
+    }
+
+    pub(crate) fn fail_master_key_upload(&self, message: &str) {
+        self.state.lock().upload_master_key_error =
+            Some(CloudStorageError::UploadFailed(message.into()));
+    }
+
+    pub(crate) fn fail_wallet_backup_upload(&self, message: &str) {
+        self.state.lock().upload_wallet_backup_error =
+            Some(CloudStorageError::UploadFailed(message.into()));
+    }
+
+    pub(crate) fn fail_wallet_backup_upload_quota_exceeded(&self) {
+        self.state.lock().upload_wallet_backup_error = Some(CloudStorageError::QuotaExceeded);
+    }
+
+    pub(crate) fn fail_next_wallet_backup_upload(&self, message: &str) {
+        self.state.lock().next_upload_wallet_backup_error =
+            Some(CloudStorageError::UploadFailed(message.into()));
+    }
+
+    pub(crate) fn clear_wallet_backup_upload_failure(&self) {
+        let mut state = self.state.lock();
+        state.next_upload_wallet_backup_error = None;
+        state.upload_wallet_backup_error = None;
+    }
+
+    pub(crate) fn set_reflect_uploaded_wallets_in_listing(&self, enabled: bool) {
+        self.state.lock().reflect_uploaded_wallets_in_listing = enabled;
+    }
+
+    pub(crate) fn uploaded_wallet_backup_count(&self) -> usize {
+        self.state.lock().uploaded_wallet_backups.len()
+    }
+
+    pub(crate) fn wallet_backup_upload_attempt_count(&self) -> usize {
+        self.state.lock().wallet_backup_upload_attempts
+    }
+
+    pub(crate) fn dirty_wallet_on_next_upload(&self, wallet_id: WalletId) {
+        self.state.lock().dirty_wallet_on_next_upload = Some(wallet_id);
+    }
+
+    pub(crate) fn change_wallet_on_next_upload(&self, wallet_id: WalletId) {
+        self.state.lock().changed_wallet_on_next_upload = Some(wallet_id);
+    }
+
+    pub(crate) fn dirty_wallet_on_next_backup_check(&self, wallet_id: WalletId) {
+        self.state.lock().dirty_wallet_on_next_backup_check = Some(wallet_id);
+    }
+}
+
+impl CloudStorageAccess for MockCloudStorage {
+    fn upload_master_key_backup(
+        &self,
+        namespace: String,
+        data: Vec<u8>,
+    ) -> Result<(), CloudStorageError> {
+        if let Some(error) = self.state.lock().upload_master_key_error.clone() {
+            return Err(error);
+        }
+
+        self.state.lock().master_key_backups.insert(namespace, data);
+        Ok(())
+    }
+
+    fn upload_wallet_backup(
+        &self,
+        namespace: String,
+        record_id: String,
+        data: Vec<u8>,
+    ) -> Result<(), CloudStorageError> {
+        let (dirty_wallet, changed_wallet) = {
+            let mut state = self.state.lock();
+            state.wallet_backup_upload_attempts += 1;
+            if let Some(error) = state.next_upload_wallet_backup_error.take() {
+                return Err(error);
+            }
+
+            if let Some(error) = state.upload_wallet_backup_error.clone() {
+                return Err(error);
+            }
+
+            let dirty_wallet = state.dirty_wallet_on_next_upload.take();
+            let changed_wallet = state.changed_wallet_on_next_upload.take();
+            state.wallet_backups.insert((namespace.clone(), record_id.clone()), data);
+            state.uploaded_wallet_backups.push((namespace, record_id));
+            (dirty_wallet, changed_wallet)
+        };
+        if let Some(wallet_id) = dirty_wallet {
+            persist_dirty_blob_state(wallet_id);
+        }
+        if let Some(wallet_id) = changed_wallet {
+            mutate_wallet_and_persist_dirty(wallet_id);
+        }
+        Ok(())
+    }
+
+    fn download_master_key_backup(&self, namespace: String) -> Result<Vec<u8>, CloudStorageError> {
+        self.state
+            .lock()
+            .master_key_backups
+            .get(&namespace)
+            .cloned()
+            .ok_or(CloudStorageError::NotFound(namespace))
+    }
+
+    fn download_wallet_backup(
+        &self,
+        namespace: String,
+        record_id: String,
+    ) -> Result<Vec<u8>, CloudStorageError> {
+        let dirty_wallet = self.state.lock().dirty_wallet_on_next_backup_check.take();
+        if let Some(wallet_id) = dirty_wallet {
+            persist_dirty_blob_state(wallet_id);
+        }
+
+        let override_key = (namespace.clone(), record_id.clone());
+        if let Some(backup) =
+            self.state.lock().wallet_backup_download_overrides.get(&override_key).cloned()
+        {
+            return Ok(backup);
+        }
+
+        self.state
+            .lock()
+            .wallet_backups
+            .get(&(namespace.clone(), record_id.clone()))
+            .cloned()
+            .ok_or(CloudStorageError::NotFound(format!("{namespace}/{record_id}")))
+    }
+
+    fn delete_wallet_backup(
+        &self,
+        _namespace: String,
+        _record_id: String,
+    ) -> Result<(), CloudStorageError> {
+        Ok(())
+    }
+
+    fn list_namespaces(&self) -> Result<Vec<String>, CloudStorageError> {
+        Ok(self.state.lock().wallet_files.keys().cloned().collect())
+    }
+
+    fn list_wallet_files(&self, namespace: String) -> Result<Vec<String>, CloudStorageError> {
+        let state = self.state.lock();
+        if let Some(error) = state.list_wallet_files_error.clone() {
+            return Err(error);
+        }
+        let mut wallet_files = state.wallet_files.get(&namespace).cloned().unwrap_or_default();
+
+        if state.reflect_uploaded_wallets_in_listing {
+            for (uploaded_namespace, record_id) in &state.uploaded_wallet_backups {
+                if uploaded_namespace == &namespace {
+                    let filename = wallet_filename_from_record_id(record_id);
+                    if !wallet_files.contains(&filename) {
+                        wallet_files.push(filename);
+                    }
+                }
+            }
+        }
+
+        Ok(wallet_files)
+    }
+
+    fn is_backup_uploaded(
+        &self,
+        _namespace: String,
+        _record_id: String,
+    ) -> Result<bool, CloudStorageError> {
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MockPasskeyProviderImpl {
+    discover_result: Arc<Mutex<MockDiscoverResult>>,
+}
+
+impl Default for MockPasskeyProviderImpl {
+    fn default() -> Self {
+        Self { discover_result: Arc::new(Mutex::new(Err(PasskeyError::NoCredentialFound))) }
+    }
+}
+
+impl MockPasskeyProviderImpl {
+    pub(crate) fn reset(&self) {
+        *self.discover_result.lock() = Err(PasskeyError::NoCredentialFound);
+    }
+
+    pub(crate) fn set_discover_result(
+        &self,
+        result: Result<DiscoveredPasskeyResult, PasskeyError>,
+    ) {
+        *self.discover_result.lock() = result.map(|value| (value.prf_output, value.credential_id));
+    }
+}
+
+impl PasskeyProvider for MockPasskeyProviderImpl {
+    fn create_passkey(
+        &self,
+        _rp_id: String,
+        _user_id: Vec<u8>,
+        _challenge: Vec<u8>,
+    ) -> Result<Vec<u8>, PasskeyError> {
+        Err(PasskeyError::CreationFailed("unexpected create_passkey call".into()))
+    }
+
+    fn authenticate_with_prf(
+        &self,
+        _rp_id: String,
+        _credential_id: Vec<u8>,
+        _prf_salt: Vec<u8>,
+        _challenge: Vec<u8>,
+    ) -> Result<Vec<u8>, PasskeyError> {
+        Err(PasskeyError::AuthenticationFailed("unexpected authenticate_with_prf call".into()))
+    }
+
+    fn discover_and_authenticate_with_prf(
+        &self,
+        _rp_id: String,
+        _prf_salt: Vec<u8>,
+        _challenge: Vec<u8>,
+    ) -> Result<DiscoveredPasskeyResult, PasskeyError> {
+        self.discover_result.lock().clone().map(|(prf_output, credential_id)| {
+            DiscoveredPasskeyResult { prf_output, credential_id }
+        })
+    }
+
+    fn is_prf_supported(&self) -> bool {
+        true
+    }
+
+    fn check_passkey_presence(
+        &self,
+        _rp_id: String,
+        _credential_id: Vec<u8>,
+    ) -> PasskeyCredentialPresence {
+        PasskeyCredentialPresence::Present
+    }
+}
+
+pub(crate) struct TestGlobals {
+    pub(crate) keychain: MockKeychain,
+    pub(crate) cloud: MockCloudStorage,
+    pub(crate) passkey: MockPasskeyProviderImpl,
+}
+
+impl TestGlobals {
+    fn init() -> Self {
+        let keychain = MockKeychain::default();
+        let cloud = MockCloudStorage::default();
+        let passkey = MockPasskeyProviderImpl::default();
+
+        let _ = Keychain::new(Box::new(keychain.clone()));
+        let _ = CloudStorage::new(Box::new(cloud.clone()));
+        let _ = PasskeyAccess::new(Box::new(passkey.clone()));
+
+        Self { keychain, cloud, passkey }
+    }
+
+    pub(crate) fn reset(&self) {
+        self.keychain.reset();
+        self.cloud.reset();
+        self.passkey.reset();
+        cove_cspp::Cspp::<Keychain>::clear_cached_master_key();
+    }
+}
+
+pub(crate) fn init_test_runtime() {
+    super::super::ensure_cloud_backup_test_tokio_runtime();
+}
+
+pub(crate) fn test_globals() -> &'static TestGlobals {
+    static GLOBALS: OnceLock<TestGlobals> = OnceLock::new();
+    init_test_runtime();
+    GLOBALS.get_or_init(TestGlobals::init)
+}
+
+pub(crate) fn test_lock() -> &'static parking_lot::Mutex<()> {
+    super::super::cloud_backup_test_lock()
+}
+
+fn clear_local_wallets() {
+    let wallets = Database::global().wallets();
+    for network in Network::iter() {
+        for mode in WalletMode::iter() {
+            wallets.save_all_wallets(network, mode, Vec::new()).unwrap();
+        }
+    }
+}
+
+pub(crate) fn persist_dirty_blob_state(wallet_id: WalletId) {
+    let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+    let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+    let changed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+    Database::global()
+        .cloud_blob_sync_states
+        .set(&PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id,
+            wallet_id: Some(wallet_id),
+            record_id,
+            state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at }),
+        })
+        .unwrap();
+}
+
+fn mutate_wallet_and_persist_dirty(wallet_id: WalletId) {
+    let mut wallet = all_local_wallets(&Database::global())
+        .unwrap()
+        .into_iter()
+        .find(|wallet| wallet.id == wallet_id)
+        .unwrap();
+    wallet.name.push_str(" updated");
+    Database::global()
+        .wallets()
+        .save_all_wallets(wallet.network, wallet.wallet_mode, vec![wallet.clone()])
+        .unwrap();
+    persist_dirty_blob_state(wallet.id);
+}
+
+pub(crate) fn persist_failed_blob_state(wallet_id: WalletId, retryable: bool) {
+    let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+    let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+    let failed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+    Database::global()
+        .cloud_blob_sync_states
+        .set(&PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id,
+            wallet_id: Some(wallet_id),
+            record_id,
+            state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                revision_hash: Some("rev-1".into()),
+                retryable,
+                error: "failed".into(),
+                failed_at,
+            }),
+        })
+        .unwrap();
+}
+
+pub(crate) fn persist_uploading_blob_state(wallet_id: WalletId, started_at: u64) {
+    let namespace_id = Keychain::global().get(CSPP_NAMESPACE_ID_KEY.into()).unwrap();
+    let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+
+    Database::global()
+        .cloud_blob_sync_states
+        .set(&PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id,
+            wallet_id: Some(wallet_id),
+            record_id,
+            state: PersistedCloudBlobState::Uploading(CloudBlobUploadingState {
+                revision_hash: "rev-1".into(),
+                started_at,
+            }),
+        })
+        .unwrap();
+}
+
+pub(crate) fn reset_cloud_backup_test_state(
+    manager: &RustCloudBackupManager,
+    globals: &TestGlobals,
+) {
+    init_test_runtime();
+    globals.reset();
+    clear_local_wallets();
+    let reset_manager = manager.clone();
+    std::thread::spawn(move || reset_manager.debug_reset_cloud_backup_state())
+        .join()
+        .expect("reset cloud backup test state thread");
+    manager.clear_wallet_upload_debouncers_for_test();
+}
+
+pub(crate) async fn wait_for_test_condition(
+    timeout: Duration,
+    message: &str,
+    mut condition: impl FnMut() -> bool,
+) {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if condition() {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect(message);
+}
+
+pub(crate) async fn assert_test_condition_stays_true(
+    duration: Duration,
+    message: &str,
+    mut condition: impl FnMut() -> bool,
+) {
+    let deadline = tokio::time::Instant::now() + duration;
+    while tokio::time::Instant::now() < deadline {
+        assert!(condition(), "{message}");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub(crate) fn configure_enabled_cloud_backup(
+    manager: &RustCloudBackupManager,
+    globals: &TestGlobals,
+    wallet_count: u32,
+) {
+    reset_cloud_backup_test_state(manager, globals);
+
+    let master_key = cove_cspp::master_key::MasterKey::generate();
+    let namespace = master_key.namespace_id();
+    let keychain = Keychain::global();
+    keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
+    cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
+
+    manager
+        .persist_cloud_backup_state(
+            &PersistedCloudBackupState {
+                status: PersistedCloudBackupStatus::Enabled,
+                wallet_count: Some(wallet_count),
+                ..PersistedCloudBackupState::default()
+            },
+            "set cloud backup enabled for test",
+        )
+        .unwrap();
+    manager.sync_persisted_state();
+}
+
+pub(crate) fn enable_cloud_backup_without_reset(
+    manager: &RustCloudBackupManager,
+    wallet_count: u32,
+) {
+    let master_key = cove_cspp::master_key::MasterKey::generate();
+    let namespace = master_key.namespace_id();
+    let keychain = Keychain::global();
+    keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
+    cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
+
+    manager
+        .persist_cloud_backup_state(
+            &PersistedCloudBackupState {
+                status: PersistedCloudBackupStatus::Enabled,
+                wallet_count: Some(wallet_count),
+                ..PersistedCloudBackupState::default()
+            },
+            "set cloud backup enabled for test",
+        )
+        .unwrap();
+    manager.sync_persisted_state();
+}
+
+pub(crate) fn xpub_only_wallet_metadata() -> WalletMetadata {
+    let mut metadata = WalletMetadata::preview_new();
+    metadata.wallet_type = WalletType::XpubOnly;
+    metadata
+}
+
+pub(crate) fn sample_xpub(metadata: &WalletMetadata) -> String {
+    let mnemonic = Mnemonic::parse(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    )
+    .unwrap();
+    mnemonic.xpub(metadata.network.into()).to_string()
+}
+
+pub(crate) fn persist_xpub_wallets(wallets: Vec<WalletMetadata>) {
+    for wallet in &wallets {
+        let xpub = sample_xpub(wallet);
+        Keychain::global().save_wallet_xpub(&wallet.id, xpub.parse().unwrap()).unwrap();
+    }
+
+    let mut wallets_by_scope = HashMap::new();
+    for wallet in wallets {
+        wallets_by_scope
+            .entry((wallet.network, wallet.wallet_mode))
+            .or_insert_with(Vec::new)
+            .push(wallet);
+    }
+
+    for ((network, wallet_mode), wallets) in wallets_by_scope {
+        Database::global().wallets().save_all_wallets(network, wallet_mode, wallets).unwrap();
+    }
+}
+
+pub(crate) fn encrypted_wallet_backup_bytes(
+    metadata: &WalletMetadata,
+    master_key: &cove_cspp::master_key::MasterKey,
+    revision_hash: &str,
+    version: u32,
+) -> Vec<u8> {
+    let mut prepared = crate::manager::cloud_backup_manager::wallets::prepare_wallet_backup(
+        metadata,
+        metadata.wallet_mode,
+    )
+    .unwrap();
+    prepared.entry.content_revision_hash = revision_hash.to_string();
+
+    let critical_key = zeroize::Zeroizing::new(master_key.critical_data_key());
+    let mut encrypted =
+        cove_cspp::wallet_crypto::encrypt_wallet_entry(&prepared.entry, &critical_key).unwrap();
+    encrypted.version = version;
+    serde_json::to_vec(&encrypted).unwrap()
+}
+
+pub(crate) fn wallet_entry_with_labels(
+    metadata: &WalletMetadata,
+    labels_jsonl: Option<&str>,
+) -> WalletEntry {
+    let labels_count = labels_jsonl
+        .map(|jsonl| jsonl.lines().filter(|line| !line.trim().is_empty()).count() as u32)
+        .unwrap_or_default();
+    let labels_zstd_jsonl =
+        labels_jsonl.map(|jsonl| crate::backup::crypto::compress(jsonl.as_bytes()).unwrap());
+    let labels_hash = labels_jsonl
+        .filter(|jsonl| !jsonl.is_empty())
+        .map(|jsonl| hex::encode(sha2::Sha256::digest(jsonl.as_bytes())));
+    let labels_uncompressed_size =
+        labels_jsonl.map(|jsonl| jsonl.len().try_into().unwrap_or(u32::MAX));
+
+    WalletEntry {
+        wallet_id: metadata.id.to_string(),
+        secret: WalletSecret::WatchOnly,
+        metadata: serde_json::to_value(metadata).unwrap(),
+        descriptors: None,
+        xpub: Some(sample_xpub(metadata)),
+        wallet_mode: CloudWalletMode::Main,
+        labels_zstd_jsonl,
+        labels_count,
+        labels_hash,
+        labels_uncompressed_size,
+        content_revision_hash: "test-content-hash".to_string(),
+        updated_at: 42,
+    }
+}
+
+pub(crate) fn encrypted_wallet_backup_bytes_for_entry(
+    entry: &WalletEntry,
+    master_key: &cove_cspp::master_key::MasterKey,
+    version: u32,
+) -> Vec<u8> {
+    let critical_key = zeroize::Zeroizing::new(master_key.critical_data_key());
+    let mut encrypted =
+        cove_cspp::wallet_crypto::encrypt_wallet_entry(entry, &critical_key).unwrap();
+    encrypted.version = version;
+    serde_json::to_vec(&encrypted).unwrap()
+}
+
+pub(crate) fn restore_from_local_master_key_fallback<S>(
+    cloud: &CloudStorage,
+    store: &S,
+    cspp: &cove_cspp::Cspp<S>,
+) -> Result<(cove_cspp::master_key::MasterKey, String), CloudBackupError>
+where
+    S: cove_cspp::CsppStore,
+    S::Error: std::fmt::Display,
+{
+    let (master_key, namespace_id) =
+        try_restore_from_local_master_key(cloud, cspp).ok_or(CloudBackupError::PasskeyMismatch)?;
+    persist_namespace_id(store, &namespace_id)?;
+    Ok((master_key, namespace_id))
+}
+
+pub(crate) fn sample_labels_jsonl() -> &'static str {
+    r#"{"type":"tx","ref":"d97bf8892657980426c879e4ab2001f09342f1ab61cfa602741a7715a3d60290","label":"last txn received","origin":"pkh([73c5da0a/44h/0h/0h])"}"#
+}
+
+pub(crate) fn prepare_deep_verify_with_unsynced_wallet(
+    manager: &RustCloudBackupManager,
+    globals: &TestGlobals,
+) -> crate::wallet::metadata::WalletMetadata {
+    reset_cloud_backup_test_state(manager, globals);
+
+    let master_key = cove_cspp::master_key::MasterKey::generate();
+    let namespace = master_key.namespace_id();
+    let prf_key = [7u8; 32];
+    let prf_salt = [9u8; 32];
+    let credential_id = vec![1, 2, 3, 4];
+    let encrypted_master =
+        cove_cspp::master_key_crypto::encrypt_master_key(&master_key, &prf_key, &prf_salt).unwrap();
+
+    globals
+        .cloud
+        .set_master_key_backup(namespace.clone(), serde_json::to_vec(&encrypted_master).unwrap());
+    globals.cloud.set_reflect_uploaded_wallets_in_listing(false);
+    globals.passkey.set_discover_result(Ok(DiscoveredPasskeyResult {
+        prf_output: prf_key.to_vec(),
+        credential_id,
+    }));
+
+    let keychain = Keychain::global();
+    keychain.save(CSPP_NAMESPACE_ID_KEY.into(), namespace).unwrap();
+    cove_cspp::Cspp::new(keychain.clone()).save_master_key(&master_key).unwrap();
+
+    manager
+        .persist_cloud_backup_state(
+            &PersistedCloudBackupState {
+                status: PersistedCloudBackupStatus::Enabled,
+                ..PersistedCloudBackupState::default()
+            },
+            "set cloud backup enabled for test",
+        )
+        .unwrap();
+
+    let mut metadata = crate::wallet::metadata::WalletMetadata::preview_new();
+    metadata.wallet_type = crate::wallet::metadata::WalletType::WatchOnly;
+    Database::global()
+        .wallets()
+        .save_all_wallets(metadata.network, metadata.wallet_mode, vec![metadata.clone()])
+        .unwrap();
+
+    metadata
+}
+pub(crate) async fn clear_wallet_upload_runtime_for_test_async(manager: &RustCloudBackupManager) {
+    call!(manager.runtime.clear_upload_runtime_state()).await.expect("clear upload runtime state");
+}
+
+pub(crate) async fn run_wallet_upload_for_test_async(
+    manager: &RustCloudBackupManager,
+    wallet_id: WalletId,
+) {
+    call!(manager.runtime.run_wallet_upload_inline_for_test(wallet_id))
+        .await
+        .expect("run wallet upload");
+}
+
+pub(crate) fn new_restore_operation_for_test(
+    manager: &RustCloudBackupManager,
+) -> super::super::runtime_actor::RestoreOperation {
+    let runtime = manager.runtime.clone();
+    std::thread::spawn(move || {
+        cove_tokio::task::block_on(call!(runtime.new_restore_operation()))
+            .expect("create restore operation")
+    })
+    .join()
+    .expect("restore operation thread")
+}

--- a/rust/src/manager/cloud_backup_manager/pending.rs
+++ b/rust/src/manager/cloud_backup_manager/pending.rs
@@ -1,15 +1,14 @@
 mod detail;
 mod queue_processor;
 
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use backon::{BackoffBuilder as _, FibonacciBackoff, FibonacciBuilder};
+use act_zero::send;
+use backon::{BackoffBuilder as _, FibonacciBuilder};
 use cove_util::ResultExt as _;
-use tracing::{error, info};
 
 use self::queue_processor::PendingUploadVerifier;
-use super::{CLOUD_BACKUP_MANAGER, CloudBackupError, RustCloudBackupManager};
+use super::{CloudBackupError, RustCloudBackupManager};
 use crate::database::Database;
 use crate::database::cloud_backup::{
     CloudBlobFailedState, CloudBlobUploadedPendingConfirmationState, CloudUploadKind,
@@ -19,28 +18,9 @@ use crate::wallet::metadata::WalletId;
 
 pub(crate) use detail::remote_wallet_revision_matches;
 
-const MAX_PENDING_UPLOAD_VERIFICATION_DELAY: Duration = Duration::from_secs(10);
+pub(super) const MAX_PENDING_UPLOAD_VERIFICATION_DELAY: Duration = Duration::from_secs(10);
 
-struct PendingUploadRetryBackoff(FibonacciBackoff);
-
-impl PendingUploadRetryBackoff {
-    fn new() -> Self {
-        Self(build_pending_upload_backoff())
-    }
-
-    fn next_delay(&mut self) -> Duration {
-        self.0
-            .next()
-            .map(|delay| delay.min(MAX_PENDING_UPLOAD_VERIFICATION_DELAY))
-            .unwrap_or(MAX_PENDING_UPLOAD_VERIFICATION_DELAY)
-    }
-
-    fn reset(&mut self) {
-        self.0 = build_pending_upload_backoff();
-    }
-}
-
-fn build_pending_upload_backoff() -> FibonacciBackoff {
+pub(super) fn build_pending_upload_backoff() -> backon::FibonacciBackoff {
     FibonacciBuilder::default()
         .with_max_delay(MAX_PENDING_UPLOAD_VERIFICATION_DELAY)
         .without_max_times()
@@ -168,68 +148,15 @@ impl RustCloudBackupManager {
     }
 
     pub(super) fn start_pending_upload_verification_loop(&self) {
-        if self
-            .pending_upload_verifier_running
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            return;
-        }
-
-        let this = CLOUD_BACKUP_MANAGER.clone();
-        let wakeup = this.pending_upload_verifier_wakeup.clone();
-        cove_tokio::task::spawn(async move {
-            info!("Pending upload verification: started");
-            let mut backoff = PendingUploadRetryBackoff::new();
-
-            loop {
-                let this_for_pass = this.clone();
-                let has_pending = cove_tokio::task::spawn_blocking(move || {
-                    this_for_pass.verify_pending_uploads_once()
-                })
-                .await
-                .unwrap_or_else(|error| {
-                    error!("Pending upload verification task failed: {error}");
-                    true
-                });
-
-                if !has_pending {
-                    break;
-                }
-
-                let delay = backoff.next_delay();
-                tokio::select! {
-                    _ = tokio::time::sleep(delay) => {}
-                    _ = wakeup.notified() => {
-                        backoff.reset();
-                    }
-                }
-            }
-
-            this.pending_upload_verifier_running.store(false, Ordering::SeqCst);
-
-            if this.has_pending_cloud_upload_verification() {
-                this.start_pending_upload_verification_loop();
-                return;
-            }
-
-            info!("Pending upload verification: idle");
-        });
+        send!(self.runtime.ensure_pending_upload_verification_loop());
     }
 
-    fn verify_pending_uploads_once(&self) -> bool {
+    pub(crate) fn verify_pending_uploads_once(&self) -> bool {
         PendingUploadVerifier(self.clone()).run_once()
     }
 
-    #[cfg(test)]
-    pub(super) fn verify_pending_uploads_once_for_test(&self) -> bool {
-        self.verify_pending_uploads_once()
-    }
-
     fn wake_pending_upload_verifier(&self) {
-        if self.pending_upload_verifier_running.load(Ordering::SeqCst) {
-            self.pending_upload_verifier_wakeup.notify_one();
-        }
+        send!(self.runtime.wake_pending_upload_verifier());
     }
 }
 
@@ -238,24 +165,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pending_upload_retry_backoff_resets_to_short_delay() {
-        let mut backoff = PendingUploadRetryBackoff::new();
-        let initial_delay = backoff.next_delay();
+    fn pending_upload_backoff_resets_to_short_delay() {
+        let mut backoff = build_pending_upload_backoff();
+        let initial_delay = backoff.next().expect("expected initial delay");
 
-        let _ = backoff.next_delay();
-        let _ = backoff.next_delay();
+        let _ = backoff.next();
+        let _ = backoff.next();
 
-        backoff.reset();
+        let mut backoff = build_pending_upload_backoff();
 
-        assert_eq!(backoff.next_delay(), initial_delay);
+        assert_eq!(backoff.next().expect("expected reset delay"), initial_delay);
     }
 
     #[test]
-    fn pending_upload_retry_backoff_caps_at_max_delay() {
-        let mut backoff = PendingUploadRetryBackoff::new();
+    fn pending_upload_backoff_caps_at_max_delay() {
+        let mut backoff = build_pending_upload_backoff();
 
         for _ in 0..10 {
-            assert!(backoff.next_delay() <= MAX_PENDING_UPLOAD_VERIFICATION_DELAY);
+            assert!(
+                backoff.next().expect("expected delay") <= MAX_PENDING_UPLOAD_VERIFICATION_DELAY
+            );
         }
     }
 }

--- a/rust/src/manager/cloud_backup_manager/pending.rs
+++ b/rust/src/manager/cloud_backup_manager/pending.rs
@@ -1,7 +1,6 @@
 mod detail;
 mod queue_processor;
 
-use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
@@ -13,10 +12,12 @@ use self::queue_processor::PendingUploadVerifier;
 use super::{CLOUD_BACKUP_MANAGER, CloudBackupError, RustCloudBackupManager};
 use crate::database::Database;
 use crate::database::cloud_backup::{
-    CloudUploadKind, CloudUploadVerificationState, PendingCloudUploadItem,
+    CloudBlobFailedState, CloudBlobUploadedPendingConfirmationState, CloudUploadKind,
+    PersistedCloudBlobState, PersistedCloudBlobSyncState,
 };
+use crate::wallet::metadata::WalletId;
 
-pub(crate) use detail::cleanup_confirmed_pending_blobs;
+pub(crate) use detail::remote_wallet_revision_matches;
 
 const MAX_PENDING_UPLOAD_VERIFICATION_DELAY: Duration = Duration::from_secs(10);
 
@@ -47,71 +48,48 @@ fn build_pending_upload_backoff() -> FibonacciBackoff {
 }
 
 impl RustCloudBackupManager {
-    pub(super) fn enqueue_pending_uploads<I>(
+    pub(crate) fn replace_blob_state_if_current(
+        &self,
+        current_state: &PersistedCloudBlobSyncState,
+        next_state: PersistedCloudBlobState,
+        error_context: &'static str,
+    ) -> Result<bool, CloudBackupError> {
+        let next_sync_state =
+            PersistedCloudBlobSyncState { state: next_state, ..current_state.clone() };
+
+        Database::global()
+            .cloud_blob_sync_states
+            .set_if_current(current_state, &next_sync_state)
+            .map_err_prefix(error_context, CloudBackupError::Internal)
+    }
+
+    pub(crate) fn mark_blob_uploaded_pending_confirmation(
         &self,
         namespace_id: &str,
-        record_ids: I,
-    ) -> Result<(), CloudBackupError>
-    where
-        I: IntoIterator<Item = String>,
-    {
-        let db = Database::global();
-        let table = &db.cloud_upload_queue;
-        let now = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
-
-        let mut pending = table
-            .get()
-            .map_err_prefix("read pending cloud upload queue", CloudBackupError::Internal)?
-            .unwrap_or_default();
-
-        let mut known_record_ids: HashSet<String> = pending
-            .items
-            .iter()
-            .filter(|item| {
-                item.kind == CloudUploadKind::BackupBlob
-                    && item.namespace_id == namespace_id
-                    && !item.is_confirmed()
-            })
-            .map(|item| item.record_id.clone())
-            .collect();
-
-        for record_id in record_ids {
-            if let Some(existing_item) = pending.items.iter_mut().find(|item| {
-                item.kind == CloudUploadKind::BackupBlob
-                    && item.namespace_id == namespace_id
-                    && item.record_id == record_id
-                    && item.is_confirmed()
-            }) {
-                existing_item.enqueued_at = now;
-                existing_item.verification = CloudUploadVerificationState::Pending {
+        wallet_id: Option<WalletId>,
+        record_id: String,
+        revision_hash: String,
+        uploaded_at: u64,
+    ) -> Result<(), CloudBackupError> {
+        let sync_state = PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id: namespace_id.to_string(),
+            wallet_id,
+            record_id,
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash,
+                    uploaded_at,
                     attempt_count: 0,
                     last_checked_at: None,
-                };
-                known_record_ids.insert(record_id);
-                continue;
-            }
+                },
+            ),
+        };
 
-            if known_record_ids.insert(record_id.clone()) {
-                pending.items.push(PendingCloudUploadItem {
-                    kind: CloudUploadKind::BackupBlob,
-                    namespace_id: namespace_id.to_string(),
-                    record_id,
-                    enqueued_at: now,
-                    verification: CloudUploadVerificationState::Pending {
-                        attempt_count: 0,
-                        last_checked_at: None,
-                    },
-                });
-            }
-        }
-
-        if pending.items.is_empty() {
-            return Ok(());
-        }
-
-        table
-            .set(&pending)
-            .map_err_prefix("persist pending cloud upload queue", CloudBackupError::Internal)?;
+        Database::global()
+            .cloud_blob_sync_states
+            .set(&sync_state)
+            .map_err_prefix("persist uploaded cloud blob state", CloudBackupError::Internal)?;
 
         self.set_pending_upload_verification(true);
         self.wake_pending_upload_verifier();
@@ -120,43 +98,70 @@ impl RustCloudBackupManager {
         Ok(())
     }
 
-    pub(super) fn remove_pending_uploads<I>(
+    pub(crate) fn mark_blob_uploaded_pending_confirmation_if_current(
         &self,
-        namespace_id: &str,
-        record_ids: I,
-    ) -> Result<(), CloudBackupError>
+        current_state: &PersistedCloudBlobSyncState,
+        revision_hash: String,
+        uploaded_at: u64,
+    ) -> Result<bool, CloudBackupError> {
+        let updated = self.replace_blob_state_if_current(
+            current_state,
+            PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash,
+                    uploaded_at,
+                    attempt_count: 0,
+                    last_checked_at: None,
+                },
+            ),
+            "persist uploaded cloud blob state",
+        )?;
+
+        if !updated {
+            return Ok(false);
+        }
+
+        self.set_pending_upload_verification(true);
+        self.wake_pending_upload_verifier();
+        self.start_pending_upload_verification_loop();
+
+        Ok(true)
+    }
+
+    pub(crate) fn mark_blob_failed_if_current(
+        &self,
+        current_state: &PersistedCloudBlobSyncState,
+        revision_hash: Option<String>,
+        retryable: bool,
+        error: String,
+    ) -> Result<bool, CloudBackupError> {
+        let failed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+        self.replace_blob_state_if_current(
+            current_state,
+            PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                revision_hash,
+                retryable,
+                error,
+                failed_at,
+            }),
+            "persist failed cloud blob state",
+        )
+    }
+
+    pub(super) fn remove_blob_sync_states<I>(&self, record_ids: I) -> Result<(), CloudBackupError>
     where
         I: IntoIterator<Item = String>,
     {
-        let db = Database::global();
-        let table = &db.cloud_upload_queue;
-        let Some(mut pending) = table
-            .get()
-            .map_err_prefix("read pending cloud upload queue", CloudBackupError::Internal)?
-        else {
-            return Ok(());
-        };
+        let table = &Database::global().cloud_blob_sync_states;
 
-        let record_ids: HashSet<String> = record_ids.into_iter().collect();
-        pending.items.retain(|item| {
-            !(item.kind == CloudUploadKind::BackupBlob
-                && item.namespace_id == namespace_id
-                && record_ids.contains(&item.record_id))
-        });
-
-        if pending.items.is_empty() {
+        for record_id in record_ids {
             table
-                .delete()
-                .map_err_prefix("clear pending cloud upload queue", CloudBackupError::Internal)?;
-            self.set_pending_upload_verification(false);
-            self.wake_pending_upload_verifier();
-            return Ok(());
+                .delete(&record_id)
+                .map_err_prefix("remove cloud blob sync state", CloudBackupError::Internal)?;
         }
 
-        table
-            .set(&pending)
-            .map_err_prefix("persist pending cloud upload queue", CloudBackupError::Internal)?;
-        self.set_pending_upload_verification(true);
+        self.set_pending_upload_verification(self.has_pending_cloud_upload_verification());
         self.wake_pending_upload_verifier();
 
         Ok(())
@@ -252,44 +257,5 @@ mod tests {
         for _ in 0..10 {
             assert!(backoff.next_delay() <= MAX_PENDING_UPLOAD_VERIFICATION_DELAY);
         }
-    }
-
-    fn test_lock() -> &'static parking_lot::Mutex<()> {
-        super::super::cloud_backup_test_lock()
-    }
-
-    #[test]
-    fn enqueue_pending_uploads_reactivates_confirmed_item() {
-        let _guard = test_lock().lock();
-        let manager = RustCloudBackupManager::init();
-        let table = &Database::global().cloud_upload_queue;
-
-        table.delete().unwrap();
-        manager.pending_upload_verifier_running.store(true, Ordering::SeqCst);
-
-        table
-            .set(&crate::database::cloud_backup::PendingCloudUploadQueue {
-                items: vec![PendingCloudUploadItem {
-                    kind: CloudUploadKind::BackupBlob,
-                    namespace_id: "namespace-1".into(),
-                    record_id: "record-1".into(),
-                    enqueued_at: 1,
-                    verification: CloudUploadVerificationState::Confirmed(2),
-                }],
-            })
-            .unwrap();
-
-        manager.enqueue_pending_uploads("namespace-1", ["record-1".to_string()]).unwrap();
-
-        let queue = table.get().unwrap().unwrap();
-        assert_eq!(queue.items.len(), 1);
-        assert!(matches!(
-            queue.items[0].verification,
-            CloudUploadVerificationState::Pending { attempt_count: 0, last_checked_at: None }
-        ));
-        assert!(queue.items[0].enqueued_at >= 2);
-
-        manager.pending_upload_verifier_running.store(false, Ordering::SeqCst);
-        table.delete().unwrap();
     }
 }

--- a/rust/src/manager/cloud_backup_manager/pending.rs
+++ b/rust/src/manager/cloud_backup_manager/pending.rs
@@ -218,7 +218,7 @@ impl RustCloudBackupManager {
     }
 
     fn verify_pending_uploads_once(&self) -> bool {
-        PendingUploadVerifier(self).run_once()
+        PendingUploadVerifier(self.clone()).run_once()
     }
 
     #[cfg(test)]

--- a/rust/src/manager/cloud_backup_manager/pending.rs
+++ b/rust/src/manager/cloud_backup_manager/pending.rs
@@ -178,13 +178,11 @@ mod tests {
     }
 
     #[test]
-    fn pending_upload_backoff_caps_at_max_delay() {
+    fn pending_upload_backoff_produces_delays() {
         let mut backoff = build_pending_upload_backoff();
 
         for _ in 0..10 {
-            assert!(
-                backoff.next().expect("expected delay") <= MAX_PENDING_UPLOAD_VERIFICATION_DELAY
-            );
+            assert!(backoff.next().is_some(), "expected delay");
         }
     }
 }

--- a/rust/src/manager/cloud_backup_manager/pending/detail.rs
+++ b/rust/src/manager/cloud_backup_manager/pending/detail.rs
@@ -1,15 +1,12 @@
-use std::collections::HashSet;
-
 use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
-use tracing::info;
+use tracing::{info, warn};
 
-use super::super::cloud_inventory::CloudWalletInventory;
 use super::super::{
-    CLOUD_BACKUP_MANAGER, CloudBackupDetail, CloudBackupDetailResult, CloudBackupStatus,
-    RustCloudBackupManager,
+    CloudBackupDetailResult, CloudBackupStatus, RustCloudBackupManager,
+    cloud_inventory::RemoteWalletTruth,
 };
 use crate::database::Database;
-use crate::database::cloud_backup::CloudUploadKind;
+use crate::database::cloud_backup::{CloudBlobConfirmedState, PersistedCloudBlobState};
 
 impl RustCloudBackupManager {
     /// List wallet backups in the current namespace and build detail
@@ -50,50 +47,98 @@ impl RustCloudBackupManager {
             Err(error) => return Some(CloudBackupDetailResult::AccessError(error.to_string())),
         };
 
-        info!(
-            "refresh_cloud_backup_detail: found {} wallet record(s) in cloud",
-            wallet_record_ids.len()
-        );
+        let remote_wallet_truth = match self.load_remote_wallet_truth(&wallet_record_ids) {
+            Ok(remote_wallet_truth) => remote_wallet_truth,
+            Err(error) => return Some(CloudBackupDetailResult::AccessError(error.to_string())),
+        };
+        self.cleanup_confirmed_pending_blobs(&remote_wallet_truth);
 
-        let listed: HashSet<_> = wallet_record_ids.iter().cloned().collect();
-        cleanup_confirmed_pending_blobs(&listed);
-
-        match build_detail_from_wallet_ids(&wallet_record_ids) {
+        match self
+            .build_cloud_backup_detail_with_remote_truth(&wallet_record_ids, remote_wallet_truth)
+        {
             Ok(detail) => Some(CloudBackupDetailResult::Success(detail)),
             Err(error) => Some(CloudBackupDetailResult::AccessError(error.to_string())),
         }
     }
-}
 
-/// Remove confirmed pending blobs that now appear in the cloud listing
-pub(crate) fn cleanup_confirmed_pending_blobs(listed_ids: &HashSet<String>) {
-    let db = Database::global();
-    let table = &db.cloud_upload_queue;
-    let mut queue = match table.get() {
-        Ok(Some(p)) => p,
-        _ => return,
-    };
-    let namespace_id = match CLOUD_BACKUP_MANAGER.current_namespace_id() {
-        Ok(namespace_id) => namespace_id,
-        Err(_) => return,
-    };
+    pub(in crate::manager::cloud_backup_manager) fn cleanup_confirmed_pending_blobs(
+        &self,
+        remote_wallet_truth: &RemoteWalletTruth,
+    ) {
+        let namespace_id = match self.current_namespace_id() {
+            Ok(namespace_id) => namespace_id,
+            Err(_) => return,
+        };
 
-    let before = queue.items.len();
-    queue.cleanup_listed(CloudUploadKind::BackupBlob, &namespace_id, listed_ids);
+        let table = &Database::global().cloud_blob_sync_states;
+        let states = match table.list() {
+            Ok(states) => states,
+            Err(error) => {
+                warn!(
+                    "cleanup_confirmed_pending_blobs: list cloud blob sync states failed: {error}"
+                );
+                return;
+            }
+        };
 
-    if queue.items.len() < before {
-        if queue.items.is_empty() {
-            let _ = table.delete();
-            CLOUD_BACKUP_MANAGER.set_pending_upload_verification(false);
-        } else {
-            let _ = table.set(&queue);
+        let confirmed_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+        let mut updated = false;
+
+        for state in states {
+            if state.namespace_id != namespace_id {
+                continue;
+            }
+
+            let PersistedCloudBlobState::UploadedPendingConfirmation(pending_state) = &state.state
+            else {
+                continue;
+            };
+            if !remote_wallet_revision_matches(
+                remote_wallet_truth,
+                &state.record_id,
+                &pending_state.revision_hash,
+            ) {
+                continue;
+            }
+
+            let confirmed_state = crate::database::cloud_backup::PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
+                    revision_hash: pending_state.revision_hash.clone(),
+                    confirmed_at,
+                }),
+                ..state.clone()
+            };
+
+            let persisted = match table.set_if_current(&state, &confirmed_state) {
+                Ok(persisted) => persisted,
+                Err(error) => {
+                    warn!(
+                        "cleanup_confirmed_pending_blobs: persist confirmed record_id={} failed: {error}",
+                        confirmed_state.record_id
+                    );
+                    continue;
+                }
+            };
+            if !persisted {
+                continue;
+            }
+
+            updated = true;
+        }
+
+        if updated {
+            self.set_pending_upload_verification(self.has_pending_cloud_upload_verification());
         }
     }
 }
 
-/// Build a CloudBackupDetail from wallet record IDs by comparing against local wallets
-pub(crate) fn build_detail_from_wallet_ids(
-    wallet_record_ids: &[String],
-) -> Result<CloudBackupDetail, super::super::CloudBackupError> {
-    Ok(CloudWalletInventory::load(wallet_record_ids)?.build_detail())
+pub(crate) fn remote_wallet_revision_matches(
+    remote_wallet_truth: &RemoteWalletTruth,
+    record_id: &str,
+    expected_revision: &str,
+) -> bool {
+    matches!(
+        remote_wallet_truth.summaries_by_record_id.get(record_id),
+        Some(summary) if summary.revision_hash == expected_revision
+    )
 }

--- a/rust/src/manager/cloud_backup_manager/pending/queue_processor.rs
+++ b/rust/src/manager/cloud_backup_manager/pending/queue_processor.rs
@@ -20,11 +20,11 @@ enum BlobCheckResult {
     Failed { error: String, retryable: bool },
 }
 
-pub(super) struct PendingUploadVerifier<'a>(pub(super) &'a RustCloudBackupManager);
+pub(super) struct PendingUploadVerifier(pub(super) RustCloudBackupManager);
 
 const MAX_PENDING_WALLET_UPLOAD_CONFIRMATION_ATTEMPTS: u32 = 3;
 
-impl PendingUploadVerifier<'_> {
+impl PendingUploadVerifier {
     pub(super) fn run_once(&self) -> bool {
         let table = &Database::global().cloud_blob_sync_states;
         let states = match table.list() {

--- a/rust/src/manager/cloud_backup_manager/pending/queue_processor.rs
+++ b/rust/src/manager/cloud_backup_manager/pending/queue_processor.rs
@@ -1,157 +1,266 @@
-use cove_device::cloud_storage::CloudStorage;
+use cove_cspp::backup_data::EncryptedWalletBackup;
+use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
+use cove_device::keychain::Keychain;
 use tracing::{error, info, warn};
+use zeroize::Zeroizing;
 
 use super::super::RustCloudBackupManager;
+use super::super::wallets::WalletBackupReader;
 use crate::database::Database;
 use crate::database::cloud_backup::{
-    CloudUploadKind, CloudUploadQueueTable, PendingCloudUploadItem, PendingCloudUploadQueue,
+    CloudBlobConfirmedState, CloudBlobDirtyState, CloudBlobFailedState,
+    CloudBlobUploadedPendingConfirmationState, PersistedCloudBlobState,
+    PersistedCloudBlobSyncState,
 };
 
 enum BlobCheckResult {
     Confirmed,
     NotYetUploaded,
-    Failed(String),
+    Stale(String),
+    Failed { error: String, retryable: bool },
 }
 
 pub(super) struct PendingUploadVerifier<'a>(pub(super) &'a RustCloudBackupManager);
 
+const MAX_PENDING_WALLET_UPLOAD_CONFIRMATION_ATTEMPTS: u32 = 3;
+
 impl PendingUploadVerifier<'_> {
     pub(super) fn run_once(&self) -> bool {
-        let db = Database::global();
-        let table = &db.cloud_upload_queue;
-        let queue = match table.get() {
-            Ok(queue) => queue,
+        let table = &Database::global().cloud_blob_sync_states;
+        let states = match table.list() {
+            Ok(states) => states,
             Err(error) => {
-                error!("Pending upload verification: failed to read queue: {error}");
+                error!("Pending upload verification: failed to read sync states: {error}");
                 return true;
             }
         };
 
-        let Some(mut queue) = queue else {
-            self.send_pending_state(false);
-            return false;
-        };
+        for sync_state in &states {
+            let PersistedCloudBlobState::UploadedPendingConfirmation(state) = &sync_state.state
+            else {
+                continue;
+            };
+            let current_state = state.clone();
 
-        if let Some(should_continue) = self.handle_terminal_state(table, &queue) {
-            return should_continue;
-        }
-
-        self.verify_blobs(&mut queue);
-
-        if let Err(error) = table.set(&queue) {
-            error!("Pending upload verification: failed to persist queue: {error}");
-            return true;
-        }
-
-        self.0.finalize_pending_verification_if_ready();
-        self.finish_pass(&queue)
-    }
-
-    fn handle_terminal_state(
-        &self,
-        table: &CloudUploadQueueTable,
-        queue: &PendingCloudUploadQueue,
-    ) -> Option<bool> {
-        if queue.items.is_empty() {
-            if let Err(error) = table.delete() {
-                error!("Pending upload verification: failed to delete empty queue: {error}");
-                return Some(true);
-            }
-
-            self.send_pending_state(false);
-            return Some(false);
-        }
-
-        if !queue.has_unconfirmed() {
-            self.send_pending_state(false);
-            return Some(false);
-        }
-
-        None
-    }
-
-    fn verify_blobs(&self, queue: &mut PendingCloudUploadQueue) {
-        let cloud = CloudStorage::global();
-        let checked_at: u64 = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
-        for item in &mut queue.items {
-            if item.kind != CloudUploadKind::BackupBlob || item.is_confirmed() {
+            let result = self.check_blob(sync_state, &current_state);
+            let next_state = Self::apply_blob_result(sync_state, &current_state, &result);
+            let persisted = match table.set_if_current(sync_state, &next_state) {
+                Ok(persisted) => persisted,
+                Err(error) => {
+                    error!("Pending upload verification: failed to persist state: {error}");
+                    return true;
+                }
+            };
+            if !persisted {
                 continue;
             }
 
-            let result = self.check_blob(cloud, &item.namespace_id, &item.record_id);
-            Self::apply_blob_result(item, checked_at, &result);
-            self.log_blob_result(item, &result);
+            self.log_blob_result(&next_state, &result);
+            self.schedule_retry_if_needed(&next_state);
         }
+
+        self.0.finalize_pending_verification_if_ready();
+        let has_pending = self.0.has_pending_cloud_upload_verification();
+        self.send_pending_state(has_pending);
+        if has_pending {
+            info!("Pending upload verification: still pending");
+        } else {
+            info!("Pending upload verification: all blobs confirmed");
+        }
+
+        has_pending
     }
 
     fn check_blob(
         &self,
-        cloud: &CloudStorage,
-        namespace_id: &str,
-        record_id: &str,
+        sync_state: &PersistedCloudBlobSyncState,
+        current: &CloudBlobUploadedPendingConfirmationState,
     ) -> BlobCheckResult {
-        match cloud.is_backup_uploaded(namespace_id.to_string(), record_id.to_string()) {
-            Ok(true) => BlobCheckResult::Confirmed,
-            Ok(false) => BlobCheckResult::NotYetUploaded,
-            Err(error) => BlobCheckResult::Failed(error.to_string()),
+        if sync_state.wallet_id.is_none() {
+            return self.check_master_key_wrapper(&sync_state.namespace_id);
+        }
+
+        self.check_wallet_blob(sync_state, current)
+    }
+
+    fn check_master_key_wrapper(&self, namespace_id: &str) -> BlobCheckResult {
+        let cloud = CloudStorage::global();
+        match cloud.download_master_key_backup(namespace_id.to_string()) {
+            Ok(_) => BlobCheckResult::Confirmed,
+            Err(CloudStorageError::NotFound(_)) => BlobCheckResult::NotYetUploaded,
+            Err(error) => cloud_storage_failure_result(error),
+        }
+    }
+
+    fn check_wallet_blob(
+        &self,
+        sync_state: &PersistedCloudBlobSyncState,
+        current: &CloudBlobUploadedPendingConfirmationState,
+    ) -> BlobCheckResult {
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        let master_key = match cspp.load_master_key_from_store() {
+            Ok(Some(master_key)) => master_key,
+            Ok(None) => return terminal_failure("no local master key available".into()),
+            Err(error) => {
+                return terminal_failure(format!("load local master key: {error}"));
+            }
+        };
+
+        let reader = WalletBackupReader::new(
+            CloudStorage::global().clone(),
+            sync_state.namespace_id.clone(),
+            Zeroizing::new(master_key.critical_data_key()),
+        );
+        let wallet_json = match CloudStorage::global()
+            .download_wallet_backup(sync_state.namespace_id.clone(), sync_state.record_id.clone())
+        {
+            Ok(wallet_json) => wallet_json,
+            Err(CloudStorageError::NotFound(_)) => return BlobCheckResult::NotYetUploaded,
+            Err(error) => return cloud_storage_failure_result(error),
+        };
+
+        let encrypted: EncryptedWalletBackup = match serde_json::from_slice(&wallet_json) {
+            Ok(encrypted) => encrypted,
+            Err(error) => {
+                return terminal_failure(format!("deserialize wallet backup: {error}"));
+            }
+        };
+        if encrypted.version != 1 {
+            return terminal_failure(format!(
+                "unsupported wallet backup version {}",
+                encrypted.version
+            ));
+        }
+
+        match reader.decrypt_entry(&encrypted) {
+            Ok(entry) => {
+                if entry.content_revision_hash == current.revision_hash {
+                    BlobCheckResult::Confirmed
+                } else {
+                    BlobCheckResult::Stale(entry.content_revision_hash.clone())
+                }
+            }
+            Err(error) => terminal_failure(format!("decrypt wallet backup: {error}")),
         }
     }
 
     fn apply_blob_result(
-        item: &mut PendingCloudUploadItem,
-        checked_at: u64,
+        sync_state: &PersistedCloudBlobSyncState,
+        current: &CloudBlobUploadedPendingConfirmationState,
         result: &BlobCheckResult,
-    ) {
-        match result {
-            BlobCheckResult::Confirmed => item.confirm(checked_at),
-            BlobCheckResult::NotYetUploaded | BlobCheckResult::Failed(_) => {
-                item.mark_checked(checked_at)
-            }
+    ) -> PersistedCloudBlobSyncState {
+        let checked_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+        let next_attempt_count = current.attempt_count + 1;
+
+        PersistedCloudBlobSyncState {
+            state: match result {
+                BlobCheckResult::Confirmed => {
+                    PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
+                        revision_hash: current.revision_hash.clone(),
+                        confirmed_at: checked_at,
+                    })
+                }
+                BlobCheckResult::NotYetUploaded | BlobCheckResult::Stale(_)
+                    if should_retry_wallet_upload(sync_state, next_attempt_count) =>
+                {
+                    PersistedCloudBlobState::Dirty(CloudBlobDirtyState { changed_at: checked_at })
+                }
+                BlobCheckResult::NotYetUploaded
+                | BlobCheckResult::Stale(_)
+                | BlobCheckResult::Failed { retryable: true, .. } => {
+                    PersistedCloudBlobState::UploadedPendingConfirmation(
+                        CloudBlobUploadedPendingConfirmationState {
+                            revision_hash: current.revision_hash.clone(),
+                            uploaded_at: current.uploaded_at,
+                            attempt_count: next_attempt_count,
+                            last_checked_at: Some(checked_at),
+                        },
+                    )
+                }
+                BlobCheckResult::Failed { error, retryable: false } => {
+                    PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                        revision_hash: Some(current.revision_hash.clone()),
+                        retryable: false,
+                        error: error.clone(),
+                        failed_at: checked_at,
+                    })
+                }
+            },
+            ..sync_state.clone()
         }
     }
 
-    fn log_blob_result(&self, item: &PendingCloudUploadItem, result: &BlobCheckResult) {
-        match result {
-            BlobCheckResult::Confirmed => {
-                let elapsed_secs =
-                    item.confirmed_at().unwrap_or_default().saturating_sub(item.enqueued_at);
+    fn schedule_retry_if_needed(&self, sync_state: &PersistedCloudBlobSyncState) {
+        let Some(wallet_id) = sync_state.wallet_id.clone() else {
+            return;
+        };
+
+        if !matches!(sync_state.state, PersistedCloudBlobState::Dirty(_)) {
+            return;
+        }
+
+        self.0.schedule_wallet_upload(wallet_id, true);
+    }
+
+    fn log_blob_result(&self, sync_state: &PersistedCloudBlobSyncState, result: &BlobCheckResult) {
+        match (&sync_state.state, result) {
+            (PersistedCloudBlobState::Confirmed(_), BlobCheckResult::Confirmed) => {
+                info!("Pending upload verification: confirmed record_id={}", sync_state.record_id);
+            }
+            (
+                PersistedCloudBlobState::UploadedPendingConfirmation(state),
+                BlobCheckResult::NotYetUploaded,
+            ) => {
                 info!(
-                    "Pending upload verification: confirmed record_id={} elapsed={elapsed_secs}s attempts={}",
-                    item.record_id,
-                    item.attempt_count()
+                    "Pending upload verification: not yet uploaded record_id={} attempts={} checked_at={}",
+                    sync_state.record_id,
+                    state.attempt_count,
+                    state.last_checked_at.unwrap_or_default()
                 );
             }
-            BlobCheckResult::NotYetUploaded => {
-                let last_checked_at = item.last_checked_at().unwrap_or_default();
-                info!(
-                    "Pending upload verification: not yet uploaded record_id={} checked_at={last_checked_at} attempts={}",
-                    item.record_id,
-                    item.attempt_count()
-                );
-            }
-            BlobCheckResult::Failed(error) => {
-                let last_checked_at = item.last_checked_at().unwrap_or_default();
+            (PersistedCloudBlobState::Dirty(_), BlobCheckResult::NotYetUploaded) => {
                 warn!(
-                    "Pending upload verification: check failed record_id={} checked_at={last_checked_at} error={error} attempts={}",
-                    item.record_id,
-                    item.attempt_count()
+                    "Pending upload verification: retrying wallet upload after repeated missing remote confirmation record_id={}",
+                    sync_state.record_id,
                 );
             }
+            (
+                PersistedCloudBlobState::UploadedPendingConfirmation(state),
+                BlobCheckResult::Stale(remote_revision),
+            ) => {
+                info!(
+                    "Pending upload verification: stale remote revision record_id={} attempts={} checked_at={} expected_revision={} remote_revision={remote_revision}",
+                    sync_state.record_id,
+                    state.attempt_count,
+                    state.last_checked_at.unwrap_or_default(),
+                    state.revision_hash
+                );
+            }
+            (PersistedCloudBlobState::Dirty(_), BlobCheckResult::Stale(remote_revision)) => {
+                warn!(
+                    "Pending upload verification: retrying wallet upload after repeated stale remote revision record_id={} remote_revision={remote_revision}",
+                    sync_state.record_id,
+                );
+            }
+            (
+                PersistedCloudBlobState::UploadedPendingConfirmation(state),
+                BlobCheckResult::Failed { error, .. },
+            ) => {
+                warn!(
+                    "Pending upload verification: check failed record_id={} attempts={} checked_at={} error={error}",
+                    sync_state.record_id,
+                    state.attempt_count,
+                    state.last_checked_at.unwrap_or_default()
+                );
+            }
+            (PersistedCloudBlobState::Failed(_), BlobCheckResult::Failed { error, .. }) => {
+                warn!(
+                    "Pending upload verification: terminal failure record_id={} error={error}",
+                    sync_state.record_id,
+                );
+            }
+            _ => {}
         }
-    }
-
-    fn finish_pass(&self, queue: &PendingCloudUploadQueue) -> bool {
-        let has_unconfirmed = queue.has_unconfirmed();
-        if has_unconfirmed {
-            let unconfirmed = queue.items.iter().filter(|item| !item.is_confirmed()).count();
-            self.send_pending_state(true);
-            info!("Pending upload verification: still pending count={unconfirmed}");
-        } else {
-            self.send_pending_state(false);
-            info!("Pending upload verification: all blobs confirmed");
-        }
-
-        has_unconfirmed
     }
 
     fn send_pending_state(&self, pending: bool) {
@@ -159,71 +268,221 @@ impl PendingUploadVerifier<'_> {
     }
 }
 
+fn should_retry_wallet_upload(
+    sync_state: &PersistedCloudBlobSyncState,
+    next_attempt_count: u32,
+) -> bool {
+    sync_state.wallet_id.is_some()
+        && next_attempt_count >= MAX_PENDING_WALLET_UPLOAD_CONFIRMATION_ATTEMPTS
+}
+
+fn terminal_failure(error: String) -> BlobCheckResult {
+    BlobCheckResult::Failed { error, retryable: false }
+}
+
+fn cloud_storage_failure_result(error: CloudStorageError) -> BlobCheckResult {
+    let retryable =
+        matches!(error, CloudStorageError::NotAvailable(_) | CloudStorageError::DownloadFailed(_));
+
+    BlobCheckResult::Failed { error: error.to_string(), retryable }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::cloud_backup::{CloudUploadKind, PersistedCloudBlobSyncState};
 
     #[test]
     fn apply_blob_result_confirms_blob() {
-        let mut blob = PendingCloudUploadItem {
+        let blob = PersistedCloudBlobSyncState {
             kind: CloudUploadKind::BackupBlob,
             namespace_id: "ns-1".into(),
+            wallet_id: None,
             record_id: "wallet-a".into(),
-            enqueued_at: 10,
-            verification: crate::database::cloud_backup::CloudUploadVerificationState::Pending {
-                attempt_count: 0,
-                last_checked_at: None,
-            },
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: 0,
+                    last_checked_at: None,
+                },
+            ),
         };
 
-        PendingUploadVerifier::apply_blob_result(&mut blob, 20, &BlobCheckResult::Confirmed);
+        let current = match &blob.state {
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => state.clone(),
+            _ => unreachable!(),
+        };
 
-        assert_eq!(blob.confirmed_at(), Some(20));
-        assert_eq!(blob.last_checked_at(), None);
-        assert_eq!(blob.attempt_count(), 0);
+        let blob =
+            PendingUploadVerifier::apply_blob_result(&blob, &current, &BlobCheckResult::Confirmed);
+
+        assert!(matches!(blob.state, PersistedCloudBlobState::Confirmed(_)));
     }
 
     #[test]
     fn apply_blob_result_tracks_pending_blob() {
-        let mut blob = PendingCloudUploadItem {
+        let blob = PersistedCloudBlobSyncState {
             kind: CloudUploadKind::BackupBlob,
             namespace_id: "ns-1".into(),
+            wallet_id: None,
             record_id: "wallet-a".into(),
-            enqueued_at: 10,
-            verification: crate::database::cloud_backup::CloudUploadVerificationState::Pending {
-                attempt_count: 0,
-                last_checked_at: None,
-            },
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: 0,
+                    last_checked_at: None,
+                },
+            ),
         };
 
-        PendingUploadVerifier::apply_blob_result(&mut blob, 20, &BlobCheckResult::NotYetUploaded);
+        let current = match &blob.state {
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => state.clone(),
+            _ => unreachable!(),
+        };
 
-        assert_eq!(blob.confirmed_at(), None);
-        assert_eq!(blob.last_checked_at(), Some(20));
-        assert_eq!(blob.attempt_count(), 1);
+        let blob = PendingUploadVerifier::apply_blob_result(
+            &blob,
+            &current,
+            &BlobCheckResult::NotYetUploaded,
+        );
+
+        let PersistedCloudBlobState::UploadedPendingConfirmation(state) = &blob.state else {
+            panic!("expected uploaded pending confirmation state");
+        };
+
+        assert_eq!(state.attempt_count, 1);
+        assert!(state.last_checked_at.is_some());
     }
 
     #[test]
-    fn apply_blob_result_tracks_failed_blob() {
-        let mut blob = PendingCloudUploadItem {
+    fn apply_blob_result_keeps_pending_blob_when_remote_revision_is_stale() {
+        let blob = PersistedCloudBlobSyncState {
             kind: CloudUploadKind::BackupBlob,
             namespace_id: "ns-1".into(),
+            wallet_id: Some("wallet-a".into()),
             record_id: "wallet-a".into(),
-            enqueued_at: 10,
-            verification: crate::database::cloud_backup::CloudUploadVerificationState::Pending {
-                attempt_count: 0,
-                last_checked_at: None,
-            },
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: 0,
+                    last_checked_at: None,
+                },
+            ),
         };
 
-        PendingUploadVerifier::apply_blob_result(
-            &mut blob,
-            20,
-            &BlobCheckResult::Failed("boom".into()),
+        let current = match &blob.state {
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => state.clone(),
+            _ => unreachable!(),
+        };
+
+        let blob = PendingUploadVerifier::apply_blob_result(
+            &blob,
+            &current,
+            &BlobCheckResult::Stale("rev-0".into()),
         );
 
-        assert_eq!(blob.confirmed_at(), None);
-        assert_eq!(blob.last_checked_at(), Some(20));
-        assert_eq!(blob.attempt_count(), 1);
+        let PersistedCloudBlobState::UploadedPendingConfirmation(state) = &blob.state else {
+            panic!("expected uploaded pending confirmation state");
+        };
+
+        assert_eq!(state.revision_hash, "rev-1");
+        assert_eq!(state.attempt_count, 1);
+        assert!(state.last_checked_at.is_some());
+    }
+
+    #[test]
+    fn apply_blob_result_retries_wallet_upload_after_threshold() {
+        let blob = PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id: "ns-1".into(),
+            wallet_id: Some("wallet-a".into()),
+            record_id: "wallet-a".into(),
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: MAX_PENDING_WALLET_UPLOAD_CONFIRMATION_ATTEMPTS - 1,
+                    last_checked_at: None,
+                },
+            ),
+        };
+
+        let current = match &blob.state {
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => state.clone(),
+            _ => unreachable!(),
+        };
+
+        let blob = PendingUploadVerifier::apply_blob_result(
+            &blob,
+            &current,
+            &BlobCheckResult::NotYetUploaded,
+        );
+
+        assert!(matches!(blob.state, PersistedCloudBlobState::Dirty(_)));
+    }
+
+    #[test]
+    fn apply_blob_result_keeps_retryable_failures_pending() {
+        let blob = PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id: "ns-1".into(),
+            wallet_id: Some("wallet-a".into()),
+            record_id: "wallet-a".into(),
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: 0,
+                    last_checked_at: None,
+                },
+            ),
+        };
+
+        let current = match &blob.state {
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => state.clone(),
+            _ => unreachable!(),
+        };
+
+        let blob = PendingUploadVerifier::apply_blob_result(
+            &blob,
+            &current,
+            &BlobCheckResult::Failed { error: "offline".into(), retryable: true },
+        );
+
+        assert!(matches!(blob.state, PersistedCloudBlobState::UploadedPendingConfirmation(_)));
+    }
+
+    #[test]
+    fn apply_blob_result_marks_terminal_failures_failed() {
+        let blob = PersistedCloudBlobSyncState {
+            kind: CloudUploadKind::BackupBlob,
+            namespace_id: "ns-1".into(),
+            wallet_id: Some("wallet-a".into()),
+            record_id: "wallet-a".into(),
+            state: PersistedCloudBlobState::UploadedPendingConfirmation(
+                CloudBlobUploadedPendingConfirmationState {
+                    revision_hash: "rev-1".into(),
+                    uploaded_at: 10,
+                    attempt_count: 0,
+                    last_checked_at: None,
+                },
+            ),
+        };
+
+        let current = match &blob.state {
+            PersistedCloudBlobState::UploadedPendingConfirmation(state) => state.clone(),
+            _ => unreachable!(),
+        };
+
+        let blob = PendingUploadVerifier::apply_blob_result(
+            &blob,
+            &current,
+            &BlobCheckResult::Failed { error: "bad data".into(), retryable: false },
+        );
+
+        assert!(matches!(blob.state, PersistedCloudBlobState::Failed(_)));
     }
 }

--- a/rust/src/manager/cloud_backup_manager/runtime_actor.rs
+++ b/rust/src/manager/cloud_backup_manager/runtime_actor.rs
@@ -1,644 +1,644 @@
 use std::collections::{HashMap, HashSet};
- use std::sync::{Arc, Weak};
- use std::time::Duration;
- 
- use act_zero::{Actor, ActorResult, Addr, Produces, WeakAddr, send};
- use cove_tokio::DebouncedTask;
- use tokio::sync::Notify;
- use tracing::{error, info, warn};
- 
- use super::pending::{MAX_PENDING_UPLOAD_VERIFICATION_DELAY, build_pending_upload_backoff};
- use super::{
-     CloudBackupError, CloudBackupStatus, PendingEnableSession, PendingVerificationCompletion,
-     RustCloudBackupManager, WalletId, live_upload_retry_delay_for_attempt,
- };
- use crate::database::cloud_backup::PersistedCloudBlobState;
- use crate::manager::cloud_backup_detail_manager::RecoveryAction;
- 
- #[derive(Debug, Clone)]
- pub(crate) enum CloudBackupOperation {
-     Enable,
-     EnableForceNew,
-     EnableNoDiscovery,
-     Verification { force_discoverable: bool },
-     Recovery { action: RecoveryAction },
-     RepairPasskey { no_discovery: bool },
-     Sync,
-     FetchCloudOnly,
-     RestoreCloudWallet,
-     DeleteCloudWallet,
-     RefreshDetail,
- }
- 
- #[derive(Clone, Debug)]
- pub(crate) struct RestoreOperation {
-     coordinator: RestoreOperationCoordinator,
-     id: u64,
- }
- 
- impl RestoreOperation {
-     fn new(coordinator: RestoreOperationCoordinator) -> Self {
-         let id = coordinator.next_operation_id();
-         Self { coordinator, id }
-     }
- 
-     pub(crate) fn ensure_current(&self) -> Result<(), CloudBackupError> {
-         self.coordinator.ensure_current(self.id)
-     }
- 
-     pub(crate) fn run<T>(&self, update: impl FnOnce() -> T) -> Result<T, CloudBackupError> {
-         self.coordinator.with_current(self.id, update)
-     }
- 
-     pub(crate) fn run_result<T>(
-         &self,
-         update: impl FnOnce() -> Result<T, CloudBackupError>,
-     ) -> Result<T, CloudBackupError> {
-         self.coordinator.with_current_result(self.id, update)
-     }
- }
- 
- #[derive(Clone, Debug, Default)]
- struct RestoreOperationCoordinator(Arc<parking_lot::Mutex<u64>>);
- 
- impl RestoreOperationCoordinator {
-     fn next_operation_id(&self) -> u64 {
-         let mut operation_id = self.0.lock();
-         *operation_id += 1;
-         *operation_id
-     }
- 
-     fn invalidate(&self) {
-         let mut operation_id = self.0.lock();
-         *operation_id += 1;
-     }
- 
-     fn ensure_current(&self, operation_id: u64) -> Result<(), CloudBackupError> {
-         let current_operation = *self.0.lock();
-         if current_operation == operation_id { Ok(()) } else { Err(CloudBackupError::Cancelled) }
-     }
- 
-     fn with_current<T>(
-         &self,
-         operation_id: u64,
-         update: impl FnOnce() -> T,
-     ) -> Result<T, CloudBackupError> {
-         let current_operation = self.0.lock();
-         if *current_operation != operation_id {
-             return Err(CloudBackupError::Cancelled);
-         }
- 
-         Ok(update())
-     }
- 
-     fn with_current_result<T>(
-         &self,
-         operation_id: u64,
-         update: impl FnOnce() -> Result<T, CloudBackupError>,
-     ) -> Result<T, CloudBackupError> {
-         let current_operation = self.0.lock();
-         if *current_operation != operation_id {
-             return Err(CloudBackupError::Cancelled);
-         }
- 
-         update()
-     }
- }
- 
- #[derive(Debug)]
- pub(crate) struct CloudBackupRuntimeActor {
-     addr: WeakAddr<Self>,
-     manager: Weak<RustCloudBackupManager>,
-     pending_enable_session: Option<PendingEnableSession>,
-     pending_verification_completion: Option<PendingVerificationCompletion>,
-     pending_upload_verifier_running: bool,
-     pending_upload_verifier_wakeup: Arc<Notify>,
-     wallet_upload_debouncers: HashMap<WalletId, DebouncedTask<()>>,
-     wallet_upload_retry_counts: HashMap<WalletId, u32>,
-     active_wallet_uploads: HashSet<WalletId>,
-     restore_operations: RestoreOperationCoordinator,
- }
- 
- #[async_trait::async_trait]
- impl Actor for CloudBackupRuntimeActor {
-     async fn started(&mut self, addr: Addr<Self>) -> ActorResult<()> {
-         self.addr = addr.downgrade();
-         Produces::ok(())
-     }
- }
- 
- impl CloudBackupRuntimeActor {
-     pub(crate) fn new(manager: Weak<RustCloudBackupManager>) -> Self {
-         Self {
-             addr: WeakAddr::default(),
-             manager,
-             pending_enable_session: None,
-             pending_verification_completion: None,
-             pending_upload_verifier_running: false,
-             pending_upload_verifier_wakeup: Arc::new(Notify::new()),
-             wallet_upload_debouncers: HashMap::new(),
-             wallet_upload_retry_counts: HashMap::new(),
-             active_wallet_uploads: HashSet::new(),
-             restore_operations: RestoreOperationCoordinator::default(),
-         }
-     }
- 
-     fn manager(&self) -> Option<Arc<RustCloudBackupManager>> {
-         self.manager.upgrade()
-     }
- 
-     fn addr(&self) -> Option<Addr<Self>> {
-         Some(self.addr.upgrade())
-     }
- 
-     fn spawn_pending_upload_verification_loop_task(
-         &mut self,
-         addr: Addr<Self>,
-         manager: Arc<RustCloudBackupManager>,
-     ) {
-         self.pending_upload_verifier_running = true;
-         let wakeup = Arc::clone(&self.pending_upload_verifier_wakeup);
-         cove_tokio::task::spawn(async move {
-             info!("Pending upload verification: started");
-             let mut backoff = PendingUploadRetryBackoff::new();
- 
-             loop {
-                 let manager_for_pass = Arc::clone(&manager);
-                 let has_pending = cove_tokio::task::spawn_blocking(move || {
-                     manager_for_pass.verify_pending_uploads_once()
-                 })
-                 .await
-                 .unwrap_or_else(|error| {
-                     error!("Pending upload verification task failed: {error}");
-                     true
-                 });
- 
-                 if !has_pending {
-                     break;
-                 }
- 
-                 let delay = backoff.next_delay();
-                 tokio::select! {
-                     _ = tokio::time::sleep(delay) => {}
-                     _ = wakeup.notified() => backoff.reset(),
-                 }
-             }
- 
-             send!(addr.pending_upload_verifier_finished());
-         });
-     }
- 
-     fn schedule_wallet_upload_after(&mut self, wallet_id: WalletId, delay: Duration) {
-         let task = DebouncedTask::new("cloud_wallet_backup_upload", delay);
-         self.wallet_upload_debouncers.insert(wallet_id.clone(), task.clone());
- 
-         let Some(addr) = self.addr() else { return };
-         task.replace(async move {
-             send!(addr.run_wallet_upload(wallet_id));
-         });
-     }
- 
-     fn next_wallet_upload_retry_delay(&mut self, wallet_id: &WalletId) -> Duration {
-         let retry_count = self.wallet_upload_retry_counts.entry(wallet_id.clone()).or_default();
-         let delay = live_upload_retry_delay_for_attempt(*retry_count);
-         *retry_count = retry_count.saturating_add(1);
-         delay
-     }
- 
-     fn reset_wallet_upload_retry_count(&mut self, wallet_id: &WalletId) {
-         self.wallet_upload_retry_counts.remove(wallet_id);
-     }
- 
-     fn schedule_wallet_upload_follow_up(&mut self, wallet_id: WalletId) {
-         let Some(manager) = self.manager() else { return };
-         let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
-         let sync_state = match crate::database::Database::global()
-             .cloud_blob_sync_states
-             .get(&record_id)
-         {
-             Ok(sync_state) => sync_state,
-             Err(error) => {
-                 error!(
-                     "Failed to read wallet upload follow-up state for record_id={record_id}: {error}"
-                 );
-                 return;
-             }
-         };
- 
-         let Some(sync_state) = sync_state else {
-             return;
-         };
- 
-         if sync_state.is_dirty() {
-             self.reset_wallet_upload_retry_count(&wallet_id);
-             if let Some(addr) = self.addr() {
-                 send!(addr.run_wallet_upload(wallet_id));
-             }
-             return;
-         }
- 
-         match sync_state.state {
-             PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
-                 let delay = self.next_wallet_upload_retry_delay(&wallet_id);
-                 self.schedule_wallet_upload_after(wallet_id, delay);
-             }
-             PersistedCloudBlobState::Failed(_) => {
-                 self.reset_wallet_upload_retry_count(&wallet_id);
-             }
-             PersistedCloudBlobState::Uploading(_)
-             | PersistedCloudBlobState::UploadedPendingConfirmation(_)
-             | PersistedCloudBlobState::Confirmed(_) => {}
-             PersistedCloudBlobState::Dirty(_) => {
-                 warn!("dirty upload follow-up should have been handled earlier");
-             }
-         }
- 
-         manager.set_pending_upload_verification(manager.has_pending_cloud_upload_verification());
-     }
- 
-     fn spawn_operation(&self, operation: CloudBackupOperation, record_id: Option<String>) {
-         let Some(manager) = self.manager() else { return };
- 
-         match operation {
-             CloudBackupOperation::Enable => {
-                 if !manager.begin_background_operation(
-                     "enable_cloud_backup",
-                     Some(CloudBackupStatus::Enabling),
-                 ) {
-                     return;
-                 }
-                 cove_tokio::task::spawn_blocking(move || {
-                     if let Err(error) = manager.do_enable_cloud_backup() {
-                         error!("enable_cloud_backup failed: {error}");
-                         manager.finish_background_operation_error(&error);
-                     }
-                 });
-             }
-             CloudBackupOperation::EnableForceNew => {
-                 if !manager.begin_background_operation(
-                     "enable_cloud_backup_force_new",
-                     Some(CloudBackupStatus::Enabling),
-                 ) {
-                     return;
-                 }
-                 cove_tokio::task::spawn_blocking(move || {
-                     if let Err(error) = manager.do_enable_cloud_backup_force_new() {
-                         error!("enable_cloud_backup_force_new failed: {error}");
-                         manager.finish_background_operation_error(&error);
-                     }
-                 });
-             }
-             CloudBackupOperation::EnableNoDiscovery => {
-                 if !manager.begin_background_operation(
-                     "enable_cloud_backup_no_discovery",
-                     Some(CloudBackupStatus::Enabling),
-                 ) {
-                     return;
-                 }
-                 cove_tokio::task::spawn_blocking(move || {
-                     if let Err(error) = manager.do_enable_cloud_backup_no_discovery() {
-                         error!("enable_cloud_backup_no_discovery failed: {error}");
-                         manager.finish_background_operation_error(&error);
-                     }
-                 });
-             }
-             CloudBackupOperation::Verification { force_discoverable } => {
-                 cove_tokio::task::spawn_blocking(move || {
-                     manager.handle_start_verification(force_discoverable);
-                 });
-             }
-             CloudBackupOperation::Recovery { action } => {
-                 cove_tokio::task::spawn_blocking(move || manager.handle_recovery(action));
-             }
-             CloudBackupOperation::RepairPasskey { no_discovery } => {
-                 cove_tokio::task::spawn_blocking(move || {
-                     manager.handle_repair_passkey(no_discovery)
-                 });
-             }
-             CloudBackupOperation::Sync => {
-                 cove_tokio::task::spawn_blocking(move || manager.handle_sync());
-             }
-             CloudBackupOperation::FetchCloudOnly => {
-                 cove_tokio::task::spawn_blocking(move || manager.handle_fetch_cloud_only());
-             }
-             CloudBackupOperation::RestoreCloudWallet => {
-                 let Some(record_id) = record_id else { return };
-                 cove_tokio::task::spawn_blocking(move || {
-                     manager.handle_restore_cloud_wallet(&record_id)
-                 });
-             }
-             CloudBackupOperation::DeleteCloudWallet => {
-                 let Some(record_id) = record_id else { return };
-                 cove_tokio::task::spawn_blocking(move || {
-                     manager.handle_delete_cloud_wallet(&record_id)
-                 });
-             }
-             CloudBackupOperation::RefreshDetail => {
-                 cove_tokio::task::spawn_blocking(move || manager.handle_refresh_detail());
-             }
-         }
-     }
- 
-     pub async fn start_operation(
-         &mut self,
-         operation: CloudBackupOperation,
-         record_id: Option<String>,
-     ) -> ActorResult<()> {
-         self.spawn_operation(operation, record_id);
-         Produces::ok(())
-     }
- 
-     pub async fn replace_pending_enable_session(
-         &mut self,
-         session: PendingEnableSession,
-     ) -> ActorResult<()> {
-         self.pending_enable_session = Some(session);
-         Produces::ok(())
-     }
- 
-     pub async fn take_pending_enable_session(
-         &mut self,
-     ) -> ActorResult<Option<PendingEnableSession>> {
-         Produces::ok(self.pending_enable_session.take())
-     }
- 
-     pub async fn clear_pending_enable_session(&mut self) -> ActorResult<()> {
-         self.pending_enable_session = None;
-         Produces::ok(())
-     }
- 
-     pub async fn discard_pending_enable_session(&mut self) -> ActorResult<()> {
-         if self.pending_enable_session.take().is_some() {
-             cove_cspp::Cspp::new(cove_device::keychain::Keychain::global().clone())
-                 .delete_master_key();
-         }
- 
-         Produces::ok(())
-     }
- 
-     pub async fn cache_pending_verification_completion(
-         &mut self,
-         completion: PendingVerificationCompletion,
-     ) -> ActorResult<()> {
-         self.pending_verification_completion = Some(completion);
-         Produces::ok(())
-     }
- 
-     pub async fn clear_pending_verification_completion(&mut self) -> ActorResult<()> {
-         self.pending_verification_completion = None;
-         Produces::ok(())
-     }
- 
-     pub async fn schedule_wallet_upload(
-         &mut self,
-         wallet_id: WalletId,
-         immediate: bool,
-     ) -> ActorResult<()> {
-         if immediate {
-             let Some(addr) = self.addr() else { return Produces::ok(()) };
-             send!(addr.run_wallet_upload(wallet_id));
-             return Produces::ok(());
-         }
- 
-         self.schedule_wallet_upload_after(wallet_id, super::LIVE_UPLOAD_DEBOUNCE);
-         Produces::ok(())
-     }
- 
-     pub async fn run_wallet_upload(&mut self, wallet_id: WalletId) -> ActorResult<()> {
-         if !self.active_wallet_uploads.insert(wallet_id.clone()) {
-             return Produces::ok(());
-         }
- 
-         let Some(addr) = self.addr() else {
-             self.active_wallet_uploads.remove(&wallet_id);
-             return Produces::ok(());
-         };
-         let Some(manager) = self.manager() else {
-             self.active_wallet_uploads.remove(&wallet_id);
-             return Produces::ok(());
-         };
- 
-         cove_tokio::task::spawn_blocking(move || {
-             let upload_result = manager.do_upload_wallet_if_dirty(&wallet_id);
-             let error_message = upload_result.as_ref().err().map(ToString::to_string);
-             send!(addr.complete_wallet_upload(wallet_id, upload_result.is_ok(), error_message));
-         });
- 
-         Produces::ok(())
-     }
- 
-     pub async fn complete_wallet_upload(
-         &mut self,
-         wallet_id: WalletId,
-         succeeded: bool,
-         error_message: Option<String>,
-     ) -> ActorResult<()> {
-         let Some(manager) = self.manager() else { return Produces::ok(()) };
- 
-         self.active_wallet_uploads.remove(&wallet_id);
- 
-         if let Some(error_message) = error_message {
-             error!("Cloud backup upload failed for wallet_id={wallet_id}: {error_message}");
-             manager.set_sync_error(Some(error_message));
-         } else if succeeded {
-             self.reset_wallet_upload_retry_count(&wallet_id);
-             manager.clear_sync_error_if_no_failed_wallet_uploads();
-         }
- 
-         self.schedule_wallet_upload_follow_up(wallet_id);
-         Produces::ok(())
-     }
- 
-     #[cfg(test)]
-     pub async fn run_wallet_upload_inline_for_test(
-         &mut self,
-         wallet_id: WalletId,
-     ) -> ActorResult<()> {
-         if !self.active_wallet_uploads.insert(wallet_id.clone()) {
-             return Produces::ok(());
-         }
- 
-         let Some(manager) = self.manager() else {
-             self.active_wallet_uploads.remove(&wallet_id);
-             return Produces::ok(());
-         };
- 
-         let upload_result = manager.do_upload_wallet_if_dirty(&wallet_id);
-         if let Err(error) = &upload_result {
-             error!("Cloud backup upload failed for wallet_id={wallet_id}: {error}");
-             manager.set_sync_error(Some(error.to_string()));
-         }
- 
-         self.active_wallet_uploads.remove(&wallet_id);
- 
-         if upload_result.is_ok() {
-             self.reset_wallet_upload_retry_count(&wallet_id);
-             manager.clear_sync_error_if_no_failed_wallet_uploads();
-         }
- 
-         self.schedule_wallet_upload_follow_up(wallet_id);
-         Produces::ok(())
-     }
- 
-     pub async fn resume_wallet_uploads_from_persisted_state(&mut self) -> ActorResult<()> {
-         let states = match crate::database::Database::global().cloud_blob_sync_states.list() {
-             Ok(states) => states,
-             Err(error) => {
-                 error!("Failed to load cloud blob sync states on startup: {error}");
-                 return Produces::ok(());
-             }
-         };
- 
-         let Some(addr) = self.addr() else { return Produces::ok(()) };
- 
-         for sync_state in states {
-             let Some(wallet_id) = sync_state.wallet_id.clone() else {
-                 continue;
-             };
- 
-             match &sync_state.state {
-                 PersistedCloudBlobState::Dirty(_) => {
-                     send!(addr.schedule_wallet_upload(wallet_id, true));
-                 }
-                 PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
-                     send!(addr.schedule_wallet_upload(wallet_id, true));
-                 }
-                 PersistedCloudBlobState::Uploading(_) => {
-                     let Some(manager) = self.manager() else { continue };
-                     if !manager.downgrade_interrupted_upload_to_dirty(&sync_state) {
-                         continue;
-                     }
-                     send!(addr.schedule_wallet_upload(wallet_id, true));
-                 }
-                 PersistedCloudBlobState::UploadedPendingConfirmation(_)
-                 | PersistedCloudBlobState::Confirmed(_)
-                 | PersistedCloudBlobState::Failed(_) => {}
-             }
-         }
- 
-         Produces::ok(())
-     }
- 
-     pub async fn ensure_pending_upload_verification_loop(&mut self) -> ActorResult<()> {
-         if self.pending_upload_verifier_running {
-             return Produces::ok(());
-         }
- 
-         let Some(addr) = self.addr() else { return Produces::ok(()) };
-         let Some(manager) = self.manager() else { return Produces::ok(()) };
- 
-         self.spawn_pending_upload_verification_loop_task(addr, manager);
- 
-         Produces::ok(())
-     }
- 
-     pub async fn wake_pending_upload_verifier(&mut self) -> ActorResult<()> {
-         if self.pending_upload_verifier_running {
-             self.pending_upload_verifier_wakeup.notify_one();
-         }
- 
-         Produces::ok(())
-     }
- 
-     pub async fn pending_upload_verifier_finished(&mut self) -> ActorResult<()> {
-         self.pending_upload_verifier_running = false;
- 
-         let Some(manager) = self.manager() else { return Produces::ok(()) };
-         if manager.has_pending_cloud_upload_verification() {
-             let Some(addr) = self.addr() else { return Produces::ok(()) };
-             self.spawn_pending_upload_verification_loop_task(addr, manager);
-             return Produces::ok(());
-         }
- 
-         info!("Pending upload verification: idle");
-         Produces::ok(())
-     }
- 
-     #[cfg(test)]
-     pub async fn new_restore_operation(&mut self) -> ActorResult<RestoreOperation> {
-         Produces::ok(RestoreOperation::new(self.restore_operations.clone()))
-     }
- 
-     #[cfg(test)]
-     pub async fn invalidate_restore_operation(&mut self) -> ActorResult<()> {
-         self.restore_operations.invalidate();
-         Produces::ok(())
-     }
- 
-     pub async fn start_restore_from_cloud_backup(&mut self) -> ActorResult<()> {
-         let Some(manager) = self.manager() else { return Produces::ok(()) };
-         let status = manager.state.read().status.clone();
-         if matches!(status, CloudBackupStatus::Enabling | CloudBackupStatus::Restoring) {
-             warn!("restore_from_cloud_backup called while {status:?}, ignoring");
-             return Produces::ok(());
-         }
- 
-         let operation = RestoreOperation::new(self.restore_operations.clone());
-         cove_tokio::task::spawn_blocking(move || {
-             info!("restore_from_cloud_backup: task started");
-             match manager.do_restore_from_cloud_backup(&operation) {
-                 Ok(()) => {}
-                 Err(CloudBackupError::Cancelled) => {
-                     info!("restore_from_cloud_backup: task cancelled");
-                 }
-                 Err(error) => {
-                     error!("restore_from_cloud_backup failed: {error}");
-                     manager.finish_background_operation_error(&error);
-                 }
-             }
-         });
- 
-         Produces::ok(())
-     }
- 
-     pub async fn cancel_restore(&mut self) -> ActorResult<()> {
-         let Some(manager) = self.manager() else { return Produces::ok(()) };
-         let status = manager.state.read().status.clone();
-         if !matches!(status, CloudBackupStatus::Restoring) {
-             return Produces::ok(());
-         }
- 
-         self.restore_operations.invalidate();
-         manager.set_progress(None);
-         manager.set_restore_progress(None);
-         manager.set_restore_report(None);
-         manager.set_status(RustCloudBackupManager::runtime_status_for(
-             &RustCloudBackupManager::load_persisted_state(),
-         ));
-         info!("restore_from_cloud_backup: cancelled active restore");
-         Produces::ok(())
-     }
- 
-     pub async fn clear_upload_runtime_state(&mut self) -> ActorResult<()> {
-         self.wallet_upload_debouncers.clear();
-         self.wallet_upload_retry_counts.clear();
-         self.active_wallet_uploads.clear();
-         Produces::ok(())
-     }
- 
-     #[cfg(test)]
-     pub async fn has_upload_debouncer_for_test(
-         &mut self,
-         wallet_id: WalletId,
-     ) -> ActorResult<bool> {
-         Produces::ok(self.wallet_upload_debouncers.contains_key(&wallet_id))
-     }
- }
- 
- struct PendingUploadRetryBackoff(backon::FibonacciBackoff);
- 
- impl PendingUploadRetryBackoff {
-     fn new() -> Self {
-         Self(build_pending_upload_backoff())
-     }
- 
-     fn next_delay(&mut self) -> Duration {
-         self.0
-             .next()
-             .map(|delay| delay.min(MAX_PENDING_UPLOAD_VERIFICATION_DELAY))
-             .unwrap_or(MAX_PENDING_UPLOAD_VERIFICATION_DELAY)
-     }
- 
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use act_zero::{Actor, ActorResult, Addr, Produces, WeakAddr, send};
+use cove_tokio::DebouncedTask;
+use tokio::sync::Notify;
+use tracing::{error, info, warn};
+
+use super::pending::{MAX_PENDING_UPLOAD_VERIFICATION_DELAY, build_pending_upload_backoff};
+use super::{
+    CloudBackupError, CloudBackupStatus, PendingEnableSession, PendingVerificationCompletion,
+    RustCloudBackupManager, WalletId, live_upload_retry_delay_for_attempt,
+};
+use crate::database::cloud_backup::PersistedCloudBlobState;
+use crate::manager::cloud_backup_detail_manager::RecoveryAction;
+
+#[derive(Debug, Clone)]
+pub(crate) enum CloudBackupOperation {
+    Enable,
+    EnableForceNew,
+    EnableNoDiscovery,
+    Verification { force_discoverable: bool },
+    Recovery { action: RecoveryAction },
+    RepairPasskey { no_discovery: bool },
+    Sync,
+    FetchCloudOnly,
+    RestoreCloudWallet,
+    DeleteCloudWallet,
+    RefreshDetail,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RestoreOperation {
+    coordinator: RestoreOperationCoordinator,
+    id: u64,
+}
+
+impl RestoreOperation {
+    fn new(coordinator: RestoreOperationCoordinator) -> Self {
+        let id = coordinator.next_operation_id();
+        Self { coordinator, id }
+    }
+
+    pub(crate) fn ensure_current(&self) -> Result<(), CloudBackupError> {
+        self.coordinator.ensure_current(self.id)
+    }
+
+    pub(crate) fn run<T>(&self, update: impl FnOnce() -> T) -> Result<T, CloudBackupError> {
+        self.coordinator.with_current(self.id, update)
+    }
+
+    pub(crate) fn run_result<T>(
+        &self,
+        update: impl FnOnce() -> Result<T, CloudBackupError>,
+    ) -> Result<T, CloudBackupError> {
+        self.coordinator.with_current_result(self.id, update)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct RestoreOperationCoordinator(Arc<parking_lot::Mutex<u64>>);
+
+impl RestoreOperationCoordinator {
+    fn next_operation_id(&self) -> u64 {
+        let mut operation_id = self.0.lock();
+        *operation_id += 1;
+        *operation_id
+    }
+
+    fn invalidate(&self) {
+        let mut operation_id = self.0.lock();
+        *operation_id += 1;
+    }
+
+    fn ensure_current(&self, operation_id: u64) -> Result<(), CloudBackupError> {
+        let current_operation = *self.0.lock();
+        if current_operation == operation_id { Ok(()) } else { Err(CloudBackupError::Cancelled) }
+    }
+
+    fn with_current<T>(
+        &self,
+        operation_id: u64,
+        update: impl FnOnce() -> T,
+    ) -> Result<T, CloudBackupError> {
+        let current_operation = self.0.lock();
+        if *current_operation != operation_id {
+            return Err(CloudBackupError::Cancelled);
+        }
+
+        Ok(update())
+    }
+
+    fn with_current_result<T>(
+        &self,
+        operation_id: u64,
+        update: impl FnOnce() -> Result<T, CloudBackupError>,
+    ) -> Result<T, CloudBackupError> {
+        let current_operation = self.0.lock();
+        if *current_operation != operation_id {
+            return Err(CloudBackupError::Cancelled);
+        }
+
+        update()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CloudBackupRuntimeActor {
+    addr: WeakAddr<Self>,
+    manager: Weak<RustCloudBackupManager>,
+    pending_enable_session: Option<PendingEnableSession>,
+    pending_verification_completion: Option<PendingVerificationCompletion>,
+    pending_upload_verifier_running: bool,
+    pending_upload_verifier_wakeup: Arc<Notify>,
+    wallet_upload_debouncers: HashMap<WalletId, DebouncedTask<()>>,
+    wallet_upload_retry_counts: HashMap<WalletId, u32>,
+    active_wallet_uploads: HashSet<WalletId>,
+    restore_operations: RestoreOperationCoordinator,
+}
+
+#[async_trait::async_trait]
+impl Actor for CloudBackupRuntimeActor {
+    async fn started(&mut self, addr: Addr<Self>) -> ActorResult<()> {
+        self.addr = addr.downgrade();
+        Produces::ok(())
+    }
+}
+
+impl CloudBackupRuntimeActor {
+    pub(crate) fn new(manager: Weak<RustCloudBackupManager>) -> Self {
+        Self {
+            addr: WeakAddr::default(),
+            manager,
+            pending_enable_session: None,
+            pending_verification_completion: None,
+            pending_upload_verifier_running: false,
+            pending_upload_verifier_wakeup: Arc::new(Notify::new()),
+            wallet_upload_debouncers: HashMap::new(),
+            wallet_upload_retry_counts: HashMap::new(),
+            active_wallet_uploads: HashSet::new(),
+            restore_operations: RestoreOperationCoordinator::default(),
+        }
+    }
+
+    fn manager(&self) -> Option<Arc<RustCloudBackupManager>> {
+        self.manager.upgrade()
+    }
+
+    fn addr(&self) -> Option<Addr<Self>> {
+        Some(self.addr.upgrade())
+    }
+
+    fn spawn_pending_upload_verification_loop_task(
+        &mut self,
+        addr: Addr<Self>,
+        manager: Arc<RustCloudBackupManager>,
+    ) {
+        self.pending_upload_verifier_running = true;
+        let wakeup = Arc::clone(&self.pending_upload_verifier_wakeup);
+        cove_tokio::task::spawn(async move {
+            info!("Pending upload verification: started");
+            let mut backoff = PendingUploadRetryBackoff::new();
+
+            loop {
+                let manager_for_pass = Arc::clone(&manager);
+                let has_pending = cove_tokio::task::spawn_blocking(move || {
+                    manager_for_pass.verify_pending_uploads_once()
+                })
+                .await
+                .unwrap_or_else(|error| {
+                    error!("Pending upload verification task failed: {error}");
+                    true
+                });
+
+                if !has_pending {
+                    break;
+                }
+
+                let delay = backoff.next_delay();
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = wakeup.notified() => backoff.reset(),
+                }
+            }
+
+            send!(addr.pending_upload_verifier_finished());
+        });
+    }
+
+    fn schedule_wallet_upload_after(&mut self, wallet_id: WalletId, delay: Duration) {
+        let task = DebouncedTask::new("cloud_wallet_backup_upload", delay);
+        self.wallet_upload_debouncers.insert(wallet_id.clone(), task.clone());
+
+        let Some(addr) = self.addr() else { return };
+        task.replace(async move {
+            send!(addr.run_wallet_upload(wallet_id));
+        });
+    }
+
+    fn next_wallet_upload_retry_delay(&mut self, wallet_id: &WalletId) -> Duration {
+        let retry_count = self.wallet_upload_retry_counts.entry(wallet_id.clone()).or_default();
+        let delay = live_upload_retry_delay_for_attempt(*retry_count);
+        *retry_count = retry_count.saturating_add(1);
+        delay
+    }
+
+    fn reset_wallet_upload_retry_count(&mut self, wallet_id: &WalletId) {
+        self.wallet_upload_retry_counts.remove(wallet_id);
+    }
+
+    fn schedule_wallet_upload_follow_up(&mut self, wallet_id: WalletId) {
+        let Some(manager) = self.manager() else { return };
+        let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+        let sync_state = match crate::database::Database::global()
+            .cloud_blob_sync_states
+            .get(&record_id)
+        {
+            Ok(sync_state) => sync_state,
+            Err(error) => {
+                error!(
+                    "Failed to read wallet upload follow-up state for record_id={record_id}: {error}"
+                );
+                return;
+            }
+        };
+
+        let Some(sync_state) = sync_state else {
+            return;
+        };
+
+        if sync_state.is_dirty() {
+            self.reset_wallet_upload_retry_count(&wallet_id);
+            if let Some(addr) = self.addr() {
+                send!(addr.run_wallet_upload(wallet_id));
+            }
+            return;
+        }
+
+        match sync_state.state {
+            PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
+                let delay = self.next_wallet_upload_retry_delay(&wallet_id);
+                self.schedule_wallet_upload_after(wallet_id, delay);
+            }
+            PersistedCloudBlobState::Failed(_) => {
+                self.reset_wallet_upload_retry_count(&wallet_id);
+            }
+            PersistedCloudBlobState::Uploading(_)
+            | PersistedCloudBlobState::UploadedPendingConfirmation(_)
+            | PersistedCloudBlobState::Confirmed(_) => {}
+            PersistedCloudBlobState::Dirty(_) => {
+                warn!("dirty upload follow-up should have been handled earlier");
+            }
+        }
+
+        manager.set_pending_upload_verification(manager.has_pending_cloud_upload_verification());
+    }
+
+    fn spawn_operation(&self, operation: CloudBackupOperation, record_id: Option<String>) {
+        let Some(manager) = self.manager() else { return };
+
+        match operation {
+            CloudBackupOperation::Enable => {
+                if !manager.begin_background_operation(
+                    "enable_cloud_backup",
+                    Some(CloudBackupStatus::Enabling),
+                ) {
+                    return;
+                }
+                cove_tokio::task::spawn_blocking(move || {
+                    if let Err(error) = manager.do_enable_cloud_backup() {
+                        error!("enable_cloud_backup failed: {error}");
+                        manager.finish_background_operation_error(&error);
+                    }
+                });
+            }
+            CloudBackupOperation::EnableForceNew => {
+                if !manager.begin_background_operation(
+                    "enable_cloud_backup_force_new",
+                    Some(CloudBackupStatus::Enabling),
+                ) {
+                    return;
+                }
+                cove_tokio::task::spawn_blocking(move || {
+                    if let Err(error) = manager.do_enable_cloud_backup_force_new() {
+                        error!("enable_cloud_backup_force_new failed: {error}");
+                        manager.finish_background_operation_error(&error);
+                    }
+                });
+            }
+            CloudBackupOperation::EnableNoDiscovery => {
+                if !manager.begin_background_operation(
+                    "enable_cloud_backup_no_discovery",
+                    Some(CloudBackupStatus::Enabling),
+                ) {
+                    return;
+                }
+                cove_tokio::task::spawn_blocking(move || {
+                    if let Err(error) = manager.do_enable_cloud_backup_no_discovery() {
+                        error!("enable_cloud_backup_no_discovery failed: {error}");
+                        manager.finish_background_operation_error(&error);
+                    }
+                });
+            }
+            CloudBackupOperation::Verification { force_discoverable } => {
+                cove_tokio::task::spawn_blocking(move || {
+                    manager.handle_start_verification(force_discoverable);
+                });
+            }
+            CloudBackupOperation::Recovery { action } => {
+                cove_tokio::task::spawn_blocking(move || manager.handle_recovery(action));
+            }
+            CloudBackupOperation::RepairPasskey { no_discovery } => {
+                cove_tokio::task::spawn_blocking(move || {
+                    manager.handle_repair_passkey(no_discovery)
+                });
+            }
+            CloudBackupOperation::Sync => {
+                cove_tokio::task::spawn_blocking(move || manager.handle_sync());
+            }
+            CloudBackupOperation::FetchCloudOnly => {
+                cove_tokio::task::spawn_blocking(move || manager.handle_fetch_cloud_only());
+            }
+            CloudBackupOperation::RestoreCloudWallet => {
+                let Some(record_id) = record_id else { return };
+                cove_tokio::task::spawn_blocking(move || {
+                    manager.handle_restore_cloud_wallet(&record_id)
+                });
+            }
+            CloudBackupOperation::DeleteCloudWallet => {
+                let Some(record_id) = record_id else { return };
+                cove_tokio::task::spawn_blocking(move || {
+                    manager.handle_delete_cloud_wallet(&record_id)
+                });
+            }
+            CloudBackupOperation::RefreshDetail => {
+                cove_tokio::task::spawn_blocking(move || manager.handle_refresh_detail());
+            }
+        }
+    }
+
+    pub async fn start_operation(
+        &mut self,
+        operation: CloudBackupOperation,
+        record_id: Option<String>,
+    ) -> ActorResult<()> {
+        self.spawn_operation(operation, record_id);
+        Produces::ok(())
+    }
+
+    pub async fn replace_pending_enable_session(
+        &mut self,
+        session: PendingEnableSession,
+    ) -> ActorResult<()> {
+        self.pending_enable_session = Some(session);
+        Produces::ok(())
+    }
+
+    pub async fn take_pending_enable_session(
+        &mut self,
+    ) -> ActorResult<Option<PendingEnableSession>> {
+        Produces::ok(self.pending_enable_session.take())
+    }
+
+    pub async fn clear_pending_enable_session(&mut self) -> ActorResult<()> {
+        self.pending_enable_session = None;
+        Produces::ok(())
+    }
+
+    pub async fn discard_pending_enable_session(&mut self) -> ActorResult<()> {
+        if self.pending_enable_session.take().is_some() {
+            cove_cspp::Cspp::new(cove_device::keychain::Keychain::global().clone())
+                .delete_master_key();
+        }
+
+        Produces::ok(())
+    }
+
+    pub async fn cache_pending_verification_completion(
+        &mut self,
+        completion: PendingVerificationCompletion,
+    ) -> ActorResult<()> {
+        self.pending_verification_completion = Some(completion);
+        Produces::ok(())
+    }
+
+    pub async fn clear_pending_verification_completion(&mut self) -> ActorResult<()> {
+        self.pending_verification_completion = None;
+        Produces::ok(())
+    }
+
+    pub async fn schedule_wallet_upload(
+        &mut self,
+        wallet_id: WalletId,
+        immediate: bool,
+    ) -> ActorResult<()> {
+        if immediate {
+            let Some(addr) = self.addr() else { return Produces::ok(()) };
+            send!(addr.run_wallet_upload(wallet_id));
+            return Produces::ok(());
+        }
+
+        self.schedule_wallet_upload_after(wallet_id, super::LIVE_UPLOAD_DEBOUNCE);
+        Produces::ok(())
+    }
+
+    pub async fn run_wallet_upload(&mut self, wallet_id: WalletId) -> ActorResult<()> {
+        if !self.active_wallet_uploads.insert(wallet_id.clone()) {
+            return Produces::ok(());
+        }
+
+        let Some(addr) = self.addr() else {
+            self.active_wallet_uploads.remove(&wallet_id);
+            return Produces::ok(());
+        };
+        let Some(manager) = self.manager() else {
+            self.active_wallet_uploads.remove(&wallet_id);
+            return Produces::ok(());
+        };
+
+        cove_tokio::task::spawn_blocking(move || {
+            let upload_result = manager.do_upload_wallet_if_dirty(&wallet_id);
+            let error_message = upload_result.as_ref().err().map(ToString::to_string);
+            send!(addr.complete_wallet_upload(wallet_id, upload_result.is_ok(), error_message));
+        });
+
+        Produces::ok(())
+    }
+
+    pub async fn complete_wallet_upload(
+        &mut self,
+        wallet_id: WalletId,
+        succeeded: bool,
+        error_message: Option<String>,
+    ) -> ActorResult<()> {
+        let Some(manager) = self.manager() else { return Produces::ok(()) };
+
+        self.active_wallet_uploads.remove(&wallet_id);
+
+        if let Some(error_message) = error_message {
+            error!("Cloud backup upload failed for wallet_id={wallet_id}: {error_message}");
+            manager.set_sync_error(Some(error_message));
+        } else if succeeded {
+            self.reset_wallet_upload_retry_count(&wallet_id);
+            manager.clear_sync_error_if_no_failed_wallet_uploads();
+        }
+
+        self.schedule_wallet_upload_follow_up(wallet_id);
+        Produces::ok(())
+    }
+
+    #[cfg(test)]
+    pub async fn run_wallet_upload_inline_for_test(
+        &mut self,
+        wallet_id: WalletId,
+    ) -> ActorResult<()> {
+        if !self.active_wallet_uploads.insert(wallet_id.clone()) {
+            return Produces::ok(());
+        }
+
+        let Some(manager) = self.manager() else {
+            self.active_wallet_uploads.remove(&wallet_id);
+            return Produces::ok(());
+        };
+
+        let upload_result = manager.do_upload_wallet_if_dirty(&wallet_id);
+        if let Err(error) = &upload_result {
+            error!("Cloud backup upload failed for wallet_id={wallet_id}: {error}");
+            manager.set_sync_error(Some(error.to_string()));
+        }
+
+        self.active_wallet_uploads.remove(&wallet_id);
+
+        if upload_result.is_ok() {
+            self.reset_wallet_upload_retry_count(&wallet_id);
+            manager.clear_sync_error_if_no_failed_wallet_uploads();
+        }
+
+        self.schedule_wallet_upload_follow_up(wallet_id);
+        Produces::ok(())
+    }
+
+    pub async fn resume_wallet_uploads_from_persisted_state(&mut self) -> ActorResult<()> {
+        let states = match crate::database::Database::global().cloud_blob_sync_states.list() {
+            Ok(states) => states,
+            Err(error) => {
+                error!("Failed to load cloud blob sync states on startup: {error}");
+                return Produces::ok(());
+            }
+        };
+
+        let Some(addr) = self.addr() else { return Produces::ok(()) };
+
+        for sync_state in states {
+            let Some(wallet_id) = sync_state.wallet_id.clone() else {
+                continue;
+            };
+
+            match &sync_state.state {
+                PersistedCloudBlobState::Dirty(_) => {
+                    send!(addr.schedule_wallet_upload(wallet_id, true));
+                }
+                PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
+                    send!(addr.schedule_wallet_upload(wallet_id, true));
+                }
+                PersistedCloudBlobState::Uploading(_) => {
+                    let Some(manager) = self.manager() else { continue };
+                    if !manager.downgrade_interrupted_upload_to_dirty(&sync_state) {
+                        continue;
+                    }
+                    send!(addr.schedule_wallet_upload(wallet_id, true));
+                }
+                PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                | PersistedCloudBlobState::Confirmed(_)
+                | PersistedCloudBlobState::Failed(_) => {}
+            }
+        }
+
+        Produces::ok(())
+    }
+
+    pub async fn ensure_pending_upload_verification_loop(&mut self) -> ActorResult<()> {
+        if self.pending_upload_verifier_running {
+            return Produces::ok(());
+        }
+
+        let Some(addr) = self.addr() else { return Produces::ok(()) };
+        let Some(manager) = self.manager() else { return Produces::ok(()) };
+
+        self.spawn_pending_upload_verification_loop_task(addr, manager);
+
+        Produces::ok(())
+    }
+
+    pub async fn wake_pending_upload_verifier(&mut self) -> ActorResult<()> {
+        if self.pending_upload_verifier_running {
+            self.pending_upload_verifier_wakeup.notify_one();
+        }
+
+        Produces::ok(())
+    }
+
+    pub async fn pending_upload_verifier_finished(&mut self) -> ActorResult<()> {
+        self.pending_upload_verifier_running = false;
+
+        let Some(manager) = self.manager() else { return Produces::ok(()) };
+        if manager.has_pending_cloud_upload_verification() {
+            let Some(addr) = self.addr() else { return Produces::ok(()) };
+            self.spawn_pending_upload_verification_loop_task(addr, manager);
+            return Produces::ok(());
+        }
+
+        info!("Pending upload verification: idle");
+        Produces::ok(())
+    }
+
+    #[cfg(test)]
+    pub async fn new_restore_operation(&mut self) -> ActorResult<RestoreOperation> {
+        Produces::ok(RestoreOperation::new(self.restore_operations.clone()))
+    }
+
+    #[cfg(test)]
+    pub async fn invalidate_restore_operation(&mut self) -> ActorResult<()> {
+        self.restore_operations.invalidate();
+        Produces::ok(())
+    }
+
+    pub async fn start_restore_from_cloud_backup(&mut self) -> ActorResult<()> {
+        let Some(manager) = self.manager() else { return Produces::ok(()) };
+        let status = manager.state.read().status.clone();
+        if matches!(status, CloudBackupStatus::Enabling | CloudBackupStatus::Restoring) {
+            warn!("restore_from_cloud_backup called while {status:?}, ignoring");
+            return Produces::ok(());
+        }
+
+        let operation = RestoreOperation::new(self.restore_operations.clone());
+        cove_tokio::task::spawn_blocking(move || {
+            info!("restore_from_cloud_backup: task started");
+            match manager.do_restore_from_cloud_backup(&operation) {
+                Ok(()) => {}
+                Err(CloudBackupError::Cancelled) => {
+                    info!("restore_from_cloud_backup: task cancelled");
+                }
+                Err(error) => {
+                    error!("restore_from_cloud_backup failed: {error}");
+                    manager.finish_background_operation_error(&error);
+                }
+            }
+        });
+
+        Produces::ok(())
+    }
+
+    pub async fn cancel_restore(&mut self) -> ActorResult<()> {
+        let Some(manager) = self.manager() else { return Produces::ok(()) };
+        let status = manager.state.read().status.clone();
+        if !matches!(status, CloudBackupStatus::Restoring) {
+            return Produces::ok(());
+        }
+
+        self.restore_operations.invalidate();
+        manager.set_progress(None);
+        manager.set_restore_progress(None);
+        manager.set_restore_report(None);
+        manager.set_status(RustCloudBackupManager::runtime_status_for(
+            &RustCloudBackupManager::load_persisted_state(),
+        ));
+        info!("restore_from_cloud_backup: cancelled active restore");
+        Produces::ok(())
+    }
+
+    pub async fn clear_upload_runtime_state(&mut self) -> ActorResult<()> {
+        self.wallet_upload_debouncers.clear();
+        self.wallet_upload_retry_counts.clear();
+        self.active_wallet_uploads.clear();
+        Produces::ok(())
+    }
+
+    #[cfg(test)]
+    pub async fn has_upload_debouncer_for_test(
+        &mut self,
+        wallet_id: WalletId,
+    ) -> ActorResult<bool> {
+        Produces::ok(self.wallet_upload_debouncers.contains_key(&wallet_id))
+    }
+}
+
+struct PendingUploadRetryBackoff(backon::FibonacciBackoff);
+
+impl PendingUploadRetryBackoff {
+    fn new() -> Self {
+        Self(build_pending_upload_backoff())
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        self.0
+            .next()
+            .map(|delay| delay.min(MAX_PENDING_UPLOAD_VERIFICATION_DELAY))
+            .unwrap_or(MAX_PENDING_UPLOAD_VERIFICATION_DELAY)
+    }
+
     fn reset(&mut self) {
         self.0 = build_pending_upload_backoff();
     }

--- a/rust/src/manager/cloud_backup_manager/runtime_actor.rs
+++ b/rust/src/manager/cloud_backup_manager/runtime_actor.rs
@@ -1,0 +1,645 @@
+use std::collections::{HashMap, HashSet};
+ use std::sync::{Arc, Weak};
+ use std::time::Duration;
+ 
+ use act_zero::{Actor, ActorResult, Addr, Produces, WeakAddr, send};
+ use cove_tokio::DebouncedTask;
+ use tokio::sync::Notify;
+ use tracing::{error, info, warn};
+ 
+ use super::pending::{MAX_PENDING_UPLOAD_VERIFICATION_DELAY, build_pending_upload_backoff};
+ use super::{
+     CloudBackupError, CloudBackupStatus, PendingEnableSession, PendingVerificationCompletion,
+     RustCloudBackupManager, WalletId, live_upload_retry_delay_for_attempt,
+ };
+ use crate::database::cloud_backup::PersistedCloudBlobState;
+ use crate::manager::cloud_backup_detail_manager::RecoveryAction;
+ 
+ #[derive(Debug, Clone)]
+ pub(crate) enum CloudBackupOperation {
+     Enable,
+     EnableForceNew,
+     EnableNoDiscovery,
+     Verification { force_discoverable: bool },
+     Recovery { action: RecoveryAction },
+     RepairPasskey { no_discovery: bool },
+     Sync,
+     FetchCloudOnly,
+     RestoreCloudWallet,
+     DeleteCloudWallet,
+     RefreshDetail,
+ }
+ 
+ #[derive(Clone, Debug)]
+ pub(crate) struct RestoreOperation {
+     coordinator: RestoreOperationCoordinator,
+     id: u64,
+ }
+ 
+ impl RestoreOperation {
+     fn new(coordinator: RestoreOperationCoordinator) -> Self {
+         let id = coordinator.next_operation_id();
+         Self { coordinator, id }
+     }
+ 
+     pub(crate) fn ensure_current(&self) -> Result<(), CloudBackupError> {
+         self.coordinator.ensure_current(self.id)
+     }
+ 
+     pub(crate) fn run<T>(&self, update: impl FnOnce() -> T) -> Result<T, CloudBackupError> {
+         self.coordinator.with_current(self.id, update)
+     }
+ 
+     pub(crate) fn run_result<T>(
+         &self,
+         update: impl FnOnce() -> Result<T, CloudBackupError>,
+     ) -> Result<T, CloudBackupError> {
+         self.coordinator.with_current_result(self.id, update)
+     }
+ }
+ 
+ #[derive(Clone, Debug, Default)]
+ struct RestoreOperationCoordinator(Arc<parking_lot::Mutex<u64>>);
+ 
+ impl RestoreOperationCoordinator {
+     fn next_operation_id(&self) -> u64 {
+         let mut operation_id = self.0.lock();
+         *operation_id += 1;
+         *operation_id
+     }
+ 
+     fn invalidate(&self) {
+         let mut operation_id = self.0.lock();
+         *operation_id += 1;
+     }
+ 
+     fn ensure_current(&self, operation_id: u64) -> Result<(), CloudBackupError> {
+         let current_operation = *self.0.lock();
+         if current_operation == operation_id { Ok(()) } else { Err(CloudBackupError::Cancelled) }
+     }
+ 
+     fn with_current<T>(
+         &self,
+         operation_id: u64,
+         update: impl FnOnce() -> T,
+     ) -> Result<T, CloudBackupError> {
+         let current_operation = self.0.lock();
+         if *current_operation != operation_id {
+             return Err(CloudBackupError::Cancelled);
+         }
+ 
+         Ok(update())
+     }
+ 
+     fn with_current_result<T>(
+         &self,
+         operation_id: u64,
+         update: impl FnOnce() -> Result<T, CloudBackupError>,
+     ) -> Result<T, CloudBackupError> {
+         let current_operation = self.0.lock();
+         if *current_operation != operation_id {
+             return Err(CloudBackupError::Cancelled);
+         }
+ 
+         update()
+     }
+ }
+ 
+ #[derive(Debug)]
+ pub(crate) struct CloudBackupRuntimeActor {
+     addr: WeakAddr<Self>,
+     manager: Weak<RustCloudBackupManager>,
+     pending_enable_session: Option<PendingEnableSession>,
+     pending_verification_completion: Option<PendingVerificationCompletion>,
+     pending_upload_verifier_running: bool,
+     pending_upload_verifier_wakeup: Arc<Notify>,
+     wallet_upload_debouncers: HashMap<WalletId, DebouncedTask<()>>,
+     wallet_upload_retry_counts: HashMap<WalletId, u32>,
+     active_wallet_uploads: HashSet<WalletId>,
+     restore_operations: RestoreOperationCoordinator,
+ }
+ 
+ #[async_trait::async_trait]
+ impl Actor for CloudBackupRuntimeActor {
+     async fn started(&mut self, addr: Addr<Self>) -> ActorResult<()> {
+         self.addr = addr.downgrade();
+         Produces::ok(())
+     }
+ }
+ 
+ impl CloudBackupRuntimeActor {
+     pub(crate) fn new(manager: Weak<RustCloudBackupManager>) -> Self {
+         Self {
+             addr: WeakAddr::default(),
+             manager,
+             pending_enable_session: None,
+             pending_verification_completion: None,
+             pending_upload_verifier_running: false,
+             pending_upload_verifier_wakeup: Arc::new(Notify::new()),
+             wallet_upload_debouncers: HashMap::new(),
+             wallet_upload_retry_counts: HashMap::new(),
+             active_wallet_uploads: HashSet::new(),
+             restore_operations: RestoreOperationCoordinator::default(),
+         }
+     }
+ 
+     fn manager(&self) -> Option<Arc<RustCloudBackupManager>> {
+         self.manager.upgrade()
+     }
+ 
+     fn addr(&self) -> Option<Addr<Self>> {
+         Some(self.addr.upgrade())
+     }
+ 
+     fn spawn_pending_upload_verification_loop_task(
+         &mut self,
+         addr: Addr<Self>,
+         manager: Arc<RustCloudBackupManager>,
+     ) {
+         self.pending_upload_verifier_running = true;
+         let wakeup = Arc::clone(&self.pending_upload_verifier_wakeup);
+         cove_tokio::task::spawn(async move {
+             info!("Pending upload verification: started");
+             let mut backoff = PendingUploadRetryBackoff::new();
+ 
+             loop {
+                 let manager_for_pass = Arc::clone(&manager);
+                 let has_pending = cove_tokio::task::spawn_blocking(move || {
+                     manager_for_pass.verify_pending_uploads_once()
+                 })
+                 .await
+                 .unwrap_or_else(|error| {
+                     error!("Pending upload verification task failed: {error}");
+                     true
+                 });
+ 
+                 if !has_pending {
+                     break;
+                 }
+ 
+                 let delay = backoff.next_delay();
+                 tokio::select! {
+                     _ = tokio::time::sleep(delay) => {}
+                     _ = wakeup.notified() => backoff.reset(),
+                 }
+             }
+ 
+             send!(addr.pending_upload_verifier_finished());
+         });
+     }
+ 
+     fn schedule_wallet_upload_after(&mut self, wallet_id: WalletId, delay: Duration) {
+         let task = DebouncedTask::new("cloud_wallet_backup_upload", delay);
+         self.wallet_upload_debouncers.insert(wallet_id.clone(), task.clone());
+ 
+         let Some(addr) = self.addr() else { return };
+         task.replace(async move {
+             send!(addr.run_wallet_upload(wallet_id));
+         });
+     }
+ 
+     fn next_wallet_upload_retry_delay(&mut self, wallet_id: &WalletId) -> Duration {
+         let retry_count = self.wallet_upload_retry_counts.entry(wallet_id.clone()).or_default();
+         let delay = live_upload_retry_delay_for_attempt(*retry_count);
+         *retry_count = retry_count.saturating_add(1);
+         delay
+     }
+ 
+     fn reset_wallet_upload_retry_count(&mut self, wallet_id: &WalletId) {
+         self.wallet_upload_retry_counts.remove(wallet_id);
+     }
+ 
+     fn schedule_wallet_upload_follow_up(&mut self, wallet_id: WalletId) {
+         let Some(manager) = self.manager() else { return };
+         let record_id = cove_cspp::backup_data::wallet_record_id(wallet_id.as_ref());
+         let sync_state = match crate::database::Database::global()
+             .cloud_blob_sync_states
+             .get(&record_id)
+         {
+             Ok(sync_state) => sync_state,
+             Err(error) => {
+                 error!(
+                     "Failed to read wallet upload follow-up state for record_id={record_id}: {error}"
+                 );
+                 return;
+             }
+         };
+ 
+         let Some(sync_state) = sync_state else {
+             return;
+         };
+ 
+         if sync_state.is_dirty() {
+             self.reset_wallet_upload_retry_count(&wallet_id);
+             if let Some(addr) = self.addr() {
+                 send!(addr.run_wallet_upload(wallet_id));
+             }
+             return;
+         }
+ 
+         match sync_state.state {
+             PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
+                 let delay = self.next_wallet_upload_retry_delay(&wallet_id);
+                 self.schedule_wallet_upload_after(wallet_id, delay);
+             }
+             PersistedCloudBlobState::Failed(_) => {
+                 self.reset_wallet_upload_retry_count(&wallet_id);
+             }
+             PersistedCloudBlobState::Uploading(_)
+             | PersistedCloudBlobState::UploadedPendingConfirmation(_)
+             | PersistedCloudBlobState::Confirmed(_) => {}
+             PersistedCloudBlobState::Dirty(_) => {
+                 warn!("dirty upload follow-up should have been handled earlier");
+             }
+         }
+ 
+         manager.set_pending_upload_verification(manager.has_pending_cloud_upload_verification());
+     }
+ 
+     fn spawn_operation(&self, operation: CloudBackupOperation, record_id: Option<String>) {
+         let Some(manager) = self.manager() else { return };
+ 
+         match operation {
+             CloudBackupOperation::Enable => {
+                 if !manager.begin_background_operation(
+                     "enable_cloud_backup",
+                     Some(CloudBackupStatus::Enabling),
+                 ) {
+                     return;
+                 }
+                 cove_tokio::task::spawn_blocking(move || {
+                     if let Err(error) = manager.do_enable_cloud_backup() {
+                         error!("enable_cloud_backup failed: {error}");
+                         manager.finish_background_operation_error(&error);
+                     }
+                 });
+             }
+             CloudBackupOperation::EnableForceNew => {
+                 if !manager.begin_background_operation(
+                     "enable_cloud_backup_force_new",
+                     Some(CloudBackupStatus::Enabling),
+                 ) {
+                     return;
+                 }
+                 cove_tokio::task::spawn_blocking(move || {
+                     if let Err(error) = manager.do_enable_cloud_backup_force_new() {
+                         error!("enable_cloud_backup_force_new failed: {error}");
+                         manager.finish_background_operation_error(&error);
+                     }
+                 });
+             }
+             CloudBackupOperation::EnableNoDiscovery => {
+                 if !manager.begin_background_operation(
+                     "enable_cloud_backup_no_discovery",
+                     Some(CloudBackupStatus::Enabling),
+                 ) {
+                     return;
+                 }
+                 cove_tokio::task::spawn_blocking(move || {
+                     if let Err(error) = manager.do_enable_cloud_backup_no_discovery() {
+                         error!("enable_cloud_backup_no_discovery failed: {error}");
+                         manager.finish_background_operation_error(&error);
+                     }
+                 });
+             }
+             CloudBackupOperation::Verification { force_discoverable } => {
+                 cove_tokio::task::spawn_blocking(move || {
+                     manager.handle_start_verification(force_discoverable);
+                 });
+             }
+             CloudBackupOperation::Recovery { action } => {
+                 cove_tokio::task::spawn_blocking(move || manager.handle_recovery(action));
+             }
+             CloudBackupOperation::RepairPasskey { no_discovery } => {
+                 cove_tokio::task::spawn_blocking(move || {
+                     manager.handle_repair_passkey(no_discovery)
+                 });
+             }
+             CloudBackupOperation::Sync => {
+                 cove_tokio::task::spawn_blocking(move || manager.handle_sync());
+             }
+             CloudBackupOperation::FetchCloudOnly => {
+                 cove_tokio::task::spawn_blocking(move || manager.handle_fetch_cloud_only());
+             }
+             CloudBackupOperation::RestoreCloudWallet => {
+                 let Some(record_id) = record_id else { return };
+                 cove_tokio::task::spawn_blocking(move || {
+                     manager.handle_restore_cloud_wallet(&record_id)
+                 });
+             }
+             CloudBackupOperation::DeleteCloudWallet => {
+                 let Some(record_id) = record_id else { return };
+                 cove_tokio::task::spawn_blocking(move || {
+                     manager.handle_delete_cloud_wallet(&record_id)
+                 });
+             }
+             CloudBackupOperation::RefreshDetail => {
+                 cove_tokio::task::spawn_blocking(move || manager.handle_refresh_detail());
+             }
+         }
+     }
+ 
+     pub async fn start_operation(
+         &mut self,
+         operation: CloudBackupOperation,
+         record_id: Option<String>,
+     ) -> ActorResult<()> {
+         self.spawn_operation(operation, record_id);
+         Produces::ok(())
+     }
+ 
+     pub async fn replace_pending_enable_session(
+         &mut self,
+         session: PendingEnableSession,
+     ) -> ActorResult<()> {
+         self.pending_enable_session = Some(session);
+         Produces::ok(())
+     }
+ 
+     pub async fn take_pending_enable_session(
+         &mut self,
+     ) -> ActorResult<Option<PendingEnableSession>> {
+         Produces::ok(self.pending_enable_session.take())
+     }
+ 
+     pub async fn clear_pending_enable_session(&mut self) -> ActorResult<()> {
+         self.pending_enable_session = None;
+         Produces::ok(())
+     }
+ 
+     pub async fn discard_pending_enable_session(&mut self) -> ActorResult<()> {
+         if self.pending_enable_session.take().is_some() {
+             cove_cspp::Cspp::new(cove_device::keychain::Keychain::global().clone())
+                 .delete_master_key();
+         }
+ 
+         Produces::ok(())
+     }
+ 
+     pub async fn cache_pending_verification_completion(
+         &mut self,
+         completion: PendingVerificationCompletion,
+     ) -> ActorResult<()> {
+         self.pending_verification_completion = Some(completion);
+         Produces::ok(())
+     }
+ 
+     pub async fn clear_pending_verification_completion(&mut self) -> ActorResult<()> {
+         self.pending_verification_completion = None;
+         Produces::ok(())
+     }
+ 
+     pub async fn schedule_wallet_upload(
+         &mut self,
+         wallet_id: WalletId,
+         immediate: bool,
+     ) -> ActorResult<()> {
+         if immediate {
+             let Some(addr) = self.addr() else { return Produces::ok(()) };
+             send!(addr.run_wallet_upload(wallet_id));
+             return Produces::ok(());
+         }
+ 
+         self.schedule_wallet_upload_after(wallet_id, super::LIVE_UPLOAD_DEBOUNCE);
+         Produces::ok(())
+     }
+ 
+     pub async fn run_wallet_upload(&mut self, wallet_id: WalletId) -> ActorResult<()> {
+         if !self.active_wallet_uploads.insert(wallet_id.clone()) {
+             return Produces::ok(());
+         }
+ 
+         let Some(addr) = self.addr() else {
+             self.active_wallet_uploads.remove(&wallet_id);
+             return Produces::ok(());
+         };
+         let Some(manager) = self.manager() else {
+             self.active_wallet_uploads.remove(&wallet_id);
+             return Produces::ok(());
+         };
+ 
+         cove_tokio::task::spawn_blocking(move || {
+             let upload_result = manager.do_upload_wallet_if_dirty(&wallet_id);
+             let error_message = upload_result.as_ref().err().map(ToString::to_string);
+             send!(addr.complete_wallet_upload(wallet_id, upload_result.is_ok(), error_message));
+         });
+ 
+         Produces::ok(())
+     }
+ 
+     pub async fn complete_wallet_upload(
+         &mut self,
+         wallet_id: WalletId,
+         succeeded: bool,
+         error_message: Option<String>,
+     ) -> ActorResult<()> {
+         let Some(manager) = self.manager() else { return Produces::ok(()) };
+ 
+         self.active_wallet_uploads.remove(&wallet_id);
+ 
+         if let Some(error_message) = error_message {
+             error!("Cloud backup upload failed for wallet_id={wallet_id}: {error_message}");
+             manager.set_sync_error(Some(error_message));
+         } else if succeeded {
+             self.reset_wallet_upload_retry_count(&wallet_id);
+             manager.clear_sync_error_if_no_failed_wallet_uploads();
+         }
+ 
+         self.schedule_wallet_upload_follow_up(wallet_id);
+         Produces::ok(())
+     }
+ 
+     #[cfg(test)]
+     pub async fn run_wallet_upload_inline_for_test(
+         &mut self,
+         wallet_id: WalletId,
+     ) -> ActorResult<()> {
+         if !self.active_wallet_uploads.insert(wallet_id.clone()) {
+             return Produces::ok(());
+         }
+ 
+         let Some(manager) = self.manager() else {
+             self.active_wallet_uploads.remove(&wallet_id);
+             return Produces::ok(());
+         };
+ 
+         let upload_result = manager.do_upload_wallet_if_dirty(&wallet_id);
+         if let Err(error) = &upload_result {
+             error!("Cloud backup upload failed for wallet_id={wallet_id}: {error}");
+             manager.set_sync_error(Some(error.to_string()));
+         }
+ 
+         self.active_wallet_uploads.remove(&wallet_id);
+ 
+         if upload_result.is_ok() {
+             self.reset_wallet_upload_retry_count(&wallet_id);
+             manager.clear_sync_error_if_no_failed_wallet_uploads();
+         }
+ 
+         self.schedule_wallet_upload_follow_up(wallet_id);
+         Produces::ok(())
+     }
+ 
+     pub async fn resume_wallet_uploads_from_persisted_state(&mut self) -> ActorResult<()> {
+         let states = match crate::database::Database::global().cloud_blob_sync_states.list() {
+             Ok(states) => states,
+             Err(error) => {
+                 error!("Failed to load cloud blob sync states on startup: {error}");
+                 return Produces::ok(());
+             }
+         };
+ 
+         let Some(addr) = self.addr() else { return Produces::ok(()) };
+ 
+         for sync_state in states {
+             let Some(wallet_id) = sync_state.wallet_id.clone() else {
+                 continue;
+             };
+ 
+             match &sync_state.state {
+                 PersistedCloudBlobState::Dirty(_) => {
+                     send!(addr.schedule_wallet_upload(wallet_id, true));
+                 }
+                 PersistedCloudBlobState::Failed(failed_state) if failed_state.retryable => {
+                     send!(addr.schedule_wallet_upload(wallet_id, true));
+                 }
+                 PersistedCloudBlobState::Uploading(_) => {
+                     let Some(manager) = self.manager() else { continue };
+                     if !manager.downgrade_interrupted_upload_to_dirty(&sync_state) {
+                         continue;
+                     }
+                     send!(addr.schedule_wallet_upload(wallet_id, true));
+                 }
+                 PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                 | PersistedCloudBlobState::Confirmed(_)
+                 | PersistedCloudBlobState::Failed(_) => {}
+             }
+         }
+ 
+         Produces::ok(())
+     }
+ 
+     pub async fn ensure_pending_upload_verification_loop(&mut self) -> ActorResult<()> {
+         if self.pending_upload_verifier_running {
+             return Produces::ok(());
+         }
+ 
+         let Some(addr) = self.addr() else { return Produces::ok(()) };
+         let Some(manager) = self.manager() else { return Produces::ok(()) };
+ 
+         self.spawn_pending_upload_verification_loop_task(addr, manager);
+ 
+         Produces::ok(())
+     }
+ 
+     pub async fn wake_pending_upload_verifier(&mut self) -> ActorResult<()> {
+         if self.pending_upload_verifier_running {
+             self.pending_upload_verifier_wakeup.notify_one();
+         }
+ 
+         Produces::ok(())
+     }
+ 
+     pub async fn pending_upload_verifier_finished(&mut self) -> ActorResult<()> {
+         self.pending_upload_verifier_running = false;
+ 
+         let Some(manager) = self.manager() else { return Produces::ok(()) };
+         if manager.has_pending_cloud_upload_verification() {
+             let Some(addr) = self.addr() else { return Produces::ok(()) };
+             self.spawn_pending_upload_verification_loop_task(addr, manager);
+             return Produces::ok(());
+         }
+ 
+         info!("Pending upload verification: idle");
+         Produces::ok(())
+     }
+ 
+     #[cfg(test)]
+     pub async fn new_restore_operation(&mut self) -> ActorResult<RestoreOperation> {
+         Produces::ok(RestoreOperation::new(self.restore_operations.clone()))
+     }
+ 
+     #[cfg(test)]
+     pub async fn invalidate_restore_operation(&mut self) -> ActorResult<()> {
+         self.restore_operations.invalidate();
+         Produces::ok(())
+     }
+ 
+     pub async fn start_restore_from_cloud_backup(&mut self) -> ActorResult<()> {
+         let Some(manager) = self.manager() else { return Produces::ok(()) };
+         let status = manager.state.read().status.clone();
+         if matches!(status, CloudBackupStatus::Enabling | CloudBackupStatus::Restoring) {
+             warn!("restore_from_cloud_backup called while {status:?}, ignoring");
+             return Produces::ok(());
+         }
+ 
+         let operation = RestoreOperation::new(self.restore_operations.clone());
+         cove_tokio::task::spawn_blocking(move || {
+             info!("restore_from_cloud_backup: task started");
+             match manager.do_restore_from_cloud_backup(&operation) {
+                 Ok(()) => {}
+                 Err(CloudBackupError::Cancelled) => {
+                     info!("restore_from_cloud_backup: task cancelled");
+                 }
+                 Err(error) => {
+                     error!("restore_from_cloud_backup failed: {error}");
+                     manager.finish_background_operation_error(&error);
+                 }
+             }
+         });
+ 
+         Produces::ok(())
+     }
+ 
+     pub async fn cancel_restore(&mut self) -> ActorResult<()> {
+         let Some(manager) = self.manager() else { return Produces::ok(()) };
+         let status = manager.state.read().status.clone();
+         if !matches!(status, CloudBackupStatus::Restoring) {
+             return Produces::ok(());
+         }
+ 
+         self.restore_operations.invalidate();
+         manager.set_progress(None);
+         manager.set_restore_progress(None);
+         manager.set_restore_report(None);
+         manager.set_status(RustCloudBackupManager::runtime_status_for(
+             &RustCloudBackupManager::load_persisted_state(),
+         ));
+         info!("restore_from_cloud_backup: cancelled active restore");
+         Produces::ok(())
+     }
+ 
+     pub async fn clear_upload_runtime_state(&mut self) -> ActorResult<()> {
+         self.wallet_upload_debouncers.clear();
+         self.wallet_upload_retry_counts.clear();
+         self.active_wallet_uploads.clear();
+         Produces::ok(())
+     }
+ 
+     #[cfg(test)]
+     pub async fn has_upload_debouncer_for_test(
+         &mut self,
+         wallet_id: WalletId,
+     ) -> ActorResult<bool> {
+         Produces::ok(self.wallet_upload_debouncers.contains_key(&wallet_id))
+     }
+ }
+ 
+ struct PendingUploadRetryBackoff(backon::FibonacciBackoff);
+ 
+ impl PendingUploadRetryBackoff {
+     fn new() -> Self {
+         Self(build_pending_upload_backoff())
+     }
+ 
+     fn next_delay(&mut self) -> Duration {
+         self.0
+             .next()
+             .map(|delay| delay.min(MAX_PENDING_UPLOAD_VERIFICATION_DELAY))
+             .unwrap_or(MAX_PENDING_UPLOAD_VERIFICATION_DELAY)
+     }
+ 
+    fn reset(&mut self) {
+        self.0 = build_pending_upload_backoff();
+    }
+}

--- a/rust/src/manager/cloud_backup_manager/runtime_actor.rs
+++ b/rust/src/manager/cloud_backup_manager/runtime_actor.rs
@@ -643,3 +643,17 @@ impl PendingUploadRetryBackoff {
         self.0 = build_pending_upload_backoff();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_upload_retry_backoff_caps_at_max_delay() {
+        let mut backoff = PendingUploadRetryBackoff::new();
+
+        for _ in 0..10 {
+            assert!(backoff.next_delay() <= MAX_PENDING_UPLOAD_VERIFICATION_DELAY);
+        }
+    }
+}

--- a/rust/src/manager/cloud_backup_manager/verify.rs
+++ b/rust/src/manager/cloud_backup_manager/verify.rs
@@ -1,23 +1,23 @@
+mod integrity;
 mod passkey_auth;
+mod pending_completion;
 mod session;
 mod wrapper_repair;
 
 use cove_cspp::CsppStore as _;
-use cove_cspp::backup_data::EncryptedWalletBackup;
+use cove_cspp::backup_data::EncryptedMasterKeyBackup;
 use cove_cspp::master_key::MasterKey;
 use cove_cspp::master_key_crypto;
-use cove_cspp::wallet_crypto;
 use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
-use cove_device::keychain::{CSPP_CREDENTIAL_ID_KEY, CSPP_PRF_SALT_KEY, Keychain};
+use cove_device::keychain::{CSPP_CREDENTIAL_ID_KEY, Keychain};
 use cove_device::passkey::PasskeyAccess;
 use cove_util::ResultExt as _;
 use tracing::{error, info, warn};
-use zeroize::Zeroizing;
 
 use self::passkey_auth::{PasskeyAuthOutcome, PasskeyAuthPolicy, authenticate_with_policy};
 use self::session::VerificationSession;
 use self::wrapper_repair::{WrapperRepairOperation, WrapperRepairStrategy};
-use super::wallets::{count_all_wallets, persist_enabled_cloud_backup_state};
+use super::wallets::persist_enabled_cloud_backup_state;
 use super::{
     CloudBackupDetailResult, CloudBackupError, CloudBackupStatus, DeepVerificationFailure,
     DeepVerificationReport, DeepVerificationResult, PendingVerificationCompletion,
@@ -32,97 +32,7 @@ enum IntegrityDowngrade {
     Unverified,
 }
 
-enum PendingWalletVerificationOutcome {
-    Verified,
-    Failed,
-    Unsupported,
-}
-
 impl RustCloudBackupManager {
-    /// Background startup health check for cloud backup integrity
-    ///
-    /// Verifies the master key is in the keychain and backup files exist in iCloud.
-    /// Returns None if everything is OK, Some(warning) if there's a problem
-    pub(super) fn verify_backup_integrity_impl(&self) -> Option<String> {
-        let state = self.state.read().status.clone();
-        if !matches!(state, CloudBackupStatus::Enabled | CloudBackupStatus::PasskeyMissing) {
-            return None;
-        }
-
-        let mut issues: Vec<&str> = Vec::new();
-
-        let keychain = Keychain::global();
-        let cspp = cove_cspp::Cspp::new(keychain.clone());
-        if !cspp.has_master_key() {
-            issues.push("master key not found in keychain");
-        }
-
-        let mut downgrade = None;
-        let has_prf_salt = keychain.get(CSPP_PRF_SALT_KEY.into()).is_some();
-        let stored_credential_id = load_stored_credential_id(keychain);
-
-        // keep launch integrity checks non-interactive so app startup never presents passkey UI
-        if stored_credential_id.is_none() {
-            issues
-                .push("passkey credential not found — open Cloud Backup in Settings to re-verify");
-            downgrade = Some(IntegrityDowngrade::Unverified);
-        }
-        if !has_prf_salt {
-            issues.push("passkey salt not found — open Cloud Backup in Settings to re-verify");
-            downgrade = Some(IntegrityDowngrade::Unverified);
-        }
-
-        let namespace = match self.current_namespace_id() {
-            Ok(ns) => ns,
-            Err(_) => {
-                issues.push("namespace_id not found in keychain");
-                self.persist_integrity_downgrade(downgrade);
-                return Some(issues.join("; "));
-            }
-        };
-
-        let cloud = CloudStorage::global();
-        if issues.is_empty() {
-            match cloud.list_wallet_backups(namespace) {
-                Ok(wallet_record_ids) => {
-                    let db = Database::global();
-                    let local_count = match count_all_wallets(&db) {
-                        Ok(local_count) => local_count,
-                        Err(error) => {
-                            warn!("Backup integrity: local wallet count failed: {error}");
-                            issues.push("local wallet inventory could not be read");
-                            0
-                        }
-                    };
-                    let cloud_count = wallet_record_ids.len() as u32;
-
-                    if local_count > cloud_count {
-                        info!(
-                            "Backup integrity: {local_count} local wallets vs {cloud_count} in cloud, auto-syncing"
-                        );
-                        if let Err(error) = self.do_sync_unsynced_wallets() {
-                            error!("Backup integrity: auto-sync failed: {error}");
-                            issues.push("some wallets are not backed up");
-                        }
-                    }
-                }
-                Err(error) => {
-                    warn!("Backup integrity: wallet list check failed: {error}");
-                }
-            }
-        }
-
-        if issues.is_empty() {
-            info!("Backup integrity check passed");
-            None
-        } else {
-            self.persist_integrity_downgrade(downgrade);
-            let message = issues.join("; ");
-            error!("Backup integrity issues: {message}");
-            Some(message)
-        }
-    }
-
     /// Deep verification of cloud backup integrity
     ///
     /// Checks state, runs do_deep_verify, wraps errors, persists result
@@ -182,21 +92,6 @@ impl RustCloudBackupManager {
         {
             error!("Failed to persist verification state: {error}");
         }
-    }
-
-    pub(crate) fn finalize_pending_verification_if_ready(&self) {
-        let Some(completion) = self.pending_verification_completion() else { return };
-
-        if !self.pending_verification_uploads_confirmed(&completion) {
-            return;
-        }
-
-        match self.finalize_pending_verification(completion.clone()) {
-            Ok(report) => self.apply_verified_report(report),
-            Err(failure) => self.apply_failed_verification(*failure),
-        }
-
-        self.clear_pending_verification_completion();
     }
 
     pub(crate) fn mark_verification_required_after_wallet_change(&self) {
@@ -286,150 +181,6 @@ impl RustCloudBackupManager {
         Ok(())
     }
 
-    fn pending_verification_uploads_confirmed(
-        &self,
-        completion: &PendingVerificationCompletion,
-    ) -> bool {
-        let pending = Database::global()
-            .cloud_upload_queue
-            .get()
-            .ok()
-            .flatten()
-            .map(|queue| queue.items)
-            .unwrap_or_default();
-
-        let listed_ids = CloudStorage::global()
-            .list_wallet_backups(completion.namespace_id().to_string())
-            .ok()
-            .map(|ids| ids.into_iter().collect::<std::collections::HashSet<_>>())
-            .unwrap_or_default();
-
-        completion.record_ids().iter().all(|record_id| {
-            if listed_ids.contains(record_id) {
-                return true;
-            }
-
-            let pending_item = pending.iter().find(|item| {
-                item.namespace_id == completion.namespace_id() && item.record_id == *record_id
-            });
-
-            pending_item.is_some_and(|item| item.is_confirmed())
-        })
-    }
-
-    fn finalize_pending_verification(
-        &self,
-        completion: PendingVerificationCompletion,
-    ) -> Result<DeepVerificationReport, Box<DeepVerificationFailure>> {
-        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
-        let master_key = cspp
-            .load_master_key_from_store()
-            .map_err_prefix("load local master key", CloudBackupError::Internal)
-            .map_err(|error| {
-                Box::new(self.pending_verification_failure(&completion, error.to_string()))
-            })?
-            .ok_or_else(|| {
-                Box::new(
-                    self.pending_verification_failure(&completion, "no local master key available"),
-                )
-            })?;
-
-        let critical_key = Zeroizing::new(master_key.critical_data_key());
-        let mut report = completion.report().clone();
-
-        for record_id in completion.record_ids() {
-            match self.verify_pending_wallet_backup(&completion, record_id, &critical_key)? {
-                PendingWalletVerificationOutcome::Verified => report.wallets_verified += 1,
-                PendingWalletVerificationOutcome::Failed => report.wallets_failed += 1,
-                PendingWalletVerificationOutcome::Unsupported => report.wallets_unsupported += 1,
-            }
-        }
-
-        report.detail = self.pending_verification_detail(&completion);
-        Ok(report)
-    }
-
-    fn verify_pending_wallet_backup(
-        &self,
-        completion: &PendingVerificationCompletion,
-        record_id: &str,
-        critical_key: &[u8; 32],
-    ) -> Result<PendingWalletVerificationOutcome, Box<DeepVerificationFailure>> {
-        let cloud = CloudStorage::global();
-        let download = cloud
-            .download_wallet_backup(completion.namespace_id().to_string(), record_id.to_string());
-        let wallet_json = match download {
-            Ok(wallet_json) => wallet_json,
-            Err(error) => {
-                warn!("Pending verification: failed to download wallet {record_id}: {error}");
-                return Ok(PendingWalletVerificationOutcome::Failed);
-            }
-        };
-
-        let encrypted: EncryptedWalletBackup =
-            serde_json::from_slice(&wallet_json).map_err(|error| {
-                Box::new(self.pending_verification_failure(
-                    completion,
-                    format!("deserialize wallet {record_id}: {error}"),
-                ))
-            })?;
-
-        if encrypted.version != 1 {
-            return Ok(PendingWalletVerificationOutcome::Unsupported);
-        }
-
-        match wallet_crypto::decrypt_wallet_backup(&encrypted, critical_key) {
-            Ok(_) => Ok(PendingWalletVerificationOutcome::Verified),
-            Err(error) => {
-                warn!("Pending verification: failed to decrypt wallet {record_id}: {error}");
-                Ok(PendingWalletVerificationOutcome::Failed)
-            }
-        }
-    }
-
-    fn pending_verification_detail(
-        &self,
-        completion: &PendingVerificationCompletion,
-    ) -> Option<super::CloudBackupDetail> {
-        match self.refresh_cloud_backup_detail() {
-            Some(CloudBackupDetailResult::Success(detail)) => Some(detail),
-            Some(CloudBackupDetailResult::AccessError(error)) => {
-                warn!("Pending verification: failed to refresh detail: {error}");
-                completion.report().detail.clone()
-            }
-            None => completion.report().detail.clone(),
-        }
-    }
-
-    fn pending_verification_failure(
-        &self,
-        completion: &PendingVerificationCompletion,
-        message: impl Into<String>,
-    ) -> DeepVerificationFailure {
-        DeepVerificationFailure {
-            kind: VerificationFailureKind::Retry,
-            message: message.into(),
-            detail: self.pending_verification_detail(completion),
-        }
-    }
-
-    pub(crate) fn apply_verified_report(&self, report: DeepVerificationReport) {
-        self.persist_verification_result(&DeepVerificationResult::Verified(report.clone()));
-        if let Some(detail) = &report.detail {
-            self.set_detail(Some(detail.clone()));
-        }
-        self.set_verification(VerificationState::Verified(report));
-        self.set_recovery(RecoveryState::Idle);
-    }
-
-    pub(crate) fn apply_failed_verification(&self, failure: DeepVerificationFailure) {
-        self.persist_verification_result(&DeepVerificationResult::Failed(failure.clone()));
-        if let Some(detail) = failure.detail.clone() {
-            self.set_detail(Some(detail));
-        }
-        self.set_verification(VerificationState::Failed(failure));
-    }
-
     pub(crate) fn do_deep_verify_cloud_backup(
         &self,
         force_discoverable: bool,
@@ -484,7 +235,7 @@ impl RustCloudBackupManager {
             }
         };
 
-        let encrypted: cove_cspp::backup_data::EncryptedMasterKeyBackup =
+        let encrypted: EncryptedMasterKeyBackup =
             serde_json::from_slice(&master_json).map_err_str(CloudBackupError::Internal)?;
         if encrypted.version != 1 {
             let version = encrypted.version;
@@ -524,27 +275,6 @@ impl RustCloudBackupManager {
 
         info!("Recovered local master key from cloud");
         Ok(master_key)
-    }
-}
-
-impl RustCloudBackupManager {
-    fn persist_integrity_downgrade(&self, downgrade: Option<IntegrityDowngrade>) {
-        let Some(downgrade) = downgrade else {
-            return;
-        };
-
-        info!("Cloud backup integrity: applying downgrade={downgrade:?}");
-
-        let current = RustCloudBackupManager::load_persisted_state();
-        let Some(new_state) = downgrade_cloud_backup_state(&current, downgrade) else {
-            return;
-        };
-
-        if let Err(error) =
-            self.persist_cloud_backup_state(&new_state, "persist backup integrity state")
-        {
-            error!("Failed to persist backup integrity state: {error}");
-        };
     }
 }
 

--- a/rust/src/manager/cloud_backup_manager/verify/integrity.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/integrity.rs
@@ -1,0 +1,235 @@
+use cove_cspp::CsppStore as _;
+use cove_device::cloud_storage::CloudStorage;
+use cove_device::keychain::{CSPP_PRF_SALT_KEY, Keychain};
+use tracing::{error, info, warn};
+
+use super::super::cloud_inventory::CloudWalletInventory;
+use super::super::wallets::{count_all_wallets, persist_enabled_cloud_backup_state};
+use super::{
+    CloudBackupStatus, IntegrityDowngrade, RustCloudBackupManager, downgrade_cloud_backup_state,
+    load_stored_credential_id,
+};
+use crate::database::Database;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackupIntegrityIssue {
+    MasterKeyMissing,
+    PasskeyCredentialMissing,
+    PasskeySaltMissing,
+    NamespaceMissing,
+    RemoteWalletListUnreadable,
+    RemoteBackupFreshnessUnknown,
+    LocalWalletInventoryUnreadable,
+    WalletsNotBackedUp,
+}
+
+impl BackupIntegrityIssue {
+    fn message(&self) -> &'static str {
+        match self {
+            Self::MasterKeyMissing => "master key not found in keychain",
+            Self::PasskeyCredentialMissing => {
+                "passkey credential not found — open Cloud Backup in Settings to re-verify"
+            }
+            Self::PasskeySaltMissing => {
+                "passkey salt not found — open Cloud Backup in Settings to re-verify"
+            }
+            Self::NamespaceMissing => "namespace_id not found in keychain",
+            Self::RemoteWalletListUnreadable => "wallet backups could not be listed",
+            Self::RemoteBackupFreshnessUnknown => "remote backup freshness could not be checked",
+            Self::LocalWalletInventoryUnreadable => "local wallet inventory could not be read",
+            Self::WalletsNotBackedUp => "some wallets are not backed up",
+        }
+    }
+}
+
+impl RustCloudBackupManager {
+    /// Background startup health check for cloud backup integrity
+    ///
+    /// Verifies the master key is in the keychain and backup files exist in iCloud
+    /// Returns None if everything is OK, Some(warning) if there's a problem
+    pub fn verify_backup_integrity_impl(&self) -> Option<String> {
+        let state = self.state.read().status.clone();
+        if !matches!(state, CloudBackupStatus::Enabled | CloudBackupStatus::PasskeyMissing) {
+            return None;
+        }
+
+        let mut issues = Vec::new();
+
+        let keychain = Keychain::global();
+        let cspp = cove_cspp::Cspp::new(keychain.clone());
+        if !cspp.has_master_key() {
+            issues.push(BackupIntegrityIssue::MasterKeyMissing);
+        }
+
+        let mut downgrade = None;
+        let has_prf_salt = keychain.get(CSPP_PRF_SALT_KEY.into()).is_some();
+        let stored_credential_id = load_stored_credential_id(keychain);
+
+        // keep launch integrity checks non-interactive so app startup never presents passkey UI
+        if stored_credential_id.is_none() {
+            issues.push(BackupIntegrityIssue::PasskeyCredentialMissing);
+            downgrade = Some(IntegrityDowngrade::Unverified);
+        }
+
+        if !has_prf_salt {
+            issues.push(BackupIntegrityIssue::PasskeySaltMissing);
+            downgrade = Some(IntegrityDowngrade::Unverified);
+        }
+
+        let namespace = match self.current_namespace_id() {
+            Ok(namespace) => namespace,
+            Err(_) => {
+                issues.push(BackupIntegrityIssue::NamespaceMissing);
+                return self.finish_backup_integrity_check(&issues, downgrade);
+            }
+        };
+
+        if !issues.is_empty() {
+            return self.finish_backup_integrity_check(&issues, downgrade);
+        }
+
+        self.verify_wallet_backups(namespace, &mut issues);
+        self.finish_backup_integrity_check(&issues, downgrade)
+    }
+
+    fn verify_wallet_backups(&self, namespace: String, issues: &mut Vec<BackupIntegrityIssue>) {
+        let cloud = CloudStorage::global();
+        let wallet_record_ids = match cloud.list_wallet_backups(namespace.clone()) {
+            Ok(wallet_record_ids) => wallet_record_ids,
+            Err(error) => {
+                warn!("Backup integrity: wallet list check failed: {error}");
+                issues.push(BackupIntegrityIssue::RemoteWalletListUnreadable);
+                return;
+            }
+        };
+
+        let remote_wallet_truth = match self.load_remote_wallet_truth(&wallet_record_ids) {
+            Ok(remote_wallet_truth) => remote_wallet_truth,
+            Err(error) => {
+                warn!("Backup integrity: remote truth refresh failed: {error}");
+                issues.push(BackupIntegrityIssue::RemoteBackupFreshnessUnknown);
+                return;
+            }
+        };
+
+        let inventory = match CloudWalletInventory::load_with_remote_truth(
+            &wallet_record_ids,
+            remote_wallet_truth,
+        ) {
+            Ok(inventory) => inventory,
+            Err(error) => {
+                warn!("Backup integrity: local wallet inventory failed: {error}");
+                issues.push(BackupIntegrityIssue::LocalWalletInventoryUnreadable);
+                return;
+            }
+        };
+
+        self.set_detail(Some(inventory.build_detail()));
+
+        let unsynced = inventory.upload_candidate_wallets();
+        let handled_unsynced = !unsynced.is_empty();
+        let mut backup_failed = false;
+        if handled_unsynced {
+            let backup_result = self.do_backup_wallets(&unsynced);
+            self.refresh_integrity_detail(&namespace, &wallet_record_ids);
+            if let Err(error) = backup_result {
+                error!("Backup integrity: auto-sync failed: {error}");
+                issues.push(BackupIntegrityIssue::WalletsNotBackedUp);
+                backup_failed = true;
+            }
+        }
+
+        let db = Database::global();
+        if db.cloud_backup_state.get().ok().and_then(|state| state.wallet_count).is_none() {
+            match count_all_wallets(&db) {
+                Ok(local_count) => {
+                    let _ = persist_enabled_cloud_backup_state(&db, local_count);
+                }
+                Err(error) => {
+                    warn!("Backup integrity: local wallet count failed: {error}");
+                }
+            }
+        }
+
+        if !backup_failed
+            && !handled_unsynced
+            && wallet_record_ids.is_empty()
+            && count_all_wallets(&db).unwrap_or_default() > 0
+        {
+            let sync_result = self.do_sync_unsynced_wallets();
+            self.refresh_integrity_detail(&namespace, &wallet_record_ids);
+            if let Err(error) = sync_result {
+                error!("Backup integrity: auto-sync failed: {error}");
+                issues.push(BackupIntegrityIssue::WalletsNotBackedUp);
+            }
+        }
+    }
+
+    fn refresh_integrity_detail(&self, namespace: &str, fallback_wallet_record_ids: &[String]) {
+        let cloud = CloudStorage::global();
+        let wallet_record_ids = match cloud.list_wallet_backups(namespace.to_string()) {
+            Ok(wallet_record_ids) => wallet_record_ids,
+            Err(error) => {
+                warn!("Backup integrity: detail relist failed: {error}");
+                fallback_wallet_record_ids.to_vec()
+            }
+        };
+
+        let remote_wallet_truth = match self.load_remote_wallet_truth(&wallet_record_ids) {
+            Ok(remote_wallet_truth) => remote_wallet_truth,
+            Err(error) => {
+                warn!("Backup integrity: detail remote truth refresh failed: {error}");
+                return;
+            }
+        };
+
+        let inventory = match CloudWalletInventory::load_with_remote_truth(
+            &wallet_record_ids,
+            remote_wallet_truth,
+        ) {
+            Ok(inventory) => inventory,
+            Err(error) => {
+                warn!("Backup integrity: detail refresh failed: {error}");
+                return;
+            }
+        };
+
+        self.set_detail(Some(inventory.build_detail()));
+    }
+
+    fn finish_backup_integrity_check(
+        &self,
+        issues: &[BackupIntegrityIssue],
+        downgrade: Option<IntegrityDowngrade>,
+    ) -> Option<String> {
+        if issues.is_empty() {
+            info!("Backup integrity check passed");
+            return None;
+        }
+
+        self.persist_integrity_downgrade(downgrade);
+        let message =
+            issues.iter().map(BackupIntegrityIssue::message).collect::<Vec<_>>().join("; ");
+        error!("Backup integrity issues: {message}");
+        Some(message)
+    }
+
+    fn persist_integrity_downgrade(&self, downgrade: Option<IntegrityDowngrade>) {
+        let Some(downgrade) = downgrade else {
+            return;
+        };
+
+        info!("Cloud backup integrity: applying downgrade={downgrade:?}");
+
+        let current = RustCloudBackupManager::load_persisted_state();
+        let Some(new_state) = downgrade_cloud_backup_state(&current, downgrade) else {
+            return;
+        };
+
+        if let Err(error) =
+            self.persist_cloud_backup_state(&new_state, "persist backup integrity state")
+        {
+            error!("Failed to persist backup integrity state: {error}");
+        };
+    }
+}

--- a/rust/src/manager/cloud_backup_manager/verify/passkey_auth.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/passkey_auth.rs
@@ -97,7 +97,7 @@ pub(super) fn authenticate_with_policy(
     }))
 }
 
-impl VerificationSession<'_> {
+impl VerificationSession {
     pub(super) fn authenticate_with_fallback(
         &self,
         prf_salt: &[u8; 32],

--- a/rust/src/manager/cloud_backup_manager/verify/pending_completion.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/pending_completion.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::database::Database;
 use crate::database::cloud_backup::{CloudBlobConfirmedState, PersistedCloudBlobState};
 use crate::manager::cloud_backup_manager::{
-    PendingVerificationUpload,
+    CloudBackupDetail, PendingVerificationUpload,
     wallets::{WalletBackupLookup, WalletBackupReader},
 };
 
@@ -27,25 +27,6 @@ enum PendingWalletVerificationOutcome {
 enum FinalizePendingVerificationResult {
     Pending,
     Completed(DeepVerificationReport),
-}
-
-fn sync_state_revision_hash(sync_state: Option<&PersistedCloudBlobState>) -> Option<&str> {
-    match sync_state {
-        Some(PersistedCloudBlobState::Uploading(state)) => Some(&state.revision_hash),
-        Some(PersistedCloudBlobState::UploadedPendingConfirmation(state)) => {
-            Some(&state.revision_hash)
-        }
-        Some(PersistedCloudBlobState::Confirmed(state)) => Some(&state.revision_hash),
-        Some(PersistedCloudBlobState::Failed(state)) => state.revision_hash.as_deref(),
-        Some(PersistedCloudBlobState::Dirty(_)) | None => None,
-    }
-}
-
-fn pending_verification_target_revision<'a>(
-    upload: &'a PendingVerificationUpload,
-    sync_state: Option<&'a PersistedCloudBlobState>,
-) -> &'a str {
-    sync_state_revision_hash(sync_state).unwrap_or(upload.expected_revision())
 }
 
 impl RustCloudBackupManager {
@@ -84,28 +65,35 @@ impl RustCloudBackupManager {
         completion.uploads().iter().all(|upload| {
             let sync_state = sync_states_by_record_id.get(upload.record_id());
 
-            match sync_state {
-                Some(PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
-                    revision_hash,
-                    ..
-                })) => revision_hash == pending_verification_target_revision(upload, sync_state),
-                Some(PersistedCloudBlobState::Failed(_)) => true,
-                Some(PersistedCloudBlobState::UploadedPendingConfirmation(_)) => {
-                    CloudStorage::global()
-                        .download_wallet_backup(
-                            completion.namespace_id().to_string(),
-                            upload.record_id().to_string(),
-                        )
-                        .map(|_| true)
-                        .or_else(|error| match error {
-                            CloudStorageError::NotFound(_) => Ok(false),
-                            other => Err(other),
-                        })
-                        .unwrap_or(false)
-                }
-                _ => false,
-            }
+            self.is_pending_upload_confirmed(completion, upload, sync_state)
         })
+    }
+
+    fn is_pending_upload_confirmed(
+        &self,
+        completion: &PendingVerificationCompletion,
+        upload: &PendingVerificationUpload,
+        sync_state: Option<&PersistedCloudBlobState>,
+    ) -> bool {
+        match sync_state {
+            Some(PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
+                revision_hash,
+                ..
+            })) => revision_hash.as_str() == upload.target_revision(sync_state),
+            Some(PersistedCloudBlobState::Failed(_)) => true,
+            Some(PersistedCloudBlobState::UploadedPendingConfirmation(_)) => CloudStorage::global()
+                .download_wallet_backup(
+                    completion.namespace_id().to_string(),
+                    upload.record_id().to_string(),
+                )
+                .map(|_| true)
+                .or_else(|error| match error {
+                    CloudStorageError::NotFound(_) => Ok(false),
+                    other => Err(other),
+                })
+                .unwrap_or(false),
+            _ => false,
+        }
     }
 
     fn finalize_pending_verification(
@@ -165,7 +153,7 @@ impl RustCloudBackupManager {
         critical_key: &[u8; 32],
     ) -> Result<PendingWalletVerificationOutcome, Box<DeepVerificationFailure>> {
         let record_id = upload.record_id();
-        let expected_revision = pending_verification_target_revision(upload, sync_state);
+        let expected_revision = upload.target_revision(sync_state);
         let reader = WalletBackupReader::new(
             CloudStorage::global().clone(),
             completion.namespace_id().to_string(),
@@ -173,17 +161,16 @@ impl RustCloudBackupManager {
         );
 
         match reader.summary(record_id) {
-            Ok(WalletBackupLookup::Found(summary)) => {
-                if summary.revision_hash != expected_revision {
-                    warn!(
-                        "Pending verification: wallet {record_id} is still stale expected_revision={} actual_revision={}",
-                        expected_revision, summary.revision_hash
-                    );
-                    return Ok(PendingWalletVerificationOutcome::Pending);
-                }
-
-                Ok(PendingWalletVerificationOutcome::Verified)
+            Ok(WalletBackupLookup::Found(summary))
+                if summary.revision_hash != expected_revision =>
+            {
+                warn!(
+                    "Pending verification: wallet {record_id} is still stale expected_revision={} actual_revision={}",
+                    expected_revision, summary.revision_hash
+                );
+                Ok(PendingWalletVerificationOutcome::Pending)
             }
+            Ok(WalletBackupLookup::Found(_)) => Ok(PendingWalletVerificationOutcome::Verified),
             Ok(WalletBackupLookup::NotFound) => {
                 warn!("Pending verification: wallet {record_id} is not ready yet: not found");
                 Ok(PendingWalletVerificationOutcome::Pending)
@@ -205,7 +192,7 @@ impl RustCloudBackupManager {
     fn pending_verification_detail(
         &self,
         completion: &PendingVerificationCompletion,
-    ) -> Option<super::super::CloudBackupDetail> {
+    ) -> Option<CloudBackupDetail> {
         match self.refresh_cloud_backup_detail() {
             Some(CloudBackupDetailResult::Success(detail)) => Some(detail),
             Some(CloudBackupDetailResult::AccessError(error)) => {

--- a/rust/src/manager/cloud_backup_manager/verify/pending_completion.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/pending_completion.rs
@@ -1,0 +1,247 @@
+use ahash::HashMap;
+use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
+use cove_device::keychain::Keychain;
+use cove_util::ResultExt as _;
+use tracing::warn;
+use zeroize::Zeroizing;
+
+use super::{
+    CloudBackupDetailResult, CloudBackupError, DeepVerificationFailure, DeepVerificationReport,
+    DeepVerificationResult, PendingVerificationCompletion, RecoveryState, RustCloudBackupManager,
+    VerificationFailureKind, VerificationState,
+};
+use crate::database::Database;
+use crate::database::cloud_backup::{CloudBlobConfirmedState, PersistedCloudBlobState};
+use crate::manager::cloud_backup_manager::{
+    PendingVerificationUpload,
+    wallets::{WalletBackupLookup, WalletBackupReader},
+};
+
+enum PendingWalletVerificationOutcome {
+    Pending,
+    Verified,
+    Failed,
+    Unsupported,
+}
+
+enum FinalizePendingVerificationResult {
+    Pending,
+    Completed(DeepVerificationReport),
+}
+
+fn sync_state_revision_hash(sync_state: Option<&PersistedCloudBlobState>) -> Option<&str> {
+    match sync_state {
+        Some(PersistedCloudBlobState::Uploading(state)) => Some(&state.revision_hash),
+        Some(PersistedCloudBlobState::UploadedPendingConfirmation(state)) => {
+            Some(&state.revision_hash)
+        }
+        Some(PersistedCloudBlobState::Confirmed(state)) => Some(&state.revision_hash),
+        Some(PersistedCloudBlobState::Failed(state)) => state.revision_hash.as_deref(),
+        Some(PersistedCloudBlobState::Dirty(_)) | None => None,
+    }
+}
+
+fn pending_verification_target_revision<'a>(
+    upload: &'a PendingVerificationUpload,
+    sync_state: Option<&'a PersistedCloudBlobState>,
+) -> &'a str {
+    sync_state_revision_hash(sync_state).unwrap_or(upload.expected_revision())
+}
+
+impl RustCloudBackupManager {
+    pub(crate) fn finalize_pending_verification_if_ready(&self) {
+        let Some(completion) = self.pending_verification_completion() else { return };
+
+        if !self.pending_verification_uploads_confirmed(&completion) {
+            return;
+        }
+
+        match self.finalize_pending_verification(completion.clone()) {
+            Ok(FinalizePendingVerificationResult::Pending) => return,
+            Ok(FinalizePendingVerificationResult::Completed(report)) => {
+                self.apply_verified_report(report)
+            }
+            Err(failure) => self.apply_failed_verification(*failure),
+        }
+
+        self.clear_pending_verification_completion();
+    }
+
+    fn pending_verification_uploads_confirmed(
+        &self,
+        completion: &PendingVerificationCompletion,
+    ) -> bool {
+        let sync_states_by_record_id: HashMap<_, _> = Database::global()
+            .cloud_blob_sync_states
+            .list()
+            .ok()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|state| state.namespace_id == completion.namespace_id())
+            .map(|state| (state.record_id.clone(), state.state))
+            .collect();
+
+        completion.uploads().iter().all(|upload| {
+            let sync_state = sync_states_by_record_id.get(upload.record_id());
+
+            match sync_state {
+                Some(PersistedCloudBlobState::Confirmed(CloudBlobConfirmedState {
+                    revision_hash,
+                    ..
+                })) => revision_hash == pending_verification_target_revision(upload, sync_state),
+                Some(PersistedCloudBlobState::Failed(_)) => true,
+                Some(PersistedCloudBlobState::UploadedPendingConfirmation(_)) => {
+                    CloudStorage::global()
+                        .download_wallet_backup(
+                            completion.namespace_id().to_string(),
+                            upload.record_id().to_string(),
+                        )
+                        .map(|_| true)
+                        .or_else(|error| match error {
+                            CloudStorageError::NotFound(_) => Ok(false),
+                            other => Err(other),
+                        })
+                        .unwrap_or(false)
+                }
+                _ => false,
+            }
+        })
+    }
+
+    fn finalize_pending_verification(
+        &self,
+        completion: PendingVerificationCompletion,
+    ) -> Result<FinalizePendingVerificationResult, Box<DeepVerificationFailure>> {
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        let master_key = cspp
+            .load_master_key_from_store()
+            .map_err_prefix("load local master key", CloudBackupError::Internal)
+            .map_err(|error| {
+                Box::new(self.pending_verification_failure(&completion, error.to_string()))
+            })?
+            .ok_or_else(|| {
+                Box::new(
+                    self.pending_verification_failure(&completion, "no local master key available"),
+                )
+            })?;
+
+        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let mut report = completion.report().clone();
+        let sync_states_by_record_id: HashMap<_, _> = Database::global()
+            .cloud_blob_sync_states
+            .list()
+            .ok()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|state| state.namespace_id == completion.namespace_id())
+            .map(|state| (state.record_id.clone(), state.state))
+            .collect();
+
+        for upload in completion.uploads() {
+            match self.verify_pending_wallet_backup(
+                &completion,
+                upload,
+                sync_states_by_record_id.get(upload.record_id()),
+                &critical_key,
+            )? {
+                PendingWalletVerificationOutcome::Pending => {
+                    return Ok(FinalizePendingVerificationResult::Pending);
+                }
+                PendingWalletVerificationOutcome::Verified => report.wallets_verified += 1,
+                PendingWalletVerificationOutcome::Failed => report.wallets_failed += 1,
+                PendingWalletVerificationOutcome::Unsupported => report.wallets_unsupported += 1,
+            }
+        }
+
+        report.detail = self.pending_verification_detail(&completion);
+        Ok(FinalizePendingVerificationResult::Completed(report))
+    }
+
+    fn verify_pending_wallet_backup(
+        &self,
+        completion: &PendingVerificationCompletion,
+        upload: &PendingVerificationUpload,
+        sync_state: Option<&PersistedCloudBlobState>,
+        critical_key: &[u8; 32],
+    ) -> Result<PendingWalletVerificationOutcome, Box<DeepVerificationFailure>> {
+        let record_id = upload.record_id();
+        let expected_revision = pending_verification_target_revision(upload, sync_state);
+        let reader = WalletBackupReader::new(
+            CloudStorage::global().clone(),
+            completion.namespace_id().to_string(),
+            Zeroizing::new(*critical_key),
+        );
+
+        match reader.summary(record_id) {
+            Ok(WalletBackupLookup::Found(summary)) => {
+                if summary.revision_hash != expected_revision {
+                    warn!(
+                        "Pending verification: wallet {record_id} is still stale expected_revision={} actual_revision={}",
+                        expected_revision, summary.revision_hash
+                    );
+                    return Ok(PendingWalletVerificationOutcome::Pending);
+                }
+
+                Ok(PendingWalletVerificationOutcome::Verified)
+            }
+            Ok(WalletBackupLookup::NotFound) => {
+                warn!("Pending verification: wallet {record_id} is not ready yet: not found");
+                Ok(PendingWalletVerificationOutcome::Pending)
+            }
+            Ok(WalletBackupLookup::UnsupportedVersion(_)) => {
+                Ok(PendingWalletVerificationOutcome::Unsupported)
+            }
+            Err(CloudBackupError::Cloud(error)) => {
+                warn!("Pending verification: wallet {record_id} is not ready yet: {error}");
+                Ok(PendingWalletVerificationOutcome::Pending)
+            }
+            Err(error) => {
+                warn!("Pending verification: failed to decrypt wallet {record_id}: {error}");
+                Ok(PendingWalletVerificationOutcome::Failed)
+            }
+        }
+    }
+
+    fn pending_verification_detail(
+        &self,
+        completion: &PendingVerificationCompletion,
+    ) -> Option<super::super::CloudBackupDetail> {
+        match self.refresh_cloud_backup_detail() {
+            Some(CloudBackupDetailResult::Success(detail)) => Some(detail),
+            Some(CloudBackupDetailResult::AccessError(error)) => {
+                warn!("Pending verification: failed to refresh detail: {error}");
+                completion.report().detail.clone()
+            }
+            None => completion.report().detail.clone(),
+        }
+    }
+
+    fn pending_verification_failure(
+        &self,
+        completion: &PendingVerificationCompletion,
+        message: impl Into<String>,
+    ) -> DeepVerificationFailure {
+        DeepVerificationFailure {
+            kind: VerificationFailureKind::Retry,
+            message: message.into(),
+            detail: self.pending_verification_detail(completion),
+        }
+    }
+
+    pub(crate) fn apply_verified_report(&self, report: DeepVerificationReport) {
+        self.persist_verification_result(&DeepVerificationResult::Verified(report.clone()));
+        if let Some(detail) = &report.detail {
+            self.set_detail(Some(detail.clone()));
+        }
+        self.set_verification(VerificationState::Verified(report));
+        self.set_recovery(RecoveryState::Idle);
+    }
+
+    pub(crate) fn apply_failed_verification(&self, failure: DeepVerificationFailure) {
+        self.persist_verification_result(&DeepVerificationResult::Failed(failure.clone()));
+        if let Some(detail) = failure.detail.clone() {
+            self.set_detail(Some(detail));
+        }
+        self.set_verification(VerificationState::Failed(failure));
+    }
+}

--- a/rust/src/manager/cloud_backup_manager/verify/session.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/session.rs
@@ -35,8 +35,8 @@ enum MasterKeyResolution {
     Finished(DeepVerificationResult),
 }
 
-pub(crate) struct VerificationSession<'a> {
-    pub(crate) manager: &'a RustCloudBackupManager,
+pub(crate) struct VerificationSession {
+    pub(crate) manager: RustCloudBackupManager,
     pub(crate) keychain: Keychain,
     pub(crate) cspp: cove_cspp::Cspp<Keychain>,
     pub(crate) cloud: CloudStorage,
@@ -49,9 +49,9 @@ pub(crate) struct VerificationSession<'a> {
     pub(crate) force_discoverable: bool,
 }
 
-impl<'a> VerificationSession<'a> {
+impl VerificationSession {
     pub(crate) fn new(
-        manager: &'a RustCloudBackupManager,
+        manager: &RustCloudBackupManager,
         force_discoverable: bool,
     ) -> Result<Self, CloudBackupError> {
         let keychain = Keychain::global().clone();
@@ -61,7 +61,7 @@ impl<'a> VerificationSession<'a> {
             .map_err_prefix("load local master key", CloudBackupError::Internal)?;
 
         Ok(Self {
-            manager,
+            manager: manager.clone(),
             keychain,
             cspp,
             cloud: CloudStorage::global().clone(),

--- a/rust/src/manager/cloud_backup_manager/verify/session.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/session.rs
@@ -61,7 +61,7 @@ impl<'a> VerificationSession<'a> {
             .map_err_prefix("load local master key", CloudBackupError::Internal)?;
 
         Ok(Self {
-            manager: manager.clone(),
+            manager,
             keychain,
             cspp,
             cloud: CloudStorage::global().clone(),

--- a/rust/src/manager/cloud_backup_manager/verify/session.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/session.rs
@@ -1,6 +1,6 @@
+use cove_cspp::backup_data::EncryptedMasterKeyBackup;
 use cove_cspp::master_key::MasterKey;
 use cove_cspp::master_key_crypto;
-use cove_cspp::wallet_crypto;
 use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
 use cove_device::keychain::Keychain;
 use cove_device::passkey::{PasskeyAccess, PasskeyCredentialPresence};
@@ -10,45 +10,47 @@ use zeroize::Zeroizing;
 
 use super::super::{
     CloudBackupDetail, CloudBackupError, DeepVerificationFailure, DeepVerificationReport,
-    DeepVerificationResult, PASSKEY_RP_ID, PendingVerificationCompletion, RustCloudBackupManager,
-    VerificationFailureKind, cloud_inventory::CloudWalletInventory,
+    DeepVerificationResult, PASSKEY_RP_ID, PendingVerificationCompletion,
+    PendingVerificationUpload, RustCloudBackupManager, VerificationFailureKind,
+    cloud_inventory::CloudWalletInventory,
+    wallets::{WalletBackupLookup, WalletBackupReader, prepare_wallet_backup},
 };
 use super::load_stored_credential_id;
 use super::passkey_auth::PasskeyAuthOutcome;
 use super::wrapper_repair::{WrapperRepairError, WrapperRepairOperation, WrapperRepairStrategy};
-use crate::manager::cloud_backup_manager::pending::cleanup_confirmed_pending_blobs;
+use crate::manager::cloud_backup_manager::pending::remote_wallet_revision_matches;
 
 const RECREATE_WARNING: &str = "Recreating from this device will remove references to wallets that only exist in the cloud backup";
 const REINITIALIZE_WARNING: &str = "This will replace your entire cloud backup set. Wallets that only exist in the cloud backup will be lost";
 
-pub(super) enum EncryptedMasterKeyStep {
-    Loaded(cove_cspp::backup_data::EncryptedMasterKeyBackup),
+enum EncryptedMasterKeyStep {
+    Loaded(EncryptedMasterKeyBackup),
     Missing,
     Finished(DeepVerificationResult),
 }
 
-pub(super) enum MasterKeyResolution {
+enum MasterKeyResolution {
     VerifiedCloudMasterKey(MasterKey),
     NeedsWrapperRepair { reuse_credential_id: Option<Vec<u8>> },
     Finished(DeepVerificationResult),
 }
 
-pub(super) struct VerificationSession<'a> {
-    pub(super) manager: &'a RustCloudBackupManager,
-    pub(super) keychain: Keychain,
-    pub(super) cspp: cove_cspp::Cspp<Keychain>,
-    pub(super) cloud: CloudStorage,
-    pub(super) passkey: PasskeyAccess,
-    pub(super) namespace: String,
-    pub(super) report: DeepVerificationReport,
-    pub(super) local_master_key: Option<MasterKey>,
-    pub(super) wallet_record_ids: Option<Vec<String>>,
-    pub(super) wallets_missing: bool,
-    pub(super) force_discoverable: bool,
+pub(crate) struct VerificationSession<'a> {
+    pub(crate) manager: &'a RustCloudBackupManager,
+    pub(crate) keychain: Keychain,
+    pub(crate) cspp: cove_cspp::Cspp<Keychain>,
+    pub(crate) cloud: CloudStorage,
+    pub(crate) passkey: PasskeyAccess,
+    pub(crate) namespace: String,
+    pub(crate) report: DeepVerificationReport,
+    pub(crate) local_master_key: Option<MasterKey>,
+    pub(crate) wallet_record_ids: Option<Vec<String>>,
+    pub(crate) wallets_missing: bool,
+    pub(crate) force_discoverable: bool,
 }
 
 impl<'a> VerificationSession<'a> {
-    pub(super) fn new(
+    pub(crate) fn new(
         manager: &'a RustCloudBackupManager,
         force_discoverable: bool,
     ) -> Result<Self, CloudBackupError> {
@@ -81,7 +83,7 @@ impl<'a> VerificationSession<'a> {
         })
     }
 
-    pub(super) fn run(mut self) -> Result<DeepVerificationResult, CloudBackupError> {
+    pub(crate) fn run(mut self) -> Result<DeepVerificationResult, CloudBackupError> {
         if let Some(result) = self.load_wallet_inventory() {
             return Ok(result);
         }
@@ -128,15 +130,21 @@ impl<'a> VerificationSession<'a> {
     fn load_wallet_inventory(&mut self) -> Option<DeepVerificationResult> {
         match self.cloud.list_wallet_backups(self.namespace.clone()) {
             Ok(ids) => {
-                let listed: std::collections::HashSet<_> = ids.iter().cloned().collect();
-                cleanup_confirmed_pending_blobs(&listed);
+                let remote_wallet_truth = match self.manager.load_remote_wallet_truth(&ids) {
+                    Ok(remote_wallet_truth) => remote_wallet_truth,
+                    Err(error) => return Some(self.remote_truth_retry_result(&error)),
+                };
+                self.manager.cleanup_confirmed_pending_blobs(&remote_wallet_truth);
 
-                let inventory = match CloudWalletInventory::load_strict(&ids) {
-                    Ok(inventory) => inventory,
+                let detail = match self
+                    .manager
+                    .build_cloud_backup_detail_with_remote_truth(&ids, remote_wallet_truth)
+                {
+                    Ok(detail) => detail,
                     Err(error) => return Some(self.local_inventory_retry_result(&error)),
                 };
 
-                self.report.detail = Some(inventory.build_detail());
+                self.report.detail = Some(detail);
                 self.wallet_record_ids = Some(ids);
                 None
             }
@@ -154,7 +162,7 @@ impl<'a> VerificationSession<'a> {
     fn load_encrypted_master_key(&self) -> Result<EncryptedMasterKeyStep, CloudBackupError> {
         match self.cloud.download_master_key_backup(self.namespace.clone()) {
             Ok(json) => {
-                let encrypted: cove_cspp::backup_data::EncryptedMasterKeyBackup =
+                let encrypted: EncryptedMasterKeyBackup =
                     serde_json::from_slice(&json).map_err_str(CloudBackupError::Internal)?;
 
                 if encrypted.version != 1 {
@@ -191,7 +199,7 @@ impl<'a> VerificationSession<'a> {
 
     fn resolve_master_key_step(
         &mut self,
-        encrypted_master: Option<&cove_cspp::backup_data::EncryptedMasterKeyBackup>,
+        encrypted_master: Option<&EncryptedMasterKeyBackup>,
     ) -> Result<MasterKeyResolution, CloudBackupError> {
         let Some(encrypted_master) = encrypted_master else {
             return Ok(MasterKeyResolution::NeedsWrapperRepair { reuse_credential_id: None });
@@ -320,9 +328,26 @@ impl<'a> VerificationSession<'a> {
         self.report.wallets_verified = verified;
         self.report.wallets_failed = failed;
         self.report.wallets_unsupported = unsupported;
+        let remote_wallet_truth = match self.manager.load_remote_wallet_truth(&wallet_record_ids) {
+            Ok(remote_wallet_truth) => remote_wallet_truth,
+            Err(error) => return Some(self.remote_truth_retry_result(&error)),
+        };
 
-        let unsynced = match CloudWalletInventory::load_strict(&wallet_record_ids) {
-            Ok(inventory) => inventory.unsynced_local_wallets(),
+        let unsynced = match CloudWalletInventory::load_with_remote_truth(
+            &wallet_record_ids,
+            remote_wallet_truth,
+        ) {
+            Ok(inventory) => {
+                let detail = inventory.build_detail();
+                self.report.detail = Some(detail.clone());
+                if inventory.has_unknown_remote_wallets() {
+                    return Some(
+                        self.retry_result("failed to refresh remote wallet truth for some wallets"),
+                    );
+                }
+
+                inventory.upload_candidate_wallets()
+            }
             Err(error) => return Some(self.local_inventory_retry_result(&error)),
         };
 
@@ -338,6 +363,17 @@ impl<'a> VerificationSession<'a> {
                 self.retry_result(format!("failed to auto-sync missing wallet backups: {error}")),
             );
         }
+        let pending_uploads = match unsynced
+            .iter()
+            .map(|wallet| {
+                let prepared = prepare_wallet_backup(wallet, wallet.wallet_mode)?;
+                Ok(PendingVerificationUpload::new(prepared.record_id, prepared.revision_hash))
+            })
+            .collect::<Result<Vec<_>, CloudBackupError>>()
+        {
+            Ok(pending_uploads) => pending_uploads,
+            Err(error) => return Some(self.local_inventory_retry_result(&error)),
+        };
 
         let updated_ids = match self.cloud.list_wallet_backups(self.namespace.clone()) {
             Ok(updated_ids) => updated_ids,
@@ -349,35 +385,57 @@ impl<'a> VerificationSession<'a> {
             }
         };
 
-        let listed: std::collections::HashSet<_> = updated_ids.iter().cloned().collect();
-        cleanup_confirmed_pending_blobs(&listed);
-
-        let inventory = match CloudWalletInventory::load_strict(&updated_ids) {
-            Ok(inventory) => inventory,
-            Err(error) => return Some(self.local_inventory_retry_result(&error)),
+        let remote_wallet_truth = match self.manager.load_remote_wallet_truth(&updated_ids) {
+            Ok(remote_wallet_truth) => remote_wallet_truth,
+            Err(error) => return Some(self.remote_truth_retry_result(&error)),
         };
+        self.manager.cleanup_confirmed_pending_blobs(&remote_wallet_truth);
+        let unconfirmed_pending_uploads = pending_uploads
+            .iter()
+            .filter(|upload| {
+                !remote_wallet_revision_matches(
+                    &remote_wallet_truth,
+                    upload.record_id(),
+                    upload.expected_revision(),
+                )
+            })
+            .count();
+        let inventory =
+            match CloudWalletInventory::load_with_remote_truth(&updated_ids, remote_wallet_truth) {
+                Ok(inventory) => inventory,
+                Err(error) => return Some(self.local_inventory_retry_result(&error)),
+            };
+        let listed: std::collections::HashSet<_> = updated_ids.iter().cloned().collect();
 
-        let remaining_unsynced = inventory.unsynced_local_wallets();
+        let remaining_unsynced = inventory.upload_candidate_wallets();
         self.report.detail = Some(inventory.build_detail());
         self.wallet_record_ids = Some(updated_ids);
+        if inventory.has_unknown_remote_wallets() {
+            return Some(
+                self.retry_result("failed to refresh remote wallet truth for some wallets"),
+            );
+        }
+        let missing_listed_uploads =
+            pending_uploads.iter().any(|upload| !listed.contains(upload.record_id()));
 
-        if remaining_unsynced.is_empty() {
+        if remaining_unsynced.is_empty()
+            && !missing_listed_uploads
+            && unconfirmed_pending_uploads == 0
+        {
             return None;
         }
 
         let remaining_count = remaining_unsynced.len();
+        let missing_count =
+            pending_uploads.iter().filter(|upload| !listed.contains(upload.record_id())).count();
+        let stale_count = unconfirmed_pending_uploads.saturating_sub(missing_count);
         warn!(
-            "Deep verify: auto-sync finished but {remaining_count} local wallet(s) are still missing in cloud"
+            "Deep verify: auto-sync finished but confirmation is still pending missing_listed={missing_count} stale={stale_count} stale_or_unsynced={remaining_count}"
         );
-
-        let uploaded_record_ids = unsynced
-            .iter()
-            .map(|wallet| cove_cspp::backup_data::wallet_record_id(wallet.id.as_ref()))
-            .collect();
         self.manager.replace_pending_verification_completion(PendingVerificationCompletion::new(
             self.report.clone(),
             self.namespace.clone(),
-            uploaded_record_ids,
+            pending_uploads,
         ));
 
         Some(DeepVerificationResult::AwaitingUploadConfirmation(self.report.clone()))
@@ -387,43 +445,26 @@ impl<'a> VerificationSession<'a> {
         let Some(wallet_record_ids) = self.wallet_record_ids.as_ref() else {
             return (0, 0, 0);
         };
+        let reader = WalletBackupReader::new(
+            self.cloud.clone(),
+            self.namespace.clone(),
+            Zeroizing::new(*critical_key),
+        );
 
         let mut verified = 0u32;
         let mut failed = 0u32;
         let mut unsupported = 0u32;
 
         for record_id in wallet_record_ids {
-            let wallet_json = match self
-                .cloud
-                .download_wallet_backup(self.namespace.clone(), record_id.clone())
-            {
-                Ok(json) => json,
+            match reader.lookup_entry(record_id) {
+                Ok(WalletBackupLookup::Found(_)) => verified += 1,
+                Ok(WalletBackupLookup::UnsupportedVersion(_)) => unsupported += 1,
+                Ok(WalletBackupLookup::NotFound) => {
+                    warn!("Verify: failed to download wallet {record_id}: not found");
+                    failed += 1;
+                }
                 Err(error) => {
                     warn!("Verify: failed to download wallet {record_id}: {error}");
-                    failed += 1;
-                    continue;
-                }
-            };
-
-            let encrypted: cove_cspp::backup_data::EncryptedWalletBackup =
-                match serde_json::from_slice(&wallet_json) {
-                    Ok(encrypted) => encrypted,
-                    Err(error) => {
-                        warn!("Verify: failed to deserialize wallet {record_id}: {error}");
-                        failed += 1;
-                        continue;
-                    }
-                };
-
-            if encrypted.version != 1 {
-                unsupported += 1;
-                continue;
-            }
-
-            match wallet_crypto::decrypt_wallet_backup(&encrypted, critical_key) {
-                Ok(_) => verified += 1,
-                Err(error) => {
-                    warn!("Verify: failed to decrypt wallet {record_id}: {error}");
                     failed += 1;
                 }
             }
@@ -442,6 +483,10 @@ impl<'a> VerificationSession<'a> {
 
     fn local_inventory_retry_result(&self, error: &CloudBackupError) -> DeepVerificationResult {
         self.retry_result(format!("failed to load local wallet inventory: {error}"))
+    }
+
+    fn remote_truth_retry_result(&self, error: &CloudBackupError) -> DeepVerificationResult {
+        self.retry_result(format!("failed to refresh remote wallet truth: {error}"))
     }
 
     fn retry_result(&self, message: impl Into<String>) -> DeepVerificationResult {

--- a/rust/src/manager/cloud_backup_manager/verify/session.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/session.rs
@@ -61,7 +61,7 @@ impl<'a> VerificationSession<'a> {
             .map_err_prefix("load local master key", CloudBackupError::Internal)?;
 
         Ok(Self {
-            manager,
+            manager: manager.clone(),
             keychain,
             cspp,
             cloud: CloudStorage::global().clone(),
@@ -285,7 +285,7 @@ impl<'a> VerificationSession<'a> {
         };
 
         let repair = WrapperRepairOperation::new(
-            self.manager,
+            &self.manager,
             &self.keychain,
             &self.cloud,
             &self.passkey,

--- a/rust/src/manager/cloud_backup_manager/verify/wrapper_repair.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/wrapper_repair.rs
@@ -1,6 +1,5 @@
 use cove_cspp::master_key::MasterKey;
 use cove_cspp::master_key_crypto;
-use cove_cspp::wallet_crypto;
 use cove_device::cloud_storage::CloudStorage;
 use cove_device::keychain::Keychain;
 use cove_device::passkey::PasskeyAccess;
@@ -13,7 +12,8 @@ use super::super::{
     CloudBackupError, PASSKEY_RP_ID, RustCloudBackupManager, cspp_master_key_record_id,
 };
 use crate::manager::cloud_backup_manager::wallets::{
-    create_prf_key_without_persisting, discover_or_create_prf_key_without_persisting,
+    WalletBackupLookup, WalletBackupReader, create_prf_key_without_persisting,
+    discover_or_create_prf_key_without_persisting,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,37 +69,29 @@ impl<'a> LocalKeyVerifier<'a> {
     }
 
     fn prove(&self, wallet_record_ids: &[String], master_key: &MasterKey) -> LocalKeyProof {
-        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let reader = WalletBackupReader::new(
+            self.cloud.clone(),
+            self.namespace.to_owned(),
+            Zeroizing::new(master_key.critical_data_key()),
+        );
         let mut had_wrong_key = false;
         let mut verified = false;
 
         for record_id in wallet_record_ids {
-            let wallet_json = match self
-                .cloud
-                .download_wallet_backup(self.namespace.to_owned(), record_id.clone())
-            {
-                Ok(json) => json,
-                Err(_) => continue,
-            };
-
-            let encrypted: cove_cspp::backup_data::EncryptedWalletBackup =
-                match serde_json::from_slice(&wallet_json) {
-                    Ok(encrypted) => encrypted,
-                    Err(_) => continue,
-                };
-
-            if encrypted.version != 1 {
-                continue;
-            }
-
-            match wallet_crypto::decrypt_wallet_backup(&encrypted, &critical_key) {
-                Ok(_) => {
-                    verified = true;
-                    break;
+            match reader.download_encrypted(record_id) {
+                Ok(WalletBackupLookup::Found(encrypted)) => {
+                    match reader.decrypt_entry(&encrypted) {
+                        Ok(_) => {
+                            verified = true;
+                            break;
+                        }
+                        Err(cove_cspp::CsppError::WrongKey) => {
+                            had_wrong_key = true;
+                        }
+                        Err(_) => {}
+                    }
                 }
-                Err(cove_cspp::CsppError::WrongKey) => {
-                    had_wrong_key = true;
-                }
+                Ok(WalletBackupLookup::NotFound | WalletBackupLookup::UnsupportedVersion(_)) => {}
                 Err(_) => {}
             }
         }
@@ -166,7 +158,13 @@ impl<'a> WrapperRepairOperation<'a> {
             .map_err_prefix("save cspp credentials", CloudBackupError::Internal)
             .map_err(WrapperRepairError::Operation)?;
         self.manager
-            .enqueue_pending_uploads(self.namespace, std::iter::once(cspp_master_key_record_id()))
+            .mark_blob_uploaded_pending_confirmation(
+                self.namespace,
+                None,
+                cspp_master_key_record_id(),
+                "master-key-wrapper".into(),
+                jiff::Timestamp::now().as_second().try_into().unwrap_or(0),
+            )
             .map_err(WrapperRepairError::Operation)?;
 
         Ok(())

--- a/rust/src/manager/cloud_backup_manager/verify/wrapper_repair.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/wrapper_repair.rs
@@ -58,40 +58,40 @@ struct WrapperRepairCredentials {
     credential_id: Vec<u8>,
 }
 
-struct LocalKeyVerifier<'a> {
-    cloud: &'a CloudStorage,
-    namespace: &'a str,
+struct LocalKeyVerifier {
+    cloud: CloudStorage,
+    namespace: String,
 }
 
-impl<'a> LocalKeyVerifier<'a> {
-    fn new(cloud: &'a CloudStorage, namespace: &'a str) -> Self {
-        Self { cloud, namespace }
+impl LocalKeyVerifier {
+    fn new(cloud: &CloudStorage, namespace: &str) -> Self {
+        Self { cloud: cloud.clone(), namespace: namespace.to_owned() }
     }
 
     fn prove(&self, wallet_record_ids: &[String], master_key: &MasterKey) -> LocalKeyProof {
         let reader = WalletBackupReader::new(
             self.cloud.clone(),
-            self.namespace.to_owned(),
+            self.namespace.clone(),
             Zeroizing::new(master_key.critical_data_key()),
         );
         let mut had_wrong_key = false;
         let mut verified = false;
 
         for record_id in wallet_record_ids {
-            match reader.download_encrypted(record_id) {
-                Ok(WalletBackupLookup::Found(encrypted)) => {
-                    match reader.decrypt_entry(&encrypted) {
-                        Ok(_) => {
-                            verified = true;
-                            break;
-                        }
-                        Err(cove_cspp::CsppError::WrongKey) => {
-                            had_wrong_key = true;
-                        }
-                        Err(_) => {}
-                    }
+            let encrypted = match reader.download_encrypted(record_id) {
+                Ok(WalletBackupLookup::Found(encrypted)) => encrypted,
+                Ok(WalletBackupLookup::NotFound | WalletBackupLookup::UnsupportedVersion(_))
+                | Err(_) => continue,
+            };
+
+            match reader.decrypt_entry(&encrypted) {
+                Ok(_) => {
+                    verified = true;
+                    break;
                 }
-                Ok(WalletBackupLookup::NotFound | WalletBackupLookup::UnsupportedVersion(_)) => {}
+                Err(cove_cspp::CsppError::WrongKey) => {
+                    had_wrong_key = true;
+                }
                 Err(_) => {}
             }
         }
@@ -108,23 +108,29 @@ impl<'a> LocalKeyVerifier<'a> {
     }
 }
 
-pub(super) struct WrapperRepairOperation<'a> {
-    manager: &'a RustCloudBackupManager,
-    keychain: &'a Keychain,
-    cloud: &'a CloudStorage,
-    passkey: &'a PasskeyAccess,
-    namespace: &'a str,
+pub(super) struct WrapperRepairOperation {
+    manager: RustCloudBackupManager,
+    keychain: Keychain,
+    cloud: CloudStorage,
+    passkey: PasskeyAccess,
+    namespace: String,
 }
 
-impl<'a> WrapperRepairOperation<'a> {
+impl WrapperRepairOperation {
     pub(super) fn new(
-        manager: &'a RustCloudBackupManager,
-        keychain: &'a Keychain,
-        cloud: &'a CloudStorage,
-        passkey: &'a PasskeyAccess,
-        namespace: &'a str,
+        manager: &RustCloudBackupManager,
+        keychain: &Keychain,
+        cloud: &CloudStorage,
+        passkey: &PasskeyAccess,
+        namespace: &str,
     ) -> Self {
-        Self { manager, keychain, cloud, passkey, namespace }
+        Self {
+            manager: manager.clone(),
+            keychain: keychain.clone(),
+            cloud: cloud.clone(),
+            passkey: passkey.clone(),
+            namespace: namespace.to_owned(),
+        }
     }
 
     pub(super) fn run(
@@ -149,7 +155,7 @@ impl<'a> WrapperRepairOperation<'a> {
             .map_err(WrapperRepairError::Operation)?;
 
         self.cloud
-            .upload_master_key_backup(self.namespace.to_owned(), backup_json)
+            .upload_master_key_backup(self.namespace.clone(), backup_json)
             .map_err_str(CloudBackupError::Cloud)
             .map_err(WrapperRepairError::Operation)?;
 
@@ -159,7 +165,7 @@ impl<'a> WrapperRepairOperation<'a> {
             .map_err(WrapperRepairError::Operation)?;
         self.manager
             .mark_blob_uploaded_pending_confirmation(
-                self.namespace,
+                self.namespace.as_str(),
                 None,
                 cspp_master_key_record_id(),
                 "master-key-wrapper".into(),
@@ -179,7 +185,7 @@ impl<'a> WrapperRepairOperation<'a> {
             return Ok(());
         }
 
-        let verifier = LocalKeyVerifier::new(self.cloud, self.namespace);
+        let verifier = LocalKeyVerifier::new(&self.cloud, &self.namespace);
         match verifier.prove(wallet_record_ids, local_master_key) {
             LocalKeyProof::Verified => Ok(()),
             LocalKeyProof::WrongKey => Err(WrapperRepairError::WrongKey),
@@ -193,7 +199,7 @@ impl<'a> WrapperRepairOperation<'a> {
     ) -> Result<WrapperRepairCredentials, CloudBackupError> {
         match strategy {
             WrapperRepairStrategy::CreateNew => {
-                let new_prf = create_prf_key_without_persisting(self.passkey)?;
+                let new_prf = create_prf_key_without_persisting(&self.passkey)?;
                 info!("Creating new passkey for wrapper repair");
 
                 Ok(WrapperRepairCredentials {
@@ -203,7 +209,7 @@ impl<'a> WrapperRepairOperation<'a> {
                 })
             }
             WrapperRepairStrategy::DiscoverOrCreate => {
-                let passkey = discover_or_create_prf_key_without_persisting(self.passkey)?;
+                let passkey = discover_or_create_prf_key_without_persisting(&self.passkey)?;
                 info!("Using discovered-or-new passkey for wrapper repair");
 
                 Ok(WrapperRepairCredentials {

--- a/rust/src/manager/cloud_backup_manager/wallets.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets.rs
@@ -1,31 +1,22 @@
-use std::str::FromStr as _;
+mod passkey;
+mod payload;
+mod restore;
+mod upload;
 
-use cove_cspp::backup_data::{
-    DescriptorPair, EncryptedWalletBackup, WalletEntry, WalletMode,
-    WalletSecret as CloudWalletSecret, wallet_record_id,
-};
-use cove_cspp::master_key_crypto;
-use cove_cspp::wallet_crypto;
-use cove_device::cloud_storage::CloudStorage;
-use cove_device::keychain::Keychain;
-use cove_device::passkey::{PasskeyAccess, PasskeyError};
-use cove_types::{WalletId, network::Network};
+use cove_cspp::backup_data::WalletEntry;
+use cove_types::network::Network;
 use cove_util::ResultExt as _;
-use rand::RngExt as _;
 use strum::IntoEnumIterator as _;
-use tracing::{info, warn};
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroize;
 
-use super::{
-    CloudBackupError, LocalDescriptorPair, LocalWalletMode, LocalWalletSecret, PASSKEY_RP_ID,
-    RustCloudBackupManager,
-};
+use super::{CloudBackupError, LocalWalletMode};
 use crate::database::Database;
 use crate::database::cloud_backup::{PersistedCloudBackupState, PersistedCloudBackupStatus};
-use crate::wallet::metadata::{WalletMetadata, WalletType};
+use crate::wallet::metadata::WalletMetadata;
 
 const UPLOAD_WALLET_RECOVERY_MESSAGE: &str =
     "Cloud backup needs verification before wallets can be uploaded";
+const MAX_CLOUD_LABELS_SIZE: usize = 10 * 1024 * 1024;
 
 #[derive(Zeroize)]
 pub(super) struct UnpersistedPrfKey {
@@ -39,291 +30,33 @@ pub(super) struct DownloadedWalletBackup {
     pub(super) entry: WalletEntry,
 }
 
-impl RustCloudBackupManager {
-    /// Upload wallets to cloud and update local cache
-    pub(super) fn do_backup_wallets(
-        &self,
-        wallets: &[crate::wallet::metadata::WalletMetadata],
-    ) -> Result<(), CloudBackupError> {
-        if wallets.is_empty() {
-            return Ok(());
-        }
-
-        let namespace = self.current_namespace_id()?;
-        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
-        let master_key = match cspp
-            .load_master_key_from_store()
-            .map_err_prefix("load local master key", CloudBackupError::Internal)?
-        {
-            Some(master_key) => master_key,
-            None => self.recover_local_master_key_from_cloud_without_discovery(
-                &namespace,
-                UPLOAD_WALLET_RECOVERY_MESSAGE,
-            )?,
-        };
-
-        let critical_key = Zeroizing::new(master_key.critical_data_key());
-        let cloud = CloudStorage::global();
-        let mut uploaded_record_ids = Vec::with_capacity(wallets.len());
-
-        for (index, metadata) in wallets.iter().enumerate() {
-            info!("Backup: uploading wallet {}/{} '{}'", index + 1, wallets.len(), metadata.name);
-            let entry = build_wallet_entry(metadata, metadata.wallet_mode)?;
-            let encrypted = wallet_crypto::encrypt_wallet_entry(&entry, &critical_key)
-                .map_err_str(CloudBackupError::Crypto)?;
-
-            let record_id = wallet_record_id(metadata.id.as_ref());
-            let wallet_json =
-                serde_json::to_vec(&encrypted).map_err_str(CloudBackupError::Internal)?;
-
-            cloud
-                .upload_wallet_backup(namespace.clone(), record_id.clone(), wallet_json)
-                .map_err_str(CloudBackupError::Cloud)?;
-            uploaded_record_ids.push(record_id);
-            info!("Backup: wallet {}/{} uploaded", index + 1, wallets.len());
-        }
-
-        let db = Database::global();
-        self.enqueue_pending_uploads(&namespace, uploaded_record_ids)?;
-
-        let previous_count =
-            db.cloud_backup_state.get().ok().and_then(|state| state.wallet_count).unwrap_or(0);
-        let wallet_count = previous_count + wallets.len() as u32;
-        persist_enabled_cloud_backup_state(&db, wallet_count)?;
-
-        info!("Backed up {} wallet(s) to cloud", wallets.len());
-        Ok(())
-    }
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteWalletBackupSummary {
+    pub(crate) revision_hash: String,
+    pub(crate) label_count: u32,
+    pub(crate) updated_at: u64,
 }
 
-/// Create a passkey and authenticate with PRF without persisting to keychain
-///
-/// Used by the wrapper-repair path where we need to defer persistence until
-/// after the cloud upload succeeds
-pub(super) fn create_prf_key_without_persisting(
-    passkey: &PasskeyAccess,
-) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    create_new_prf_key_for_wrapper_repair(passkey)
+pub(crate) struct PreparedWalletBackup {
+    pub(crate) metadata: WalletMetadata,
+    pub(crate) record_id: String,
+    pub(crate) revision_hash: String,
+    pub(crate) entry: WalletEntry,
 }
 
-/// Try to discover an existing passkey, fall back to creating a new one
-///
-/// Used by wrapper repair so keychain persistence still happens only after
-/// the repaired master-key wrapper upload succeeds
-pub(super) fn discover_or_create_prf_key_without_persisting(
-    passkey: &PasskeyAccess,
-) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    info!("Attempting passkey discovery before creating new wrapper-repair passkey");
-    let prf_salt: [u8; 32] = rand::rng().random();
-
-    match passkey.discover_and_authenticate_with_prf(
-        PASSKEY_RP_ID.to_string(),
-        prf_salt.to_vec(),
-        random_challenge(),
-    ) {
-        Ok(discovered) => {
-            let prf_key = prf_output_to_key(discovered.prf_output)?;
-            info!("Discovered existing passkey for wrapper repair");
-
-            Ok(UnpersistedPrfKey { prf_key, prf_salt, credential_id: discovered.credential_id })
-        }
-        Err(cove_device::passkey::PasskeyError::UserCancelled) => {
-            info!("User cancelled passkey discovery for wrapper repair");
-            Err(CloudBackupError::PasskeyDiscoveryCancelled)
-        }
-        Err(cove_device::passkey::PasskeyError::NoCredentialFound) => {
-            info!("No existing passkey found for wrapper repair, creating new");
-            create_prf_key_without_persisting(passkey)
-        }
-        Err(error) => {
-            warn!("Wrapper-repair discovery failed ({error}), falling back to create");
-            create_prf_key_without_persisting(passkey)
-        }
-    }
-}
-
-#[allow(dead_code)]
-pub(super) struct NamespaceMatch {
-    pub(super) namespace_id: String,
-    pub(super) master_key: cove_cspp::master_key::MasterKey,
-    pub(super) prf_key: [u8; 32],
-    pub(super) prf_salt: [u8; 32],
-    pub(super) credential_id: Vec<u8>,
-}
-
-pub(super) enum NamespaceMatchOutcome {
-    /// User's passkey decrypted a namespace's master key
-    Matched(NamespaceMatch),
-    /// User cancelled the picker or biometric, or no credentials on device
-    UserDeclined,
-    /// The selected passkey didn't match any downloaded v1 backup
-    NoMatch,
-    /// Some namespaces couldn't be downloaded — result is inconclusive
-    Inconclusive,
-    /// Some/all namespaces had unsupported version — app may be too old
-    UnsupportedVersions,
-}
-
-/// Try to match the selected passkey against cloud namespaces
-///
-/// Downloads all encrypted master keys, then does a discovery auth with the first
-/// v1 backup's salt. If that passkey doesn't match, targeted auth reuses the same
-/// selected credential across the remaining namespaces with each namespace's own
-/// salt. Returns `NoMatch` when that selected passkey doesn't match any downloaded
-/// namespace
-pub(super) fn try_match_namespace_with_passkey(
-    cloud: &CloudStorage,
-    passkey: &PasskeyAccess,
-    namespaces: &[String],
-) -> Result<NamespaceMatchOutcome, CloudBackupError> {
-    if namespaces.is_empty() {
-        return Ok(NamespaceMatchOutcome::NoMatch);
-    }
-
-    // download all encrypted master key backups
-    let mut downloaded: Vec<(String, cove_cspp::backup_data::EncryptedMasterKeyBackup)> =
-        Vec::with_capacity(namespaces.len());
-    let mut had_download_failures = false;
-    let mut had_unsupported_versions = false;
-
-    for ns in namespaces {
-        let master_json = match cloud.download_master_key_backup(ns.clone()) {
-            Ok(json) => json,
-            Err(error) => {
-                warn!("Failed to download master key for namespace {ns}: {error}");
-                had_download_failures = true;
-                continue;
-            }
-        };
-
-        let encrypted: cove_cspp::backup_data::EncryptedMasterKeyBackup =
-            match serde_json::from_slice(&master_json) {
-                Ok(e) => e,
-                Err(error) => {
-                    warn!("Failed to deserialize master key for namespace {ns}: {error}");
-                    had_download_failures = true;
-                    continue;
-                }
-            };
-
-        if encrypted.version != 1 {
-            had_unsupported_versions = true;
-            continue;
-        }
-
-        downloaded.push((ns.clone(), encrypted));
-    }
-
-    if downloaded.is_empty() {
-        if had_download_failures {
-            return Ok(NamespaceMatchOutcome::Inconclusive);
-        }
-
-        return Ok(NamespaceMatchOutcome::UnsupportedVersions);
-    }
-
-    // discovery auth with first downloaded backup's salt
-    let first_prf_salt = downloaded[0].1.prf_salt;
-
-    let discovered = match passkey.discover_and_authenticate_with_prf(
-        PASSKEY_RP_ID.to_string(),
-        first_prf_salt.to_vec(),
-        random_challenge(),
-    ) {
-        Ok(result) => result,
-        Err(cove_device::passkey::PasskeyError::UserCancelled)
-        | Err(cove_device::passkey::PasskeyError::NoCredentialFound) => {
-            return Ok(NamespaceMatchOutcome::UserDeclined);
-        }
-        Err(error) => return Err(CloudBackupError::Passkey(error.to_string())),
-    };
-
-    let prf_key = prf_output_to_key(discovered.prf_output)?;
-
-    // try first backup
-    if let Ok(master_key) = master_key_crypto::decrypt_master_key(&downloaded[0].1, &prf_key) {
-        return Ok(NamespaceMatchOutcome::Matched(NamespaceMatch {
-            namespace_id: downloaded[0].0.clone(),
-            master_key,
-            prf_key,
-            prf_salt: first_prf_salt,
-            credential_id: discovered.credential_id,
-        }));
-    }
-
-    // try remaining with targeted auth using each namespace's own salt
-    for (namespace, encrypted) in &downloaded[1..] {
-        let namespace_prf_output = match passkey.authenticate_with_prf(
-            PASSKEY_RP_ID.to_string(),
-            discovered.credential_id.clone(),
-            encrypted.prf_salt.to_vec(),
-            random_challenge(),
-        ) {
-            Ok(output) => output,
-            Err(cove_device::passkey::PasskeyError::UserCancelled) => {
-                return Ok(NamespaceMatchOutcome::UserDeclined);
-            }
-            Err(error) => {
-                warn!("Targeted auth failed for namespace {namespace}: {error}");
-                continue;
-            }
-        };
-
-        let namespace_prf_key = match prf_output_to_key(namespace_prf_output) {
-            Ok(key) => key,
-            Err(_) => continue,
-        };
-
-        if let Ok(master_key) = master_key_crypto::decrypt_master_key(encrypted, &namespace_prf_key)
-        {
-            return Ok(NamespaceMatchOutcome::Matched(NamespaceMatch {
-                namespace_id: namespace.clone(),
-                master_key,
-                prf_key: namespace_prf_key,
-                prf_salt: encrypted.prf_salt,
-                credential_id: discovered.credential_id.clone(),
-            }));
-        }
-    }
-
-    // none matched
-    if had_download_failures {
-        return Ok(NamespaceMatchOutcome::Inconclusive);
-    }
-
-    if had_unsupported_versions {
-        return Ok(NamespaceMatchOutcome::UnsupportedVersions);
-    }
-
-    Ok(NamespaceMatchOutcome::NoMatch)
-}
-
-/// Encrypt and hand off all local wallets to the given namespace
-pub(super) fn upload_all_wallets(
-    cloud: &CloudStorage,
-    namespace: &str,
-    critical_key: &[u8; 32],
-    db: &Database,
-) -> Result<Vec<String>, CloudBackupError> {
-    let mut uploaded_record_ids = Vec::new();
-
-    for metadata in all_local_wallets(db)? {
-        let entry = build_wallet_entry(&metadata, metadata.wallet_mode)?;
-        let encrypted = wallet_crypto::encrypt_wallet_entry(&entry, critical_key)
-            .map_err_str(CloudBackupError::Crypto)?;
-
-        let record_id = wallet_record_id(metadata.id.as_ref());
-        let wallet_json = serde_json::to_vec(&encrypted).map_err_str(CloudBackupError::Internal)?;
-
-        cloud
-            .upload_wallet_backup(namespace.to_string(), record_id.clone(), wallet_json)
-            .map_err_str(CloudBackupError::Cloud)?;
-
-        uploaded_record_ids.push(record_id);
-    }
-
-    Ok(uploaded_record_ids)
-}
+pub(crate) use passkey::{
+    NamespaceMatch, NamespaceMatchOutcome, create_new_prf_key, create_prf_key_without_persisting,
+    discover_or_create_prf_key_without_persisting, try_match_namespace_with_passkey,
+};
+#[cfg(test)]
+pub(crate) use payload::convert_cloud_secret;
+pub(crate) use payload::{
+    decode_cloud_labels_jsonl, prepare_wallet_backup, wallet_metadata_change_requires_upload,
+};
+pub(crate) use restore::{
+    WalletBackupLookup, WalletBackupReader, WalletRestoreOutcome, WalletRestoreSession,
+};
+pub(crate) use upload::upload_all_wallets;
 
 pub(super) fn persist_enabled_cloud_backup_state(
     db: &Database,
@@ -340,15 +73,15 @@ pub(super) fn persist_enabled_cloud_backup_state_reset_verification(
     db: &Database,
     wallet_count: u32,
 ) -> Result<(), CloudBackupError> {
-    let now = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
     db.cloud_backup_state
         .set(&PersistedCloudBackupState {
-            status: PersistedCloudBackupStatus::Enabled,
-            last_sync: Some(now),
+            status: PersistedCloudBackupStatus::Unverified,
+            last_sync: Some(jiff::Timestamp::now().as_second().try_into().unwrap_or(0)),
             wallet_count: Some(wallet_count),
             last_verified_at: None,
             last_verification_requested_at: None,
             last_verification_dismissed_at: None,
+            pending_verification_completion: None,
         })
         .map_err_prefix("persist cloud backup state", CloudBackupError::Internal)
 }
@@ -374,11 +107,11 @@ fn persist_enabled_cloud_backup_state_with_last_verified_at(
             last_verified_at,
             last_verification_requested_at: current.last_verification_requested_at,
             last_verification_dismissed_at: current.last_verification_dismissed_at,
+            pending_verification_completion: current.pending_verification_completion,
         })
         .map_err_prefix("persist cloud backup state", CloudBackupError::Internal)
 }
 
-/// All local wallets across every network and mode
 pub(super) fn all_local_wallets(db: &Database) -> Result<Vec<WalletMetadata>, CloudBackupError> {
     all_local_wallets_from(|network, mode| {
         db.wallets.get_all(network, mode).map_err(|error| {
@@ -406,320 +139,10 @@ pub(super) fn count_all_wallets(db: &Database) -> Result<u32, CloudBackupError> 
     Ok(all_local_wallets(db)?.len() as u32)
 }
 
-pub(super) fn restore_single_wallet(
-    cloud: &CloudStorage,
-    namespace: &str,
-    record_id: &str,
-    critical_key: &[u8; 32],
-    existing_fingerprints: &mut Vec<(
-        crate::wallet::fingerprint::Fingerprint,
-        Network,
-        LocalWalletMode,
-    )>,
-) -> Result<(), CloudBackupError> {
-    let wallet = download_wallet_backup(cloud, namespace, record_id, critical_key)?;
-    restore_downloaded_wallet_for_restore(&wallet, existing_fingerprints)
-}
-
-pub(super) fn restore_downloaded_wallet_for_restore(
-    wallet: &DownloadedWalletBackup,
-    existing_fingerprints: &mut Vec<(
-        crate::wallet::fingerprint::Fingerprint,
-        Network,
-        LocalWalletMode,
-    )>,
-) -> Result<(), CloudBackupError> {
-    if should_skip_duplicate_wallet(&wallet.metadata, existing_fingerprints) {
-        return Ok(());
-    }
-
-    restore_downloaded_wallet(&wallet.metadata, &wallet.entry)?;
-    remember_restored_wallet_fingerprint(&wallet.metadata, existing_fingerprints);
-
-    Ok(())
-}
-
-pub(super) fn download_wallet_backup(
-    cloud: &CloudStorage,
-    namespace: &str,
-    record_id: &str,
-    critical_key: &[u8; 32],
-) -> Result<DownloadedWalletBackup, CloudBackupError> {
-    let wallet_json = cloud
-        .download_wallet_backup(namespace.to_string(), record_id.to_string())
-        .map_err(|e| CloudBackupError::Cloud(format!("download {record_id}: {e}")))?;
-
-    let encrypted: EncryptedWalletBackup = serde_json::from_slice(&wallet_json)
-        .map_err_prefix("deserialize wallet", CloudBackupError::Internal)?;
-
-    if encrypted.version != 1 {
-        let version = encrypted.version;
-        return Err(CloudBackupError::Internal(format!(
-            "unsupported wallet backup version: {version}",
-        )));
-    }
-
-    let entry = wallet_crypto::decrypt_wallet_backup(&encrypted, critical_key)
-        .map_err_prefix("decrypt wallet", CloudBackupError::Crypto)?;
-
-    let metadata = serde_json::from_value(entry.metadata.clone())
-        .map_err_prefix("parse wallet metadata", CloudBackupError::Internal)?;
-
-    Ok(DownloadedWalletBackup { metadata, entry })
-}
-
-pub(super) fn create_new_prf_key(
-    passkey: &PasskeyAccess,
-    log_message: &str,
-) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    info!("{log_message}");
-    let prf_salt: [u8; 32] = rand::rng().random();
-    let credential_id = passkey
-        .create_passkey(
-            PASSKEY_RP_ID.to_string(),
-            rand::rng().random::<[u8; 16]>().to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_enable_passkey_error)?;
-
-    let prf_output = passkey
-        .authenticate_with_prf(
-            PASSKEY_RP_ID.to_string(),
-            credential_id.clone(),
-            prf_salt.to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_enable_passkey_error)?;
-
-    Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
-}
-
-fn create_new_prf_key_for_wrapper_repair(
-    passkey: &PasskeyAccess,
-) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    info!("Creating new passkey for wrapper repair");
-    let prf_salt: [u8; 32] = rand::rng().random();
-    let credential_id = passkey
-        .create_passkey(
-            PASSKEY_RP_ID.to_string(),
-            rand::rng().random::<[u8; 16]>().to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_wrapper_repair_passkey_error)?;
-
-    let prf_output = passkey
-        .authenticate_with_prf(
-            PASSKEY_RP_ID.to_string(),
-            credential_id.clone(),
-            prf_salt.to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_wrapper_repair_passkey_error)?;
-
-    Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
-}
-
-fn map_wrapper_repair_passkey_error(error: PasskeyError) -> CloudBackupError {
-    match error {
-        PasskeyError::PrfUnsupportedProvider => CloudBackupError::UnsupportedPasskeyProvider,
-        PasskeyError::UserCancelled => {
-            info!("User cancelled new passkey flow for wrapper repair");
-            CloudBackupError::PasskeyDiscoveryCancelled
-        }
-        other => CloudBackupError::Passkey(other.to_string()),
-    }
-}
-
-fn map_enable_passkey_error(error: PasskeyError) -> CloudBackupError {
-    match error {
-        PasskeyError::PrfUnsupportedProvider => CloudBackupError::UnsupportedPasskeyProvider,
-        PasskeyError::UserCancelled => {
-            info!("User cancelled new passkey flow for cloud backup enable");
-            CloudBackupError::PasskeyDiscoveryCancelled
-        }
-        other => CloudBackupError::Passkey(other.to_string()),
-    }
-}
-
-fn prf_output_to_key(prf_output: Vec<u8>) -> Result<[u8; 32], CloudBackupError> {
-    prf_output
-        .try_into()
-        .map_err(|_| CloudBackupError::Internal("PRF output is not 32 bytes".into()))
-}
-
-fn random_challenge() -> Vec<u8> {
-    rand::rng().random::<[u8; 32]>().to_vec()
-}
-
-fn should_skip_duplicate_wallet(
-    metadata: &WalletMetadata,
-    existing_fingerprints: &[(crate::wallet::fingerprint::Fingerprint, Network, LocalWalletMode)],
-) -> bool {
-    if crate::backup::import::is_wallet_duplicate(metadata, existing_fingerprints)
-        .inspect_err(|e| warn!("is_wallet_duplicate check failed for {}: {e}", metadata.name))
-        .unwrap_or(false)
-    {
-        info!("Skipping duplicate wallet {}", metadata.name);
-        true
-    } else {
-        false
-    }
-}
-
-fn restore_downloaded_wallet(
-    metadata: &WalletMetadata,
-    entry: &WalletEntry,
-) -> Result<(), CloudBackupError> {
-    let backup_model = crate::backup::model::WalletBackup {
-        metadata: entry.metadata.clone(),
-        secret: convert_cloud_secret(&entry.secret),
-        descriptors: entry.descriptors.as_ref().map(|descriptors| LocalDescriptorPair {
-            external: descriptors.external.clone(),
-            internal: descriptors.internal.clone(),
-        }),
-        xpub: entry.xpub.clone(),
-        labels_jsonl: None,
-    };
-
-    match &backup_model.secret {
-        LocalWalletSecret::Mnemonic(words) => {
-            let mnemonic = bip39::Mnemonic::from_str(words)
-                .map_err_prefix("invalid mnemonic", CloudBackupError::Internal)?;
-
-            crate::backup::import::restore_cloud_mnemonic_wallet(metadata, mnemonic).map_err(
-                |(error, _)| {
-                    CloudBackupError::Internal(format!("restore mnemonic wallet: {error}"))
-                },
-            )?;
-        }
-        _ => {
-            crate::backup::import::restore_cloud_descriptor_wallet(metadata, &backup_model)
-                .map_err(|(error, _)| {
-                    CloudBackupError::Internal(format!("restore descriptor wallet: {error}"))
-                })?;
-        }
-    }
-
-    Ok(())
-}
-
-fn remember_restored_wallet_fingerprint(
-    metadata: &WalletMetadata,
-    existing_fingerprints: &mut Vec<(
-        crate::wallet::fingerprint::Fingerprint,
-        Network,
-        LocalWalletMode,
-    )>,
-) {
-    if let Some(fingerprint) = &metadata.master_fingerprint {
-        existing_fingerprints.push((**fingerprint, metadata.network, metadata.wallet_mode));
-    }
-}
-
-pub(super) fn convert_cloud_secret(secret: &CloudWalletSecret) -> LocalWalletSecret {
-    match secret {
-        CloudWalletSecret::Mnemonic(mnemonic) => LocalWalletSecret::Mnemonic(mnemonic.clone()),
-        CloudWalletSecret::TapSignerBackup(backup) => {
-            LocalWalletSecret::TapSignerBackup(backup.clone())
-        }
-        CloudWalletSecret::Descriptor(_) | CloudWalletSecret::WatchOnly => LocalWalletSecret::None,
-    }
-}
-
-pub(super) fn build_wallet_entry(
-    metadata: &crate::wallet::metadata::WalletMetadata,
-    mode: LocalWalletMode,
-) -> Result<WalletEntry, CloudBackupError> {
-    let keychain = Keychain::global();
-    let id = &metadata.id;
-    let name = &metadata.name;
-
-    let secret = match metadata.wallet_type {
-        WalletType::Hot => match keychain.get_wallet_key(id) {
-            Ok(Some(mnemonic)) => CloudWalletSecret::Mnemonic(mnemonic.to_string()),
-            Ok(None) => {
-                return Err(CloudBackupError::Internal(format!(
-                    "hot wallet '{name}' has no mnemonic"
-                )));
-            }
-            Err(error) => {
-                return Err(CloudBackupError::Internal(format!(
-                    "failed to get mnemonic for '{name}': {error}"
-                )));
-            }
-        },
-        WalletType::Cold => build_cold_wallet_secret(keychain, metadata, id, name)?,
-        WalletType::XpubOnly | WalletType::WatchOnly => CloudWalletSecret::WatchOnly,
-    };
-
-    let xpub = match keychain.get_wallet_xpub(id) {
-        Ok(Some(xpub)) => Some(xpub.to_string()),
-        Ok(None) => None,
-        Err(error) => {
-            return Err(CloudBackupError::Internal(format!(
-                "failed to read xpub for '{name}': {error}"
-            )));
-        }
-    };
-
-    let descriptors = match keychain.get_public_descriptor(id) {
-        Ok(Some((external, internal))) => {
-            Some(DescriptorPair { external: external.to_string(), internal: internal.to_string() })
-        }
-        Ok(None) => None,
-        Err(error) => {
-            return Err(CloudBackupError::Internal(format!(
-                "failed to read descriptors for '{name}': {error}"
-            )));
-        }
-    };
-
-    let metadata_value = serde_json::to_value(metadata)
-        .map_err_prefix("serialize metadata", CloudBackupError::Internal)?;
-
-    let wallet_mode = match mode {
-        LocalWalletMode::Main => WalletMode::Main,
-        LocalWalletMode::Decoy => WalletMode::Decoy,
-    };
-
-    Ok(WalletEntry {
-        wallet_id: id.to_string(),
-        secret,
-        metadata: metadata_value,
-        descriptors,
-        xpub,
-        wallet_mode,
-    })
-}
-
-fn build_cold_wallet_secret(
-    keychain: &Keychain,
-    metadata: &WalletMetadata,
-    id: &WalletId,
-    name: &str,
-) -> Result<CloudWalletSecret, CloudBackupError> {
-    let is_tap_signer =
-        metadata.hardware_metadata.as_ref().is_some_and(|hardware| hardware.is_tap_signer());
-
-    if !is_tap_signer {
-        return Ok(CloudWalletSecret::WatchOnly);
-    }
-
-    match keychain.get_tap_signer_backup(id) {
-        Ok(Some(backup)) => Ok(CloudWalletSecret::TapSignerBackup(backup)),
-        Ok(None) => {
-            warn!("Tap signer wallet '{name}' has no backup, exporting without it");
-            Ok(CloudWalletSecret::WatchOnly)
-        }
-        Err(error) => Err(CloudBackupError::Internal(format!(
-            "failed to read tap signer backup for '{name}': {error}"
-        ))),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::cloud_backup::PersistedCloudBackupStatus;
 
     #[test]
     fn all_local_wallets_from_returns_error_when_any_bucket_fails() {
@@ -737,5 +160,34 @@ mod tests {
         assert!(
             matches!(error, CloudBackupError::Internal(message) if message == "read wallets for test bucket failed")
         );
+    }
+
+    #[test]
+    fn reset_verification_does_not_preserve_passkey_missing() {
+        let _guard = crate::manager::cloud_backup_manager::cloud_backup_test_lock().lock();
+        let db = Database::global();
+        let _ = db.cloud_backup_state.delete();
+        db.cloud_backup_state
+            .set(&PersistedCloudBackupState {
+                status: PersistedCloudBackupStatus::PasskeyMissing,
+                last_sync: Some(10),
+                wallet_count: Some(2),
+                last_verified_at: Some(11),
+                last_verification_requested_at: Some(12),
+                last_verification_dismissed_at: Some(13),
+                pending_verification_completion: None,
+            })
+            .unwrap();
+
+        persist_enabled_cloud_backup_state_reset_verification(&db, 7).unwrap();
+
+        let state = db.cloud_backup_state.get().unwrap();
+        assert_eq!(state.status, PersistedCloudBackupStatus::Unverified);
+        assert_eq!(state.wallet_count, Some(7));
+        assert!(state.last_sync.is_some());
+        assert_eq!(state.last_verified_at, None);
+        assert_eq!(state.last_verification_requested_at, None);
+        assert_eq!(state.last_verification_dismissed_at, None);
+        let _ = db.cloud_backup_state.delete();
     }
 }

--- a/rust/src/manager/cloud_backup_manager/wallets/passkey.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/passkey.rs
@@ -1,0 +1,269 @@
+use cove_cspp::backup_data::EncryptedMasterKeyBackup;
+use cove_device::cloud_storage::CloudStorage;
+use cove_device::passkey::{PasskeyAccess, PasskeyError};
+use rand::RngExt as _;
+use tracing::{info, warn};
+
+use super::super::{CloudBackupError, PASSKEY_RP_ID};
+use super::UnpersistedPrfKey;
+
+pub struct NamespaceMatch {
+    pub namespace_id: String,
+    pub master_key: cove_cspp::master_key::MasterKey,
+    pub prf_salt: [u8; 32],
+    pub credential_id: Vec<u8>,
+}
+
+pub enum NamespaceMatchOutcome {
+    Matched(NamespaceMatch),
+    UserDeclined,
+    NoMatch,
+    Inconclusive,
+    UnsupportedVersions,
+}
+
+/// Create a passkey and authenticate with PRF without persisting to keychain
+///
+/// Used by the wrapper-repair path where we need to defer persistence until
+/// after the cloud upload succeeds
+pub fn create_prf_key_without_persisting(
+    passkey: &PasskeyAccess,
+) -> Result<UnpersistedPrfKey, CloudBackupError> {
+    create_new_prf_key_for_wrapper_repair(passkey)
+}
+
+/// Try to discover an existing passkey, fall back to creating a new one
+///
+/// Used by wrapper repair so keychain persistence still happens only after
+/// the repaired master-key wrapper upload succeeds
+pub fn discover_or_create_prf_key_without_persisting(
+    passkey: &PasskeyAccess,
+) -> Result<UnpersistedPrfKey, CloudBackupError> {
+    info!("Attempting passkey discovery before creating new wrapper-repair passkey");
+    let prf_salt: [u8; 32] = rand::rng().random();
+
+    match passkey.discover_and_authenticate_with_prf(
+        PASSKEY_RP_ID.to_string(),
+        prf_salt.to_vec(),
+        random_challenge(),
+    ) {
+        Ok(discovered) => {
+            let prf_key = prf_output_to_key(discovered.prf_output)?;
+            info!("Discovered existing passkey for wrapper repair");
+
+            Ok(UnpersistedPrfKey { prf_key, prf_salt, credential_id: discovered.credential_id })
+        }
+        Err(PasskeyError::UserCancelled) => {
+            info!("User cancelled passkey discovery for wrapper repair");
+            Err(CloudBackupError::PasskeyDiscoveryCancelled)
+        }
+        Err(PasskeyError::NoCredentialFound) => {
+            info!("No existing passkey found for wrapper repair, creating new");
+            create_prf_key_without_persisting(passkey)
+        }
+        Err(PasskeyError::PrfUnsupportedProvider) => {
+            Err(CloudBackupError::UnsupportedPasskeyProvider)
+        }
+        Err(error) => {
+            warn!("Wrapper-repair discovery failed ({error}), falling back to create");
+            create_prf_key_without_persisting(passkey)
+        }
+    }
+}
+
+/// Try to match the selected passkey against cloud namespaces
+pub fn try_match_namespace_with_passkey(
+    cloud: &CloudStorage,
+    passkey: &PasskeyAccess,
+    namespaces: &[String],
+) -> Result<NamespaceMatchOutcome, CloudBackupError> {
+    if namespaces.is_empty() {
+        return Ok(NamespaceMatchOutcome::NoMatch);
+    }
+
+    let mut downloaded: Vec<(String, EncryptedMasterKeyBackup)> =
+        Vec::with_capacity(namespaces.len());
+    let mut had_download_failures = false;
+    let mut had_unsupported_versions = false;
+
+    for namespace in namespaces {
+        let master_json = match cloud.download_master_key_backup(namespace.clone()) {
+            Ok(json) => json,
+            Err(error) => {
+                warn!("Failed to download master key for namespace {namespace}: {error}");
+                had_download_failures = true;
+                continue;
+            }
+        };
+
+        let encrypted: EncryptedMasterKeyBackup = match serde_json::from_slice(&master_json) {
+            Ok(encrypted) => encrypted,
+            Err(error) => {
+                warn!("Failed to deserialize master key for namespace {namespace}: {error}");
+                had_download_failures = true;
+                continue;
+            }
+        };
+
+        if encrypted.version != 1 {
+            had_unsupported_versions = true;
+            continue;
+        }
+
+        downloaded.push((namespace.clone(), encrypted));
+    }
+
+    if downloaded.is_empty() && had_download_failures {
+        return Ok(NamespaceMatchOutcome::Inconclusive);
+    }
+
+    if downloaded.is_empty() && had_unsupported_versions {
+        return Ok(NamespaceMatchOutcome::UnsupportedVersions);
+    }
+
+    let (namespace_id, first_encrypted) = &downloaded[0];
+    let discovery = passkey.discover_and_authenticate_with_prf(
+        PASSKEY_RP_ID.to_string(),
+        first_encrypted.prf_salt.to_vec(),
+        random_challenge(),
+    );
+    let discovered = match discovery {
+        Ok(discovered) => discovered,
+        Err(PasskeyError::UserCancelled) => return Ok(NamespaceMatchOutcome::UserDeclined),
+        Err(PasskeyError::NoCredentialFound) => return Ok(NamespaceMatchOutcome::NoMatch),
+        Err(error) => return Err(CloudBackupError::Passkey(error.to_string())),
+    };
+
+    let prf_key = prf_output_to_key(discovered.prf_output.clone())?;
+    let try_first = cove_cspp::master_key_crypto::decrypt_master_key(first_encrypted, &prf_key);
+    if let Ok(master_key) = try_first {
+        return Ok(NamespaceMatchOutcome::Matched(NamespaceMatch {
+            namespace_id: namespace_id.clone(),
+            master_key,
+            prf_salt: first_encrypted.prf_salt,
+            credential_id: discovered.credential_id,
+        }));
+    }
+
+    for (namespace_id, encrypted) in downloaded.iter().skip(1) {
+        let prf_output = match passkey.authenticate_with_prf(
+            PASSKEY_RP_ID.to_string(),
+            discovered.credential_id.clone(),
+            encrypted.prf_salt.to_vec(),
+            random_challenge(),
+        ) {
+            Ok(prf_output) => prf_output,
+            Err(PasskeyError::UserCancelled) => return Ok(NamespaceMatchOutcome::UserDeclined),
+            Err(error) => {
+                warn!("Failed targeted passkey auth for namespace {namespace_id}: {error}");
+                had_download_failures = true;
+                continue;
+            }
+        };
+
+        let prf_key = prf_output_to_key(prf_output)?;
+        if let Ok(master_key) =
+            cove_cspp::master_key_crypto::decrypt_master_key(encrypted, &prf_key)
+        {
+            return Ok(NamespaceMatchOutcome::Matched(NamespaceMatch {
+                namespace_id: namespace_id.clone(),
+                master_key,
+                prf_salt: encrypted.prf_salt,
+                credential_id: discovered.credential_id.clone(),
+            }));
+        }
+    }
+
+    if had_download_failures {
+        return Ok(NamespaceMatchOutcome::Inconclusive);
+    }
+
+    if downloaded.is_empty() && had_unsupported_versions {
+        return Ok(NamespaceMatchOutcome::UnsupportedVersions);
+    }
+
+    Ok(NamespaceMatchOutcome::NoMatch)
+}
+
+pub fn create_new_prf_key(
+    passkey: &PasskeyAccess,
+    log_message: &str,
+) -> Result<UnpersistedPrfKey, CloudBackupError> {
+    info!("{log_message}");
+    let prf_salt: [u8; 32] = rand::rng().random();
+    let credential_id = passkey
+        .create_passkey(
+            PASSKEY_RP_ID.to_string(),
+            rand::rng().random::<[u8; 16]>().to_vec(),
+            random_challenge(),
+        )
+        .map_err(map_enable_passkey_error)?;
+
+    let prf_output = passkey
+        .authenticate_with_prf(
+            PASSKEY_RP_ID.to_string(),
+            credential_id.clone(),
+            prf_salt.to_vec(),
+            random_challenge(),
+        )
+        .map_err(map_enable_passkey_error)?;
+
+    Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
+}
+
+fn create_new_prf_key_for_wrapper_repair(
+    passkey: &PasskeyAccess,
+) -> Result<UnpersistedPrfKey, CloudBackupError> {
+    info!("Creating new passkey for wrapper repair");
+    let prf_salt: [u8; 32] = rand::rng().random();
+    let credential_id = passkey
+        .create_passkey(
+            PASSKEY_RP_ID.to_string(),
+            rand::rng().random::<[u8; 16]>().to_vec(),
+            random_challenge(),
+        )
+        .map_err(map_wrapper_repair_passkey_error)?;
+
+    let prf_output = passkey
+        .authenticate_with_prf(
+            PASSKEY_RP_ID.to_string(),
+            credential_id.clone(),
+            prf_salt.to_vec(),
+            random_challenge(),
+        )
+        .map_err(map_wrapper_repair_passkey_error)?;
+
+    Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
+}
+
+fn map_wrapper_repair_passkey_error(error: PasskeyError) -> CloudBackupError {
+    match error {
+        PasskeyError::PrfUnsupportedProvider => CloudBackupError::UnsupportedPasskeyProvider,
+        PasskeyError::UserCancelled => {
+            info!("User cancelled new passkey flow for wrapper repair");
+            CloudBackupError::PasskeyDiscoveryCancelled
+        }
+        other => CloudBackupError::Passkey(other.to_string()),
+    }
+}
+
+fn map_enable_passkey_error(error: PasskeyError) -> CloudBackupError {
+    match error {
+        PasskeyError::PrfUnsupportedProvider => CloudBackupError::UnsupportedPasskeyProvider,
+        PasskeyError::UserCancelled => {
+            info!("User cancelled new passkey flow for cloud backup enable");
+            CloudBackupError::PasskeyDiscoveryCancelled
+        }
+        other => CloudBackupError::Passkey(other.to_string()),
+    }
+}
+
+fn prf_output_to_key(prf_output: Vec<u8>) -> Result<[u8; 32], CloudBackupError> {
+    prf_output
+        .try_into()
+        .map_err(|_| CloudBackupError::Internal("PRF output is not 32 bytes".into()))
+}
+
+fn random_challenge() -> Vec<u8> {
+    rand::rng().random::<[u8; 32]>().to_vec()
+}

--- a/rust/src/manager/cloud_backup_manager/wallets/passkey.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/passkey.rs
@@ -7,6 +7,59 @@ use tracing::{info, warn};
 use super::super::{CloudBackupError, PASSKEY_RP_ID};
 use super::UnpersistedPrfKey;
 
+trait PasskeyAccessExt {
+    fn create_new_prf_key(&self, log_message: &str) -> Result<UnpersistedPrfKey, CloudBackupError>;
+    fn create_new_prf_key_for_wrapper_repair(&self) -> Result<UnpersistedPrfKey, CloudBackupError>;
+}
+
+impl PasskeyAccessExt for PasskeyAccess {
+    fn create_new_prf_key(&self, log_message: &str) -> Result<UnpersistedPrfKey, CloudBackupError> {
+        info!("{log_message}");
+        let prf_salt: [u8; 32] = rand::rng().random();
+        let credential_id = self
+            .create_passkey(
+                PASSKEY_RP_ID.to_string(),
+                rand::rng().random::<[u8; 16]>().to_vec(),
+                random_challenge(),
+            )
+            .map_err(map_enable_passkey_error)?;
+
+        let prf_output = self
+            .authenticate_with_prf(
+                PASSKEY_RP_ID.to_string(),
+                credential_id.clone(),
+                prf_salt.to_vec(),
+                random_challenge(),
+            )
+            .map_err(map_enable_passkey_error)?;
+
+        Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
+    }
+
+    fn create_new_prf_key_for_wrapper_repair(&self) -> Result<UnpersistedPrfKey, CloudBackupError> {
+        info!("Creating new passkey for wrapper repair");
+        let prf_salt: [u8; 32] = rand::rng().random();
+        let credential_id = self
+            .create_passkey(
+                PASSKEY_RP_ID.to_string(),
+                rand::rng().random::<[u8; 16]>().to_vec(),
+                random_challenge(),
+            )
+            .map_err(map_wrapper_repair_passkey_error)?;
+
+        let prf_output = self
+            .authenticate_with_prf(
+                PASSKEY_RP_ID.to_string(),
+                credential_id.clone(),
+                prf_salt.to_vec(),
+                random_challenge(),
+            )
+            .map_err(map_wrapper_repair_passkey_error)?;
+
+        Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
+    }
+}
+
 pub struct NamespaceMatch {
     pub namespace_id: String,
     pub master_key: cove_cspp::master_key::MasterKey,
@@ -29,7 +82,7 @@ pub enum NamespaceMatchOutcome {
 pub fn create_prf_key_without_persisting(
     passkey: &PasskeyAccess,
 ) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    create_new_prf_key_for_wrapper_repair(passkey)
+    passkey.create_new_prf_key_for_wrapper_repair()
 }
 
 /// Try to discover an existing passkey, fall back to creating a new one
@@ -87,22 +140,22 @@ pub fn try_match_namespace_with_passkey(
     let mut had_unsupported_versions = false;
 
     for namespace in namespaces {
-        let master_json = match cloud.download_master_key_backup(namespace.clone()) {
-            Ok(json) => json,
-            Err(error) => {
+        let Ok(master_json) =
+            cloud.download_master_key_backup(namespace.clone()).inspect_err(|error| {
                 warn!("Failed to download master key for namespace {namespace}: {error}");
                 had_download_failures = true;
-                continue;
-            }
+            })
+        else {
+            continue;
         };
 
-        let encrypted: EncryptedMasterKeyBackup = match serde_json::from_slice(&master_json) {
-            Ok(encrypted) => encrypted,
-            Err(error) => {
+        let Ok(encrypted) = serde_json::from_slice::<EncryptedMasterKeyBackup>(&master_json)
+            .inspect_err(|error| {
                 warn!("Failed to deserialize master key for namespace {namespace}: {error}");
                 had_download_failures = true;
-                continue;
-            }
+            })
+        else {
+            continue;
         };
 
         if encrypted.version != 1 {
@@ -165,12 +218,13 @@ pub fn try_match_namespace_with_passkey(
         if let Ok(master_key) =
             cove_cspp::master_key_crypto::decrypt_master_key(encrypted, &prf_key)
         {
-            return Ok(NamespaceMatchOutcome::Matched(NamespaceMatch {
+            let matched = NamespaceMatch {
                 namespace_id: namespace_id.clone(),
                 master_key,
                 prf_salt: encrypted.prf_salt,
                 credential_id: discovered.credential_id.clone(),
-            }));
+            };
+            return Ok(NamespaceMatchOutcome::Matched(matched));
         }
     }
 
@@ -189,51 +243,7 @@ pub fn create_new_prf_key(
     passkey: &PasskeyAccess,
     log_message: &str,
 ) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    info!("{log_message}");
-    let prf_salt: [u8; 32] = rand::rng().random();
-    let credential_id = passkey
-        .create_passkey(
-            PASSKEY_RP_ID.to_string(),
-            rand::rng().random::<[u8; 16]>().to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_enable_passkey_error)?;
-
-    let prf_output = passkey
-        .authenticate_with_prf(
-            PASSKEY_RP_ID.to_string(),
-            credential_id.clone(),
-            prf_salt.to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_enable_passkey_error)?;
-
-    Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
-}
-
-fn create_new_prf_key_for_wrapper_repair(
-    passkey: &PasskeyAccess,
-) -> Result<UnpersistedPrfKey, CloudBackupError> {
-    info!("Creating new passkey for wrapper repair");
-    let prf_salt: [u8; 32] = rand::rng().random();
-    let credential_id = passkey
-        .create_passkey(
-            PASSKEY_RP_ID.to_string(),
-            rand::rng().random::<[u8; 16]>().to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_wrapper_repair_passkey_error)?;
-
-    let prf_output = passkey
-        .authenticate_with_prf(
-            PASSKEY_RP_ID.to_string(),
-            credential_id.clone(),
-            prf_salt.to_vec(),
-            random_challenge(),
-        )
-        .map_err(map_wrapper_repair_passkey_error)?;
-
-    Ok(UnpersistedPrfKey { prf_key: prf_output_to_key(prf_output)?, prf_salt, credential_id })
+    passkey.create_new_prf_key(log_message)
 }
 
 fn map_wrapper_repair_passkey_error(error: PasskeyError) -> CloudBackupError {

--- a/rust/src/manager/cloud_backup_manager/wallets/payload.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/payload.rs
@@ -1,0 +1,497 @@
+use cove_cspp::backup_data::{
+    DescriptorPair, WalletEntry, WalletMode, WalletSecret as CloudWalletSecret,
+};
+use cove_device::keychain::Keychain;
+use cove_util::ResultExt as _;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tracing::warn;
+
+use super::super::LocalWalletSecret;
+use super::{CloudBackupError, LocalWalletMode, MAX_CLOUD_LABELS_SIZE, PreparedWalletBackup};
+use crate::backup::model::DescriptorPair as LocalDescriptorPair;
+use crate::label_manager::LabelManager;
+use crate::wallet::{
+    WalletAddressType,
+    metadata::{WalletColor, WalletMetadata, WalletType},
+};
+
+#[derive(Debug)]
+struct PreparedCloudLabels {
+    labels_zstd_jsonl: Option<Vec<u8>>,
+    labels_count: u32,
+    labels_hash: Option<String>,
+    labels_uncompressed_size: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WalletBackupRevisionPayload {
+    name: String,
+    color: WalletColor,
+    address_type: WalletAddressType,
+    wallet_type: WalletType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    origin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    labels_hash: Option<String>,
+    secret_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    descriptor_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xpub_hash: Option<String>,
+}
+
+impl WalletBackupRevisionPayload {
+    fn for_metadata(metadata: &WalletMetadata) -> Self {
+        Self {
+            name: metadata.name.clone(),
+            color: metadata.color,
+            address_type: metadata.address_type,
+            wallet_type: metadata.wallet_type,
+            origin: metadata.origin.clone(),
+            fingerprint: metadata.master_fingerprint.as_ref().map(|fp| fp.as_uppercase()),
+            labels_hash: None,
+            secret_hash: String::new(),
+            descriptor_hash: None,
+            xpub_hash: None,
+        }
+    }
+
+    fn for_backup(
+        metadata: &WalletMetadata,
+        labels_hash: Option<String>,
+        secret: &CloudWalletSecret,
+        descriptors: &Option<DescriptorPair>,
+        xpub: &Option<String>,
+    ) -> Result<Self, CloudBackupError> {
+        Ok(Self {
+            name: metadata.name.clone(),
+            color: metadata.color,
+            address_type: metadata.address_type,
+            wallet_type: metadata.wallet_type,
+            origin: metadata.origin.clone(),
+            fingerprint: metadata.master_fingerprint.as_ref().map(|fp| fp.as_uppercase()),
+            labels_hash,
+            secret_hash: stable_sync_hash(secret)?,
+            descriptor_hash: stable_sync_hash_option(descriptors)?,
+            xpub_hash: stable_sync_hash_option(xpub)?,
+        })
+    }
+
+    fn content_revision_hash(&self) -> Result<String, CloudBackupError> {
+        let bytes = serde_json::to_vec(self)
+            .map_err_prefix("serialize revision payload", CloudBackupError::Internal)?;
+
+        Ok(hex::encode(Sha256::digest(bytes)))
+    }
+}
+
+impl From<LocalWalletMode> for WalletMode {
+    fn from(mode: LocalWalletMode) -> Self {
+        match mode {
+            LocalWalletMode::Main => Self::Main,
+            LocalWalletMode::Decoy => Self::Decoy,
+        }
+    }
+}
+
+pub fn build_wallet_entry(
+    metadata: &WalletMetadata,
+    mode: LocalWalletMode,
+) -> Result<WalletEntry, CloudBackupError> {
+    let keychain = Keychain::global();
+    let id = &metadata.id;
+    let name = &metadata.name;
+
+    let secret = match metadata.wallet_type {
+        WalletType::Hot => match keychain.get_wallet_key(id) {
+            Ok(Some(mnemonic)) => CloudWalletSecret::Mnemonic(mnemonic.to_string()),
+            Ok(None) => {
+                return Err(CloudBackupError::Internal(format!(
+                    "hot wallet '{name}' has no mnemonic"
+                )));
+            }
+            Err(error) => {
+                return Err(CloudBackupError::Internal(format!(
+                    "failed to get mnemonic for '{name}': {error}"
+                )));
+            }
+        },
+        WalletType::Cold => build_cold_wallet_secret(keychain, metadata, id, name)?,
+        WalletType::XpubOnly | WalletType::WatchOnly => CloudWalletSecret::WatchOnly,
+    };
+
+    let xpub = match keychain.get_wallet_xpub(id) {
+        Ok(Some(xpub)) => Some(xpub.to_string()),
+        Ok(None) => None,
+        Err(error) => {
+            return Err(CloudBackupError::Internal(format!(
+                "failed to read xpub for '{name}': {error}"
+            )));
+        }
+    };
+
+    let descriptors = match keychain.get_public_descriptor(id) {
+        Ok(Some((external, internal))) => {
+            Some(DescriptorPair { external: external.to_string(), internal: internal.to_string() })
+        }
+        Ok(None) => None,
+        Err(error) => {
+            return Err(CloudBackupError::Internal(format!(
+                "failed to read descriptors for '{name}': {error}"
+            )));
+        }
+    };
+
+    let metadata_value = serde_json::to_value(metadata)
+        .map_err_prefix("serialize metadata", CloudBackupError::Internal)?;
+
+    let wallet_mode = mode.into();
+
+    let labels_jsonl = export_wallet_labels_jsonl(id)?;
+    let prepared_labels = prepare_cloud_labels(&labels_jsonl)?;
+    let revision_payload = WalletBackupRevisionPayload::for_backup(
+        metadata,
+        prepared_labels.labels_hash.clone(),
+        &secret,
+        &descriptors,
+        &xpub,
+    )?;
+    let content_revision_hash = revision_payload.content_revision_hash()?;
+    let updated_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+
+    Ok(WalletEntry {
+        wallet_id: id.to_string(),
+        secret,
+        metadata: metadata_value,
+        descriptors,
+        xpub,
+        wallet_mode,
+        labels_zstd_jsonl: prepared_labels.labels_zstd_jsonl,
+        labels_count: prepared_labels.labels_count,
+        labels_hash: prepared_labels.labels_hash,
+        labels_uncompressed_size: prepared_labels.labels_uncompressed_size,
+        content_revision_hash,
+        updated_at,
+    })
+}
+
+fn build_cold_wallet_secret(
+    keychain: &Keychain,
+    metadata: &WalletMetadata,
+    id: &crate::wallet::metadata::WalletId,
+    name: &str,
+) -> Result<CloudWalletSecret, CloudBackupError> {
+    let is_tap_signer =
+        metadata.hardware_metadata.as_ref().is_some_and(|hardware| hardware.is_tap_signer());
+
+    if !is_tap_signer {
+        return Ok(CloudWalletSecret::WatchOnly);
+    }
+
+    match keychain.get_tap_signer_backup(id) {
+        Ok(Some(backup)) => Ok(CloudWalletSecret::TapSignerBackup(backup)),
+        Ok(None) => {
+            warn!("Tap signer wallet '{name}' has no backup, exporting without it");
+            Ok(CloudWalletSecret::WatchOnly)
+        }
+        Err(error) => Err(CloudBackupError::Internal(format!(
+            "failed to read tap signer backup for '{name}': {error}"
+        ))),
+    }
+}
+
+pub fn prepare_wallet_backup(
+    metadata: &WalletMetadata,
+    mode: LocalWalletMode,
+) -> Result<PreparedWalletBackup, CloudBackupError> {
+    let entry = build_wallet_entry(metadata, mode)?;
+    let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
+    let revision_hash = entry.content_revision_hash.clone();
+
+    Ok(PreparedWalletBackup { metadata: metadata.clone(), record_id, revision_hash, entry })
+}
+
+fn prepare_cloud_labels(labels_jsonl: &str) -> Result<PreparedCloudLabels, CloudBackupError> {
+    ensure_cloud_labels_size(labels_jsonl.len(), "uncompressed")?;
+
+    let labels_count = labels_jsonl.lines().filter(|line| !line.trim().is_empty()).count() as u32;
+    let labels_hash =
+        (!labels_jsonl.is_empty()).then(|| hex::encode(Sha256::digest(labels_jsonl.as_bytes())));
+    let labels_uncompressed_size =
+        (!labels_jsonl.is_empty()).then(|| labels_jsonl.len().try_into().unwrap_or(u32::MAX));
+    let labels_zstd_jsonl = if labels_jsonl.is_empty() {
+        None
+    } else {
+        Some(
+            crate::backup::crypto::compress(labels_jsonl.as_bytes())
+                .map_err_prefix("compress labels", CloudBackupError::Internal)?,
+        )
+    };
+
+    Ok(PreparedCloudLabels {
+        labels_zstd_jsonl,
+        labels_count,
+        labels_hash,
+        labels_uncompressed_size,
+    })
+}
+
+pub fn wallet_metadata_change_requires_upload(
+    before: &WalletMetadata,
+    after: &WalletMetadata,
+) -> bool {
+    WalletBackupRevisionPayload::for_metadata(before)
+        != WalletBackupRevisionPayload::for_metadata(after)
+}
+
+fn stable_sync_hash<T>(value: &T) -> Result<String, CloudBackupError>
+where
+    T: Serialize,
+{
+    let bytes = serde_json::to_vec(value)
+        .map_err_prefix("serialize sync field", CloudBackupError::Internal)?;
+    Ok(hex::encode(Sha256::digest(bytes)))
+}
+
+fn stable_sync_hash_option<T>(value: &Option<T>) -> Result<Option<String>, CloudBackupError>
+where
+    T: Serialize,
+{
+    value.as_ref().map(stable_sync_hash).transpose()
+}
+
+fn export_wallet_labels_jsonl(
+    wallet_id: &crate::wallet::metadata::WalletId,
+) -> Result<String, CloudBackupError> {
+    let manager = LabelManager::try_new(wallet_id.clone())
+        .map_err(|error| CloudBackupError::Internal(format!("open labels db: {error}")))?;
+
+    manager.export_blocking().map_err(|error| CloudBackupError::Internal(error.to_string()))
+}
+
+pub fn decode_cloud_labels_jsonl(entry: &WalletEntry) -> Result<Option<String>, CloudBackupError> {
+    let Some(compressed_labels) = &entry.labels_zstd_jsonl else {
+        return Ok(None);
+    };
+
+    let decompressed = crate::backup::crypto::decompress(compressed_labels)
+        .map_err_prefix("decompress labels", CloudBackupError::Internal)?;
+
+    ensure_cloud_labels_size(decompressed.len(), "decompressed")?;
+
+    String::from_utf8(decompressed.to_vec())
+        .map(Some)
+        .map_err(|error| CloudBackupError::Internal(format!("decode labels as utf8: {error}")))
+}
+
+fn ensure_cloud_labels_size(size: usize, label_state: &str) -> Result<(), CloudBackupError> {
+    if size <= MAX_CLOUD_LABELS_SIZE {
+        return Ok(());
+    }
+
+    Err(CloudBackupError::Internal(format!(
+        "{label_state} labels exceed {MAX_CLOUD_LABELS_SIZE} byte limit",
+    )))
+}
+
+pub fn convert_cloud_secret(secret: &CloudWalletSecret) -> LocalWalletSecret {
+    match secret {
+        CloudWalletSecret::Mnemonic(mnemonic) => LocalWalletSecret::Mnemonic(mnemonic.clone()),
+        CloudWalletSecret::TapSignerBackup(backup) => {
+            LocalWalletSecret::TapSignerBackup(backup.clone())
+        }
+        CloudWalletSecret::Descriptor(_) | CloudWalletSecret::WatchOnly => LocalWalletSecret::None,
+    }
+}
+
+pub fn descriptor_pair_from_cloud(
+    descriptors: &Option<DescriptorPair>,
+) -> Option<LocalDescriptorPair> {
+    descriptors.as_ref().map(|descriptors| LocalDescriptorPair {
+        external: descriptors.external.clone(),
+        internal: descriptors.internal.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn content_revision_hash_for_metadata(metadata: &WalletMetadata) -> String {
+        WalletBackupRevisionPayload::for_metadata(metadata).content_revision_hash().unwrap()
+    }
+
+    #[test]
+    fn prepare_cloud_labels_rejects_uncompressed_labels_over_limit() {
+        let labels_jsonl = "a".repeat(MAX_CLOUD_LABELS_SIZE + 1);
+
+        let error = prepare_cloud_labels(&labels_jsonl).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CloudBackupError::Internal(message)
+                if message == format!("uncompressed labels exceed {MAX_CLOUD_LABELS_SIZE} byte limit")
+        ));
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_wallet_name_changes() {
+        let mut metadata = WalletMetadata::preview_new();
+        let original_hash = content_revision_hash_for_metadata(&metadata);
+
+        metadata.name = "Renamed wallet".into();
+
+        assert_ne!(content_revision_hash_for_metadata(&metadata), original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_wallet_color_changes() {
+        let mut metadata = WalletMetadata::preview_new();
+        let original_hash = content_revision_hash_for_metadata(&metadata);
+
+        metadata.color = alternate_wallet_color(metadata.color);
+
+        assert_ne!(content_revision_hash_for_metadata(&metadata), original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_labels_hash_changes() {
+        let metadata = WalletMetadata::preview_new();
+        let original_hash = WalletBackupRevisionPayload::for_backup(
+            &metadata,
+            None,
+            &CloudWalletSecret::WatchOnly,
+            &None,
+            &None,
+        )
+        .unwrap()
+        .content_revision_hash()
+        .unwrap();
+
+        let updated_hash = WalletBackupRevisionPayload::for_backup(
+            &metadata,
+            Some("labels-hash".into()),
+            &CloudWalletSecret::WatchOnly,
+            &None,
+            &None,
+        )
+        .unwrap()
+        .content_revision_hash()
+        .unwrap();
+
+        assert_ne!(updated_hash, original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_address_type_changes() {
+        let mut metadata = WalletMetadata::preview_new();
+        let original_hash = content_revision_hash_for_metadata(&metadata);
+
+        metadata.address_type = crate::wallet::WalletAddressType::Legacy;
+
+        assert_ne!(content_revision_hash_for_metadata(&metadata), original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_wallet_type_changes() {
+        let mut metadata = WalletMetadata::preview_new();
+        let original_hash = content_revision_hash_for_metadata(&metadata);
+
+        metadata.wallet_type = WalletType::WatchOnly;
+
+        assert_ne!(content_revision_hash_for_metadata(&metadata), original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_origin_changes() {
+        let mut metadata = WalletMetadata::preview_new();
+        let original_hash = content_revision_hash_for_metadata(&metadata);
+
+        metadata.origin = Some("wpkh([abcd1234/84h/0h/0h])".into());
+
+        assert_ne!(content_revision_hash_for_metadata(&metadata), original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_changes_when_secret_changes() {
+        let metadata = WalletMetadata::preview_new();
+        let original_hash = WalletBackupRevisionPayload::for_backup(
+            &metadata,
+            None,
+            &CloudWalletSecret::WatchOnly,
+            &None,
+            &None,
+        )
+        .unwrap()
+        .content_revision_hash()
+        .unwrap();
+
+        let updated_hash = WalletBackupRevisionPayload::for_backup(
+            &metadata,
+            None,
+            &CloudWalletSecret::Mnemonic("abandon abandon abandon".into()),
+            &None,
+            &None,
+        )
+        .unwrap()
+        .content_revision_hash()
+        .unwrap();
+
+        assert_ne!(updated_hash, original_hash);
+    }
+
+    #[test]
+    fn content_revision_hash_ignores_non_sync_metadata_fields() {
+        let mut metadata = WalletMetadata::preview_new();
+        let original_hash = content_revision_hash_for_metadata(&metadata);
+
+        metadata.selected_unit = crate::transaction::Unit::Sat;
+        metadata.sensitive_visible = !metadata.sensitive_visible;
+        metadata.details_expanded = !metadata.details_expanded;
+        metadata.show_labels = !metadata.show_labels;
+        metadata.discovery_state = crate::wallet::metadata::DiscoveryState::ChoseAdressType;
+        metadata.verified = !metadata.verified;
+
+        assert_eq!(content_revision_hash_for_metadata(&metadata), original_hash);
+    }
+
+    #[test]
+    fn wallet_metadata_change_requires_upload_only_for_sync_fields() {
+        let original = WalletMetadata::preview_new();
+
+        let mut renamed = original.clone();
+        renamed.name = "Renamed wallet".into();
+        assert!(wallet_metadata_change_requires_upload(&original, &renamed));
+
+        let mut recolored = original.clone();
+        recolored.color = alternate_wallet_color(recolored.color);
+        assert!(wallet_metadata_change_requires_upload(&original, &recolored));
+
+        let mut address_type_changed = original.clone();
+        address_type_changed.address_type = crate::wallet::WalletAddressType::Legacy;
+        assert!(wallet_metadata_change_requires_upload(&original, &address_type_changed));
+
+        let mut wallet_type_changed = original.clone();
+        wallet_type_changed.wallet_type = WalletType::WatchOnly;
+        assert!(wallet_metadata_change_requires_upload(&original, &wallet_type_changed));
+
+        let mut origin_changed = original.clone();
+        origin_changed.origin = Some("wpkh([abcd1234/84h/0h/0h])".into());
+        assert!(wallet_metadata_change_requires_upload(&original, &origin_changed));
+
+        let mut view_only = original.clone();
+        view_only.selected_unit = crate::transaction::Unit::Sat;
+        view_only.details_expanded = !view_only.details_expanded;
+        assert!(!wallet_metadata_change_requires_upload(&original, &view_only));
+    }
+
+    fn alternate_wallet_color(color: WalletColor) -> WalletColor {
+        match color {
+            WalletColor::Blue => WalletColor::Green,
+            _ => WalletColor::Blue,
+        }
+    }
+}

--- a/rust/src/manager/cloud_backup_manager/wallets/payload.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/payload.rs
@@ -106,19 +106,18 @@ pub fn build_wallet_entry(
     let name = &metadata.name;
 
     let secret = match metadata.wallet_type {
-        WalletType::Hot => match keychain.get_wallet_key(id) {
-            Ok(Some(mnemonic)) => CloudWalletSecret::Mnemonic(mnemonic.to_string()),
-            Ok(None) => {
+        WalletType::Hot => {
+            let mnemonic = keychain.get_wallet_key(id).map_err(|error| {
+                CloudBackupError::Internal(format!("failed to get mnemonic for '{name}': {error}"))
+            })?;
+            let Some(mnemonic) = mnemonic else {
                 return Err(CloudBackupError::Internal(format!(
                     "hot wallet '{name}' has no mnemonic"
                 )));
-            }
-            Err(error) => {
-                return Err(CloudBackupError::Internal(format!(
-                    "failed to get mnemonic for '{name}': {error}"
-                )));
-            }
-        },
+            };
+
+            CloudWalletSecret::Mnemonic(mnemonic.to_string())
+        }
         WalletType::Cold => build_cold_wallet_secret(keychain, metadata, id, name)?,
         WalletType::XpubOnly | WalletType::WatchOnly => CloudWalletSecret::WatchOnly,
     };

--- a/rust/src/manager/cloud_backup_manager/wallets/restore.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/restore.rs
@@ -1,0 +1,385 @@
+use std::str::FromStr as _;
+
+use cove_cspp::backup_data::{EncryptedWalletBackup, WalletEntry};
+use cove_cspp::wallet_crypto;
+use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
+use cove_util::ResultExt as _;
+use tracing::{info, warn};
+use zeroize::Zeroizing;
+
+use super::super::{CloudBackupError, LocalWalletMode, LocalWalletSecret};
+use super::payload::{convert_cloud_secret, descriptor_pair_from_cloud};
+use super::{DownloadedWalletBackup, RemoteWalletBackupSummary, decode_cloud_labels_jsonl};
+use crate::backup::import::{LabelRestoreBehavior, LabelRestoreWarning, restore_wallet_labels};
+use crate::wallet::fingerprint::Fingerprint;
+use crate::wallet::metadata::WalletMetadata;
+
+pub(crate) enum WalletBackupLookup<T> {
+    Found(T),
+    NotFound,
+    UnsupportedVersion(u32),
+}
+
+type ExistingFingerprints = Vec<(Fingerprint, cove_types::network::Network, LocalWalletMode)>;
+
+pub(crate) struct WalletBackupReader {
+    cloud: CloudStorage,
+    namespace: String,
+    critical_key: Zeroizing<[u8; 32]>,
+}
+
+impl WalletBackupReader {
+    pub(crate) fn new(
+        cloud: CloudStorage,
+        namespace: String,
+        critical_key: Zeroizing<[u8; 32]>,
+    ) -> Self {
+        Self { cloud, namespace, critical_key }
+    }
+
+    pub(crate) fn download(
+        &self,
+        record_id: &str,
+    ) -> Result<DownloadedWalletBackup, CloudBackupError> {
+        match self.lookup(record_id)? {
+            WalletBackupLookup::Found(wallet) => Ok(wallet),
+            WalletBackupLookup::NotFound => Err(CloudBackupError::Cloud(format!(
+                "download {record_id}: not found in cloud backup"
+            ))),
+            WalletBackupLookup::UnsupportedVersion(version) => Err(CloudBackupError::Internal(
+                format!("download {record_id}: unsupported wallet backup version {version}"),
+            )),
+        }
+    }
+
+    pub(crate) fn summary(
+        &self,
+        record_id: &str,
+    ) -> Result<WalletBackupLookup<RemoteWalletBackupSummary>, CloudBackupError> {
+        Ok(match self.lookup_entry(record_id)? {
+            WalletBackupLookup::Found(entry) => {
+                WalletBackupLookup::Found(RemoteWalletBackupSummary {
+                    revision_hash: entry.content_revision_hash.clone(),
+                    label_count: entry.labels_count,
+                    updated_at: entry.updated_at,
+                })
+            }
+            WalletBackupLookup::NotFound => WalletBackupLookup::NotFound,
+            WalletBackupLookup::UnsupportedVersion(version) => {
+                WalletBackupLookup::UnsupportedVersion(version)
+            }
+        })
+    }
+
+    pub(crate) fn lookup(
+        &self,
+        record_id: &str,
+    ) -> Result<WalletBackupLookup<DownloadedWalletBackup>, CloudBackupError> {
+        Ok(match self.lookup_entry(record_id)? {
+            WalletBackupLookup::Found(entry) => {
+                let metadata = serde_json::from_value(entry.metadata.clone())
+                    .map_err_prefix("parse wallet metadata", CloudBackupError::Internal)?;
+                WalletBackupLookup::Found(DownloadedWalletBackup { metadata, entry })
+            }
+            WalletBackupLookup::NotFound => WalletBackupLookup::NotFound,
+            WalletBackupLookup::UnsupportedVersion(version) => {
+                WalletBackupLookup::UnsupportedVersion(version)
+            }
+        })
+    }
+
+    pub(crate) fn lookup_entry(
+        &self,
+        record_id: &str,
+    ) -> Result<WalletBackupLookup<WalletEntry>, CloudBackupError> {
+        Ok(match self.download_encrypted(record_id)? {
+            WalletBackupLookup::Found(encrypted) => WalletBackupLookup::Found(
+                self.decrypt_entry(&encrypted)
+                    .map_err_prefix("decrypt wallet", CloudBackupError::Crypto)?,
+            ),
+            WalletBackupLookup::NotFound => WalletBackupLookup::NotFound,
+            WalletBackupLookup::UnsupportedVersion(version) => {
+                WalletBackupLookup::UnsupportedVersion(version)
+            }
+        })
+    }
+
+    pub(crate) fn download_encrypted(
+        &self,
+        record_id: &str,
+    ) -> Result<WalletBackupLookup<EncryptedWalletBackup>, CloudBackupError> {
+        let wallet_json = match self
+            .cloud
+            .download_wallet_backup(self.namespace.clone(), record_id.to_string())
+        {
+            Ok(wallet_json) => wallet_json,
+            Err(CloudStorageError::NotFound(_)) => return Ok(WalletBackupLookup::NotFound),
+            Err(error) => {
+                return Err(CloudBackupError::Cloud(format!("download {record_id}: {error}")));
+            }
+        };
+
+        let encrypted: EncryptedWalletBackup = serde_json::from_slice(&wallet_json)
+            .map_err_prefix("deserialize wallet", CloudBackupError::Internal)?;
+
+        if encrypted.version != 1 {
+            let version = encrypted.version;
+            warn!(
+                "Skipping wallet backup {record_id}: unsupported wallet backup version {version}"
+            );
+            return Ok(WalletBackupLookup::UnsupportedVersion(version));
+        }
+
+        Ok(WalletBackupLookup::Found(encrypted))
+    }
+
+    pub(crate) fn decrypt_entry(
+        &self,
+        encrypted: &EncryptedWalletBackup,
+    ) -> Result<WalletEntry, cove_cspp::CsppError> {
+        wallet_crypto::decrypt_wallet_backup(encrypted, &self.critical_key)
+    }
+}
+
+pub(crate) struct WalletRestoreSession(ExistingFingerprints);
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct WalletRestoreOutcome {
+    pub(crate) labels_warning: Option<LabelRestoreWarning>,
+}
+
+impl WalletRestoreSession {
+    pub(crate) fn new(existing_fingerprints: ExistingFingerprints) -> Self {
+        Self(existing_fingerprints)
+    }
+
+    pub(crate) fn restore_record(
+        &mut self,
+        reader: &WalletBackupReader,
+        record_id: &str,
+    ) -> Result<WalletRestoreOutcome, CloudBackupError> {
+        let wallet = reader.download(record_id)?;
+        self.restore_downloaded(&wallet)
+    }
+
+    pub(crate) fn restore_downloaded(
+        &mut self,
+        wallet: &DownloadedWalletBackup,
+    ) -> Result<WalletRestoreOutcome, CloudBackupError> {
+        if should_skip_duplicate_wallet(&wallet.metadata, &self.0) {
+            return Ok(WalletRestoreOutcome::default());
+        }
+
+        let outcome = restore_downloaded_wallet(&wallet.metadata, &wallet.entry)?;
+        remember_restored_wallet_fingerprint(&wallet.metadata, &mut self.0);
+
+        Ok(outcome)
+    }
+}
+
+fn should_skip_duplicate_wallet(
+    metadata: &WalletMetadata,
+    existing_fingerprints: &ExistingFingerprints,
+) -> bool {
+    if crate::backup::import::is_wallet_duplicate(metadata, existing_fingerprints)
+        .inspect_err(|error| {
+            warn!("is_wallet_duplicate check failed for {}: {error}", metadata.name)
+        })
+        .unwrap_or(false)
+    {
+        info!("Skipping duplicate wallet {}", metadata.name);
+        true
+    } else {
+        false
+    }
+}
+
+fn restore_downloaded_wallet(
+    metadata: &WalletMetadata,
+    entry: &WalletEntry,
+) -> Result<WalletRestoreOutcome, CloudBackupError> {
+    let backup_model = crate::backup::model::WalletBackup {
+        metadata: entry.metadata.clone(),
+        secret: convert_cloud_secret(&entry.secret),
+        descriptors: descriptor_pair_from_cloud(&entry.descriptors),
+        xpub: entry.xpub.clone(),
+        labels_jsonl: decode_cloud_labels_jsonl(entry)?,
+    };
+
+    match &backup_model.secret {
+        LocalWalletSecret::Mnemonic(words) => {
+            let mnemonic = bip39::Mnemonic::from_str(words)
+                .map_err_prefix("invalid mnemonic", CloudBackupError::Internal)?;
+
+            crate::backup::import::restore_cloud_mnemonic_wallet(metadata, mnemonic).map_err(
+                |(error, _)| {
+                    CloudBackupError::Internal(format!("restore mnemonic wallet: {error}"))
+                },
+            )?;
+        }
+        _ => {
+            crate::backup::import::restore_cloud_descriptor_wallet(metadata, &backup_model)
+                .map_err(|(error, _)| {
+                    CloudBackupError::Internal(format!("restore descriptor wallet: {error}"))
+                })?;
+        }
+    }
+
+    let labels_outcome = restore_wallet_labels(
+        &metadata.id,
+        &metadata.name,
+        backup_model.labels_jsonl.as_deref(),
+        LabelRestoreBehavior::PreserveCloudBackupClean,
+    );
+    if let Some(warning) = &labels_outcome.warning {
+        warn!("Failed to restore labels for wallet {}: {}", metadata.name, warning.error);
+    }
+
+    Ok(WalletRestoreOutcome { labels_warning: labels_outcome.warning })
+}
+
+fn remember_restored_wallet_fingerprint(
+    metadata: &WalletMetadata,
+    existing_fingerprints: &mut ExistingFingerprints,
+) {
+    if let Some(fingerprint) = &metadata.master_fingerprint {
+        existing_fingerprints.push((**fingerprint, metadata.network, metadata.wallet_mode));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cove_cspp::backup_data::WalletSecret;
+    use cove_device::cloud_storage::{CloudStorageAccess, CloudStorageError};
+
+    fn test_wallet_entry(metadata: &WalletMetadata) -> WalletEntry {
+        WalletEntry {
+            wallet_id: metadata.id.to_string(),
+            secret: WalletSecret::WatchOnly,
+            metadata: serde_json::to_value(metadata).unwrap(),
+            descriptors: None,
+            xpub: None,
+            wallet_mode: cove_cspp::backup_data::WalletMode::Main,
+            labels_zstd_jsonl: None,
+            labels_count: 0,
+            labels_hash: None,
+            labels_uncompressed_size: None,
+            content_revision_hash: "test-revision".into(),
+            updated_at: 42,
+        }
+    }
+
+    #[derive(Debug)]
+    struct NoopCloudStorage;
+
+    impl CloudStorageAccess for NoopCloudStorage {
+        fn upload_master_key_backup(
+            &self,
+            _namespace: String,
+            _data: Vec<u8>,
+        ) -> Result<(), CloudStorageError> {
+            Err(CloudStorageError::NotAvailable("unused in test".into()))
+        }
+
+        fn upload_wallet_backup(
+            &self,
+            _namespace: String,
+            _record_id: String,
+            _data: Vec<u8>,
+        ) -> Result<(), CloudStorageError> {
+            Err(CloudStorageError::NotAvailable("unused in test".into()))
+        }
+
+        fn download_master_key_backup(
+            &self,
+            _namespace: String,
+        ) -> Result<Vec<u8>, CloudStorageError> {
+            Err(CloudStorageError::NotAvailable("unused in test".into()))
+        }
+
+        fn download_wallet_backup(
+            &self,
+            _namespace: String,
+            _record_id: String,
+        ) -> Result<Vec<u8>, CloudStorageError> {
+            Err(CloudStorageError::NotAvailable("unused in test".into()))
+        }
+
+        fn delete_wallet_backup(
+            &self,
+            _namespace: String,
+            _record_id: String,
+        ) -> Result<(), CloudStorageError> {
+            Err(CloudStorageError::NotAvailable("unused in test".into()))
+        }
+
+        fn list_namespaces(&self) -> Result<Vec<String>, CloudStorageError> {
+            Ok(Vec::new())
+        }
+
+        fn list_wallet_files(&self, _namespace: String) -> Result<Vec<String>, CloudStorageError> {
+            Ok(Vec::new())
+        }
+
+        fn is_backup_uploaded(
+            &self,
+            _namespace: String,
+            _record_id: String,
+        ) -> Result<bool, CloudStorageError> {
+            Ok(false)
+        }
+    }
+
+    fn test_cloud_storage() -> CloudStorage {
+        CloudStorage::new(Box::new(NoopCloudStorage))
+    }
+
+    #[test]
+    fn decrypt_entry_round_trips_encrypted_wallet_entry() {
+        let metadata = WalletMetadata::preview_new();
+        let entry = test_wallet_entry(&metadata);
+        let critical_key = [7; 32];
+        let encrypted = wallet_crypto::encrypt_wallet_entry(&entry, &critical_key).unwrap();
+        let reader = WalletBackupReader::new(
+            test_cloud_storage(),
+            "test-namespace".into(),
+            Zeroizing::new(critical_key),
+        );
+
+        let decrypted = reader.decrypt_entry(&encrypted).unwrap();
+
+        assert_eq!(decrypted.wallet_id, entry.wallet_id);
+        assert_eq!(decrypted.content_revision_hash, entry.content_revision_hash);
+    }
+
+    #[test]
+    fn restore_session_skips_duplicate_wallet() {
+        let metadata = WalletMetadata::preview_new();
+        let wallet = DownloadedWalletBackup {
+            metadata: metadata.clone(),
+            entry: test_wallet_entry(&metadata),
+        };
+        let existing_fingerprints = vec![(
+            *metadata.master_fingerprint.as_ref().unwrap().as_ref(),
+            metadata.network,
+            metadata.wallet_mode,
+        )];
+        let mut session = WalletRestoreSession::new(existing_fingerprints);
+
+        session.restore_downloaded(&wallet).unwrap();
+
+        assert_eq!(session.0.len(), 1);
+    }
+
+    #[test]
+    fn remember_restored_wallet_fingerprint_tracks_restored_wallet() {
+        let metadata = WalletMetadata::preview_new();
+        let mut existing_fingerprints = Vec::new();
+
+        remember_restored_wallet_fingerprint(&metadata, &mut existing_fingerprints);
+
+        assert_eq!(existing_fingerprints.len(), 1);
+        assert_eq!(existing_fingerprints[0].0, *metadata.master_fingerprint.unwrap().as_ref());
+    }
+}

--- a/rust/src/manager/cloud_backup_manager/wallets/restore.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/restore.rs
@@ -56,52 +56,52 @@ impl WalletBackupReader {
         &self,
         record_id: &str,
     ) -> Result<WalletBackupLookup<RemoteWalletBackupSummary>, CloudBackupError> {
-        Ok(match self.lookup_entry(record_id)? {
+        match self.lookup_entry(record_id)? {
             WalletBackupLookup::Found(entry) => {
-                WalletBackupLookup::Found(RemoteWalletBackupSummary {
+                Ok(WalletBackupLookup::Found(RemoteWalletBackupSummary {
                     revision_hash: entry.content_revision_hash.clone(),
                     label_count: entry.labels_count,
                     updated_at: entry.updated_at,
-                })
+                }))
             }
-            WalletBackupLookup::NotFound => WalletBackupLookup::NotFound,
+            WalletBackupLookup::NotFound => Ok(WalletBackupLookup::NotFound),
             WalletBackupLookup::UnsupportedVersion(version) => {
-                WalletBackupLookup::UnsupportedVersion(version)
+                Ok(WalletBackupLookup::UnsupportedVersion(version))
             }
-        })
+        }
     }
 
     pub(crate) fn lookup(
         &self,
         record_id: &str,
     ) -> Result<WalletBackupLookup<DownloadedWalletBackup>, CloudBackupError> {
-        Ok(match self.lookup_entry(record_id)? {
+        match self.lookup_entry(record_id)? {
             WalletBackupLookup::Found(entry) => {
                 let metadata = serde_json::from_value(entry.metadata.clone())
                     .map_err_prefix("parse wallet metadata", CloudBackupError::Internal)?;
-                WalletBackupLookup::Found(DownloadedWalletBackup { metadata, entry })
+                Ok(WalletBackupLookup::Found(DownloadedWalletBackup { metadata, entry }))
             }
-            WalletBackupLookup::NotFound => WalletBackupLookup::NotFound,
+            WalletBackupLookup::NotFound => Ok(WalletBackupLookup::NotFound),
             WalletBackupLookup::UnsupportedVersion(version) => {
-                WalletBackupLookup::UnsupportedVersion(version)
+                Ok(WalletBackupLookup::UnsupportedVersion(version))
             }
-        })
+        }
     }
 
     pub(crate) fn lookup_entry(
         &self,
         record_id: &str,
     ) -> Result<WalletBackupLookup<WalletEntry>, CloudBackupError> {
-        Ok(match self.download_encrypted(record_id)? {
-            WalletBackupLookup::Found(encrypted) => WalletBackupLookup::Found(
+        match self.download_encrypted(record_id)? {
+            WalletBackupLookup::Found(encrypted) => Ok(WalletBackupLookup::Found(
                 self.decrypt_entry(&encrypted)
                     .map_err_prefix("decrypt wallet", CloudBackupError::Crypto)?,
-            ),
-            WalletBackupLookup::NotFound => WalletBackupLookup::NotFound,
+            )),
+            WalletBackupLookup::NotFound => Ok(WalletBackupLookup::NotFound),
             WalletBackupLookup::UnsupportedVersion(version) => {
-                WalletBackupLookup::UnsupportedVersion(version)
+                Ok(WalletBackupLookup::UnsupportedVersion(version))
             }
-        })
+        }
     }
 
     pub(crate) fn download_encrypted(
@@ -166,84 +166,79 @@ impl WalletRestoreSession {
         &mut self,
         wallet: &DownloadedWalletBackup,
     ) -> Result<WalletRestoreOutcome, CloudBackupError> {
-        if should_skip_duplicate_wallet(&wallet.metadata, &self.0) {
+        if self.should_skip_duplicate_wallet(&wallet.metadata) {
             return Ok(WalletRestoreOutcome::default());
         }
 
-        let outcome = restore_downloaded_wallet(&wallet.metadata, &wallet.entry)?;
-        remember_restored_wallet_fingerprint(&wallet.metadata, &mut self.0);
+        let outcome = wallet.restore()?;
+        self.remember_restored_wallet_fingerprint(&wallet.metadata);
 
         Ok(outcome)
     }
-}
 
-fn should_skip_duplicate_wallet(
-    metadata: &WalletMetadata,
-    existing_fingerprints: &ExistingFingerprints,
-) -> bool {
-    if crate::backup::import::is_wallet_duplicate(metadata, existing_fingerprints)
-        .inspect_err(|error| {
-            warn!("is_wallet_duplicate check failed for {}: {error}", metadata.name)
-        })
-        .unwrap_or(false)
-    {
-        info!("Skipping duplicate wallet {}", metadata.name);
-        true
-    } else {
-        false
+    fn should_skip_duplicate_wallet(&self, metadata: &WalletMetadata) -> bool {
+        if crate::backup::import::is_wallet_duplicate(metadata, &self.0)
+            .inspect_err(|error| {
+                warn!("is_wallet_duplicate check failed for {}: {error}", metadata.name)
+            })
+            .unwrap_or(false)
+        {
+            info!("Skipping duplicate wallet {}", metadata.name);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn remember_restored_wallet_fingerprint(&mut self, metadata: &WalletMetadata) {
+        if let Some(fingerprint) = &metadata.master_fingerprint {
+            self.0.push((**fingerprint, metadata.network, metadata.wallet_mode));
+        }
     }
 }
 
-fn restore_downloaded_wallet(
-    metadata: &WalletMetadata,
-    entry: &WalletEntry,
-) -> Result<WalletRestoreOutcome, CloudBackupError> {
-    let backup_model = crate::backup::model::WalletBackup {
-        metadata: entry.metadata.clone(),
-        secret: convert_cloud_secret(&entry.secret),
-        descriptors: descriptor_pair_from_cloud(&entry.descriptors),
-        xpub: entry.xpub.clone(),
-        labels_jsonl: decode_cloud_labels_jsonl(entry)?,
-    };
+impl DownloadedWalletBackup {
+    fn restore(&self) -> Result<WalletRestoreOutcome, CloudBackupError> {
+        let backup_model = crate::backup::model::WalletBackup {
+            metadata: self.entry.metadata.clone(),
+            secret: convert_cloud_secret(&self.entry.secret),
+            descriptors: descriptor_pair_from_cloud(&self.entry.descriptors),
+            xpub: self.entry.xpub.clone(),
+            labels_jsonl: decode_cloud_labels_jsonl(&self.entry)?,
+        };
 
-    match &backup_model.secret {
-        LocalWalletSecret::Mnemonic(words) => {
-            let mnemonic = bip39::Mnemonic::from_str(words)
-                .map_err_prefix("invalid mnemonic", CloudBackupError::Internal)?;
+        match &backup_model.secret {
+            LocalWalletSecret::Mnemonic(words) => {
+                let mnemonic = bip39::Mnemonic::from_str(words)
+                    .map_err_prefix("invalid mnemonic", CloudBackupError::Internal)?;
 
-            crate::backup::import::restore_cloud_mnemonic_wallet(metadata, mnemonic).map_err(
-                |(error, _)| {
-                    CloudBackupError::Internal(format!("restore mnemonic wallet: {error}"))
-                },
-            )?;
-        }
-        _ => {
-            crate::backup::import::restore_cloud_descriptor_wallet(metadata, &backup_model)
+                crate::backup::import::restore_cloud_mnemonic_wallet(&self.metadata, mnemonic)
+                    .map_err(|(error, _)| {
+                        CloudBackupError::Internal(format!("restore mnemonic wallet: {error}"))
+                    })?;
+            }
+            _ => {
+                crate::backup::import::restore_cloud_descriptor_wallet(
+                    &self.metadata,
+                    &backup_model,
+                )
                 .map_err(|(error, _)| {
                     CloudBackupError::Internal(format!("restore descriptor wallet: {error}"))
                 })?;
+            }
         }
-    }
 
-    let labels_outcome = restore_wallet_labels(
-        &metadata.id,
-        &metadata.name,
-        backup_model.labels_jsonl.as_deref(),
-        LabelRestoreBehavior::PreserveCloudBackupClean,
-    );
-    if let Some(warning) = &labels_outcome.warning {
-        warn!("Failed to restore labels for wallet {}: {}", metadata.name, warning.error);
-    }
+        let labels_outcome = restore_wallet_labels(
+            &self.metadata.id,
+            &self.metadata.name,
+            backup_model.labels_jsonl.as_deref(),
+            LabelRestoreBehavior::PreserveCloudBackupClean,
+        );
+        if let Some(warning) = &labels_outcome.warning {
+            warn!("Failed to restore labels for wallet {}: {}", self.metadata.name, warning.error);
+        }
 
-    Ok(WalletRestoreOutcome { labels_warning: labels_outcome.warning })
-}
-
-fn remember_restored_wallet_fingerprint(
-    metadata: &WalletMetadata,
-    existing_fingerprints: &mut ExistingFingerprints,
-) {
-    if let Some(fingerprint) = &metadata.master_fingerprint {
-        existing_fingerprints.push((**fingerprint, metadata.network, metadata.wallet_mode));
+        Ok(WalletRestoreOutcome { labels_warning: labels_outcome.warning })
     }
 }
 
@@ -375,11 +370,11 @@ mod tests {
     #[test]
     fn remember_restored_wallet_fingerprint_tracks_restored_wallet() {
         let metadata = WalletMetadata::preview_new();
-        let mut existing_fingerprints = Vec::new();
+        let mut session = WalletRestoreSession::new(Vec::new());
 
-        remember_restored_wallet_fingerprint(&metadata, &mut existing_fingerprints);
+        session.remember_restored_wallet_fingerprint(&metadata);
 
-        assert_eq!(existing_fingerprints.len(), 1);
-        assert_eq!(existing_fingerprints[0].0, *metadata.master_fingerprint.unwrap().as_ref());
+        assert_eq!(session.0.len(), 1);
+        assert_eq!(session.0[0].0, *metadata.master_fingerprint.unwrap().as_ref());
     }
 }

--- a/rust/src/manager/cloud_backup_manager/wallets/upload.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/upload.rs
@@ -1,0 +1,402 @@
+use std::collections::HashSet;
+
+use crate::database::Database;
+use crate::database::cloud_backup::{
+    CloudBlobDirtyState, CloudBlobUploadingState, PersistedCloudBlobState,
+    PersistedCloudBlobSyncState,
+};
+use crate::wallet::metadata::WalletMetadata;
+use cove_cspp::backup_data::wallet_record_id;
+use cove_cspp::wallet_crypto;
+use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
+use cove_device::keychain::Keychain;
+use cove_util::ResultExt as _;
+use tracing::info;
+use zeroize::Zeroizing;
+
+use super::super::ops::load_master_key_for_cloud_action;
+use super::super::{CloudBackupError, RustCloudBackupManager};
+use super::{
+    PreparedWalletBackup, UPLOAD_WALLET_RECOVERY_MESSAGE, all_local_wallets,
+    persist_enabled_cloud_backup_state, prepare_wallet_backup,
+};
+
+struct PreparedDirtyWalletUpload {
+    prepared: PreparedWalletBackup,
+    wallet_json: Vec<u8>,
+}
+
+struct DirtyWalletUploadPreparationError {
+    revision_hash: Option<String>,
+    source: CloudBackupError,
+}
+
+const STALE_UPLOADING_RETRY_THRESHOLD_SECS: u64 = 60;
+
+impl DirtyWalletUploadPreparationError {
+    fn new(source: CloudBackupError, revision_hash: Option<String>) -> Self {
+        Self { revision_hash, source }
+    }
+
+    fn without_revision_hash(source: CloudBackupError) -> Self {
+        Self::new(source, None)
+    }
+}
+
+impl RustCloudBackupManager {
+    /// Upload wallets to cloud and update local cache
+    pub fn do_backup_wallets(
+        &self,
+        wallets: &[crate::wallet::metadata::WalletMetadata],
+    ) -> Result<(), CloudBackupError> {
+        if wallets.is_empty() {
+            return Ok(());
+        }
+
+        let namespace = self.current_namespace_id()?;
+        let db = Database::global();
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        let master_key = match cspp
+            .load_master_key_from_store()
+            .map_err_prefix("load local master key", CloudBackupError::Internal)?
+        {
+            Some(master_key) => master_key,
+            None => self.recover_local_master_key_from_cloud_without_discovery(
+                &namespace,
+                UPLOAD_WALLET_RECOVERY_MESSAGE,
+            )?,
+        };
+
+        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let cloud = CloudStorage::global();
+        let existing_cloud_record_ids = cloud
+            .list_wallet_backups(namespace.clone())
+            .ok()
+            .map(|record_ids| record_ids.into_iter().collect::<HashSet<_>>());
+
+        let existing_sync_state_record_ids =
+            db.cloud_blob_sync_states.list().ok().map(|states| {
+                states.into_iter().map(|state| state.record_id).collect::<HashSet<_>>()
+            });
+        let mut uploaded_record_ids = Vec::with_capacity(wallets.len());
+
+        for (index, metadata) in wallets.iter().enumerate() {
+            info!("Backup: uploading wallet {}/{} '{}'", index + 1, wallets.len(), metadata.name);
+            let prepared = prepare_wallet_backup(metadata, metadata.wallet_mode)?;
+            let encrypted = wallet_crypto::encrypt_wallet_entry(&prepared.entry, &critical_key)
+                .map_err_str(CloudBackupError::Crypto)?;
+
+            let wallet_json =
+                serde_json::to_vec(&encrypted).map_err_str(CloudBackupError::Internal)?;
+
+            cloud
+                .upload_wallet_backup(namespace.clone(), prepared.record_id.clone(), wallet_json)
+                .map_err_str(CloudBackupError::Cloud)?;
+
+            let uploaded_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+            self.mark_wallet_uploaded_pending_confirmation_if_revision_current(
+                &namespace,
+                prepared.metadata.id.clone(),
+                prepared.record_id.clone(),
+                prepared.revision_hash.clone(),
+                uploaded_at,
+            )?;
+
+            uploaded_record_ids.push(prepared.record_id);
+            info!("Backup: wallet {}/{} uploaded", index + 1, wallets.len());
+        }
+
+        let previous_count =
+            db.cloud_backup_state.get().ok().and_then(|state| state.wallet_count).unwrap_or(0);
+        let uploaded_record_ids = uploaded_record_ids.into_iter().collect::<HashSet<_>>();
+
+        let estimated_wallet_count =
+            existing_cloud_record_ids.as_ref().map(|existing_record_ids| {
+                let new_record_count = uploaded_record_ids
+                    .iter()
+                    .filter(|record_id| !existing_record_ids.contains(*record_id))
+                    .count() as u32;
+
+                existing_record_ids.len() as u32 + new_record_count
+            });
+
+        let sync_state_estimated_wallet_count =
+            existing_sync_state_record_ids.as_ref().map(|existing_record_ids| {
+                let new_record_count = uploaded_record_ids
+                    .iter()
+                    .filter(|record_id| !existing_record_ids.contains(*record_id))
+                    .count() as u32;
+
+                previous_count + new_record_count
+            });
+
+        let listed_wallet_count =
+            cloud.list_wallet_backups(namespace).ok().map(|record_ids| record_ids.len() as u32);
+
+        let wallet_count = [
+            Some(previous_count),
+            estimated_wallet_count,
+            sync_state_estimated_wallet_count,
+            listed_wallet_count,
+        ]
+        .into_iter()
+        .flatten()
+        .max()
+        .unwrap_or(previous_count);
+        persist_enabled_cloud_backup_state(&db, wallet_count)?;
+
+        info!("Backed up {} wallet(s) to cloud", wallets.len());
+        Ok(())
+    }
+
+    pub fn do_upload_wallet_if_dirty(
+        &self,
+        wallet_id: &crate::wallet::metadata::WalletId,
+    ) -> Result<(), CloudBackupError> {
+        let namespace = self.current_namespace_id()?;
+        let record_id = wallet_record_id(wallet_id.as_ref());
+        let Some(current_state) = Database::global()
+            .cloud_blob_sync_states
+            .get(&record_id)
+            .map_err_prefix("read cloud blob sync state", CloudBackupError::Internal)?
+        else {
+            return Ok(());
+        };
+        let Some(current_state) = self.recover_uploadable_blob_state(current_state)? else {
+            return Ok(());
+        };
+
+        if !matches!(
+            current_state.state,
+            PersistedCloudBlobState::Dirty(_) | PersistedCloudBlobState::Failed(_)
+        ) {
+            return Ok(());
+        }
+
+        let Some(metadata) = all_local_wallets(&Database::global())?
+            .into_iter()
+            .find(|wallet| wallet.id == *wallet_id)
+        else {
+            self.remove_blob_sync_states(std::iter::once(record_id))?;
+            return Ok(());
+        };
+
+        let prepared_upload = match self.prepare_dirty_wallet_upload(&namespace, &metadata) {
+            Ok(prepared_upload) => prepared_upload,
+            Err(error) => {
+                self.mark_blob_failed_if_current(
+                    &current_state,
+                    error.revision_hash,
+                    is_upload_preparation_failure_retryable(&error.source),
+                    error.source.to_string(),
+                )?;
+                return Err(error.source);
+            }
+        };
+
+        let PreparedDirtyWalletUpload { prepared, wallet_json } = prepared_upload;
+        let cloud = CloudStorage::global();
+        let uploading_state = PersistedCloudBlobSyncState {
+            state: PersistedCloudBlobState::Uploading(CloudBlobUploadingState {
+                revision_hash: prepared.revision_hash.clone(),
+                started_at: jiff::Timestamp::now().as_second().try_into().unwrap_or(0),
+            }),
+            ..current_state.clone()
+        };
+
+        let wrote_uploading = Database::global()
+            .cloud_blob_sync_states
+            .set_if_current(&current_state, &uploading_state)
+            .map_err_prefix("persist uploading cloud blob state", CloudBackupError::Internal)?;
+        if !wrote_uploading {
+            return Ok(());
+        }
+
+        if let Err(error) =
+            cloud.upload_wallet_backup(namespace.clone(), record_id.clone(), wallet_json)
+        {
+            self.mark_blob_failed_if_current(
+                &uploading_state,
+                Some(prepared.revision_hash.clone()),
+                is_upload_failure_retryable(&error),
+                error.to_string(),
+            )?;
+            return Err(CloudBackupError::Cloud(error.to_string()));
+        }
+
+        let uploaded_at = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+        let _ = self.mark_blob_uploaded_pending_confirmation_if_current(
+            &uploading_state,
+            prepared.revision_hash,
+            uploaded_at,
+        )?;
+
+        Ok(())
+    }
+
+    fn recover_uploadable_blob_state(
+        &self,
+        current_state: PersistedCloudBlobSyncState,
+    ) -> Result<Option<PersistedCloudBlobSyncState>, CloudBackupError> {
+        let PersistedCloudBlobState::Uploading(uploading_state) = &current_state.state else {
+            return Ok(Some(current_state));
+        };
+
+        if !is_stale_uploading_state(uploading_state.started_at) {
+            return Ok(Some(current_state));
+        }
+
+        let dirty_state = PersistedCloudBlobSyncState {
+            state: PersistedCloudBlobState::Dirty(CloudBlobDirtyState {
+                changed_at: jiff::Timestamp::now().as_second().try_into().unwrap_or(0),
+            }),
+            ..current_state.clone()
+        };
+        let wrote_dirty = Database::global()
+            .cloud_blob_sync_states
+            .set_if_current(&current_state, &dirty_state)
+            .map_err_prefix(
+                "persist stale uploading cloud blob state",
+                CloudBackupError::Internal,
+            )?;
+
+        Ok(wrote_dirty.then_some(dirty_state))
+    }
+
+    fn prepare_dirty_wallet_upload(
+        &self,
+        namespace: &str,
+        metadata: &WalletMetadata,
+    ) -> Result<PreparedDirtyWalletUpload, DirtyWalletUploadPreparationError> {
+        let prepared = prepare_wallet_backup(metadata, metadata.wallet_mode)
+            .map_err(DirtyWalletUploadPreparationError::without_revision_hash)?;
+
+        let revision_hash = Some(prepared.revision_hash.clone());
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        let master_key = load_master_key_for_cloud_action(&cspp, || {
+            self.recover_local_master_key_from_cloud_without_discovery(
+                namespace,
+                UPLOAD_WALLET_RECOVERY_MESSAGE,
+            )
+        })
+        .map_err(|source| DirtyWalletUploadPreparationError::new(source, revision_hash.clone()))?;
+
+        let critical_key = Zeroizing::new(master_key.critical_data_key());
+        let encrypted = wallet_crypto::encrypt_wallet_entry(&prepared.entry, &critical_key)
+            .map_err_str(CloudBackupError::Crypto)
+            .map_err(|source| {
+                DirtyWalletUploadPreparationError::new(source, revision_hash.clone())
+            })?;
+
+        let wallet_json = serde_json::to_vec(&encrypted)
+            .map_err_str(CloudBackupError::Internal)
+            .map_err(|source| DirtyWalletUploadPreparationError::new(source, revision_hash))?;
+
+        Ok(PreparedDirtyWalletUpload { prepared, wallet_json })
+    }
+
+    fn mark_wallet_uploaded_pending_confirmation_if_revision_current(
+        &self,
+        namespace_id: &str,
+        wallet_id: crate::wallet::metadata::WalletId,
+        record_id: String,
+        revision_hash: String,
+        uploaded_at: u64,
+    ) -> Result<(), CloudBackupError> {
+        let Some(current_metadata) = all_local_wallets(&Database::global())?
+            .into_iter()
+            .find(|wallet| wallet.id == wallet_id)
+        else {
+            return self.mark_blob_uploaded_pending_confirmation(
+                namespace_id,
+                Some(wallet_id),
+                record_id,
+                revision_hash,
+                uploaded_at,
+            );
+        };
+
+        let current_revision_hash =
+            prepare_wallet_backup(&current_metadata, current_metadata.wallet_mode)?.revision_hash;
+
+        if current_revision_hash != revision_hash {
+            return Ok(());
+        }
+
+        let current_state = Database::global()
+            .cloud_blob_sync_states
+            .get(&record_id)
+            .map_err_prefix("read cloud blob sync state", CloudBackupError::Internal)?;
+
+        if let Some(current_state) = current_state {
+            let _ = self.mark_blob_uploaded_pending_confirmation_if_current(
+                &current_state,
+                revision_hash,
+                uploaded_at,
+            )?;
+            return Ok(());
+        }
+
+        self.mark_blob_uploaded_pending_confirmation(
+            namespace_id,
+            Some(wallet_id),
+            record_id,
+            revision_hash,
+            uploaded_at,
+        )
+    }
+}
+
+fn is_stale_uploading_state(started_at: u64) -> bool {
+    let now: u64 = jiff::Timestamp::now().as_second().try_into().unwrap_or(0);
+    now.saturating_sub(started_at) >= STALE_UPLOADING_RETRY_THRESHOLD_SECS
+}
+
+pub fn upload_all_wallets(
+    cloud: &CloudStorage,
+    namespace: &str,
+    critical_key: &[u8; 32],
+    db: &Database,
+) -> Result<Vec<PreparedWalletBackup>, CloudBackupError> {
+    let mut uploaded_wallets = Vec::new();
+
+    for metadata in all_local_wallets(db)? {
+        let prepared = prepare_wallet_backup(&metadata, metadata.wallet_mode)?;
+        let encrypted = wallet_crypto::encrypt_wallet_entry(&prepared.entry, critical_key)
+            .map_err_str(CloudBackupError::Crypto)?;
+
+        let wallet_json = serde_json::to_vec(&encrypted).map_err_str(CloudBackupError::Internal)?;
+
+        cloud
+            .upload_wallet_backup(namespace.to_string(), prepared.record_id.clone(), wallet_json)
+            .map_err_str(CloudBackupError::Cloud)?;
+
+        uploaded_wallets.push(prepared);
+    }
+
+    Ok(uploaded_wallets)
+}
+
+fn is_upload_preparation_failure_retryable(error: &CloudBackupError) -> bool {
+    match error {
+        CloudBackupError::Cloud(_) => true,
+        CloudBackupError::NotSupported(_)
+        | CloudBackupError::UnsupportedPasskeyProvider
+        | CloudBackupError::RecoveryRequired(_)
+        | CloudBackupError::Passkey(_)
+        | CloudBackupError::Crypto(_)
+        | CloudBackupError::Internal(_)
+        | CloudBackupError::PasskeyMismatch
+        | CloudBackupError::PasskeyDiscoveryCancelled
+        | CloudBackupError::Cancelled => false,
+    }
+}
+
+fn is_upload_failure_retryable(error: &CloudStorageError) -> bool {
+    matches!(
+        error,
+        CloudStorageError::NotAvailable(_)
+            | CloudStorageError::UploadFailed(_)
+            | CloudStorageError::DownloadFailed(_)
+    )
+}

--- a/rust/src/manager/cloud_backup_manager/wallets/upload.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/upload.rs
@@ -21,6 +21,8 @@ use super::{
     persist_enabled_cloud_backup_state, prepare_wallet_backup,
 };
 
+const STALE_UPLOADING_RETRY_THRESHOLD_SECS: u64 = 60;
+
 struct PreparedDirtyWalletUpload {
     prepared: PreparedWalletBackup,
     wallet_json: Vec<u8>,
@@ -30,8 +32,6 @@ struct DirtyWalletUploadPreparationError {
     revision_hash: Option<String>,
     source: CloudBackupError,
 }
-
-const STALE_UPLOADING_RETRY_THRESHOLD_SECS: u64 = 60;
 
 impl DirtyWalletUploadPreparationError {
     fn new(source: CloudBackupError, revision_hash: Option<String>) -> Self {
@@ -162,6 +162,7 @@ impl RustCloudBackupManager {
         else {
             return Ok(());
         };
+
         let Some(current_state) = self.recover_uploadable_blob_state(current_state)? else {
             return Ok(());
         };

--- a/rust/src/manager/import_wallet_manager.rs
+++ b/rust/src/manager/import_wallet_manager.rs
@@ -135,7 +135,7 @@ impl RustImportWalletManager {
 
             Wallet::try_new_persisted_and_selected(wallet_metadata.clone(), mnemonic.clone(), None)
                 .map_err_str(ImportWalletError::WalletImportError)?;
-            CLOUD_BACKUP_MANAGER.mark_verification_required_after_wallet_change();
+            CLOUD_BACKUP_MANAGER.handle_wallet_set_change();
 
             return Ok(wallet_metadata);
         }
@@ -180,7 +180,7 @@ impl RustImportWalletManager {
         Database::global().wallets.update_wallet_metadata(metadata.clone())?;
         Database::global().global_config.select_wallet(id.clone())?;
         Updater::send_update(Update::ClearCachedWalletManager(id));
-        CLOUD_BACKUP_MANAGER.mark_verification_required_after_wallet_change();
+        CLOUD_BACKUP_MANAGER.handle_wallet_backup_change_and_reverify(metadata.id.clone());
 
         Ok(metadata)
     }

--- a/rust/src/manager/pending_wallet_manager.rs
+++ b/rust/src/manager/pending_wallet_manager.rs
@@ -130,7 +130,7 @@ impl RustPendingWalletManager {
             self.state.read().wallet.mnemonic.clone(),
             None,
         )?;
-        CLOUD_BACKUP_MANAGER.mark_verification_required_after_wallet_change();
+        CLOUD_BACKUP_MANAGER.handle_wallet_set_change();
 
         Ok(wallet.metadata)
     }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -1410,7 +1410,6 @@ fn downgrade_and_notify_if_needed(
     Database::global().wallets.update_wallet_metadata(updated.clone()).map_err(|e| {
         Error::UnknownError(format!("failed to persist watch-only downgrade for {id}: {e}",))
     })?;
-    CLOUD_BACKUP_MANAGER.handle_wallet_backup_change(updated.id.clone());
 
     deferred.queue(Message::HotWalletKeyMissing(updated.id.clone()));
     Ok(updated)

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -27,6 +27,7 @@ use crate::{
     keychain::{Keychain, KeychainError},
     label_manager::{LabelManager, LabelManagerError},
     loading_popup::with_loading_popup,
+    manager::cloud_backup_manager::CLOUD_BACKUP_MANAGER,
     psbt::Psbt,
     reporting::HistoricalFiatPriceReport,
     router::Route,
@@ -939,7 +940,8 @@ impl RustWalletManager {
 
     #[uniffi::method]
     pub fn set_wallet_type(&self, wallet_type: WalletType) -> Result<(), Error> {
-        let mut metadata = self.metadata.read().clone();
+        let before_metadata = self.metadata.read().clone();
+        let mut metadata = before_metadata.clone();
         metadata.wallet_type = wallet_type;
 
         Database::global()
@@ -948,35 +950,35 @@ impl RustWalletManager {
             .map_err_debug(Error::SetWalletTypeError)?;
 
         *self.metadata.write() = metadata.clone();
-        self.reconciler.send(Message::WalletMetadataChanged(metadata));
+        self.reconciler.send(Message::WalletMetadataChanged(metadata.clone()));
+
+        CLOUD_BACKUP_MANAGER.handle_wallet_metadata_update(&before_metadata, &metadata);
 
         Ok(())
     }
 
     #[uniffi::method]
     pub fn validate_metadata(&self) {
-        let name = {
-            let metadata = self.metadata.read();
-            if !metadata.name.trim().is_empty() {
-                return;
-            }
-            metadata
-                .master_fingerprint
-                .as_deref()
-                .map_or_else(|| "Unnamed Wallet".to_string(), Fingerprint::as_uppercase)
-        };
-
-        let metadata = {
-            let mut metadata = self.metadata.write();
-            metadata.name = name;
-            metadata.clone()
-        };
-
-        self.reconciler.send(Message::WalletMetadataChanged(metadata.clone()));
-
-        if let Err(error) = Database::global().wallets.update_wallet_metadata(metadata) {
-            error!("Unable to update wallet metadata: {error:?}");
+        let before_metadata = self.metadata.read().clone();
+        if !before_metadata.name.trim().is_empty() {
+            return;
         }
+
+        let name = before_metadata
+            .master_fingerprint
+            .as_deref()
+            .map_or_else(|| "Unnamed Wallet".to_string(), Fingerprint::as_uppercase);
+        let mut metadata = before_metadata.clone();
+        metadata.name = name;
+
+        if let Err(error) = Database::global().wallets.update_wallet_metadata(metadata.clone()) {
+            error!("Unable to update wallet metadata: {error:?}");
+            return;
+        }
+
+        *self.metadata.write() = metadata.clone();
+        self.reconciler.send(Message::WalletMetadataChanged(metadata.clone()));
+        CLOUD_BACKUP_MANAGER.handle_wallet_metadata_update(&before_metadata, &metadata);
     }
 
     #[uniffi::method]
@@ -1214,39 +1216,28 @@ impl RustWalletManager {
     /// Action from the frontend to change the state of the view model
     #[uniffi::method]
     pub fn dispatch(&self, action: Action) {
+        let before_metadata = self.metadata.read().clone();
+        let mut candidate = before_metadata.clone();
+
         match action {
-            Action::UpdateName(name) => {
-                let mut metadata = self.metadata.write();
-                metadata.name = name;
-            }
+            Action::UpdateName(name) => candidate.name = name,
 
-            Action::UpdateColor(color) => {
-                let mut metadata = self.metadata.write();
-                metadata.color = color;
-            }
+            Action::UpdateColor(color) => candidate.color = color,
 
-            Action::UpdateUnit(unit) => {
-                let mut metadata = self.metadata.write();
-                metadata.selected_unit = unit;
-            }
+            Action::UpdateUnit(unit) => candidate.selected_unit = unit,
 
             Action::ToggleSensitiveVisibility => {
-                let mut metadata = self.metadata.write();
-                metadata.sensitive_visible = !metadata.sensitive_visible;
+                candidate.sensitive_visible = !candidate.sensitive_visible;
             }
 
             Action::ToggleFiatOrBtc => {
-                let mut metadata = self.metadata.write();
-                metadata.fiat_or_btc = match metadata.fiat_or_btc {
+                candidate.fiat_or_btc = match candidate.fiat_or_btc {
                     FiatOrBtc::Btc => FiatOrBtc::Fiat,
                     FiatOrBtc::Fiat => FiatOrBtc::Btc,
                 };
             }
 
-            Action::UpdateFiatOrBtc(fiat_or_btc) => {
-                let mut metadata = self.metadata.write();
-                metadata.fiat_or_btc = fiat_or_btc;
-            }
+            Action::UpdateFiatOrBtc(fiat_or_btc) => candidate.fiat_or_btc = fiat_or_btc,
 
             Action::ToggleFiatBtcPrimarySecondary => {
                 const ORDER: &[(FiatOrBtc, Unit); 4] = &[
@@ -1256,10 +1247,7 @@ impl RustWalletManager {
                     (FiatOrBtc::Fiat, Unit::Sat),
                 ];
 
-                let current = {
-                    let md = self.metadata.read();
-                    (md.fiat_or_btc, md.selected_unit)
-                };
+                let current = (candidate.fiat_or_btc, candidate.selected_unit);
 
                 let current_index = ORDER
                     .iter()
@@ -1269,31 +1257,24 @@ impl RustWalletManager {
                 let next_index = (current_index + 1) % ORDER.len();
                 let (fiat_or_btc, unit) = ORDER[next_index];
 
-                let mut metadata = self.metadata.write();
-                metadata.fiat_or_btc = fiat_or_btc;
-                metadata.selected_unit = unit;
+                candidate.fiat_or_btc = fiat_or_btc;
+                candidate.selected_unit = unit;
             }
 
             Action::ToggleDetailsExpanded => {
-                let mut metadata = self.metadata.write();
-                metadata.details_expanded = !metadata.details_expanded;
+                candidate.details_expanded = !candidate.details_expanded;
             }
 
             Action::SelectCurrentWalletAddressType => {
-                let mut metadata = self.metadata.write();
-                metadata.discovery_state = DiscoveryState::ChoseAdressType;
+                candidate.discovery_state = DiscoveryState::ChoseAdressType;
             }
 
             Action::SelectDifferentWalletAddressType(wallet_address_type) => {
-                let mut metadata = self.metadata.write();
-                metadata.address_type = wallet_address_type;
-                metadata.discovery_state = DiscoveryState::ChoseAdressType;
+                candidate.address_type = wallet_address_type;
+                candidate.discovery_state = DiscoveryState::ChoseAdressType;
             }
 
-            Action::ToggleShowLabels => {
-                let mut metadata = self.metadata.write();
-                metadata.show_labels = !metadata.show_labels;
-            }
+            Action::ToggleShowLabels => candidate.show_labels = !candidate.show_labels,
 
             Action::SelectedWalletDisappeared => {
                 send!(self.actor.stop_all_scans());
@@ -1305,12 +1286,14 @@ impl RustWalletManager {
             }
         }
 
-        let metadata = self.metadata.read().clone();
-        self.reconciler.send(Message::WalletMetadataChanged(metadata.clone()));
-
-        if let Err(error) = Database::global().wallets.update_wallet_metadata(metadata) {
+        if let Err(error) = Database::global().wallets.update_wallet_metadata(candidate.clone()) {
             error!("Unable to update wallet metadata: {error:?}");
+            return;
         }
+
+        *self.metadata.write() = candidate.clone();
+        self.reconciler.send(Message::WalletMetadataChanged(candidate.clone()));
+        CLOUD_BACKUP_MANAGER.handle_wallet_metadata_update(&before_metadata, &candidate);
     }
 }
 
@@ -1427,6 +1410,7 @@ fn downgrade_and_notify_if_needed(
     Database::global().wallets.update_wallet_metadata(updated.clone()).map_err(|e| {
         Error::UnknownError(format!("failed to persist watch-only downgrade for {id}: {e}",))
     })?;
+    CLOUD_BACKUP_MANAGER.handle_wallet_backup_change(updated.id.clone());
 
     deferred.queue(Message::HotWalletKeyMissing(updated.id.clone()));
     Ok(updated)

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -356,7 +356,7 @@ impl Wallet {
         )?;
 
         database.wallets.save_new_wallet_metadata(metadata.clone())?;
-        CLOUD_BACKUP_MANAGER.mark_verification_required_after_wallet_change();
+        CLOUD_BACKUP_MANAGER.handle_wallet_set_change();
 
         Ok(Self { id, metadata, network, bdk: wallet, db: Mutex::new(store.conn) })
     }
@@ -419,7 +419,7 @@ impl Wallet {
         }
 
         database.wallets.save_new_wallet_metadata(metadata.clone())?;
-        CLOUD_BACKUP_MANAGER.mark_verification_required_after_wallet_change();
+        CLOUD_BACKUP_MANAGER.handle_wallet_set_change();
 
         Ok(Self { id, metadata, network, bdk: wallet, db: Mutex::new(store.conn) })
     }
@@ -637,7 +637,7 @@ impl Wallet {
         database.global_config.select_wallet(id.clone())?;
 
         Updater::send_update(Update::ClearCachedWalletManager(id.clone()));
-        CLOUD_BACKUP_MANAGER.mark_verification_required_after_wallet_change();
+        CLOUD_BACKUP_MANAGER.handle_wallet_backup_change_and_reverify(id.clone());
         Self::try_load_persisted(id)
     }
 }


### PR DESCRIPTION
## Summary

- add persisted per-wallet cloud sync state so mutable backups can move through Dirty, Uploading, UploadedPendingConfirmation, Confirmed, and Failed
- upload wallet changes incrementally after local metadata or label updates instead of only during full backup flows
- include labels in the encrypted wallet backup payload, with revision hashing and size checks so restore and sync use the same constraints
- update cloud inventory, verification, and wrapper-repair flows to compare local wallets against remote backup revisions and reflect the new sync states
- surface the new sync behavior in iOS cloud backup details and regenerate mobile UniFFI bindings for the updated Rust API

## Why

Cloud backup previously treated wallet backups as mostly static. This branch adds the state needed to keep existing cloud backups up to date when local wallet metadata or labels change, while preserving verification and recovery behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet list shows optional network/type icons, label counts, and "backup updated" timestamps; expanded multi-state sync badges and orange warning captions for cloud-only messages.
  * New "Open Cloud Backup" button appears in hot-wallet missing alerts when cloud backup is enabled; alert text now mentions recovering from Cloud Backup.

* **Bug Fixes / Improvements**
  * Sections renamed to "Up to date" / "Needs sync" and sync-button visibility corrected.
  * App resumes pending cloud verification/uploads on startup and improves per-wallet upload/retry/resume reliability and error reporting; restores report label-import failures to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->