### PR TITLE
Extract pj and pjos params from BIP 21 URIs

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -9224,7 +9224,7 @@ public object FfiConverterTypeBlockSizeLast: FfiConverterRustBuffer<BlockSizeLas
 data class PayJoinParams (
     var `endpoint`: kotlin.String
     , 
-    var `outputSubstitution`: kotlin.Boolean
+    var `outputSubstitutionEnabled`: kotlin.Boolean
     
 ){
     
@@ -9248,12 +9248,12 @@ public object FfiConverterTypePayJoinParams: FfiConverterRustBuffer<PayJoinParam
 
     override fun allocationSize(value: PayJoinParams) = (
             FfiConverterString.allocationSize(value.`endpoint`) +
-            FfiConverterBoolean.allocationSize(value.`outputSubstitution`)
+            FfiConverterBoolean.allocationSize(value.`outputSubstitutionEnabled`)
     )
 
     override fun write(value: PayJoinParams, buf: ByteBuffer) {
             FfiConverterString.write(value.`endpoint`, buf)
-            FfiConverterBoolean.write(value.`outputSubstitution`, buf)
+            FfiConverterBoolean.write(value.`outputSubstitutionEnabled`, buf)
     }
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -694,9 +694,7 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_types_checksum_method_addresswithnetwork_network(
     ): Short
-    external fun uniffi_cove_types_checksum_method_addresswithnetwork_pj(
-    ): Short
-    external fun uniffi_cove_types_checksum_method_addresswithnetwork_pjos(
+    external fun uniffi_cove_types_checksum_method_addresswithnetwork_payjoin(
     ): Short
     external fun uniffi_cove_types_checksum_method_amount_as_btc(
     ): Short
@@ -966,9 +964,7 @@ internal object UniffiLib {
     ): Byte
     external fun uniffi_cove_types_fn_method_addresswithnetwork_network(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
-    external fun uniffi_cove_types_fn_method_addresswithnetwork_pj(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_types_fn_method_addresswithnetwork_pjos(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    external fun uniffi_cove_types_fn_method_addresswithnetwork_payjoin(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_types_fn_clone_amount(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
@@ -1490,10 +1486,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_network() != 25441.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_pj() != 25366.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_pjos() != 29355.toShort()) {
+    if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_payjoin() != 1526.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_amount_as_btc() != 12153.toShort()) {
@@ -3287,9 +3280,7 @@ public interface AddressWithNetworkInterface {
     
     fun `network`(): Network
     
-    fun `pj`(): kotlin.String?
-    
-    fun `pjos`(): kotlin.Boolean?
+    fun `payjoin`(): PayJoinParams?
     
     companion object
 }
@@ -3461,24 +3452,11 @@ open class AddressWithNetwork: Disposable, AutoCloseable, AddressWithNetworkInte
     }
     
 
-    override fun `pj`(): kotlin.String? {
-            return FfiConverterOptionalString.lift(
+    override fun `payjoin`(): PayJoinParams? {
+            return FfiConverterOptionalTypePayJoinParams.lift(
     callWithHandle {
     uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_types_fn_method_addresswithnetwork_pj(
-        it,
-        _status)
-}
-    }
-    )
-    }
-    
-
-    override fun `pjos`(): kotlin.Boolean? {
-            return FfiConverterOptionalBoolean.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_types_fn_method_addresswithnetwork_pjos(
+    UniffiLib.uniffi_cove_types_fn_method_addresswithnetwork_payjoin(
         it,
         _status)
 }
@@ -9243,6 +9221,44 @@ public object FfiConverterTypeBlockSizeLast: FfiConverterRustBuffer<BlockSizeLas
 
 
 
+data class PayJoinParams (
+    var `endpoint`: kotlin.String
+    , 
+    var `outputSubstitution`: kotlin.Boolean
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypePayJoinParams: FfiConverterRustBuffer<PayJoinParams> {
+    override fun read(buf: ByteBuffer): PayJoinParams {
+        return PayJoinParams(
+            FfiConverterString.read(buf),
+            FfiConverterBoolean.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: PayJoinParams) = (
+            FfiConverterString.allocationSize(value.`endpoint`) +
+            FfiConverterBoolean.allocationSize(value.`outputSubstitution`)
+    )
+
+    override fun write(value: PayJoinParams, buf: ByteBuffer) {
+            FfiConverterString.write(value.`endpoint`, buf)
+            FfiConverterBoolean.write(value.`outputSubstitution`, buf)
+    }
+}
+
+
+
 data class Rgb (
     var `r`: kotlin.UByte
     , 
@@ -10539,38 +10555,6 @@ public object FfiConverterTypeUtxoType: FfiConverterRustBuffer<UtxoType> {
 /**
  * @suppress
  */
-public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
-    override fun read(buf: ByteBuffer): kotlin.Boolean? {
-        if (buf.get().toInt() == 0) {
-            return null
-        }
-        return FfiConverterBoolean.read(buf)
-    }
-
-    override fun allocationSize(value: kotlin.Boolean?): ULong {
-        if (value == null) {
-            return 1UL
-        } else {
-            return 1UL + FfiConverterBoolean.allocationSize(value)
-        }
-    }
-
-    override fun write(value: kotlin.Boolean?, buf: ByteBuffer) {
-        if (value == null) {
-            buf.put(0)
-        } else {
-            buf.put(1)
-            FfiConverterBoolean.write(value, buf)
-        }
-    }
-}
-
-
-
-
-/**
- * @suppress
- */
 public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?> {
     override fun read(buf: ByteBuffer): kotlin.String? {
         if (buf.get().toInt() == 0) {
@@ -10657,6 +10641,38 @@ public object FfiConverterOptionalTypeFeeRateOptionWithTotalFee: FfiConverterRus
         } else {
             buf.put(1)
             FfiConverterTypeFeeRateOptionWithTotalFee.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypePayJoinParams: FfiConverterRustBuffer<PayJoinParams?> {
+    override fun read(buf: ByteBuffer): PayJoinParams? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypePayJoinParams.read(buf)
+    }
+
+    override fun allocationSize(value: PayJoinParams?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypePayJoinParams.allocationSize(value)
+        }
+    }
+
+    override fun write(value: PayJoinParams?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypePayJoinParams.write(value, buf)
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -694,6 +694,10 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_types_checksum_method_addresswithnetwork_network(
     ): Short
+    external fun uniffi_cove_types_checksum_method_addresswithnetwork_pj(
+    ): Short
+    external fun uniffi_cove_types_checksum_method_addresswithnetwork_pjos(
+    ): Short
     external fun uniffi_cove_types_checksum_method_amount_as_btc(
     ): Short
     external fun uniffi_cove_types_checksum_method_amount_as_sats(
@@ -961,6 +965,10 @@ internal object UniffiLib {
     external fun uniffi_cove_types_fn_method_addresswithnetwork_isvalidfornetwork(`ptr`: Long,`network`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_cove_types_fn_method_addresswithnetwork_network(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_types_fn_method_addresswithnetwork_pj(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_types_fn_method_addresswithnetwork_pjos(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_types_fn_clone_amount(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
@@ -1480,6 +1488,12 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_network() != 25441.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_pj() != 25366.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_types_checksum_method_addresswithnetwork_pjos() != 29355.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_types_checksum_method_amount_as_btc() != 12153.toShort()) {
@@ -3273,6 +3287,10 @@ public interface AddressWithNetworkInterface {
     
     fun `network`(): Network
     
+    fun `pj`(): kotlin.String?
+    
+    fun `pjos`(): kotlin.Boolean?
+    
     companion object
 }
 
@@ -3435,6 +3453,32 @@ open class AddressWithNetwork: Disposable, AutoCloseable, AddressWithNetworkInte
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_types_fn_method_addresswithnetwork_network(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `pj`(): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_types_fn_method_addresswithnetwork_pj(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `pjos`(): kotlin.Boolean? {
+            return FfiConverterOptionalBoolean.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_types_fn_method_addresswithnetwork_pjos(
         it,
         _status)
 }
@@ -10488,6 +10532,38 @@ public object FfiConverterTypeUtxoType: FfiConverterRustBuffer<UtxoType> {
 }
 
 
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
+    override fun read(buf: ByteBuffer): kotlin.Boolean? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterBoolean.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.Boolean?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterBoolean.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.Boolean?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterBoolean.write(value, buf)
+        }
+    }
+}
 
 
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -1132,9 +1132,7 @@ public protocol AddressWithNetworkProtocol: AnyObject, Sendable {
     
     func network()  -> Network
     
-    func pj()  -> String?
-    
-    func pjos()  -> Bool?
+    func payjoin()  -> PayJoinParams?
     
 }
 open class AddressWithNetwork: AddressWithNetworkProtocol, @unchecked Sendable {
@@ -1237,17 +1235,9 @@ open func network() -> Network  {
 })
 }
     
-open func pj() -> String?  {
-    return try!  FfiConverterOptionString.lift(try! rustCall() {
-    uniffi_cove_types_fn_method_addresswithnetwork_pj(
-            self.uniffiCloneHandle(),$0
-    )
-})
-}
-    
-open func pjos() -> Bool?  {
-    return try!  FfiConverterOptionBool.lift(try! rustCall() {
-    uniffi_cove_types_fn_method_addresswithnetwork_pjos(
+open func payjoin() -> PayJoinParams?  {
+    return try!  FfiConverterOptionTypePayJoinParams.lift(try! rustCall() {
+    uniffi_cove_types_fn_method_addresswithnetwork_payjoin(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -4362,6 +4352,60 @@ public func FfiConverterTypeBlockSizeLast_lower(_ value: BlockSizeLast) -> RustB
 }
 
 
+public struct PayJoinParams: Equatable, Hashable {
+    public var endpoint: String
+    public var outputSubstitution: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(endpoint: String, outputSubstitution: Bool) {
+        self.endpoint = endpoint
+        self.outputSubstitution = outputSubstitution
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension PayJoinParams: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayJoinParams: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayJoinParams {
+        return
+            try PayJoinParams(
+                endpoint: FfiConverterString.read(from: &buf), 
+                outputSubstitution: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PayJoinParams, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.endpoint, into: &buf)
+        FfiConverterBool.write(value.outputSubstitution, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayJoinParams_lift(_ buf: RustBuffer) throws -> PayJoinParams {
+    return try FfiConverterTypePayJoinParams.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayJoinParams_lower(_ value: PayJoinParams) -> RustBuffer {
+    return FfiConverterTypePayJoinParams.lower(value)
+}
+
+
 public struct Rgb: Equatable, Hashable {
     public var r: UInt8
     public var g: UInt8
@@ -5692,30 +5736,6 @@ public func FfiConverterTypeUtxoType_lower(_ value: UtxoType) -> RustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionBool: FfiConverterRustBuffer {
-    typealias SwiftType = Bool?
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        guard let value = value else {
-            writeInt(&buf, Int8(0))
-            return
-        }
-        writeInt(&buf, Int8(1))
-        FfiConverterBool.write(value, into: &buf)
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
-        switch try readInt(&buf) as Int8 {
-        case 0: return nil
-        case 1: return try FfiConverterBool.read(from: &buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
 fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
     typealias SwiftType = String?
 
@@ -5780,6 +5800,30 @@ fileprivate struct FfiConverterOptionTypeFeeRateOptionWithTotalFee: FfiConverter
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeFeeRateOptionWithTotalFee.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypePayJoinParams: FfiConverterRustBuffer {
+    typealias SwiftType = PayJoinParams?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypePayJoinParams.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypePayJoinParams.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -6252,10 +6296,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_types_checksum_method_addresswithnetwork_network() != 25441) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_types_checksum_method_addresswithnetwork_pj() != 25366) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_types_checksum_method_addresswithnetwork_pjos() != 29355) {
+    if (uniffi_cove_types_checksum_method_addresswithnetwork_payjoin() != 1526) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_amount_as_btc() != 12153) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -4354,13 +4354,13 @@ public func FfiConverterTypeBlockSizeLast_lower(_ value: BlockSizeLast) -> RustB
 
 public struct PayJoinParams: Equatable, Hashable {
     public var endpoint: String
-    public var outputSubstitution: Bool
+    public var outputSubstitutionEnabled: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(endpoint: String, outputSubstitution: Bool) {
+    public init(endpoint: String, outputSubstitutionEnabled: Bool) {
         self.endpoint = endpoint
-        self.outputSubstitution = outputSubstitution
+        self.outputSubstitutionEnabled = outputSubstitutionEnabled
     }
 
     
@@ -4380,13 +4380,13 @@ public struct FfiConverterTypePayJoinParams: FfiConverterRustBuffer {
         return
             try PayJoinParams(
                 endpoint: FfiConverterString.read(from: &buf), 
-                outputSubstitution: FfiConverterBool.read(from: &buf)
+                outputSubstitutionEnabled: FfiConverterBool.read(from: &buf)
         )
     }
 
     public static func write(_ value: PayJoinParams, into buf: inout [UInt8]) {
         FfiConverterString.write(value.endpoint, into: &buf)
-        FfiConverterBool.write(value.outputSubstitution, into: &buf)
+        FfiConverterBool.write(value.outputSubstitutionEnabled, into: &buf)
     }
 }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -1132,6 +1132,10 @@ public protocol AddressWithNetworkProtocol: AnyObject, Sendable {
     
     func network()  -> Network
     
+    func pj()  -> String?
+    
+    func pjos()  -> Bool?
+    
 }
 open class AddressWithNetwork: AddressWithNetworkProtocol, @unchecked Sendable {
     fileprivate let handle: UInt64
@@ -1228,6 +1232,22 @@ open func isValidForNetwork(network: Network) -> Bool  {
 open func network() -> Network  {
     return try!  FfiConverterTypeNetwork_lift(try! rustCall() {
     uniffi_cove_types_fn_method_addresswithnetwork_network(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func pj() -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_cove_types_fn_method_addresswithnetwork_pj(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func pjos() -> Bool?  {
+    return try!  FfiConverterOptionBool.lift(try! rustCall() {
+    uniffi_cove_types_fn_method_addresswithnetwork_pjos(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -5672,6 +5692,30 @@ public func FfiConverterTypeUtxoType_lower(_ value: UtxoType) -> RustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionBool: FfiConverterRustBuffer {
+    typealias SwiftType = Bool?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterBool.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterBool.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
     typealias SwiftType = String?
 
@@ -6206,6 +6250,12 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_addresswithnetwork_network() != 25441) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_types_checksum_method_addresswithnetwork_pj() != 25366) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_types_checksum_method_addresswithnetwork_pjos() != 29355) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_types_checksum_method_amount_as_btc() != 12153) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -632,6 +632,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin_uri"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0a228e083d1702f83389b0ac71eb70078dc8d7fcbb6cde864d1cbca145f5cc"
+dependencies = [
+ "bitcoin",
+ "percent-encoding-rfc3986",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1262,7 @@ dependencies = [
  "jiff",
  "nid",
  "numfmt",
+ "payjoin",
  "rand 0.10.0",
  "redb",
  "serde",
@@ -1261,7 +1272,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "uniffi 0.31.0",
- "url",
 ]
 
 [[package]]
@@ -2919,10 +2929,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "payjoin"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844f2404db4ae16c4062a53da2c73812c7a130abf612149c06650a36e34d0a35"
+dependencies = [
+ "bitcoin",
+ "bitcoin_uri",
+ "http",
+ "serde",
+ "serde_json",
+ "tracing",
+ "url",
+ "web-time",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "petgraph"
@@ -4694,6 +4726,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,6 +57,7 @@ bitcoin = { version = "0.32" }
 bdk_wallet = { version = "2.3", features = ["keys-bip39", "file_store", "rusqlite"] }
 bip39 = { version = "2.2", features = ["zeroize"] }
 bip329 = { version = "0.4" }
+payjoin = { version = "0.25", default-features = false, features = ["v1"] }
 pubport = { version = "0.5" }
 
 # bitcoin nodes

--- a/rust/crates/cove-types/Cargo.toml
+++ b/rust/crates/cove-types/Cargo.toml
@@ -13,6 +13,7 @@ cove-util = { path = "../cove-util" }
 # bitcoin
 bitcoin = { workspace = true, features = ["serde"] }
 bdk_wallet = { workspace = true }
+payjoin = { workspace = true }
 
 # error handling
 thiserror = { workspace = true }
@@ -69,7 +70,6 @@ hex = { workspace = true }
 # util
 ahash = { workspace = true }
 tap = { workspace = true }
-url = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -14,9 +14,9 @@ use bitcoin::{
     address::{NetworkChecked, NetworkUnchecked},
     params::Params,
 };
+use payjoin::UriExt as _;
 use serde::Deserialize;
 use strum::IntoEnumIterator as _;
-use url::Url;
 
 use crate::{Network, amount::Amount, transaction::TransactionDirection};
 
@@ -211,53 +211,35 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         return Err(Error::EmptyAddress);
     }
 
-    let has_scheme =
-        input.split_once(':').is_some_and(|(scheme, _)| scheme.eq_ignore_ascii_case("bitcoin"));
-
-    let normalized = if has_scheme { input.to_string() } else { format!("bitcoin:{input}") };
-    let url = Url::parse(&normalized).map_err(|_| Error::InvalidAddress)?;
-
-    if !url.scheme().eq_ignore_ascii_case("bitcoin") {
-        return Err(Error::InvalidAddress);
-    }
-
-    let address = match (url.path(), url.host_str()) {
-        (address, None) | ("", Some(address)) if !address.is_empty() => String::from(address),
-        _ => {
-            return Err(Error::EmptyAddress);
+    // Normalize: strip "bitcoin://" to "bitcoin:" and prepend scheme if missing
+    let normalized = match input.split_once(':') {
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("bitcoin") => {
+            let rest = rest.strip_prefix("//").unwrap_or(rest);
+            format!("bitcoin:{rest}")
         }
+        _ => format!("bitcoin:{input}"),
     };
 
-    // take amount from query params
-    let amount = url.query_pairs().find(|(key, _)| key == "amount").and_then(|(_, value)| {
-        let value = value.trim();
-        value.parse::<f64>().ok().and_then(|btc| Amount::from_btc(btc).ok())
-    });
+    let uri = payjoin::Uri::try_from(normalized.as_str()).map_err(|_| Error::InvalidAddress)?;
 
-    // payjoin endpoint
-    let pj = url
-        .query_pairs()
-        .find(|(key, _)| key == "pj")
-        .map(|(_, value)| value.to_string())
-        .filter(|v| !v.is_empty())
-        .and_then(|v| Url::parse(&v).ok().map(|_| v));
+    let amount = uri.amount.map(|a| Amount::from_sat(a.to_sat()));
 
-    // payjoin output substitution — per PDK/rust-payjoin:
-    // pjos=0 -> Some(false), pjos=1 -> Some(true), other values -> error, omitted -> None
-    let pjos = url
-        .query_pairs()
-        .find(|(key, _)| key == "pjos")
-        .map(|(_, value)| match value.trim() {
-            "0" => Ok(false),
-            "1" => Ok(true),
-            _ => Err(Error::InvalidAddress),
-        })
-        .transpose()?;
+    // skip network check; try_new() validates later
+    let checked = uri.assume_checked();
+    let address = checked.address.to_string();
 
-    // pjos without pj is a malformed URI
-    if pjos.is_some() && pj.is_none() {
-        return Err(Error::InvalidAddress);
-    }
+    // Extract payjoin params if present
+    let (pj, pjos) = match checked.check_pj_supported() {
+        Ok(pj_uri) => {
+            let endpoint = pj_uri.extras.endpoint();
+            let pjos = match pj_uri.extras.output_substitution() {
+                payjoin::OutputSubstitution::Enabled => Some(true),
+                payjoin::OutputSubstitution::Disabled => Some(false),
+            };
+            (Some(endpoint), pjos)
+        }
+        Err(_) => (None, None),
+    };
 
     Ok(ParsedBitcoinUri { address, amount, pj, pjos })
 }
@@ -494,41 +476,42 @@ mod tests {
 
     #[test]
     fn test_parse_bitcoin_uri_no_amount() {
-        let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f";
+        let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, None);
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_amount() {
-        let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?amount=0.001";
+        let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_amount_and_spaces() {
-        let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?amount=0.001  ";
+        // trailing whitespace is trimmed before parsing
+        let a = "  bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001  ";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_amount_and_other_query_params() {
-        let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?amount=0.002&foo=bar";
+        let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.002&foo=bar";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.002).unwrap()));
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_scheme_and_unused_params() {
-        let a = "bitcoin://bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?label=Donation&foo=bar";
+        let a = "bitcoin://bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?label=Donation&foo=bar";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, None);
     }
 
@@ -638,7 +621,8 @@ mod tests {
         assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
         assert_eq!(parsed.pj.as_deref(), Some("https://example.com/payjoin"));
-        assert_eq!(parsed.pjos, None);
+        // pjos defaults to enabled when omitted
+        assert_eq!(parsed.pjos, Some(true));
     }
 
     #[test]
@@ -658,10 +642,9 @@ mod tests {
 
     #[test]
     fn test_parse_bitcoin_uri_with_invalid_pj_url() {
-        // malformed pj URL should be treated as absent
+        // payjoin rejects the entire URI when pj is not a valid URL
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=not-a-url";
-        let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.pj, None);
+        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
     }
 
     #[test]

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -55,21 +55,25 @@ pub struct AddressInfoWithDerivation {
     pub derivation_path: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Record)]
+pub struct PayJoinParams {
+    pub endpoint: String,
+    pub output_substitution: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Object)]
 pub struct AddressWithNetwork {
     pub address: Address,
     pub network: Network,
     pub amount: Option<Amount>,
-    pub pj: Option<String>,
-    pub pjos: Option<bool>,
+    pub payjoin: Option<PayJoinParams>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedBitcoinUri {
     address: String,
     amount: Option<Amount>,
-    pj: Option<String>,
-    pjos: Option<bool>,
+    payjoin: Option<PayJoinParams>,
 }
 
 type Error = AddressError;
@@ -188,8 +192,7 @@ impl AddressWithNetwork {
                     address: checked.into(),
                     network,
                     amount: parsed.amount,
-                    pj: parsed.pj,
-                    pjos: parsed.pjos,
+                    payjoin: parsed.payjoin,
                 });
             }
         }
@@ -229,19 +232,19 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
     let address = checked.address.to_string();
 
     // Extract payjoin params if present
-    let (pj, pjos) = match checked.check_pj_supported() {
+    let payjoin = match checked.check_pj_supported() {
         Ok(pj_uri) => {
             let endpoint = pj_uri.extras.endpoint();
-            let pjos = match pj_uri.extras.output_substitution() {
-                payjoin::OutputSubstitution::Enabled => Some(true),
-                payjoin::OutputSubstitution::Disabled => Some(false),
+            let output_substitution = match pj_uri.extras.output_substitution() {
+                payjoin::OutputSubstitution::Enabled => true,
+                payjoin::OutputSubstitution::Disabled => false,
             };
-            (Some(endpoint), pjos)
+            Some(PayJoinParams { endpoint, output_substitution })
         }
-        Err(_) => (None, None),
+        Err(_) => None,
     };
 
-    Ok(ParsedBitcoinUri { address, amount, pj, pjos })
+    Ok(ParsedBitcoinUri { address, amount, payjoin })
 }
 
 #[uniffi::export]
@@ -268,12 +271,8 @@ impl AddressWithNetwork {
         self.amount.map(Arc::new)
     }
 
-    fn pj(&self) -> Option<String> {
-        self.pj.clone()
-    }
-
-    fn pjos(&self) -> Option<bool> {
-        self.pjos
+    fn payjoin(&self) -> Option<PayJoinParams> {
+        self.payjoin.clone()
     }
 
     #[uniffi::method(name = "isValidForNetwork")]
@@ -620,17 +619,19 @@ mod tests {
         let parsed = parse_bitcoin_uri(a).unwrap();
         assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
-        assert_eq!(parsed.pj.as_deref(), Some("https://example.com/payjoin"));
+        let pj = parsed.payjoin.as_ref().unwrap();
+        assert_eq!(pj.endpoint, "https://example.com/payjoin");
         // pjos defaults to enabled when omitted
-        assert_eq!(parsed.pjos, Some(true));
+        assert!(pj.output_substitution);
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_pj_and_pjos_disabled() {
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin&pjos=0";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.pj.as_deref(), Some("https://example.com/payjoin"));
-        assert_eq!(parsed.pjos, Some(false));
+        let pj = parsed.payjoin.as_ref().unwrap();
+        assert_eq!(pj.endpoint, "https://example.com/payjoin");
+        assert!(!pj.output_substitution);
     }
 
     #[test]
@@ -652,7 +653,7 @@ mod tests {
         // pjos=1 means output substitution is enabled
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=1";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.pjos, Some(true));
+        assert!(parsed.payjoin.as_ref().unwrap().output_substitution);
     }
 
     #[test]
@@ -671,8 +672,7 @@ mod tests {
     fn test_parse_bitcoin_uri_no_pj() {
         let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.pj, None);
-        assert_eq!(parsed.pjos, None);
+        assert_eq!(parsed.payjoin, None);
     }
 
     #[test]
@@ -682,8 +682,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(address_with_network.pj.as_deref(), Some("https://example.com/payjoin"));
-        assert_eq!(address_with_network.pjos, Some(false));
+        let pj = address_with_network.payjoin.as_ref().unwrap();
+        assert_eq!(pj.endpoint, "https://example.com/payjoin");
+        assert!(!pj.output_substitution);
         assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 }

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -60,6 +60,16 @@ pub struct AddressWithNetwork {
     pub address: Address,
     pub network: Network,
     pub amount: Option<Amount>,
+    pub pj: Option<String>,
+    pub pjos: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedBitcoinUri {
+    address: String,
+    amount: Option<Amount>,
+    pj: Option<String>,
+    pjos: Option<bool>,
 }
 
 type Error = AddressError;
@@ -167,24 +177,21 @@ impl AddressWithNetwork {
     /// Returns `AddressError::EmptyAddress` if the address is empty
     /// Returns `AddressError::UnsupportedNetwork` if the network is not supported
     pub fn try_new(str: &str) -> Result<Self, Error> {
-        let (address_str, amount) = parse_bitcoin_uri(str)?;
+        let parsed = parse_bitcoin_uri(str)?;
 
         let address: BdkAddress<NetworkUnchecked> =
-            address_str.parse().map_err(|_| Error::InvalidAddress)?;
+            parsed.address.parse().map_err(|_| Error::InvalidAddress)?;
 
-        let network = Network::Bitcoin;
-        if let Ok(address) = address.clone().require_network(network.into()) {
-            return Ok(Self { address: address.into(), network, amount });
-        }
-
-        let network = Network::Testnet;
-        if let Ok(address) = address.clone().require_network(network.into()) {
-            return Ok(Self { address: address.into(), network, amount });
-        }
-
-        let network = Network::Signet;
-        if let Ok(address) = address.require_network(network.into()) {
-            return Ok(Self { address: address.into(), network, amount });
+        for network in Network::iter() {
+            if let Ok(checked) = address.clone().require_network(network.into()) {
+                return Ok(Self {
+                    address: checked.into(),
+                    network,
+                    amount: parsed.amount,
+                    pj: parsed.pj,
+                    pjos: parsed.pjos,
+                });
+            }
         }
 
         Err(Error::UnsupportedNetwork)
@@ -198,7 +205,7 @@ impl AddressWithNetwork {
     }
 }
 
-fn parse_bitcoin_uri(input: &str) -> Result<(String, Option<Amount>), Error> {
+fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
     let input = input.trim();
     if input.is_empty() {
         return Err(Error::EmptyAddress);
@@ -227,7 +234,32 @@ fn parse_bitcoin_uri(input: &str) -> Result<(String, Option<Amount>), Error> {
         value.parse::<f64>().ok().and_then(|btc| Amount::from_btc(btc).ok())
     });
 
-    Ok((address, amount))
+    // payjoin endpoint
+    let pj = url
+        .query_pairs()
+        .find(|(key, _)| key == "pj")
+        .map(|(_, value)| value.to_string())
+        .filter(|v| !v.is_empty())
+        .and_then(|v| Url::parse(&v).ok().map(|_| v));
+
+    // payjoin output substitution — per PDK/rust-payjoin:
+    // pjos=0 -> Some(false), pjos=1 -> Some(true), other values -> error, omitted -> None
+    let pjos = url
+        .query_pairs()
+        .find(|(key, _)| key == "pjos")
+        .map(|(_, value)| match value.trim() {
+            "0" => Ok(false),
+            "1" => Ok(true),
+            _ => Err(Error::InvalidAddress),
+        })
+        .transpose()?;
+
+    // pjos without pj is a malformed URI
+    if pjos.is_some() && pj.is_none() {
+        return Err(Error::InvalidAddress);
+    }
+
+    Ok(ParsedBitcoinUri { address, amount, pj, pjos })
 }
 
 #[uniffi::export]
@@ -252,6 +284,14 @@ impl AddressWithNetwork {
 
     fn amount(&self) -> Option<Arc<Amount>> {
         self.amount.map(Arc::new)
+    }
+
+    fn pj(&self) -> Option<String> {
+        self.pj.clone()
+    }
+
+    fn pjos(&self) -> Option<bool> {
+        self.pjos
     }
 
     #[uniffi::method(name = "isValidForNetwork")]
@@ -455,41 +495,41 @@ mod tests {
     #[test]
     fn test_parse_bitcoin_uri_no_amount() {
         let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f";
-        let (a, amount) = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(a, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
-        assert_eq!(amount, None);
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.amount, None);
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_amount() {
         let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?amount=0.001";
-        let (a, amount) = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(a, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
-        assert_eq!(amount, Some(Amount::from_btc(0.001).unwrap()));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_amount_and_spaces() {
         let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?amount=0.001  ";
-        let (a, amount) = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(a, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
-        assert_eq!(amount, Some(Amount::from_btc(0.001).unwrap()));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_amount_and_other_query_params() {
         let a = "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?amount=0.002&foo=bar";
-        let (a, amount) = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(a, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
-        assert_eq!(amount, Some(Amount::from_btc(0.002).unwrap()));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.amount, Some(Amount::from_btc(0.002).unwrap()));
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_scheme_and_unused_params() {
         let a = "bitcoin://bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f?label=Donation&foo=bar";
-        let (a, amount) = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(a, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
-        assert_eq!(amount, None);
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q0g0vn4yqyk0zjwxw0zv5pltyy9jm89vclxgsv3f");
+        assert_eq!(parsed.amount, None);
     }
 
     #[test]
@@ -589,5 +629,78 @@ mod tests {
                 "bitcoin://bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.002&foo=bar",
             )
         )
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_with_pj() {
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
+        assert_eq!(parsed.pj.as_deref(), Some("https://example.com/payjoin"));
+        assert_eq!(parsed.pjos, None);
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_with_pj_and_pjos_disabled() {
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin&pjos=0";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.pj.as_deref(), Some("https://example.com/payjoin"));
+        assert_eq!(parsed.pjos, Some(false));
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_with_pjos_only() {
+        // pjos without pj is a malformed URI
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pjos=0";
+        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_with_invalid_pj_url() {
+        // malformed pj URL should be treated as absent
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=not-a-url";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.pj, None);
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_pjos_enabled() {
+        // pjos=1 means output substitution is enabled
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=1";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.pjos, Some(true));
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_pjos_invalid_value() {
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=garbage";
+        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_pjos_without_pj_is_error() {
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pjos=1";
+        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_no_pj() {
+        let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.pj, None);
+        assert_eq!(parsed.pjos, None);
+    }
+
+    #[test]
+    fn test_address_with_network_carries_pj() {
+        let address_with_network = AddressWithNetwork::try_new(
+            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin&pjos=0",
+        )
+        .unwrap();
+
+        assert_eq!(address_with_network.pj.as_deref(), Some("https://example.com/payjoin"));
+        assert_eq!(address_with_network.pjos, Some(false));
+        assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 }

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -223,28 +223,58 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         _ => format!("bitcoin:{input}"),
     };
 
-    let uri = payjoin::Uri::try_from(normalized.as_str()).map_err(|_| Error::InvalidAddress)?;
+    // Try full payjoin URI parsing first
+    if let Ok(uri) = payjoin::Uri::try_from(normalized.as_str()) {
+        let amount = uri.amount.map(|a| Amount::from_sat(a.to_sat()));
 
+        // skip network check; try_new() validates later
+        let checked = uri.assume_checked();
+        let address = checked.address.to_string();
+
+        // Extract payjoin params if present
+        let payjoin = match checked.check_pj_supported() {
+            Ok(pj_uri) => {
+                let endpoint = pj_uri.extras.endpoint();
+                let output_substitution = match pj_uri.extras.output_substitution() {
+                    payjoin::OutputSubstitution::Enabled => true,
+                    payjoin::OutputSubstitution::Disabled => false,
+                };
+                Some(PayJoinParams { endpoint, output_substitution })
+            }
+            Err(_) => None,
+        };
+
+        return Ok(ParsedBitcoinUri { address, amount, payjoin });
+    }
+
+    // Fallback: strip payjoin params (pj, pjos) and re-parse as regular bitcoin URI.
+    // Per BIP 78 backward compatibility, non-payjoin senders should ignore pj/pjos
+    // and proceed with a normal payment.
+    let stripped = strip_payjoin_params(&normalized);
+    let uri = payjoin::Uri::try_from(stripped.as_str()).map_err(|_| Error::InvalidAddress)?;
     let amount = uri.amount.map(|a| Amount::from_sat(a.to_sat()));
-
-    // skip network check; try_new() validates later
     let checked = uri.assume_checked();
     let address = checked.address.to_string();
 
-    // Extract payjoin params if present
-    let payjoin = match checked.check_pj_supported() {
-        Ok(pj_uri) => {
-            let endpoint = pj_uri.extras.endpoint();
-            let output_substitution = match pj_uri.extras.output_substitution() {
-                payjoin::OutputSubstitution::Enabled => true,
-                payjoin::OutputSubstitution::Disabled => false,
-            };
-            Some(PayJoinParams { endpoint, output_substitution })
-        }
-        Err(_) => None,
+    Ok(ParsedBitcoinUri { address, amount, payjoin: None })
+}
+
+/// Strips `pj` and `pjos` query parameters from a `bitcoin:` URI string.
+fn strip_payjoin_params(uri: &str) -> String {
+    let (base, query) = match uri.split_once('?') {
+        Some((b, q)) => (b, q),
+        None => return uri.to_string(),
     };
 
-    Ok(ParsedBitcoinUri { address, amount, payjoin })
+    let filtered: Vec<&str> = query
+        .split('&')
+        .filter(|param| {
+            let key = param.split_once('=').map_or(*param, |(k, _)| k);
+            key != "pj" && key != "pjos"
+        })
+        .collect();
+
+    if filtered.is_empty() { base.to_string() } else { format!("{base}?{}", filtered.join("&")) }
 }
 
 #[uniffi::export]
@@ -636,16 +666,23 @@ mod tests {
 
     #[test]
     fn test_parse_bitcoin_uri_with_pjos_only() {
-        // pjos without pj is a malformed URI
+        // pjos without pj is ignored per BIP 78 backward compatibility
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pjos=0";
-        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, None);
+        assert_eq!(parsed.payjoin, None);
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_invalid_pj_url() {
-        // payjoin rejects the entire URI when pj is not a valid URL
+        // malformed pj is ignored per BIP 78 backward compatibility;
+        // address and amount are still extracted
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=not-a-url";
-        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, None);
+        assert_eq!(parsed.payjoin, None);
     }
 
     #[test]
@@ -658,14 +695,22 @@ mod tests {
 
     #[test]
     fn test_parse_bitcoin_uri_pjos_invalid_value() {
+        // invalid pjos value causes payjoin params to be ignored per BIP 78
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=garbage";
-        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, None);
+        assert_eq!(parsed.payjoin, None);
     }
 
     #[test]
-    fn test_parse_bitcoin_uri_pjos_without_pj_is_error() {
+    fn test_parse_bitcoin_uri_pjos_without_pj_is_ignored() {
+        // pjos without pj is ignored per BIP 78 backward compatibility
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pjos=1";
-        assert_eq!(parse_bitcoin_uri(a), Err(AddressError::InvalidAddress));
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, None);
+        assert_eq!(parsed.payjoin, None);
     }
 
     #[test]
@@ -686,5 +731,16 @@ mod tests {
         assert_eq!(pj.endpoint, "https://example.com/payjoin");
         assert!(!pj.output_substitution);
         assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_malformed_pj_falls_back() {
+        // BIP 78 backward compatibility: a malformed pj= URL should not prevent
+        // parsing the address and amount; payjoin is simply ignored.
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.005&pj=http://not-https.example.com/payjoin";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, Some(Amount::from_btc(0.005).unwrap()));
+        assert_eq!(parsed.payjoin, None);
     }
 }

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -58,7 +58,7 @@ pub struct AddressInfoWithDerivation {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Record)]
 pub struct PayJoinParams {
     pub endpoint: String,
-    pub output_substitution: bool,
+    pub output_substitution_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Object)]
@@ -235,11 +235,11 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         let payjoin = match checked.check_pj_supported() {
             Ok(pj_uri) => {
                 let endpoint = pj_uri.extras.endpoint();
-                let output_substitution = match pj_uri.extras.output_substitution() {
+                let output_substitution_enabled = match pj_uri.extras.output_substitution() {
                     payjoin::OutputSubstitution::Enabled => true,
                     payjoin::OutputSubstitution::Disabled => false,
                 };
-                Some(PayJoinParams { endpoint, output_substitution })
+                Some(PayJoinParams { endpoint, output_substitution_enabled })
             }
             Err(_) => None,
         };
@@ -652,7 +652,7 @@ mod tests {
         let pj = parsed.payjoin.as_ref().unwrap();
         assert_eq!(pj.endpoint, "https://example.com/payjoin");
         // pjos defaults to enabled when omitted
-        assert!(pj.output_substitution);
+        assert!(pj.output_substitution_enabled);
     }
 
     #[test]
@@ -661,7 +661,7 @@ mod tests {
         let parsed = parse_bitcoin_uri(a).unwrap();
         let pj = parsed.payjoin.as_ref().unwrap();
         assert_eq!(pj.endpoint, "https://example.com/payjoin");
-        assert!(!pj.output_substitution);
+        assert!(!pj.output_substitution_enabled);
     }
 
     #[test]
@@ -690,7 +690,7 @@ mod tests {
         // pjos=1 means output substitution is enabled
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=1";
         let parsed = parse_bitcoin_uri(a).unwrap();
-        assert!(parsed.payjoin.as_ref().unwrap().output_substitution);
+        assert!(parsed.payjoin.as_ref().unwrap().output_substitution_enabled);
     }
 
     #[test]
@@ -729,7 +729,7 @@ mod tests {
 
         let pj = address_with_network.payjoin.as_ref().unwrap();
         assert_eq!(pj.endpoint, "https://example.com/payjoin");
-        assert!(!pj.output_substitution);
+        assert!(!pj.output_substitution_enabled);
         assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 


### PR DESCRIPTION
Switched to PDK's payjoin::Uri for BIP21 parsing instead of manually extracting query params. This is the foundation for sender-side PayJoin support, no negotiation or UI yet.

pj and pjos are extracted through PDK's parser and carried through AddressWithNetwork to the FFI layer. Invalid pj URLs now reject the whole URI per BIP78. pjos defaults to enabled when omitted, matching PDK semantics. Removed the url crate from cove-types since it's no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Payjoin metadata in Bitcoin payment URIs (pj and pjos), exposed via new public accessors (including Kotlin bindings).

* **Refactor**
  * URI parsing now returns a richer parsed result so amount and Payjoin fields reliably propagate into address objects.

* **Tests**
  * Added tests for pj/pjos parsing, malformed pj, invalid pjos values, and pjos-without-pj rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->