### PR TITLE
feat: tapsigner pin length increase

### DIFF
--- a/ios/Cove/Flows/TapSignerFlow/TapSignerConfirmPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerConfirmPinView.swift
@@ -123,13 +123,16 @@ struct TapSignerConfirmPinView: View {
                 }
                 .padding(.horizontal)
 
-                HStack {
-                    ForEach(0 ..< 6, id: \.self) { index in
+                let columns = Array(repeating: GridItem(.flexible(), spacing: 12, alignment: .center), count: 6)
+                LazyVGrid(columns: columns, alignment: .center, spacing: 12) {
+                    ForEach(0 ..< min(max(confirmPin.count, 6), 32), id: \.self) { index in
                         Circle()
                             .stroke(.primary, lineWidth: 1.3)
-                            .fill(confirmPin.count <= index ? Color.clear : .primary)
-                            .frame(width: 18)
-                            .padding(.horizontal, 10)
+                            .background(
+                                Circle()
+                                    .fill(confirmPin.count <= index ? Color.clear : .primary)
+                            )
+                            .frame(width: 18, height: 18)
                             .id(index)
                     }
                 }
@@ -137,8 +140,7 @@ struct TapSignerConfirmPinView: View {
                     initialValue: CGFloat.zero,
                     trigger: animateField,
                     content: { content, value in
-                        content
-                            .offset(x: value)
+                        content.offset(x: value)
                     },
                     keyframes: { _ in
                         KeyframeTrack {
@@ -152,15 +154,33 @@ struct TapSignerConfirmPinView: View {
                         }
                     }
                 )
-                .fixedSize(horizontal: true, vertical: true)
+                .padding(.horizontal, 36)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .contentShape(Rectangle())
                 .onTapGesture { isFocused = true }
+
+                Text("\(confirmPin.count)/32 characters")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
 
                 TextField("Hidden Input", text: $confirmPin)
                     .opacity(0)
                     .frame(width: 0, height: 0)
                     .focused($isFocused)
                     .keyboardType(.numberPad)
+
+                Button(action: {
+                    checkPin()
+                }) {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(confirmPin.count >= 6 ? Color.blue : Color.gray)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                .disabled(confirmPin.count < 6)
+                .padding(.horizontal)
 
                 Spacer()
             }
@@ -169,21 +189,9 @@ struct TapSignerConfirmPinView: View {
                 isFocused = true
             }
             .onChange(of: isFocused) { _, _ in isFocused = true }
-            .onChange(of: confirmPin) { old, pin in
-                if pin.count == 6 {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        checkPin()
-                    }
-                }
-
-                if pin.count > 6, old.count < 6 {
-                    confirmPin = old
-                    return
-                }
-
-                if pin.count > 6 {
-                    confirmPin = String(args.startingPin.prefix(6))
-                    return
+            .onChange(of: confirmPin) { _, pin in
+                if pin.count > 32 {
+                    confirmPin = String(pin.prefix(32))
                 }
             }
         }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
@@ -15,7 +15,7 @@ struct TapSignerEnterPin: View {
     let action: AfterPinAction
 
     var message: String {
-        action.userMessage()
+        action.userMessage() + " (6-32 characters)"
     }
 
     // private
@@ -174,25 +174,48 @@ struct TapSignerEnterPin: View {
                 }
                 .padding(.horizontal)
 
-                HStack {
-                    ForEach(0 ..< 6, id: \.self) { index in
+                let columns = Array(repeating: GridItem(.flexible(), spacing: 12, alignment: .center), count: 6)
+                LazyVGrid(columns: columns, alignment: .center, spacing: 12) {
+                    ForEach(0 ..< min(max(pin.count, 6), 32), id: \.self) { index in
                         Circle()
                             .stroke(.primary, lineWidth: 1.3)
-                            .fill(pin.count <= index ? Color.clear : .primary)
-                            .frame(width: 18)
-                            .padding(.horizontal, 10)
+                            .background(
+                                Circle()
+                                    .fill(pin.count <= index ? Color.clear : .primary)
+                            )
+                            .frame(width: 18, height: 18)
                             .id(index)
                     }
                 }
-                .fixedSize(horizontal: true, vertical: true)
+                .padding(.horizontal, 36)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .contentShape(Rectangle())
                 .onTapGesture { isFocused = true }
+
+                Text("\(pin.count)/32 characters")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
 
                 TextField("Hidden Input", text: $pin)
                     .opacity(0)
                     .frame(width: 0, height: 0)
                     .focused($isFocused)
                     .keyboardType(.numberPad)
+
+                Button(action: {
+                    let nfc = manager.getOrCreateNfc(tapSigner)
+                    manager.enteredPin = pin
+                    runAction(nfc, pin)
+                }) {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(pin.count >= 6 ? Color.blue : Color.gray)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                .disabled(pin.count < 6)
+                .padding(.horizontal)
 
                 Spacer()
             }
@@ -201,22 +224,9 @@ struct TapSignerEnterPin: View {
                 isFocused = true
             }
             .onChange(of: isFocused) { _, _ in isFocused = true }
-            .onChange(of: pin) { old, newPin in
-                let nfc = manager.getOrCreateNfc(tapSigner)
-
-                if newPin.count == 6 {
-                    manager.enteredPin = newPin
-                    return runAction(nfc, newPin)
-                }
-
-                if newPin.count > 6, old.count < 6 {
-                    pin = old
-                    return
-                }
-
-                if newPin.count > 6 {
-                    pin = String(pin.prefix(6))
-                    return
+            .onChange(of: pin) { _, newPin in
+                if newPin.count > 32 {
+                    pin = String(newPin.prefix(32))
                 }
             }
         }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerNewPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerNewPinView.swift
@@ -46,7 +46,7 @@ struct TapSignerNewPinView: View {
                         .fontWeight(.bold)
 
                     Text(
-                        "The PIN code is a security feature that prevents unauthorized access to your key. Please back it up and keep it safe. You'll need it for signing transactions."
+                        "The PIN code (6-32 characters) is a security feature that prevents unauthorized access to your key. Please back it up and keep it safe. You'll need it for signing transactions."
                     )
                     .font(.subheadline)
                     .multilineTextAlignment(.center)
@@ -54,25 +54,49 @@ struct TapSignerNewPinView: View {
                 }
                 .padding(.horizontal)
 
-                HStack {
-                    ForEach(0 ..< 6, id: \.self) { index in
+                let columns = Array(repeating: GridItem(.flexible(), spacing: 12, alignment: .center), count: 6)
+                LazyVGrid(columns: columns, alignment: .center, spacing: 12) {
+                    ForEach(0 ..< min(max(newPin.count, 6), 32), id: \.self) { index in
                         Circle()
                             .stroke(.primary, lineWidth: 1.3)
-                            .fill(newPin.count <= index ? Color.clear : .primary)
-                            .frame(width: 18)
-                            .padding(.horizontal, 10)
+                            .background(
+                                Circle()
+                                    .fill(newPin.count <= index ? Color.clear : .primary)
+                            )
+                            .frame(width: 18, height: 18)
                             .id(index)
                     }
                 }
-                .fixedSize(horizontal: true, vertical: true)
+                .padding(.horizontal, 36)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .contentShape(Rectangle())
                 .onTapGesture { isFocused = true }
+
+                Text("\(newPin.count)/32 characters")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+                    .frame(maxWidth: .infinity, alignment: .center)
 
                 TextField("Hidden Input", text: $newPin)
                     .opacity(0)
                     .frame(width: 0, height: 0)
                     .focused($isFocused)
                     .keyboardType(.numberPad)
+
+                Button(action: {
+                    manager.navigate(
+                        to: .confirmPin(TapSignerConfirmPinArgs(from: args, newPin: newPin))
+                    )
+                }) {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(newPin.count >= 6 ? Color.blue : Color.gray)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                .disabled(newPin.count < 6)
+                .padding(.horizontal)
 
                 Spacer()
             }
@@ -81,22 +105,9 @@ struct TapSignerNewPinView: View {
                 isFocused = true
             }
             .onChange(of: isFocused) { _, _ in isFocused = true }
-            .onChange(of: newPin) { old, pin in
-                if pin.count == 6 {
-                    return
-                        manager.navigate(
-                            to: .confirmPin(TapSignerConfirmPinArgs(from: args, newPin: pin))
-                        )
-                }
-
-                if pin.count > 6, old.count < 6 {
-                    newPin = old
-                    return
-                }
-
-                if pin.count > 6 {
-                    newPin = String(args.startingPin.prefix(6))
-                    return
+            .onChange(of: newPin) { _, pin in
+                if pin.count > 32 {
+                    newPin = String(pin.prefix(32))
                 }
             }
         }

--- a/ios/Cove/Views/NumberPadPinView.swift
+++ b/ios/Cove/Views/NumberPadPinView.swift
@@ -15,6 +15,8 @@ struct NumberPadPinView: View {
     let isPinCorrect: (String) -> Bool
     var showPin: Bool
     var pinLength: Int
+    var manualSubmit: Bool
+    var showCharacterCount: Bool
 
     // back button
     private var backEnabled: Bool
@@ -34,6 +36,8 @@ struct NumberPadPinView: View {
         isPinCorrect: @escaping (String) -> Bool,
         showPin: Bool = false,
         pinLength: Int = 6,
+        manualSubmit: Bool = false,
+        showCharacterCount: Bool = false,
         backAction: (() -> Void)? = nil,
         onUnlock: @escaping (String) -> Void = { _ in },
         onWrongPin: @escaping (String) -> Void = { _ in }
@@ -43,6 +47,8 @@ struct NumberPadPinView: View {
         self.isPinCorrect = isPinCorrect
         self.showPin = showPin
         self.pinLength = pinLength
+        self.manualSubmit = manualSubmit
+        self.showCharacterCount = showCharacterCount
         backEnabled = backAction != nil
         self.backAction = backAction ?? {}
         self.onUnlock = onUnlock
@@ -69,24 +75,33 @@ struct NumberPadPinView: View {
             Spacer()
 
             // Adding Wiggling Animation for Wrong Password With Keyframe Animator
-            HStack(spacing: 10) {
-                ForEach(0 ..< pinLength, id: \.self) { index in
-                    RoundedRectangle(cornerRadius: 10)
-                        .frame(width: 40, height: 45)
-                        .foregroundStyle(.white)
-                        // Showing Pin at each box with the help of Index
-                        .overlay {
-                            // Safe Check
-                            if pin.count > index {
-                                let index = pin.index(pin.startIndex, offsetBy: index)
-                                let string = showPin ? String(pin[index]) : "●"
+            VStack {
+                HStack(spacing: 10) {
+                    ForEach(0 ..< pinLength, id: \.self) { index in
+                        RoundedRectangle(cornerRadius: 10)
+                            .frame(width: 40, height: 45)
+                            .foregroundStyle(.white)
+                            // Showing Pin at each box with the help of Index
+                            .overlay {
+                                // Safe Check
+                                if pin.count > index {
+                                    let index = pin.index(pin.startIndex, offsetBy: index)
+                                    let string = showPin ? String(pin[index]) : "●"
 
-                                Text(string)
-                                    .font(showPin ? .title : .body)
-                                    .fontWeight(.bold)
-                                    .foregroundStyle(.black)
+                                    Text(string)
+                                        .font(showPin ? .title : .body)
+                                        .fontWeight(.bold)
+                                        .foregroundStyle(.black)
+                                }
                             }
-                        }
+                    }
+                }
+
+                if showCharacterCount {
+                    Text("\(pin.count)/32 characters")
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                        .padding(.top, 4)
                 }
             }
             .keyframeAnimator(
@@ -178,7 +193,7 @@ struct NumberPadPinView: View {
             })
             .padding(.vertical)
             .onChange(of: pin) { _, newValue in
-                if newValue.count == pinLength {
+                if newValue.count == pinLength, !manualSubmit {
                     let pin = newValue
 
                     // Validate Pin
@@ -193,6 +208,31 @@ struct NumberPadPinView: View {
                         animateField.toggle()
                     }
                 }
+            }
+
+            if manualSubmit {
+                Button(action: {
+                    if isPinCorrect(pin) {
+                        withAnimation(.snappy, completionCriteria: .logicallyComplete) {
+                            lockState = .unlocked
+                        } completion: {
+                            onUnlock(pin)
+                            self.pin = ""
+                        }
+                    } else {
+                        animateField.toggle()
+                    }
+                }) {
+                    Text("Continue")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(pin.count >= 6 ? Color.blue : Color.gray)
+                        .cornerRadius(10)
+                }
+                .disabled(pin.count < 6)
+                .padding(.horizontal)
             }
         }
         .padding()

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -295,7 +295,7 @@ impl GlobalConfigTable {
             return Err(GlobalConfigTableError::PinCodeMustBeHashed.into());
         }
 
-        if hashed_pin_code.len() <= 6 {
+        if hashed_pin_code.len() < 6 {
             return Err(GlobalConfigTableError::PinCodeMustBeHashed.into());
         }
 

--- a/rust/src/tap_card/tap_signer_reader.rs
+++ b/rust/src/tap_card/tap_signer_reader.rs
@@ -37,7 +37,7 @@ pub enum TapSignerReaderError {
     #[error("No command")]
     NoCommand,
 
-    #[error("Invalid pin length, must be betweeen 6 and 32, found {0}")]
+    #[error("Invalid pin length, must be between 6 and 32, found {0}")]
     InvalidPinLength(u8),
 
     #[error("PIN must be numeric only, found {0}")]


### PR DESCRIPTION
close: #488 

- Accept 6-32 character PINs (only for ios)

<img width="338" height="631" alt="image" src="https://github.com/user-attachments/assets/1786b8bf-c841-4bfb-a31b-d2fe0e3c2111" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PIN input now supports 6–32 characters (previously limited to 6)
  * Added character count display to PIN entry screens
  * Introduced explicit "Continue" buttons for PIN submission

* **Bug Fixes**
  * Fixed typo in PIN length validation error message
  * Corrected PIN validation logic to accept minimum 6-character PINs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->