### PR TITLE
fix: update PIN prompts to specify Cove PIN and TapSigner PIN

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerEnterPinView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerEnterPinView.kt
@@ -119,7 +119,7 @@ fun TapSignerEnterPinView(
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             Text(
-                text = "Enter PIN",
+                text = "Enter TAPSIGNER PIN",
                 style = MaterialTheme.typography.headlineLarge,
                 fontWeight = FontWeight.Bold,
             )

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/LockView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/LockView.kt
@@ -192,6 +192,7 @@ fun LockView(
                     // show PIN screen
                     else -> {
                         NumberPadPinView(
+                            title = "Enter Cove PIN",
                             isPinCorrect = { pin ->
                                 when (auth.handleAndReturnUnlockMode(pin)) {
                                     UnlockMode.MAIN, UnlockMode.DECOY, UnlockMode.WIPE -> true
@@ -338,7 +339,7 @@ private fun BiometricView(
                 color = Color.White.copy(alpha = 0.1f),
             ) {
                 Text(
-                    text = "Enter Pin",
+                    text = "Enter Cove PIN",
                     color = Color.White,
                     modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
                     fontWeight = FontWeight.Normal,

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
@@ -163,7 +163,7 @@ struct TapSignerEnterPin: View {
                 }
 
                 VStack(spacing: 20) {
-                    Text("Enter PIN")
+                    Text("Enter TAPSIGNER PIN")
                         .font(.largeTitle)
                         .fontWeight(.bold)
 

--- a/ios/Cove/Views/LockView.swift
+++ b/ios/Cove/Views/LockView.swift
@@ -172,6 +172,7 @@ struct LockView<Content: View>: View {
 
     var numberPadPinView: NumberPadPinView {
         NumberPadPinView(
+            title: "Enter Cove PIN",
             lockState: lockState,
             isPinCorrect: isPinCorrect,
             showPin: showPin,
@@ -215,7 +216,7 @@ struct LockView<Content: View>: View {
 
             if lockType == .both {
                 Button(action: { screen = .pin }) {
-                    Text("Enter Pin")
+                    Text("Enter Cove PIN")
                         .frame(width: 100, height: 40)
                         .background(
                             .ultraThinMaterial,


### PR DESCRIPTION
## Issue
Fixes #512 

## Changes
- Android lock screen PIN entry now shows Enter Cove PIN in the lock keypad flow
- Android biometric fallback button now says Enter Cove PIN
- Android TapSigner PIN screen title now says Enter TapSigner PIN
- iOS lock screen keypad title now says Enter Cove PIN
- iOS biometric fallback button now says Enter Cove PIN
- iOS TapSigner PIN screen title now says Enter TapSigner PIN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated PIN entry labels on Android and iOS: the main lock screen now shows "Enter Cove PIN" instead of "Enter PIN", biometric screens reflect the same wording, and the TapSigner authentication flow now displays "Enter TAPSIGNER PIN".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->