### PR TITLE
fix(tap-card): add type-safe ConnectionLost error for NFC tag drops

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/nfc/TapCardNfcManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/nfc/TapCardNfcManager.kt
@@ -260,7 +260,7 @@ private class TapCardTransport(
             response
         } catch (e: Exception) {
             Log.e(tag, "APDU error", e)
-            throw TransportException.UnknownException("Tag connection lost, please hold your phone still")
+            throw TransportException.ConnectionLostException("Tag connection lost, please hold your phone still")
         }
     }
 }

--- a/ios/Cove/TapSignerNFC.swift
+++ b/ios/Cove/TapSignerNFC.swift
@@ -394,7 +394,7 @@ private class TapCardNFC: NSObject, NFCTagReaderSessionDelegate {
         case let .some(error):
             switch error.code {
             case .readerTransceiveErrorTagConnectionLost:
-                tapSignerError = .Unknown("Tag connection lost, please hold your phone still")
+                tapSignerError = .ConnectionLost("Tag connection lost, please hold your phone still")
                 session.invalidate(
                     errorMessage: "Tag connection lost, please hold your phone still"
                 )

--- a/rust/src/tap_card.rs
+++ b/rust/src/tap_card.rs
@@ -25,6 +25,9 @@ pub enum TransportError {
     #[error("CvcChangeError: {0}")]
     CvcChangeError(String),
 
+    #[error("ConnectionLost: {0}")]
+    ConnectionLost(String),
+
     #[error("UnknownError: {0}")]
     UnknownError(String),
 }
@@ -108,6 +111,7 @@ impl From<TransportError> for ApduError {
             TransportError::IncorrectSignature(msg) => Self::IncorrectSignature(msg),
             TransportError::UnknownCardType(msg) => Self::UnknownCardType(msg),
             TransportError::CvcChangeError(_) => Self::CkTap(CkTapError::BadArguments.into()),
+            TransportError::ConnectionLost(_) => Self::CkTap(CkTapError::BadArguments.into()),
             TransportError::UnknownError(_) => Self::CkTap(CkTapError::BadArguments.into()),
         }
     }

--- a/rust/src/tap_card/tap_signer_reader.rs
+++ b/rust/src/tap_card/tap_signer_reader.rs
@@ -539,6 +539,10 @@ impl TapSignerReaderError {
     pub const fn is_no_backup_error(&self) -> bool {
         matches!(self, Self::TapSignerError(TransportError::CkTap(CkTapError::BackupFirst)))
     }
+
+    pub const fn is_connection_error(&self) -> bool {
+        matches!(self, Self::TapSignerError(TransportError::ConnectionLost(_)))
+    }
 }
 
 mod ffi {
@@ -621,6 +625,11 @@ impl TapSignerReaderError {
     #[uniffi::method(name = "isNoBackupError")]
     fn ffi_is_no_backup_error(&self) -> bool {
         self.is_no_backup_error()
+    }
+
+    #[uniffi::method(name = "isConnectionError")]
+    fn ffi_is_connection_error(&self) -> bool {
+        self.is_connection_error()
     }
 }
 


### PR DESCRIPTION
### Description

NFC tag disconnections during APDU communication are reported as `TransportError::UnknownError` / `TransportException.UnknownException`. Callers have no type-safe way to distinguish a connection drop from other unknown errors, making retry logic fragile (string matching on error messages).

### Issue
- Fixes #439 

### Changes

- Add `ConnectionLost(String)` variant to `TransportError` (Rust)
- Map `ConnectionLost` through `From<TransportError> for ApduError`
- Add `is_connection_error()` to `TapSignerReaderError` + UniFFI export `isConnectionError()`
- **Android**: `TapCardTransport.transmitApdu` throws `ConnectionLostException` instead of `UnknownException`
- **iOS**: `readerTransceiveErrorTagConnectionLost` maps to `.ConnectionLost` instead of `.Unknown`