### PR TITLE
Fix PSBT export share sheet on hardware send flow

### DIFF
--- a/ios/Cove/Flows/SendFlow/SendFlowHardwareScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowHardwareScreen.swift
@@ -441,14 +441,18 @@ struct SendFlowHardwareScreen: View {
             app.nfcWriter.writeToTag(data: details.psbtBytes())
         }
 
-        ShareLink(
-            item: PSBTFile(data: details.psbtBytes(), filename: "transaction.psbt"),
-            preview: SharePreview(
-                "transaction.psbt - A Partially Signed Bitcoin Transaction",
-                image: Image(.bitcoinShield)
-            )
-        ) {
-            Text("More...")
+        Button("More...") {
+            // Defer presentation until the confirmationDialog's dismissal
+            // animation completes. A SwiftUI `ShareLink` presented directly
+            // from a confirmationDialog action races the dialog's dismissal
+            // and either fails silently (Save to Files) or surfaces extension
+            // errors (Signal). See issues #449 and #313.
+            let psbtBytes = details.psbtBytes()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                ShareSheet.present(data: psbtBytes, filename: "transaction.psbt") { success in
+                    if !success { Log.warn("PSBT export cancelled or failed") }
+                }
+            }
         }
     }
 

--- a/ios/Cove/PSBTFile.swift
+++ b/ios/Cove/PSBTFile.swift
@@ -5,30 +5,7 @@
 //  Created by Praveen Perera on 11/24/24.
 //
 import Foundation
-import SwiftUI
 import UniformTypeIdentifiers
-
-struct PSBTFile: Transferable {
-    let data: Data
-    let filename: String
-
-    static var transferRepresentation: some TransferRepresentation {
-        FileRepresentation(contentType: .psbt) { file in
-            let url = FileManager.default.temporaryDirectory
-                .appendingPathComponent(file.filename)
-            try file.data.write(to: url)
-            return SentTransferredFile(url)
-        } importing: { url in
-            Log.warn("Importing PSBT files is not supported: \(url)")
-            // Importing closure - must return PSBTFile
-            guard let data = try? Data(contentsOf: url.file) else {
-                throw CocoaError(.fileReadUnknown)
-            }
-
-            return PSBTFile(data: data, filename: url.file.path())
-        }
-    }
-}
 
 extension UTType {
     static var psbt: UTType {

--- a/ios/Cove/ShareSheet.swift
+++ b/ios/Cove/ShareSheet.swift
@@ -108,6 +108,25 @@ enum ShareSheet {
         filename: String,
         completion: @escaping (Bool) -> Void
     ) {
+        guard let bytes = data.data(using: .utf8) else {
+            Log.error("Failed to encode share-sheet payload as UTF-8")
+            completion(false)
+            return
+        }
+        present(data: bytes, filename: filename, completion: completion)
+    }
+
+    /// Presents share sheet for binary data by writing to a temporary file
+    /// - Parameters:
+    ///   - data: the raw bytes to share
+    ///   - filename: the filename to use for the temporary file
+    ///   - completion: called after the share sheet dismisses with success/failure result
+    @MainActor
+    static func present(
+        data: Data,
+        filename: String,
+        completion: @escaping (Bool) -> Void
+    ) {
         guard let windowScene = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .first,
@@ -123,7 +142,7 @@ enum ShareSheet {
         let fileURL = tempDir.appendingPathComponent(filename)
 
         do {
-            try data.write(to: fileURL, atomically: true, encoding: .utf8)
+            try data.write(to: fileURL, options: .atomic)
         } catch {
             Log.error("Failed to write temp file for share sheet: \(error.localizedDescription)")
             completion(false)


### PR DESCRIPTION
Replace the SwiftUI ShareLink inside the export-transaction confirmationDialog with an imperative UIActivityViewController call, deferred by 400ms so the dialog's dismissal animation can finish before the share sheet presents.

Presenting a ShareLink directly from a confirmationDialog action races the UIAlertController dismissal: Save to Files fails silently and share extensions like Signal surface a generic error. The deferred call goes through the existing ShareSheet helper (already used by MoreInfoPopover.exportTransactions) which wraps UIActivityViewController with proper iPad popover anchoring and temp-file cleanup.

Adds a Data variant of ShareSheet.present for binary payloads and drops the now-unused PSBTFile Transferable struct. iOS only; Android's FileProvider + ACTION_SEND path is unaffected.

Closes #449
Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for PSBT file exports with explicit failure notifications.

* **Refactor**
  * Enhanced file sharing mechanism with more robust and reliable write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->