### PR TITLE
fix: `TapSignerFlow` preview xcode crash for unvalid pubkey

### DIFF
--- a/rust/crates/cove-tap-card/src/lib.rs
+++ b/rust/crates/cove-tap-card/src/lib.rs
@@ -123,12 +123,19 @@ impl From<parse::Error> for TapCardParseError {
 #[uniffi::export]
 pub fn tap_signer_preview_new(preview: bool) -> TapSigner {
     assert!(preview);
+
+    // Derive a public key from a dummy secret key
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let secret_key =
+        bitcoin::secp256k1::SecretKey::from_slice(&[1u8; 32]).expect("32 bytes, valid secret key");
+    let pubkey = bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
+
     TapSigner {
             state: TapSignerState::Unused,
             card_ident: "0000000000000000".to_string(),
             nonce: "0000000000000000".to_string(),
             signature: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
-            pubkey: Arc::new(PublicKey::from_slice(&[0u8; 33]).unwrap()),
+            pubkey: Arc::new(pubkey),
         }
 }
 


### PR DESCRIPTION
- close: #637 
- Derive a valid public key from dummy secret key for TapSigner
- Test on `TapSignerFlow/TapSignerConfirmPinView.swift` page

|Before|After|
|-|-|
|<img width="534" height="798" alt="image" src="https://github.com/user-attachments/assets/0b97647b-c678-4aa7-be35-ee8b72ef2172" />|<img width="534" height="798" alt="image" src="https://github.com/user-attachments/assets/ddecfa01-12ed-4cb8-acd6-a0df5ee30ee4" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TapSigner preview initialization to derive a valid public key for previews instead of using a placeholder, preventing invalid preview keys.
  * No changes to public APIs or function signatures; behavior and interfaces remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->