### PR TITLE
Add shared connectivity manager

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/ConnectivityMonitor.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/ConnectivityMonitor.kt
@@ -1,0 +1,53 @@
+package org.bitcoinppl.cove
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import org.bitcoinppl.cove_core.RustConnectivityManager
+import org.bitcoinppl.cove_core.device.ConnectivityAccess
+
+class ConnectivityMonitor(
+    context: Context,
+) : ConnectivityAccess {
+    private val connectivityManager =
+        context.getSystemService(ConnectivityManager::class.java)
+            ?: error("ConnectivityManager unavailable")
+    private var started = false
+
+    private val callback =
+        object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                pushConnectivityState(true)
+            }
+
+            override fun onLost(network: Network) {
+                pushConnectivityState(isConnected())
+            }
+
+            override fun onUnavailable() {
+                pushConnectivityState(false)
+            }
+        }
+
+    override fun isConnected(): Boolean {
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    fun start() {
+        if (started) return
+        started = true
+
+        pushConnectivityState(isConnected())
+        connectivityManager.registerDefaultNetworkCallback(callback)
+    }
+
+    private fun pushConnectivityState(connected: Boolean) {
+        RustConnectivityManager().use { rustConnectivityManager ->
+            rustConnectivityManager.setConnectionState(connected)
+        }
+    }
+}

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoveApplication.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoveApplication.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import org.bitcoinppl.cove_core.AuthType
+import org.bitcoinppl.cove_core.device.Connectivity
 import org.bitcoinppl.cove_core.RustCloudBackupManager
 import org.bitcoinppl.cove_core.device.Device
 import org.bitcoinppl.cove_core.device.Keychain
@@ -22,6 +23,8 @@ class CoveApplication : Application() {
     // hold references to FFI objects for proper cleanup
     private var keychain: Keychain? = null
     private var device: Device? = null
+    private var connectivity: Connectivity? = null
+    private var connectivityMonitor: ConnectivityMonitor? = null
     private var bootstrapCompleted = false
 
     override fun onCreate() {
@@ -43,6 +46,8 @@ class CoveApplication : Application() {
         try {
             keychain = Keychain(KeychainAccessor(this))
             device = Device(DeviceAccessor())
+            connectivityMonitor = ConnectivityMonitor(this)
+            connectivity = Connectivity(connectivityMonitor!!)
             Log.d(TAG, "Keychain and device initialized")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize keychain and device", e)
@@ -58,6 +63,7 @@ class CoveApplication : Application() {
         bootstrapCompleted = true
 
         AppManager.getInstance()
+        connectivityMonitor?.start()
         RustCloudBackupManager().use { rustCloudBackupManager ->
             rustCloudBackupManager.resumePendingCloudUploadVerification()
         }
@@ -85,6 +91,14 @@ class CoveApplication : Application() {
             Log.d(TAG, "Device FFI object closed")
         } catch (e: Exception) {
             Log.e(TAG, "Error closing Device FFI object", e)
+        }
+
+        try {
+            connectivity?.close()
+            connectivity = null
+            Log.d(TAG, "Connectivity FFI object closed")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error closing Connectivity FFI object", e)
         }
 
         try {

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -746,6 +746,9 @@ internal interface UniffiCallbackInterfaceCoinControlManagerReconcilerMethod0 : 
 internal interface UniffiCallbackInterfaceCoinControlManagerReconcilerMethod1 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`messages`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
 }
+internal interface UniffiCallbackInterfaceConnectivityManagerReconcilerMethod0 : com.sun.jna.Callback {
+    fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
+}
 internal interface UniffiCallbackInterfaceImportWalletManagerReconcilerMethod0 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
 }
@@ -858,6 +861,25 @@ internal open class UniffiVTableCallbackInterfaceCoinControlManagerReconciler(
         `uniffiClone` = other.`uniffiClone`
         `reconcile` = other.`reconcile`
         `reconcileMany` = other.`reconcileMany`
+    }
+
+}
+@Structure.FieldOrder("uniffiFree", "uniffiClone", "reconcile")
+internal open class UniffiVTableCallbackInterfaceConnectivityManagerReconciler(
+    @JvmField internal var `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+    @JvmField internal var `uniffiClone`: UniffiCallbackInterfaceClone? = null,
+    @JvmField internal var `reconcile`: UniffiCallbackInterfaceConnectivityManagerReconcilerMethod0? = null,
+) : Structure() {
+    class UniffiByValue(
+        `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+        `uniffiClone`: UniffiCallbackInterfaceClone? = null,
+        `reconcile`: UniffiCallbackInterfaceConnectivityManagerReconcilerMethod0? = null,
+    ): UniffiVTableCallbackInterfaceConnectivityManagerReconciler(`uniffiFree`,`uniffiClone`,`reconcile`,), Structure.ByValue
+
+   internal fun uniffiSetValue(other: UniffiVTableCallbackInterfaceConnectivityManagerReconciler) {
+        `uniffiFree` = other.`uniffiFree`
+        `uniffiClone` = other.`uniffiClone`
+        `reconcile` = other.`reconcile`
     }
 
 }
@@ -1414,8 +1436,6 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_sync_persisted_state(
     ): Short
-    external fun uniffi_cove_checksum_method_rustcloudbackupmanager_update_connectivity_hint(
-    ): Short
     external fun uniffi_cove_checksum_method_rustcloudbackupmanager_verify_backup_integrity(
     ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_button_presentation(
@@ -1433,6 +1453,14 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_unit(
     ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_utxos(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustconnectivitymanager_is_connected(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustconnectivitymanager_listen_for_updates(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustconnectivitymanager_set_connection_state(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustconnectivitymanager_state(
     ): Short
     external fun uniffi_cove_checksum_method_rustimportwalletmanager_dispatch(
     ): Short
@@ -1876,6 +1904,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_constructor_coincontrolmanagerstate_preview_new(
     ): Short
+    external fun uniffi_cove_checksum_constructor_rustconnectivitymanager_new(
+    ): Short
     external fun uniffi_cove_checksum_constructor_rustimportwalletmanager_new(
     ): Short
     external fun uniffi_cove_checksum_constructor_rustonboardingmanager_new(
@@ -1960,6 +1990,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_coincontrolmanagerreconciler_reconcile_many(
     ): Short
+    external fun uniffi_cove_checksum_method_connectivitymanagerreconciler_reconcile(
+    ): Short
     external fun uniffi_cove_checksum_method_importwalletmanagerreconciler_reconcile(
     ): Short
     external fun uniffi_cove_checksum_method_onboardingmanagerreconciler_reconcile(
@@ -2000,6 +2032,7 @@ internal object UniffiLib {
         uniffiCallbackInterfaceAuthManagerReconciler.register(this)
         uniffiCallbackInterfaceCloudBackupManagerReconciler.register(this)
         uniffiCallbackInterfaceCoinControlManagerReconciler.register(this)
+        uniffiCallbackInterfaceConnectivityManagerReconciler.register(this)
         uniffiCallbackInterfaceFfiReconcile.register(this)
         uniffiCallbackInterfaceImportWalletManagerReconciler.register(this)
         uniffiCallbackInterfaceOnboardingManagerReconciler.register(this)
@@ -2434,8 +2467,6 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_sync_persisted_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
-    external fun uniffi_cove_fn_method_rustcloudbackupmanager_update_connectivity_hint(`ptr`: Long,`hint`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): Unit
     external fun uniffi_cove_fn_method_rustcloudbackupmanager_verify_backup_integrity(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_clone_rustcoincontrolmanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -2470,6 +2501,20 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_free_filteredutxos(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    external fun uniffi_cove_fn_clone_rustconnectivitymanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_fn_free_rustconnectivitymanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_fn_constructor_rustconnectivitymanager_new(uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_fn_method_rustconnectivitymanager_is_connected(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
+    external fun uniffi_cove_fn_method_rustconnectivitymanager_listen_for_updates(`ptr`: Long,`reconciler`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_fn_method_rustconnectivitymanager_set_connection_state(`ptr`: Long,`isConnected`: Byte,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_fn_method_rustconnectivitymanager_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_clone_rustimportwalletmanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_free_rustimportwalletmanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -3089,6 +3134,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_init_callback_vtable_cloudbackupmanagerreconciler(`vtable`: UniffiVTableCallbackInterfaceCloudBackupManagerReconciler,
     ): Unit
     external fun uniffi_cove_fn_init_callback_vtable_coincontrolmanagerreconciler(`vtable`: UniffiVTableCallbackInterfaceCoinControlManagerReconciler,
+    ): Unit
+    external fun uniffi_cove_fn_init_callback_vtable_connectivitymanagerreconciler(`vtable`: UniffiVTableCallbackInterfaceConnectivityManagerReconciler,
     ): Unit
     external fun uniffi_cove_fn_init_callback_vtable_importwalletmanagerreconciler(`vtable`: UniffiVTableCallbackInterfaceImportWalletManagerReconciler,
     ): Unit
@@ -4056,9 +4103,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_sync_persisted_state() != 19758.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_update_connectivity_hint() != 42789.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
     if (lib.uniffi_cove_checksum_method_rustcloudbackupmanager_verify_backup_integrity() != 47801.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4084,6 +4128,18 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_utxos() != 43520.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustconnectivitymanager_is_connected() != 47607.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustconnectivitymanager_listen_for_updates() != 49341.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustconnectivitymanager_set_connection_state() != 17798.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustconnectivitymanager_state() != 43225.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustimportwalletmanager_dispatch() != 59923.toShort()) {
@@ -4749,6 +4805,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_constructor_coincontrolmanagerstate_preview_new() != 11196.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_constructor_rustconnectivitymanager_new() != 58689.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_constructor_rustimportwalletmanager_new() != 12433.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4873,6 +4932,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_coincontrolmanagerreconciler_reconcile_many() != 14668.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_connectivitymanagerreconciler_reconcile() != 20375.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_importwalletmanagerreconciler_reconcile() != 13279.toShort()) {
@@ -17767,8 +17829,6 @@ public interface RustCloudBackupManagerInterface {
      */
     fun `syncPersistedState`()
     
-    fun `updateConnectivityHint`(`hint`: CloudConnectivityHint)
-    
     /**
      * Background startup health check for cloud backup integrity
      */
@@ -18109,18 +18169,6 @@ open class RustCloudBackupManager: Disposable, AutoCloseable, RustCloudBackupMan
     UniffiLib.uniffi_cove_fn_method_rustcloudbackupmanager_sync_persisted_state(
         it,
         _status)
-}
-    }
-    
-    
-
-    override fun `updateConnectivityHint`(`hint`: CloudConnectivityHint)
-        = 
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_method_rustcloudbackupmanager_update_connectivity_hint(
-        it,
-        FfiConverterTypeCloudConnectivityHint.lower(`hint`),_status)
 }
     }
     
@@ -18557,6 +18605,312 @@ public object FfiConverterTypeRustCoinControlManager: FfiConverter<RustCoinContr
     override fun allocationSize(value: RustCoinControlManager) = 8UL
 
     override fun write(value: RustCoinControlManager, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+public interface RustConnectivityManagerInterface {
+    
+    fun `isConnected`(): kotlin.Boolean
+    
+    fun `listenForUpdates`(`reconciler`: ConnectivityManagerReconciler)
+    
+    fun `setConnectionState`(`isConnected`: kotlin.Boolean)
+    
+    fun `state`(): ConnectivityState
+    
+    companion object
+}
+
+open class RustConnectivityManager: Disposable, AutoCloseable, RustConnectivityManagerInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+    constructor() :
+        this(UniffiWithHandle, 
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_constructor_rustconnectivitymanager_new(
+    
+        _status)
+}
+    )
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    /**
+     * Whether the current object has been destroyed and its reference is gone in the Rust side.
+     */
+    val uniffiIsDestroyed: Boolean get() = wasDestroyed.get()
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_cove_fn_free_rustconnectivitymanager(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_cove_fn_clone_rustconnectivitymanager(handle, status)
+        }
+    }
+
+    override fun `isConnected`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustconnectivitymanager_is_connected(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `listenForUpdates`(`reconciler`: ConnectivityManagerReconciler)
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustconnectivitymanager_listen_for_updates(
+        it,
+        FfiConverterTypeConnectivityManagerReconciler.lower(`reconciler`),_status)
+}
+    }
+    
+    
+
+    override fun `setConnectionState`(`isConnected`: kotlin.Boolean)
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustconnectivitymanager_set_connection_state(
+        it,
+        FfiConverterBoolean.lower(`isConnected`),_status)
+}
+    }
+    
+    
+
+    override fun `state`(): ConnectivityState {
+            return FfiConverterTypeConnectivityState.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustconnectivitymanager_state(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeRustConnectivityManager: FfiConverter<RustConnectivityManager, Long> {
+    override fun lower(value: RustConnectivityManager): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): RustConnectivityManager {
+        return RustConnectivityManager(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): RustConnectivityManager {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: RustConnectivityManager) = 8UL
+
+    override fun write(value: RustConnectivityManager, buf: ByteBuffer) {
         buf.putLong(lower(value))
     }
 }
@@ -27516,8 +27870,6 @@ public object FfiConverterTypeCloudBackupRestoreReport: FfiConverterRustBuffer<C
 data class CloudBackupState (
     var `status`: CloudBackupStatus
     , 
-    var `connectivityHint`: CloudConnectivityHint
-    , 
     var `syncHealth`: CloudSyncHealth
     , 
     var `promptIntent`: CloudBackupPromptIntent
@@ -27564,7 +27916,6 @@ public object FfiConverterTypeCloudBackupState: FfiConverterRustBuffer<CloudBack
     override fun read(buf: ByteBuffer): CloudBackupState {
         return CloudBackupState(
             FfiConverterTypeCloudBackupStatus.read(buf),
-            FfiConverterTypeCloudConnectivityHint.read(buf),
             FfiConverterTypeCloudSyncHealth.read(buf),
             FfiConverterTypeCloudBackupPromptIntent.read(buf),
             FfiConverterOptionalTypeCloudBackupProgress.read(buf),
@@ -27585,7 +27936,6 @@ public object FfiConverterTypeCloudBackupState: FfiConverterRustBuffer<CloudBack
 
     override fun allocationSize(value: CloudBackupState) = (
             FfiConverterTypeCloudBackupStatus.allocationSize(value.`status`) +
-            FfiConverterTypeCloudConnectivityHint.allocationSize(value.`connectivityHint`) +
             FfiConverterTypeCloudSyncHealth.allocationSize(value.`syncHealth`) +
             FfiConverterTypeCloudBackupPromptIntent.allocationSize(value.`promptIntent`) +
             FfiConverterOptionalTypeCloudBackupProgress.allocationSize(value.`progress`) +
@@ -27605,7 +27955,6 @@ public object FfiConverterTypeCloudBackupState: FfiConverterRustBuffer<CloudBack
 
     override fun write(value: CloudBackupState, buf: ByteBuffer) {
             FfiConverterTypeCloudBackupStatus.write(value.`status`, buf)
-            FfiConverterTypeCloudConnectivityHint.write(value.`connectivityHint`, buf)
             FfiConverterTypeCloudSyncHealth.write(value.`syncHealth`, buf)
             FfiConverterTypeCloudBackupPromptIntent.write(value.`promptIntent`, buf)
             FfiConverterOptionalTypeCloudBackupProgress.write(value.`progress`, buf)
@@ -27735,6 +28084,39 @@ public object FfiConverterTypeConfirmedDetails: FfiConverterRustBuffer<Confirmed
     override fun write(value: ConfirmedDetails, buf: ByteBuffer) {
             FfiConverterUInt.write(value.`blockNumber`, buf)
             FfiConverterULong.write(value.`confirmationTime`, buf)
+    }
+}
+
+
+
+data class ConnectivityState (
+    var `status`: ConnectivityStatus
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeConnectivityState: FfiConverterRustBuffer<ConnectivityState> {
+    override fun read(buf: ByteBuffer): ConnectivityState {
+        return ConnectivityState(
+            FfiConverterTypeConnectivityStatus.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ConnectivityState) = (
+            FfiConverterTypeConnectivityStatus.allocationSize(value.`status`)
+    )
+
+    override fun write(value: ConnectivityState, buf: ByteBuffer) {
+            FfiConverterTypeConnectivityStatus.write(value.`status`, buf)
     }
 }
 
@@ -33794,15 +34176,6 @@ sealed class CloudBackupReconcileMessage {
         companion object
     }
     
-    data class ConnectivityHint(
-        val v1: org.bitcoinppl.cove_core.CloudConnectivityHint) : CloudBackupReconcileMessage()
-        
-    {
-        
-
-        companion object
-    }
-    
     data class SyncHealth(
         val v1: org.bitcoinppl.cove_core.device.CloudSyncHealth) : CloudBackupReconcileMessage()
         
@@ -33957,52 +34330,49 @@ public object FfiConverterTypeCloudBackupReconcileMessage : FfiConverterRustBuff
             1 -> CloudBackupReconcileMessage.Status(
                 FfiConverterTypeCloudBackupStatus.read(buf),
                 )
-            2 -> CloudBackupReconcileMessage.ConnectivityHint(
-                FfiConverterTypeCloudConnectivityHint.read(buf),
-                )
-            3 -> CloudBackupReconcileMessage.SyncHealth(
+            2 -> CloudBackupReconcileMessage.SyncHealth(
                 FfiConverterTypeCloudSyncHealth.read(buf),
                 )
-            4 -> CloudBackupReconcileMessage.Progress(
+            3 -> CloudBackupReconcileMessage.Progress(
                 FfiConverterOptionalTypeCloudBackupProgress.read(buf),
                 )
-            5 -> CloudBackupReconcileMessage.RestoreProgress(
+            4 -> CloudBackupReconcileMessage.RestoreProgress(
                 FfiConverterOptionalTypeCloudBackupRestoreProgress.read(buf),
                 )
-            6 -> CloudBackupReconcileMessage.RestoreReport(
+            5 -> CloudBackupReconcileMessage.RestoreReport(
                 FfiConverterOptionalTypeCloudBackupRestoreReport.read(buf),
                 )
-            7 -> CloudBackupReconcileMessage.SyncError(
+            6 -> CloudBackupReconcileMessage.SyncError(
                 FfiConverterOptionalString.read(buf),
                 )
-            8 -> CloudBackupReconcileMessage.VerificationPrompt(
+            7 -> CloudBackupReconcileMessage.VerificationPrompt(
                 FfiConverterBoolean.read(buf),
                 )
-            9 -> CloudBackupReconcileMessage.VerificationMetadata(
+            8 -> CloudBackupReconcileMessage.VerificationMetadata(
                 FfiConverterTypeCloudBackupVerificationMetadata.read(buf),
                 )
-            10 -> CloudBackupReconcileMessage.PendingUploadVerification(
+            9 -> CloudBackupReconcileMessage.PendingUploadVerification(
                 FfiConverterBoolean.read(buf),
                 )
-            11 -> CloudBackupReconcileMessage.Detail(
+            10 -> CloudBackupReconcileMessage.Detail(
                 FfiConverterOptionalTypeCloudBackupDetail.read(buf),
                 )
-            12 -> CloudBackupReconcileMessage.Verification(
+            11 -> CloudBackupReconcileMessage.Verification(
                 FfiConverterTypeVerificationState.read(buf),
                 )
-            13 -> CloudBackupReconcileMessage.Sync(
+            12 -> CloudBackupReconcileMessage.Sync(
                 FfiConverterTypeSyncState.read(buf),
                 )
-            14 -> CloudBackupReconcileMessage.Recovery(
+            13 -> CloudBackupReconcileMessage.Recovery(
                 FfiConverterTypeRecoveryState.read(buf),
                 )
-            15 -> CloudBackupReconcileMessage.CloudOnly(
+            14 -> CloudBackupReconcileMessage.CloudOnly(
                 FfiConverterTypeCloudOnlyState.read(buf),
                 )
-            16 -> CloudBackupReconcileMessage.CloudOnlyOperation(
+            15 -> CloudBackupReconcileMessage.CloudOnlyOperation(
                 FfiConverterTypeCloudOnlyOperation.read(buf),
                 )
-            17 -> CloudBackupReconcileMessage.PromptIntent(
+            16 -> CloudBackupReconcileMessage.PromptIntent(
                 FfiConverterTypeCloudBackupPromptIntent.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -34015,13 +34385,6 @@ public object FfiConverterTypeCloudBackupReconcileMessage : FfiConverterRustBuff
             (
                 4UL
                 + FfiConverterTypeCloudBackupStatus.allocationSize(value.v1)
-            )
-        }
-        is CloudBackupReconcileMessage.ConnectivityHint -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-                + FfiConverterTypeCloudConnectivityHint.allocationSize(value.v1)
             )
         }
         is CloudBackupReconcileMessage.SyncHealth -> {
@@ -34138,83 +34501,78 @@ public object FfiConverterTypeCloudBackupReconcileMessage : FfiConverterRustBuff
                 FfiConverterTypeCloudBackupStatus.write(value.v1, buf)
                 Unit
             }
-            is CloudBackupReconcileMessage.ConnectivityHint -> {
-                buf.putInt(2)
-                FfiConverterTypeCloudConnectivityHint.write(value.v1, buf)
-                Unit
-            }
             is CloudBackupReconcileMessage.SyncHealth -> {
-                buf.putInt(3)
+                buf.putInt(2)
                 FfiConverterTypeCloudSyncHealth.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.Progress -> {
-                buf.putInt(4)
+                buf.putInt(3)
                 FfiConverterOptionalTypeCloudBackupProgress.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.RestoreProgress -> {
-                buf.putInt(5)
+                buf.putInt(4)
                 FfiConverterOptionalTypeCloudBackupRestoreProgress.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.RestoreReport -> {
-                buf.putInt(6)
+                buf.putInt(5)
                 FfiConverterOptionalTypeCloudBackupRestoreReport.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.SyncError -> {
-                buf.putInt(7)
+                buf.putInt(6)
                 FfiConverterOptionalString.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.VerificationPrompt -> {
-                buf.putInt(8)
+                buf.putInt(7)
                 FfiConverterBoolean.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.VerificationMetadata -> {
-                buf.putInt(9)
+                buf.putInt(8)
                 FfiConverterTypeCloudBackupVerificationMetadata.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.PendingUploadVerification -> {
-                buf.putInt(10)
+                buf.putInt(9)
                 FfiConverterBoolean.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.Detail -> {
-                buf.putInt(11)
+                buf.putInt(10)
                 FfiConverterOptionalTypeCloudBackupDetail.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.Verification -> {
-                buf.putInt(12)
+                buf.putInt(11)
                 FfiConverterTypeVerificationState.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.Sync -> {
-                buf.putInt(13)
+                buf.putInt(12)
                 FfiConverterTypeSyncState.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.Recovery -> {
-                buf.putInt(14)
+                buf.putInt(13)
                 FfiConverterTypeRecoveryState.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.CloudOnly -> {
-                buf.putInt(15)
+                buf.putInt(14)
                 FfiConverterTypeCloudOnlyState.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.CloudOnlyOperation -> {
-                buf.putInt(16)
+                buf.putInt(15)
                 FfiConverterTypeCloudOnlyOperation.write(value.v1, buf)
                 Unit
             }
             is CloudBackupReconcileMessage.PromptIntent -> {
-                buf.putInt(17)
+                buf.putInt(16)
                 FfiConverterTypeCloudBackupPromptIntent.write(value.v1, buf)
                 Unit
             }
@@ -34537,41 +34895,6 @@ public object FfiConverterTypeCloudBackupWalletStatus: FfiConverterRustBuffer<Cl
     override fun allocationSize(value: CloudBackupWalletStatus) = 4UL
 
     override fun write(value: CloudBackupWalletStatus, buf: ByteBuffer) {
-        buf.putInt(value.ordinal + 1)
-    }
-}
-
-
-
-
-
-
-enum class CloudConnectivityHint {
-    
-    ONLINE,
-    OFFLINE,
-    UNKNOWN;
-
-    
-
-
-    companion object
-}
-
-
-/**
- * @suppress
- */
-public object FfiConverterTypeCloudConnectivityHint: FfiConverterRustBuffer<CloudConnectivityHint> {
-    override fun read(buf: ByteBuffer) = try {
-        CloudConnectivityHint.values()[buf.getInt() - 1]
-    } catch (e: IndexOutOfBoundsException) {
-        throw RuntimeException("invalid enum value, something is very wrong!!", e)
-    }
-
-    override fun allocationSize(value: CloudConnectivityHint) = 4UL
-
-    override fun write(value: CloudConnectivityHint, buf: ByteBuffer) {
         buf.putInt(value.ordinal + 1)
     }
 }
@@ -35589,6 +35912,99 @@ public object FfiConverterTypeColdWalletRoute: FfiConverterRustBuffer<ColdWallet
     override fun allocationSize(value: ColdWalletRoute) = 4UL
 
     override fun write(value: ColdWalletRoute, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+sealed class ConnectivityManagerReconcileMessage {
+    
+    data class Status(
+        val v1: org.bitcoinppl.cove_core.ConnectivityStatus) : ConnectivityManagerReconcileMessage()
+        
+    {
+        
+
+        companion object
+    }
+    
+
+    
+
+    
+    
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeConnectivityManagerReconcileMessage : FfiConverterRustBuffer<ConnectivityManagerReconcileMessage>{
+    override fun read(buf: ByteBuffer): ConnectivityManagerReconcileMessage {
+        return when(buf.getInt()) {
+            1 -> ConnectivityManagerReconcileMessage.Status(
+                FfiConverterTypeConnectivityStatus.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: ConnectivityManagerReconcileMessage): ULong = when(value) {
+        is ConnectivityManagerReconcileMessage.Status -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeConnectivityStatus.allocationSize(value.v1)
+            )
+        }
+    }
+
+    override fun write(value: ConnectivityManagerReconcileMessage, buf: ByteBuffer) {
+        when(value) {
+            is ConnectivityManagerReconcileMessage.Status -> {
+                buf.putInt(1)
+                FfiConverterTypeConnectivityStatus.write(value.v1, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
+
+enum class ConnectivityStatus {
+    
+    CONNECTED,
+    DISCONNECTED;
+
+    
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeConnectivityStatus: FfiConverterRustBuffer<ConnectivityStatus> {
+    override fun read(buf: ByteBuffer) = try {
+        ConnectivityStatus.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: ConnectivityStatus) = 4UL
+
+    override fun write(value: ConnectivityStatus, buf: ByteBuffer) {
         buf.putInt(value.ordinal + 1)
     }
 }
@@ -51766,6 +52182,66 @@ internal object uniffiCallbackInterfaceCoinControlManagerReconciler {
  * @suppress
  */
 public object FfiConverterTypeCoinControlManagerReconciler: FfiConverterCallbackInterface<CoinControlManagerReconciler>()
+
+
+
+
+
+public interface ConnectivityManagerReconciler {
+    
+    fun `reconcile`(`message`: ConnectivityManagerReconcileMessage)
+    
+    companion object
+}
+
+
+
+// Put the implementation in an object so we don't pollute the top-level namespace
+internal object uniffiCallbackInterfaceConnectivityManagerReconciler {
+    internal object `reconcile`: UniffiCallbackInterfaceConnectivityManagerReconcilerMethod0 {
+        override fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeConnectivityManagerReconciler.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`reconcile`(
+                    FfiConverterTypeConnectivityManagerReconcileMessage.lift(`message`),
+                )
+            }
+            val writeReturn = { _: Unit -> Unit }
+            uniffiTraitInterfaceCall(uniffiCallStatus, makeCall, writeReturn)
+        }
+    }
+
+    internal object uniffiFree: UniffiCallbackInterfaceFree {
+        override fun callback(handle: Long) {
+            FfiConverterTypeConnectivityManagerReconciler.handleMap.remove(handle)
+        }
+    }
+
+    internal object uniffiClone: UniffiCallbackInterfaceClone {
+        override fun callback(handle: Long): Long {
+            return FfiConverterTypeConnectivityManagerReconciler.handleMap.clone(handle)
+        }
+    }
+
+    internal var vtable = UniffiVTableCallbackInterfaceConnectivityManagerReconciler.UniffiByValue(
+        uniffiFree,
+        uniffiClone,
+        `reconcile`,
+    )
+
+    // Registers the foreign callback with the Rust side.
+    // This method is generated for each callback interface.
+    internal fun register(lib: UniffiLib) {
+        lib.uniffi_cove_fn_init_callback_vtable_connectivitymanagerreconciler(vtable)
+    }
+}
+
+/**
+ * The ffiConverter which transforms the Callbacks in to handles to pass to Rust.
+ *
+ * @suppress
+ */
+public object FfiConverterTypeConnectivityManagerReconciler: FfiConverterCallbackInterface<ConnectivityManagerReconciler>()
 
 
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/device/cove_device.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/device/cove_device.kt
@@ -640,6 +640,9 @@ internal interface UniffiCallbackInterfaceCloudStorageAccessMethod7 : com.sun.jn
 internal interface UniffiCallbackInterfaceCloudStorageAccessMethod8 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`uniffiOutReturn`: RustBuffer,uniffiCallStatus: UniffiRustCallStatus,)
 }
+internal interface UniffiCallbackInterfaceConnectivityAccessMethod0 : com.sun.jna.Callback {
+    fun callback(`uniffiHandle`: Long,`uniffiOutReturn`: ByteByReference,uniffiCallStatus: UniffiRustCallStatus,)
+}
 internal interface UniffiCallbackInterfaceDeviceAccessMethod0 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`uniffiOutReturn`: RustBuffer,uniffiCallStatus: UniffiRustCallStatus,)
 }
@@ -707,6 +710,25 @@ internal open class UniffiVTableCallbackInterfaceCloudStorageAccess(
         `listWalletFiles` = other.`listWalletFiles`
         `isBackupUploaded` = other.`isBackupUploaded`
         `overallSyncHealth` = other.`overallSyncHealth`
+    }
+
+}
+@Structure.FieldOrder("uniffiFree", "uniffiClone", "isConnected")
+internal open class UniffiVTableCallbackInterfaceConnectivityAccess(
+    @JvmField internal var `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+    @JvmField internal var `uniffiClone`: UniffiCallbackInterfaceClone? = null,
+    @JvmField internal var `isConnected`: UniffiCallbackInterfaceConnectivityAccessMethod0? = null,
+) : Structure() {
+    class UniffiByValue(
+        `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+        `uniffiClone`: UniffiCallbackInterfaceClone? = null,
+        `isConnected`: UniffiCallbackInterfaceConnectivityAccessMethod0? = null,
+    ): UniffiVTableCallbackInterfaceConnectivityAccess(`uniffiFree`,`uniffiClone`,`isConnected`,), Structure.ByValue
+
+   internal fun uniffiSetValue(other: UniffiVTableCallbackInterfaceConnectivityAccess) {
+        `uniffiFree` = other.`uniffiFree`
+        `uniffiClone` = other.`uniffiClone`
+        `isConnected` = other.`isConnected`
     }
 
 }
@@ -814,6 +836,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_device_checksum_constructor_cloudstorage_new(
     ): Short
+    external fun uniffi_cove_device_checksum_constructor_connectivity_new(
+    ): Short
     external fun uniffi_cove_device_checksum_constructor_device_new(
     ): Short
     external fun uniffi_cove_device_checksum_constructor_keychain_new(
@@ -837,6 +861,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_device_checksum_method_cloudstorageaccess_is_backup_uploaded(
     ): Short
     external fun uniffi_cove_device_checksum_method_cloudstorageaccess_overall_sync_health(
+    ): Short
+    external fun uniffi_cove_device_checksum_method_connectivityaccess_is_connected(
     ): Short
     external fun uniffi_cove_device_checksum_method_deviceaccess_timezone(
     ): Short
@@ -873,6 +899,7 @@ internal object UniffiLib {
     init {
         Native.register(UniffiLib::class.java, findLibraryName(componentName = "cove_device"))
         uniffiCallbackInterfaceCloudStorageAccess.register(this)
+        uniffiCallbackInterfaceConnectivityAccess.register(this)
         uniffiCallbackInterfaceDeviceAccess.register(this)
         uniffiCallbackInterfaceKeychainAccess.register(this)
         uniffiCallbackInterfacePasskeyProvider.register(this)
@@ -886,6 +913,12 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_device_fn_method_cloudstorage_has_any_cloud_backup(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
+    external fun uniffi_cove_device_fn_clone_connectivity(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_device_fn_free_connectivity(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_device_fn_constructor_connectivity_new(`connectivity`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
     external fun uniffi_cove_device_fn_clone_device(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_device_fn_free_device(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -907,6 +940,8 @@ internal object UniffiLib {
     external fun uniffi_cove_device_fn_method_passkeyaccess_is_prf_supported(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_cove_device_fn_init_callback_vtable_cloudstorageaccess(`vtable`: UniffiVTableCallbackInterfaceCloudStorageAccess,
+    ): Unit
+    external fun uniffi_cove_device_fn_init_callback_vtable_connectivityaccess(`vtable`: UniffiVTableCallbackInterfaceConnectivityAccess,
     ): Unit
     external fun uniffi_cove_device_fn_init_callback_vtable_deviceaccess(`vtable`: UniffiVTableCallbackInterfaceDeviceAccess,
     ): Unit
@@ -1048,6 +1083,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_device_checksum_constructor_cloudstorage_new() != 17602.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_device_checksum_constructor_connectivity_new() != 64633.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_device_checksum_constructor_device_new() != 18892.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1082,6 +1120,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_device_checksum_method_cloudstorageaccess_overall_sync_health() != 51383.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_device_checksum_method_connectivityaccess_is_connected() != 15918.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_device_checksum_method_deviceaccess_timezone() != 54194.toShort()) {
@@ -1664,6 +1705,254 @@ public object FfiConverterTypeCloudStorage: FfiConverter<CloudStorage, Long> {
     override fun allocationSize(value: CloudStorage) = 8UL
 
     override fun write(value: CloudStorage, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+public interface ConnectivityInterface {
+    
+    companion object
+}
+
+open class Connectivity: Disposable, AutoCloseable, ConnectivityInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+    constructor(`connectivity`: ConnectivityAccess) :
+        this(UniffiWithHandle, 
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_device_fn_constructor_connectivity_new(
+    
+        FfiConverterTypeConnectivityAccess.lower(`connectivity`),_status)
+}
+    )
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    /**
+     * Whether the current object has been destroyed and its reference is gone in the Rust side.
+     */
+    val uniffiIsDestroyed: Boolean get() = wasDestroyed.get()
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_cove_device_fn_free_connectivity(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_cove_device_fn_clone_connectivity(handle, status)
+        }
+    }
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeConnectivity: FfiConverter<Connectivity, Long> {
+    override fun lower(value: Connectivity): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): Connectivity {
+        return Connectivity(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): Connectivity {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: Connectivity) = 8UL
+
+    override fun write(value: Connectivity, buf: ByteBuffer) {
         buf.putLong(lower(value))
     }
 }
@@ -3341,6 +3630,65 @@ internal object uniffiCallbackInterfaceCloudStorageAccess {
  * @suppress
  */
 public object FfiConverterTypeCloudStorageAccess: FfiConverterCallbackInterface<CloudStorageAccess>()
+
+
+
+
+
+public interface ConnectivityAccess {
+    
+    fun `isConnected`(): kotlin.Boolean
+    
+    companion object
+}
+
+
+
+// Put the implementation in an object so we don't pollute the top-level namespace
+internal object uniffiCallbackInterfaceConnectivityAccess {
+    internal object `isConnected`: UniffiCallbackInterfaceConnectivityAccessMethod0 {
+        override fun callback(`uniffiHandle`: Long,`uniffiOutReturn`: ByteByReference,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeConnectivityAccess.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`isConnected`(
+                )
+            }
+            val writeReturn = { value: kotlin.Boolean -> uniffiOutReturn.setValue(FfiConverterBoolean.lower(value)) }
+            uniffiTraitInterfaceCall(uniffiCallStatus, makeCall, writeReturn)
+        }
+    }
+
+    internal object uniffiFree: UniffiCallbackInterfaceFree {
+        override fun callback(handle: Long) {
+            FfiConverterTypeConnectivityAccess.handleMap.remove(handle)
+        }
+    }
+
+    internal object uniffiClone: UniffiCallbackInterfaceClone {
+        override fun callback(handle: Long): Long {
+            return FfiConverterTypeConnectivityAccess.handleMap.clone(handle)
+        }
+    }
+
+    internal var vtable = UniffiVTableCallbackInterfaceConnectivityAccess.UniffiByValue(
+        uniffiFree,
+        uniffiClone,
+        `isConnected`,
+    )
+
+    // Registers the foreign callback with the Rust side.
+    // This method is generated for each callback interface.
+    internal fun register(lib: UniffiLib) {
+        lib.uniffi_cove_device_fn_init_callback_vtable_connectivityaccess(vtable)
+    }
+}
+
+/**
+ * The ffiConverter which transforms the Callbacks in to handles to pass to Rust.
+ *
+ * @suppress
+ */
+public object FfiConverterTypeConnectivityAccess: FfiConverterCallbackInterface<ConnectivityAccess>()
 
 
 

--- a/ios/Cove/CloudBackupManager.swift
+++ b/ios/Cove/CloudBackupManager.swift
@@ -40,10 +40,6 @@ final class CloudBackupManager: AnyReconciler, CloudBackupManagerReconciler, @un
         state.promptIntent
     }
 
-    var connectivityHint: CloudConnectivityHint {
-        state.connectivityHint
-    }
-
     var syncHealth: CloudSyncHealth {
         state.syncHealth
     }
@@ -144,8 +140,6 @@ final class CloudBackupManager: AnyReconciler, CloudBackupManagerReconciler, @un
         switch message {
         case let .status(status):
             state.status = status
-        case let .connectivityHint(connectivityHint):
-            state.connectivityHint = connectivityHint
         case let .syncHealth(syncHealth):
             state.syncHealth = syncHealth
         case let .promptIntent(promptIntent):

--- a/ios/Cove/CoveApp.swift
+++ b/ios/Cove/CoveApp.swift
@@ -52,6 +52,7 @@ struct CoveApp: App {
     init() {
         _ = Keychain(keychain: KeychainAccessor())
         _ = Device(device: DeviceAccesor())
+        _ = Connectivity(connectivity: CloudConnectivityMonitor.shared)
         _ = PasskeyAccess(provider: PasskeyProviderImpl())
         _ = CloudStorage(cloudStorage: CloudStorageAccessImpl())
         Self.excludeDataDirFromBackup(logFailure: false)
@@ -309,13 +310,14 @@ private struct BootstrapTimeoutError: LocalizedError {
     }
 }
 
-final class CloudConnectivityMonitor: @unchecked Sendable {
+final class CloudConnectivityMonitor: ConnectivityAccess, @unchecked Sendable {
     static let shared = CloudConnectivityMonitor()
 
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "cove.CloudConnectivityMonitor")
     private let lock = NSLock()
     private var started = false
+    private var isConnectedValue = true
 
     private init() {}
 
@@ -326,18 +328,25 @@ final class CloudConnectivityMonitor: @unchecked Sendable {
         started = true
 
         monitor.pathUpdateHandler = { path in
-            let hint: CloudConnectivityHint =
-                if path.status == .satisfied {
-                    .online
-                } else if path.status == .unsatisfied {
-                    .offline
-                } else {
-                    .unknown
-                }
-
-            CloudBackupManager.shared.rust.updateConnectivityHint(hint: hint)
+            let connected = path.status == .satisfied
+            self.lock.lock()
+            self.isConnectedValue = connected
+            self.lock.unlock()
+            self.updateRustConnectivity(connected)
         }
 
         monitor.start(queue: queue)
+        isConnectedValue = monitor.currentPath.status == .satisfied
+        updateRustConnectivity(isConnectedValue)
+    }
+
+    func isConnected() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isConnectedValue
+    }
+
+    private func updateRustConnectivity(_ isConnected: Bool) {
+        RustConnectivityManager().setConnectionState(isConnected: isConnected)
     }
 }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -7103,8 +7103,6 @@ public protocol RustCloudBackupManagerProtocol: AnyObject, Sendable {
      */
     func syncPersistedState() 
     
-    func updateConnectivityHint(hint: CloudConnectivityHint) 
-    
     /**
      * Background startup health check for cloud backup integrity
      */
@@ -7318,14 +7316,6 @@ open func state() -> CloudBackupState  {
 open func syncPersistedState()  {try! rustCall() {
     uniffi_cove_fn_method_rustcloudbackupmanager_sync_persisted_state(
             self.uniffiCloneHandle(),$0
-    )
-}
-}
-    
-open func updateConnectivityHint(hint: CloudConnectivityHint)  {try! rustCall() {
-    uniffi_cove_fn_method_rustcloudbackupmanager_update_connectivity_hint(
-            self.uniffiCloneHandle(),
-        FfiConverterTypeCloudConnectivityHint_lower(hint),$0
     )
 }
 }
@@ -7596,6 +7586,159 @@ public func FfiConverterTypeRustCoinControlManager_lift(_ handle: UInt64) throws
 #endif
 public func FfiConverterTypeRustCoinControlManager_lower(_ value: RustCoinControlManager) -> UInt64 {
     return FfiConverterTypeRustCoinControlManager.lower(value)
+}
+
+
+
+
+
+
+public protocol RustConnectivityManagerProtocol: AnyObject, Sendable {
+    
+    func isConnected()  -> Bool
+    
+    func listenForUpdates(reconciler: ConnectivityManagerReconciler) 
+    
+    func setConnectionState(isConnected: Bool) 
+    
+    func state()  -> ConnectivityState
+    
+}
+open class RustConnectivityManager: RustConnectivityManagerProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_cove_fn_clone_rustconnectivitymanager(self.handle, $0) }
+    }
+public convenience init() {
+    let handle =
+        try! rustCall() {
+    uniffi_cove_fn_constructor_rustconnectivitymanager_new($0
+    )
+}
+    self.init(unsafeFromHandle: handle)
+}
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_cove_fn_free_rustconnectivitymanager(handle, $0) }
+    }
+
+    
+
+    
+open func isConnected() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_cove_fn_method_rustconnectivitymanager_is_connected(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func listenForUpdates(reconciler: ConnectivityManagerReconciler)  {try! rustCall() {
+    uniffi_cove_fn_method_rustconnectivitymanager_listen_for_updates(
+            self.uniffiCloneHandle(),
+        FfiConverterCallbackInterfaceConnectivityManagerReconciler_lower(reconciler),$0
+    )
+}
+}
+    
+open func setConnectionState(isConnected: Bool)  {try! rustCall() {
+    uniffi_cove_fn_method_rustconnectivitymanager_set_connection_state(
+            self.uniffiCloneHandle(),
+        FfiConverterBool.lower(isConnected),$0
+    )
+}
+}
+    
+open func state() -> ConnectivityState  {
+    return try!  FfiConverterTypeConnectivityState_lift(try! rustCall() {
+    uniffi_cove_fn_method_rustconnectivitymanager_state(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeRustConnectivityManager: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = RustConnectivityManager
+
+    public static func lift(_ handle: UInt64) throws -> RustConnectivityManager {
+        return RustConnectivityManager(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: RustConnectivityManager) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RustConnectivityManager {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: RustConnectivityManager, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeRustConnectivityManager_lift(_ handle: UInt64) throws -> RustConnectivityManager {
+    return try FfiConverterTypeRustConnectivityManager.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeRustConnectivityManager_lower(_ value: RustConnectivityManager) -> UInt64 {
+    return FfiConverterTypeRustConnectivityManager.lower(value)
 }
 
 
@@ -13070,7 +13213,6 @@ public func FfiConverterTypeCloudBackupRestoreReport_lower(_ value: CloudBackupR
 
 public struct CloudBackupState: Equatable, Hashable {
     public var status: CloudBackupStatus
-    public var connectivityHint: CloudConnectivityHint
     public var syncHealth: CloudSyncHealth
     public var promptIntent: CloudBackupPromptIntent
     public var progress: CloudBackupProgress?
@@ -13089,9 +13231,8 @@ public struct CloudBackupState: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(status: CloudBackupStatus, connectivityHint: CloudConnectivityHint, syncHealth: CloudSyncHealth, promptIntent: CloudBackupPromptIntent, progress: CloudBackupProgress?, restoreProgress: CloudBackupRestoreProgress?, restoreReport: CloudBackupRestoreReport?, syncError: String?, hasPendingUploadVerification: Bool, shouldPromptVerification: Bool, verificationMetadata: CloudBackupVerificationMetadata, detail: CloudBackupDetail?, verification: VerificationState, sync: SyncState, recovery: RecoveryState, cloudOnly: CloudOnlyState, cloudOnlyOperation: CloudOnlyOperation) {
+    public init(status: CloudBackupStatus, syncHealth: CloudSyncHealth, promptIntent: CloudBackupPromptIntent, progress: CloudBackupProgress?, restoreProgress: CloudBackupRestoreProgress?, restoreReport: CloudBackupRestoreReport?, syncError: String?, hasPendingUploadVerification: Bool, shouldPromptVerification: Bool, verificationMetadata: CloudBackupVerificationMetadata, detail: CloudBackupDetail?, verification: VerificationState, sync: SyncState, recovery: RecoveryState, cloudOnly: CloudOnlyState, cloudOnlyOperation: CloudOnlyOperation) {
         self.status = status
-        self.connectivityHint = connectivityHint
         self.syncHealth = syncHealth
         self.promptIntent = promptIntent
         self.progress = progress
@@ -13126,7 +13267,6 @@ public struct FfiConverterTypeCloudBackupState: FfiConverterRustBuffer {
         return
             try CloudBackupState(
                 status: FfiConverterTypeCloudBackupStatus.read(from: &buf), 
-                connectivityHint: FfiConverterTypeCloudConnectivityHint.read(from: &buf), 
                 syncHealth: FfiConverterTypeCloudSyncHealth.read(from: &buf), 
                 promptIntent: FfiConverterTypeCloudBackupPromptIntent.read(from: &buf), 
                 progress: FfiConverterOptionTypeCloudBackupProgress.read(from: &buf), 
@@ -13147,7 +13287,6 @@ public struct FfiConverterTypeCloudBackupState: FfiConverterRustBuffer {
 
     public static func write(_ value: CloudBackupState, into buf: inout [UInt8]) {
         FfiConverterTypeCloudBackupStatus.write(value.status, into: &buf)
-        FfiConverterTypeCloudConnectivityHint.write(value.connectivityHint, into: &buf)
         FfiConverterTypeCloudSyncHealth.write(value.syncHealth, into: &buf)
         FfiConverterTypeCloudBackupPromptIntent.write(value.promptIntent, into: &buf)
         FfiConverterOptionTypeCloudBackupProgress.write(value.progress, into: &buf)
@@ -13321,6 +13460,56 @@ public func FfiConverterTypeConfirmedDetails_lift(_ buf: RustBuffer) throws -> C
 #endif
 public func FfiConverterTypeConfirmedDetails_lower(_ value: ConfirmedDetails) -> RustBuffer {
     return FfiConverterTypeConfirmedDetails.lower(value)
+}
+
+
+public struct ConnectivityState: Equatable, Hashable {
+    public var status: ConnectivityStatus
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(status: ConnectivityStatus) {
+        self.status = status
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension ConnectivityState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeConnectivityState: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnectivityState {
+        return
+            try ConnectivityState(
+                status: FfiConverterTypeConnectivityStatus.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ConnectivityState, into buf: inout [UInt8]) {
+        FfiConverterTypeConnectivityStatus.write(value.status, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivityState_lift(_ buf: RustBuffer) throws -> ConnectivityState {
+    return try FfiConverterTypeConnectivityState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivityState_lower(_ value: ConnectivityState) -> RustBuffer {
+    return FfiConverterTypeConnectivityState.lower(value)
 }
 
 
@@ -18513,8 +18702,6 @@ public enum CloudBackupReconcileMessage: Equatable, Hashable {
     
     case status(CloudBackupStatus
     )
-    case connectivityHint(CloudConnectivityHint
-    )
     case syncHealth(CloudSyncHealth
     )
     case progress(CloudBackupProgress?
@@ -18569,52 +18756,49 @@ public struct FfiConverterTypeCloudBackupReconcileMessage: FfiConverterRustBuffe
         case 1: return .status(try FfiConverterTypeCloudBackupStatus.read(from: &buf)
         )
         
-        case 2: return .connectivityHint(try FfiConverterTypeCloudConnectivityHint.read(from: &buf)
+        case 2: return .syncHealth(try FfiConverterTypeCloudSyncHealth.read(from: &buf)
         )
         
-        case 3: return .syncHealth(try FfiConverterTypeCloudSyncHealth.read(from: &buf)
+        case 3: return .progress(try FfiConverterOptionTypeCloudBackupProgress.read(from: &buf)
         )
         
-        case 4: return .progress(try FfiConverterOptionTypeCloudBackupProgress.read(from: &buf)
+        case 4: return .restoreProgress(try FfiConverterOptionTypeCloudBackupRestoreProgress.read(from: &buf)
         )
         
-        case 5: return .restoreProgress(try FfiConverterOptionTypeCloudBackupRestoreProgress.read(from: &buf)
+        case 5: return .restoreReport(try FfiConverterOptionTypeCloudBackupRestoreReport.read(from: &buf)
         )
         
-        case 6: return .restoreReport(try FfiConverterOptionTypeCloudBackupRestoreReport.read(from: &buf)
+        case 6: return .syncError(try FfiConverterOptionString.read(from: &buf)
         )
         
-        case 7: return .syncError(try FfiConverterOptionString.read(from: &buf)
+        case 7: return .verificationPrompt(try FfiConverterBool.read(from: &buf)
         )
         
-        case 8: return .verificationPrompt(try FfiConverterBool.read(from: &buf)
+        case 8: return .verificationMetadata(try FfiConverterTypeCloudBackupVerificationMetadata.read(from: &buf)
         )
         
-        case 9: return .verificationMetadata(try FfiConverterTypeCloudBackupVerificationMetadata.read(from: &buf)
+        case 9: return .pendingUploadVerification(try FfiConverterBool.read(from: &buf)
         )
         
-        case 10: return .pendingUploadVerification(try FfiConverterBool.read(from: &buf)
+        case 10: return .detail(try FfiConverterOptionTypeCloudBackupDetail.read(from: &buf)
         )
         
-        case 11: return .detail(try FfiConverterOptionTypeCloudBackupDetail.read(from: &buf)
+        case 11: return .verification(try FfiConverterTypeVerificationState.read(from: &buf)
         )
         
-        case 12: return .verification(try FfiConverterTypeVerificationState.read(from: &buf)
+        case 12: return .sync(try FfiConverterTypeSyncState.read(from: &buf)
         )
         
-        case 13: return .sync(try FfiConverterTypeSyncState.read(from: &buf)
+        case 13: return .recovery(try FfiConverterTypeRecoveryState.read(from: &buf)
         )
         
-        case 14: return .recovery(try FfiConverterTypeRecoveryState.read(from: &buf)
+        case 14: return .cloudOnly(try FfiConverterTypeCloudOnlyState.read(from: &buf)
         )
         
-        case 15: return .cloudOnly(try FfiConverterTypeCloudOnlyState.read(from: &buf)
+        case 15: return .cloudOnlyOperation(try FfiConverterTypeCloudOnlyOperation.read(from: &buf)
         )
         
-        case 16: return .cloudOnlyOperation(try FfiConverterTypeCloudOnlyOperation.read(from: &buf)
-        )
-        
-        case 17: return .promptIntent(try FfiConverterTypeCloudBackupPromptIntent.read(from: &buf)
+        case 16: return .promptIntent(try FfiConverterTypeCloudBackupPromptIntent.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -18630,83 +18814,78 @@ public struct FfiConverterTypeCloudBackupReconcileMessage: FfiConverterRustBuffe
             FfiConverterTypeCloudBackupStatus.write(v1, into: &buf)
             
         
-        case let .connectivityHint(v1):
-            writeInt(&buf, Int32(2))
-            FfiConverterTypeCloudConnectivityHint.write(v1, into: &buf)
-            
-        
         case let .syncHealth(v1):
-            writeInt(&buf, Int32(3))
+            writeInt(&buf, Int32(2))
             FfiConverterTypeCloudSyncHealth.write(v1, into: &buf)
             
         
         case let .progress(v1):
-            writeInt(&buf, Int32(4))
+            writeInt(&buf, Int32(3))
             FfiConverterOptionTypeCloudBackupProgress.write(v1, into: &buf)
             
         
         case let .restoreProgress(v1):
-            writeInt(&buf, Int32(5))
+            writeInt(&buf, Int32(4))
             FfiConverterOptionTypeCloudBackupRestoreProgress.write(v1, into: &buf)
             
         
         case let .restoreReport(v1):
-            writeInt(&buf, Int32(6))
+            writeInt(&buf, Int32(5))
             FfiConverterOptionTypeCloudBackupRestoreReport.write(v1, into: &buf)
             
         
         case let .syncError(v1):
-            writeInt(&buf, Int32(7))
+            writeInt(&buf, Int32(6))
             FfiConverterOptionString.write(v1, into: &buf)
             
         
         case let .verificationPrompt(v1):
-            writeInt(&buf, Int32(8))
+            writeInt(&buf, Int32(7))
             FfiConverterBool.write(v1, into: &buf)
             
         
         case let .verificationMetadata(v1):
-            writeInt(&buf, Int32(9))
+            writeInt(&buf, Int32(8))
             FfiConverterTypeCloudBackupVerificationMetadata.write(v1, into: &buf)
             
         
         case let .pendingUploadVerification(v1):
-            writeInt(&buf, Int32(10))
+            writeInt(&buf, Int32(9))
             FfiConverterBool.write(v1, into: &buf)
             
         
         case let .detail(v1):
-            writeInt(&buf, Int32(11))
+            writeInt(&buf, Int32(10))
             FfiConverterOptionTypeCloudBackupDetail.write(v1, into: &buf)
             
         
         case let .verification(v1):
-            writeInt(&buf, Int32(12))
+            writeInt(&buf, Int32(11))
             FfiConverterTypeVerificationState.write(v1, into: &buf)
             
         
         case let .sync(v1):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(12))
             FfiConverterTypeSyncState.write(v1, into: &buf)
             
         
         case let .recovery(v1):
-            writeInt(&buf, Int32(14))
+            writeInt(&buf, Int32(13))
             FfiConverterTypeRecoveryState.write(v1, into: &buf)
             
         
         case let .cloudOnly(v1):
-            writeInt(&buf, Int32(15))
+            writeInt(&buf, Int32(14))
             FfiConverterTypeCloudOnlyState.write(v1, into: &buf)
             
         
         case let .cloudOnlyOperation(v1):
-            writeInt(&buf, Int32(16))
+            writeInt(&buf, Int32(15))
             FfiConverterTypeCloudOnlyOperation.write(v1, into: &buf)
             
         
         case let .promptIntent(v1):
-            writeInt(&buf, Int32(17))
+            writeInt(&buf, Int32(16))
             FfiConverterTypeCloudBackupPromptIntent.write(v1, into: &buf)
             
         }
@@ -19094,79 +19273,6 @@ public func FfiConverterTypeCloudBackupWalletStatus_lift(_ buf: RustBuffer) thro
 #endif
 public func FfiConverterTypeCloudBackupWalletStatus_lower(_ value: CloudBackupWalletStatus) -> RustBuffer {
     return FfiConverterTypeCloudBackupWalletStatus.lower(value)
-}
-
-
-
-
-public enum CloudConnectivityHint: Equatable, Hashable {
-    
-    case online
-    case offline
-    case unknown
-
-
-
-
-
-}
-
-#if compiler(>=6)
-extension CloudConnectivityHint: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeCloudConnectivityHint: FfiConverterRustBuffer {
-    typealias SwiftType = CloudConnectivityHint
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CloudConnectivityHint {
-        let variant: Int32 = try readInt(&buf)
-        switch variant {
-        
-        case 1: return .online
-        
-        case 2: return .offline
-        
-        case 3: return .unknown
-        
-        default: throw UniffiInternalError.unexpectedEnumCase
-        }
-    }
-
-    public static func write(_ value: CloudConnectivityHint, into buf: inout [UInt8]) {
-        switch value {
-        
-        
-        case .online:
-            writeInt(&buf, Int32(1))
-        
-        
-        case .offline:
-            writeInt(&buf, Int32(2))
-        
-        
-        case .unknown:
-            writeInt(&buf, Int32(3))
-        
-        }
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeCloudConnectivityHint_lift(_ buf: RustBuffer) throws -> CloudConnectivityHint {
-    return try FfiConverterTypeCloudConnectivityHint.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeCloudConnectivityHint_lower(_ value: CloudConnectivityHint) -> RustBuffer {
-    return FfiConverterTypeCloudConnectivityHint.lower(value)
 }
 
 
@@ -19941,6 +20047,134 @@ public func FfiConverterTypeColdWalletRoute_lift(_ buf: RustBuffer) throws -> Co
 #endif
 public func FfiConverterTypeColdWalletRoute_lower(_ value: ColdWalletRoute) -> RustBuffer {
     return FfiConverterTypeColdWalletRoute.lower(value)
+}
+
+
+
+
+public enum ConnectivityManagerReconcileMessage: Equatable, Hashable {
+    
+    case status(ConnectivityStatus
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension ConnectivityManagerReconcileMessage: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeConnectivityManagerReconcileMessage: FfiConverterRustBuffer {
+    typealias SwiftType = ConnectivityManagerReconcileMessage
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnectivityManagerReconcileMessage {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .status(try FfiConverterTypeConnectivityStatus.read(from: &buf)
+        )
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: ConnectivityManagerReconcileMessage, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case let .status(v1):
+            writeInt(&buf, Int32(1))
+            FfiConverterTypeConnectivityStatus.write(v1, into: &buf)
+            
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivityManagerReconcileMessage_lift(_ buf: RustBuffer) throws -> ConnectivityManagerReconcileMessage {
+    return try FfiConverterTypeConnectivityManagerReconcileMessage.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivityManagerReconcileMessage_lower(_ value: ConnectivityManagerReconcileMessage) -> RustBuffer {
+    return FfiConverterTypeConnectivityManagerReconcileMessage.lower(value)
+}
+
+
+
+
+public enum ConnectivityStatus: Equatable, Hashable {
+    
+    case connected
+    case disconnected
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension ConnectivityStatus: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeConnectivityStatus: FfiConverterRustBuffer {
+    typealias SwiftType = ConnectivityStatus
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnectivityStatus {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .connected
+        
+        case 2: return .disconnected
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: ConnectivityStatus, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .connected:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .disconnected:
+            writeInt(&buf, Int32(2))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivityStatus_lift(_ buf: RustBuffer) throws -> ConnectivityStatus {
+    return try FfiConverterTypeConnectivityStatus.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivityStatus_lower(_ value: ConnectivityStatus) -> RustBuffer {
+    return FfiConverterTypeConnectivityStatus.lower(value)
 }
 
 
@@ -32634,6 +32868,137 @@ public func FfiConverterCallbackInterfaceCoinControlManagerReconciler_lower(_ v:
 
 
 
+public protocol ConnectivityManagerReconciler: AnyObject, Sendable {
+    
+    func reconcile(message: ConnectivityManagerReconcileMessage) 
+    
+}
+
+
+// Put the implementation in a struct so we don't pollute the top-level namespace
+fileprivate struct UniffiCallbackInterfaceConnectivityManagerReconciler {
+
+    // Create the VTable using a series of closures.
+    // Swift automatically converts these into C callback functions.
+    //
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceConnectivityManagerReconciler = UniffiVTableCallbackInterfaceConnectivityManagerReconciler(
+        uniffiFree: { (uniffiHandle: UInt64) -> () in
+            do {
+                try FfiConverterCallbackInterfaceConnectivityManagerReconciler.handleMap.remove(handle: uniffiHandle)
+            } catch {
+                print("Uniffi callback interface ConnectivityManagerReconciler: handle missing in uniffiFree")
+            }
+        },
+        uniffiClone: { (uniffiHandle: UInt64) -> UInt64 in
+            do {
+                return try FfiConverterCallbackInterfaceConnectivityManagerReconciler.handleMap.clone(handle: uniffiHandle)
+            } catch {
+                fatalError("Uniffi callback interface ConnectivityManagerReconciler: handle missing in uniffiClone")
+            }
+        },
+        reconcile: { (
+            uniffiHandle: UInt64,
+            message: RustBuffer,
+            uniffiOutReturn: UnsafeMutableRawPointer,
+            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
+        ) in
+            let makeCall = {
+                () throws -> () in
+                guard let uniffiObj = try? FfiConverterCallbackInterfaceConnectivityManagerReconciler.handleMap.get(handle: uniffiHandle) else {
+                    throw UniffiInternalError.unexpectedStaleHandle
+                }
+                return uniffiObj.reconcile(
+                     message: try FfiConverterTypeConnectivityManagerReconcileMessage_lift(message)
+                )
+            }
+
+            
+            let writeReturn = { () }
+            uniffiTraitInterfaceCall(
+                callStatus: uniffiCallStatus,
+                makeCall: makeCall,
+                writeReturn: writeReturn
+            )
+        }
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceConnectivityManagerReconciler> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceConnectivityManagerReconciler>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
+}
+
+private func uniffiCallbackInitConnectivityManagerReconciler() {
+    uniffi_cove_fn_init_callback_vtable_connectivitymanagerreconciler(UniffiCallbackInterfaceConnectivityManagerReconciler.vtablePtr)
+}
+
+// FfiConverter protocol for callback interfaces
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterCallbackInterfaceConnectivityManagerReconciler {
+    fileprivate static let handleMap = UniffiHandleMap<ConnectivityManagerReconciler>()
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+extension FfiConverterCallbackInterfaceConnectivityManagerReconciler : FfiConverter {
+    typealias SwiftType = ConnectivityManagerReconciler
+    typealias FfiType = UInt64
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func lift(_ handle: UInt64) throws -> SwiftType {
+        try handleMap.get(handle: handle)
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func lower(_ v: SwiftType) -> UInt64 {
+        return handleMap.insert(obj: v)
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func write(_ v: SwiftType, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(v))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterCallbackInterfaceConnectivityManagerReconciler_lift(_ handle: UInt64) throws -> ConnectivityManagerReconciler {
+    return try FfiConverterCallbackInterfaceConnectivityManagerReconciler.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterCallbackInterfaceConnectivityManagerReconciler_lower(_ v: ConnectivityManagerReconciler) -> UInt64 {
+    return FfiConverterCallbackInterfaceConnectivityManagerReconciler.lower(v)
+}
+
+
+
+
 public protocol FfiReconcile: AnyObject, Sendable {
     
     /**
@@ -36339,9 +36704,6 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_sync_persisted_state() != 19758) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustcloudbackupmanager_update_connectivity_hint() != 42789) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_cove_checksum_method_rustcloudbackupmanager_verify_backup_integrity() != 47801) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -36367,6 +36729,18 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcoincontrolmanager_utxos() != 43520) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustconnectivitymanager_is_connected() != 47607) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustconnectivitymanager_listen_for_updates() != 49341) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustconnectivitymanager_set_connection_state() != 17798) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustconnectivitymanager_state() != 43225) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustimportwalletmanager_dispatch() != 59923) {
@@ -37032,6 +37406,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_constructor_coincontrolmanagerstate_preview_new() != 11196) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_constructor_rustconnectivitymanager_new() != 58689) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_constructor_rustimportwalletmanager_new() != 12433) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -37158,6 +37535,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_coincontrolmanagerreconciler_reconcile_many() != 14668) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_connectivitymanagerreconciler_reconcile() != 20375) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_importwalletmanagerreconciler_reconcile() != 13279) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -37193,6 +37573,7 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitAuthManagerReconciler()
     uniffiCallbackInitCloudBackupManagerReconciler()
     uniffiCallbackInitCoinControlManagerReconciler()
+    uniffiCallbackInitConnectivityManagerReconciler()
     uniffiCallbackInitFfiReconcile()
     uniffiCallbackInitImportWalletManagerReconciler()
     uniffiCallbackInitOnboardingManagerReconciler()

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_device.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_device.swift
@@ -638,6 +638,120 @@ public func FfiConverterTypeCloudStorage_lower(_ value: CloudStorage) -> UInt64 
 
 
 
+public protocol ConnectivityProtocol: AnyObject, Sendable {
+    
+}
+open class Connectivity: ConnectivityProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_cove_device_fn_clone_connectivity(self.handle, $0) }
+    }
+public convenience init(connectivity: ConnectivityAccess) {
+    let handle =
+        try! rustCall() {
+    uniffi_cove_device_fn_constructor_connectivity_new(
+        FfiConverterCallbackInterfaceConnectivityAccess_lower(connectivity),$0
+    )
+}
+    self.init(unsafeFromHandle: handle)
+}
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_cove_device_fn_free_connectivity(handle, $0) }
+    }
+
+    
+
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeConnectivity: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = Connectivity
+
+    public static func lift(_ handle: UInt64) throws -> Connectivity {
+        return Connectivity(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: Connectivity) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Connectivity {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: Connectivity, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivity_lift(_ handle: UInt64) throws -> Connectivity {
+    return try FfiConverterTypeConnectivity.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeConnectivity_lower(_ value: Connectivity) -> UInt64 {
+    return FfiConverterTypeConnectivity.lower(value)
+}
+
+
+
+
+
+
 public protocol DeviceProtocol: AnyObject, Sendable {
     
 }
@@ -1971,6 +2085,135 @@ public func FfiConverterCallbackInterfaceCloudStorageAccess_lower(_ v: CloudStor
 
 
 
+public protocol ConnectivityAccess: AnyObject, Sendable {
+    
+    func isConnected()  -> Bool
+    
+}
+
+
+// Put the implementation in a struct so we don't pollute the top-level namespace
+fileprivate struct UniffiCallbackInterfaceConnectivityAccess {
+
+    // Create the VTable using a series of closures.
+    // Swift automatically converts these into C callback functions.
+    //
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceConnectivityAccess = UniffiVTableCallbackInterfaceConnectivityAccess(
+        uniffiFree: { (uniffiHandle: UInt64) -> () in
+            do {
+                try FfiConverterCallbackInterfaceConnectivityAccess.handleMap.remove(handle: uniffiHandle)
+            } catch {
+                print("Uniffi callback interface ConnectivityAccess: handle missing in uniffiFree")
+            }
+        },
+        uniffiClone: { (uniffiHandle: UInt64) -> UInt64 in
+            do {
+                return try FfiConverterCallbackInterfaceConnectivityAccess.handleMap.clone(handle: uniffiHandle)
+            } catch {
+                fatalError("Uniffi callback interface ConnectivityAccess: handle missing in uniffiClone")
+            }
+        },
+        isConnected: { (
+            uniffiHandle: UInt64,
+            uniffiOutReturn: UnsafeMutablePointer<Int8>,
+            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
+        ) in
+            let makeCall = {
+                () throws -> Bool in
+                guard let uniffiObj = try? FfiConverterCallbackInterfaceConnectivityAccess.handleMap.get(handle: uniffiHandle) else {
+                    throw UniffiInternalError.unexpectedStaleHandle
+                }
+                return uniffiObj.isConnected(
+                )
+            }
+
+            
+            let writeReturn = { uniffiOutReturn.pointee = FfiConverterBool.lower($0) }
+            uniffiTraitInterfaceCall(
+                callStatus: uniffiCallStatus,
+                makeCall: makeCall,
+                writeReturn: writeReturn
+            )
+        }
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceConnectivityAccess> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceConnectivityAccess>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
+}
+
+private func uniffiCallbackInitConnectivityAccess() {
+    uniffi_cove_device_fn_init_callback_vtable_connectivityaccess(UniffiCallbackInterfaceConnectivityAccess.vtablePtr)
+}
+
+// FfiConverter protocol for callback interfaces
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterCallbackInterfaceConnectivityAccess {
+    fileprivate static let handleMap = UniffiHandleMap<ConnectivityAccess>()
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+extension FfiConverterCallbackInterfaceConnectivityAccess : FfiConverter {
+    typealias SwiftType = ConnectivityAccess
+    typealias FfiType = UInt64
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func lift(_ handle: UInt64) throws -> SwiftType {
+        try handleMap.get(handle: handle)
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func lower(_ v: SwiftType) -> UInt64 {
+        return handleMap.insert(obj: v)
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public static func write(_ v: SwiftType, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(v))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterCallbackInterfaceConnectivityAccess_lift(_ handle: UInt64) throws -> ConnectivityAccess {
+    return try FfiConverterCallbackInterfaceConnectivityAccess.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterCallbackInterfaceConnectivityAccess_lower(_ v: ConnectivityAccess) -> UInt64 {
+    return FfiConverterCallbackInterfaceConnectivityAccess.lower(v)
+}
+
+
+
+
 public protocol DeviceAccess: AnyObject, Sendable {
     
     func timezone()  -> String
@@ -2635,6 +2878,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_device_checksum_constructor_cloudstorage_new() != 17602) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_device_checksum_constructor_connectivity_new() != 64633) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_device_checksum_constructor_device_new() != 18892) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -2671,6 +2917,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_device_checksum_method_cloudstorageaccess_overall_sync_health() != 51383) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_device_checksum_method_connectivityaccess_is_connected() != 15918) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_device_checksum_method_deviceaccess_timezone() != 54194) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -2700,6 +2949,7 @@ private let initializationResult: InitializationResult = {
     }
 
     uniffiCallbackInitCloudStorageAccess()
+    uniffiCallbackInitConnectivityAccess()
     uniffiCallbackInitDeviceAccess()
     uniffiCallbackInitKeychainAccess()
     uniffiCallbackInitPasskeyProvider()

--- a/rust/crates/cove-device/src/connectivity.rs
+++ b/rust/crates/cove-device/src/connectivity.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use tracing::warn;
+
+static REF: OnceCell<Connectivity> = OnceCell::new();
+
+#[uniffi::export(callback_interface)]
+pub trait ConnectivityAccess: Send + Sync + std::fmt::Debug + 'static {
+    fn is_connected(&self) -> bool;
+}
+
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct Connectivity(Arc<Box<dyn ConnectivityAccess>>);
+
+impl Connectivity {
+    pub fn try_global() -> Option<&'static Self> {
+        REF.get()
+    }
+
+    pub fn global() -> &'static Self {
+        Self::try_global().expect("connectivity is not initialized")
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.0.is_connected()
+    }
+}
+
+#[uniffi::export]
+impl Connectivity {
+    #[uniffi::constructor]
+    pub fn new(connectivity: Box<dyn ConnectivityAccess>) -> Self {
+        if let Some(me) = REF.get() {
+            warn!("connectivity is already initialized");
+            return me.clone();
+        }
+
+        let me = Self(Arc::new(connectivity));
+        REF.set(me).expect("failed to set connectivity");
+
+        Self::global().clone()
+    }
+}

--- a/rust/crates/cove-device/src/lib.rs
+++ b/rust/crates/cove-device/src/lib.rs
@@ -1,5 +1,6 @@
 //! Module for interacting with the device
 pub mod cloud_storage;
+pub mod connectivity;
 pub mod device;
 pub mod keychain;
 pub mod passkey;

--- a/rust/src/manager.rs
+++ b/rust/src/manager.rs
@@ -2,6 +2,7 @@ pub mod auth_manager;
 pub mod cloud_backup_detail_manager;
 pub mod cloud_backup_manager;
 pub mod coin_control_manager;
+pub mod connectivity_manager;
 pub mod deferred_dispatch;
 pub mod deferred_sender;
 pub mod import_wallet_manager;

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -46,6 +46,7 @@ use self::wallets::{
 use super::cloud_backup_detail_manager::{
     CloudOnlyOperation, CloudOnlyState, RecoveryState, SyncState, VerificationState,
 };
+use super::connectivity_manager::CONNECTIVITY_MANAGER;
 
 type LocalWalletSecret = crate::backup::model::WalletSecret;
 
@@ -81,14 +82,6 @@ pub enum CloudBackupPromptIntent {
     VerificationPrompt,
 }
 
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default, uniffi::Enum)]
-pub enum CloudConnectivityHint {
-    Online,
-    Offline,
-    #[default]
-    Unknown,
-}
-
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum CloudBackupManagerAction {
     EnableCloudBackup,
@@ -116,7 +109,6 @@ pub enum CloudBackupManagerAction {
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum CloudBackupReconcileMessage {
     Status(CloudBackupStatus),
-    ConnectivityHint(CloudConnectivityHint),
     SyncHealth(CloudSyncHealth),
     Progress(Option<CloudBackupProgress>),
     RestoreProgress(Option<CloudBackupRestoreProgress>),
@@ -261,7 +253,6 @@ pub enum VerificationFailureKind {
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct CloudBackupState {
     pub status: CloudBackupStatus,
-    pub connectivity_hint: CloudConnectivityHint,
     pub sync_health: CloudSyncHealth,
     pub prompt_intent: CloudBackupPromptIntent,
     pub progress: Option<CloudBackupProgress>,
@@ -283,7 +274,6 @@ impl Default for CloudBackupState {
     fn default() -> Self {
         Self {
             status: CloudBackupStatus::Disabled,
-            connectivity_hint: CloudConnectivityHint::Unknown,
             sync_health: CloudSyncHealth::NoFiles,
             prompt_intent: CloudBackupPromptIntent::None,
             progress: None,
@@ -670,12 +660,8 @@ impl RustCloudBackupManager {
         matches!(issue, CloudStorageIssue::Offline | CloudStorageIssue::Unavailable)
     }
 
-    pub(crate) fn current_connectivity_hint(&self) -> CloudConnectivityHint {
-        self.state.read().connectivity_hint
-    }
-
-    pub(crate) fn is_definitely_offline(&self) -> bool {
-        matches!(self.current_connectivity_hint(), CloudConnectivityHint::Offline)
+    pub(crate) fn is_offline(&self) -> bool {
+        !CONNECTIVITY_MANAGER.is_connected()
     }
 
     fn offline_message_for_step(step: BlockingCloudStep) -> &'static str {
@@ -712,7 +698,7 @@ impl RustCloudBackupManager {
         &self,
         step: BlockingCloudStep,
     ) -> Result<(), CloudBackupError> {
-        if self.is_definitely_offline() {
+        if self.is_offline() {
             return Err(self.offline_error_for_step(step));
         }
 
@@ -737,13 +723,16 @@ impl RustCloudBackupManager {
 
         let (sender, receiver) = flume::bounded(1000);
 
-        Arc::new_cyclic(|manager| Self {
+        let manager = Arc::new_cyclic(|manager| Self {
             state: Arc::new(RwLock::new(CloudBackupState::default())),
             reconciler: sender,
             reconcile_receiver: Arc::new(receiver),
             prompt_state: Arc::new(parking_lot::Mutex::new(CloudBackupPromptState::default())),
             runtime: spawn_actor(CloudBackupRuntimeActor::new(manager.clone())),
-        })
+        });
+
+        manager.start_connectivity_listener();
+        manager
     }
 
     fn verification_metadata_for(
@@ -816,14 +805,31 @@ impl RustCloudBackupManager {
         self.refresh_prompt_intent();
     }
 
-    fn set_connectivity_hint(&self, connectivity_hint: CloudConnectivityHint) -> bool {
-        let changed = self.current_connectivity_hint() != connectivity_hint;
-        self.set_and_notify_field(
-            connectivity_hint,
-            |state| &mut state.connectivity_hint,
-            Message::ConnectivityHint,
-        );
-        changed
+    fn start_connectivity_listener(self: &Arc<Self>) {
+        // use a weak reference so the listener thread exits when the manager is dropped
+        let manager = Arc::downgrade(self);
+        let receiver = CONNECTIVITY_MANAGER.subscribe();
+
+        std::thread::spawn(move || {
+            while let Ok(connected) = receiver.recv() {
+                let Some(manager) = manager.upgrade() else {
+                    break;
+                };
+
+                manager.handle_connectivity_change(connected);
+            }
+        });
+    }
+
+    pub(crate) fn handle_connectivity_change(&self, connected: bool) {
+        if !connected {
+            return;
+        }
+
+        self.clear_sync_error_if_no_failed_wallet_uploads();
+        send!(self.runtime.resume_wallet_uploads_from_persisted_state());
+        send!(self.runtime.wake_pending_upload_verifier());
+        self.start_pending_upload_verification_loop();
     }
 
     pub(crate) fn set_sync_health(&self, sync_health: CloudSyncHealth) {
@@ -1094,7 +1100,7 @@ impl RustCloudBackupManager {
             return;
         }
 
-        if self.is_definitely_offline() {
+        if self.is_offline() {
             return;
         }
 
@@ -1458,19 +1464,6 @@ impl RustCloudBackupManager {
         self.sync_persisted_state();
         send!(self.runtime.resume_wallet_uploads_from_persisted_state());
         self.start_pending_upload_verification_loop();
-    }
-
-    pub fn update_connectivity_hint(&self, hint: CloudConnectivityHint) {
-        if !self.set_connectivity_hint(hint) {
-            return;
-        }
-
-        if matches!(hint, CloudConnectivityHint::Online) {
-            self.clear_sync_error_if_no_failed_wallet_uploads();
-            send!(self.runtime.resume_wallet_uploads_from_persisted_state());
-            send!(self.runtime.wake_pending_upload_verifier());
-            self.start_pending_upload_verification_loop();
-        }
     }
 
     /// Reset local cloud backup state (keychain + DB) without touching iCloud

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -1058,9 +1058,10 @@ mod tests {
     };
     use crate::label_manager::LabelManager;
     use crate::manager::cloud_backup_manager::{
-        CLOUD_BACKUP_MANAGER, CloudBackupDetailResult, CloudConnectivityHint,
-        DeepVerificationResult, VerificationFailureKind, VerificationState,
+        CLOUD_BACKUP_MANAGER, CloudBackupDetailResult, DeepVerificationResult,
+        VerificationFailureKind, VerificationState,
     };
+    use crate::manager::connectivity_manager::CONNECTIVITY_MANAGER;
     use crate::manager::wallet_manager::RustWalletManager;
     use crate::network::Network;
     use crate::wallet::{
@@ -1539,7 +1540,7 @@ mod tests {
         let manager = RustCloudBackupManager::init();
 
         reset_cloud_backup_test_state(&manager, globals);
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        CONNECTIVITY_MANAGER.set_connection_state(true);
         globals.passkey.set_create_result(Ok(vec![1, 2, 3]));
         globals.passkey.set_authenticate_result(Ok(vec![7; 32]));
 
@@ -1555,7 +1556,7 @@ mod tests {
         let manager = RustCloudBackupManager::init();
 
         reset_cloud_backup_test_state(&manager, globals);
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        CONNECTIVITY_MANAGER.set_connection_state(true);
         globals.passkey.set_create_result(Ok(vec![1, 2, 3]));
         globals.passkey.set_authenticate_result(Ok(vec![7; 32]));
 
@@ -1923,7 +1924,7 @@ mod tests {
     }
 
     #[test]
-    fn update_connectivity_hint_preserves_sync_error_when_failed_wallet_uploads_exist() {
+    fn connectivity_reconnect_preserves_sync_error_when_failed_wallet_uploads_exist() {
         let _guard = test_lock().lock();
         let globals = test_globals();
         let manager = RustCloudBackupManager::init();
@@ -1948,20 +1949,20 @@ mod tests {
             .unwrap();
         manager.set_sync_error(Some("upload failed".into()));
 
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        manager.handle_connectivity_change(true);
 
         assert_eq!(manager.state().sync_error.as_deref(), Some("upload failed"));
     }
 
     #[test]
-    fn update_connectivity_hint_clears_sync_error_when_failed_wallet_uploads_are_gone() {
+    fn connectivity_reconnect_clears_sync_error_when_failed_wallet_uploads_are_gone() {
         let _guard = test_lock().lock();
         let globals = test_globals();
         let manager = RustCloudBackupManager::init();
         configure_enabled_cloud_backup(&manager, globals, 0);
         manager.set_sync_error(Some("upload failed".into()));
 
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        manager.handle_connectivity_change(true);
 
         assert!(manager.state().sync_error.is_none());
     }
@@ -2466,7 +2467,7 @@ mod tests {
         persist_xpub_wallets(vec![metadata.clone()]);
         let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
         persist_uploading_blob_state(metadata.id.clone(), 1);
-        manager.update_connectivity_hint(CloudConnectivityHint::Offline);
+        CONNECTIVITY_MANAGER.set_connection_state(false);
 
         let error = manager.do_upload_wallet_if_dirty(&metadata.id).unwrap_err();
 
@@ -3076,7 +3077,7 @@ mod tests {
         let manager = RustCloudBackupManager::init();
 
         reset_cloud_backup_test_state(&manager, globals);
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        CONNECTIVITY_MANAGER.set_connection_state(true);
         let existing_master_key = cove_cspp::master_key::MasterKey::generate();
         let existing_namespace = existing_master_key.namespace_id();
         let encrypted_master = cove_cspp::master_key_crypto::encrypt_master_key(
@@ -3119,7 +3120,7 @@ mod tests {
         let manager = RustCloudBackupManager::init();
 
         reset_cloud_backup_test_state(&manager, globals);
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        CONNECTIVITY_MANAGER.set_connection_state(true);
         globals.passkey.set_discover_result(Err(PasskeyError::UserCancelled));
 
         let master_key = cove_cspp::master_key::MasterKey::generate();
@@ -3149,7 +3150,7 @@ mod tests {
         let manager = RustCloudBackupManager::init();
 
         reset_cloud_backup_test_state(&manager, globals);
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        CONNECTIVITY_MANAGER.set_connection_state(true);
         globals.passkey.set_create_result(Err(PasskeyError::UserCancelled));
 
         let master_key = cove_cspp::master_key::MasterKey::generate();
@@ -3179,7 +3180,7 @@ mod tests {
         let manager = RustCloudBackupManager::init();
 
         reset_cloud_backup_test_state(&manager, globals);
-        manager.update_connectivity_hint(CloudConnectivityHint::Online);
+        CONNECTIVITY_MANAGER.set_connection_state(true);
 
         manager.replace_pending_enable_session(PendingEnableSession::new(
             cove_cspp::master_key::MasterKey::generate(),

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -27,6 +27,7 @@ use crate::database::cloud_backup::{
     PersistedCloudBackupState, PersistedCloudBackupStatus, PersistedCloudBlobState,
     PersistedCloudBlobSyncState,
 };
+use crate::manager::connectivity_manager::CONNECTIVITY_MANAGER;
 use crate::mnemonic::MnemonicExt as _;
 use crate::network::Network;
 use crate::wallet::metadata::{WalletId, WalletMetadata, WalletMode, WalletType};
@@ -535,6 +536,7 @@ pub(crate) fn reset_cloud_backup_test_state(
     globals: &TestGlobals,
 ) {
     init_test_runtime();
+    CONNECTIVITY_MANAGER.set_connection_state(true);
     globals.reset();
     clear_local_wallets();
     let reset_manager = manager.clone();

--- a/rust/src/manager/cloud_backup_manager/pending/detail.rs
+++ b/rust/src/manager/cloud_backup_manager/pending/detail.rs
@@ -25,7 +25,7 @@ impl RustCloudBackupManager {
             Err(error) => return Some(CloudBackupDetailResult::AccessError(error.to_string())),
         };
 
-        if self.is_definitely_offline() {
+        if self.is_offline() {
             return Some(CloudBackupDetailResult::AccessError(
                 self.offline_error_for_step(BlockingCloudStep::DetailRefresh).to_string(),
             ));

--- a/rust/src/manager/cloud_backup_manager/wallets/upload.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/upload.rs
@@ -181,7 +181,7 @@ impl RustCloudBackupManager {
             return Ok(());
         };
 
-        if self.is_definitely_offline() {
+        if self.is_offline() {
             return Err(CloudBackupError::Deferred(
                 "wallet backup upload is waiting for a connection".into(),
             ));

--- a/rust/src/manager/connectivity_manager.rs
+++ b/rust/src/manager/connectivity_manager.rs
@@ -1,0 +1,158 @@
+use std::sync::{
+    Arc, LazyLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+use flume::{Receiver, Sender};
+use parking_lot::Mutex;
+use tracing::warn;
+
+use cove_device::connectivity::Connectivity;
+
+type ReconcilerMessage = ConnectivityManagerReconcileMessage;
+
+pub static CONNECTIVITY_MANAGER: LazyLock<Arc<RustConnectivityManager>> =
+    LazyLock::new(RustConnectivityManager::init);
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum ConnectivityStatus {
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, uniffi::Record)]
+pub struct ConnectivityState {
+    pub status: ConnectivityStatus,
+}
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum ConnectivityManagerReconcileMessage {
+    Status(ConnectivityStatus),
+}
+
+#[uniffi::export(callback_interface)]
+pub trait ConnectivityManagerReconciler: Send + Sync + std::fmt::Debug + 'static {
+    fn reconcile(&self, message: ConnectivityManagerReconcileMessage);
+}
+
+#[derive(Clone, Debug, uniffi::Object)]
+pub struct RustConnectivityManager {
+    is_connected: Arc<AtomicBool>,
+    subscribers: Arc<Mutex<Vec<Sender<bool>>>>,
+    reconciler: Sender<ReconcilerMessage>,
+    reconcile_receiver: Arc<Receiver<ReconcilerMessage>>,
+}
+
+impl RustConnectivityManager {
+    fn init() -> Arc<Self> {
+        let initial_connected = Connectivity::try_global().is_none_or(Connectivity::is_connected);
+        let (sender, receiver) = flume::bounded(1000);
+
+        Arc::new(Self {
+            is_connected: Arc::new(AtomicBool::new(initial_connected)),
+            subscribers: Arc::new(Mutex::new(Vec::new())),
+            reconciler: sender,
+            reconcile_receiver: Arc::new(receiver),
+        })
+    }
+
+    pub(crate) fn connected(&self) -> bool {
+        self.is_connected.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn subscribe(&self) -> Receiver<bool> {
+        let (sender, receiver) = flume::bounded(16);
+        self.subscribers.lock().push(sender);
+        receiver
+    }
+
+    fn set_connection_state_internal(&self, is_connected: bool) -> bool {
+        let previous = self.is_connected.swap(is_connected, Ordering::AcqRel);
+        if previous == is_connected {
+            return false;
+        }
+
+        self.broadcast(is_connected);
+        self.send_reconcile(is_connected);
+        true
+    }
+
+    fn broadcast(&self, is_connected: bool) {
+        let mut subscribers = self.subscribers.lock();
+        subscribers.retain(|sender| sender.send(is_connected).is_ok());
+    }
+
+    fn send_reconcile(&self, is_connected: bool) {
+        let message = if is_connected {
+            ConnectivityManagerReconcileMessage::Status(ConnectivityStatus::Connected)
+        } else {
+            ConnectivityManagerReconcileMessage::Status(ConnectivityStatus::Disconnected)
+        };
+
+        if let Err(error) = self.reconciler.send(message) {
+            warn!("Failed to send connectivity reconcile message: {error}");
+        }
+    }
+}
+
+#[uniffi::export]
+impl RustConnectivityManager {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> {
+        CONNECTIVITY_MANAGER.clone()
+    }
+
+    pub fn listen_for_updates(&self, reconciler: Box<dyn ConnectivityManagerReconciler>) {
+        let reconcile_receiver = self.reconcile_receiver.clone();
+
+        std::thread::spawn(move || {
+            while let Ok(message) = reconcile_receiver.recv() {
+                reconciler.reconcile(message);
+            }
+        });
+    }
+
+    pub fn state(&self) -> ConnectivityState {
+        ConnectivityState {
+            status: if self.connected() {
+                ConnectivityStatus::Connected
+            } else {
+                ConnectivityStatus::Disconnected
+            },
+        }
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.connected()
+    }
+
+    pub fn set_connection_state(&self, is_connected: bool) {
+        self.set_connection_state_internal(is_connected);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_receives_changes() {
+        let manager = RustConnectivityManager::init();
+        let receiver = manager.subscribe();
+
+        manager.set_connection_state(false);
+
+        assert_eq!(receiver.recv().unwrap(), false);
+    }
+
+    #[test]
+    fn subscribe_ignores_unchanged_value() {
+        let manager = RustConnectivityManager::init();
+        let receiver = manager.subscribe();
+        let initial = manager.connected();
+
+        manager.set_connection_state(initial);
+
+        assert!(receiver.try_recv().is_err());
+    }
+}

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -398,7 +398,7 @@ impl RustOnboardingManager {
     fn start_cloud_check(self: &Arc<Self>) {
         let me = Arc::clone(self);
         thread::spawn(move || {
-            if CLOUD_BACKUP_MANAGER.is_definitely_offline() {
+            if CLOUD_BACKUP_MANAGER.is_offline() {
                 me.finish_cloud_check(CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline));
                 return;
             }


### PR DESCRIPTION
Introduce a reusable device-level connectivity abstraction and a shared RustConnectivityManager so iOS and Android can report connection state through the same path.

Replace the cloud-backup-specific connectivity hint flow with this shared manager, keep cloud backup's offline and reconnect behavior wired to the new state, and add platform monitors plus regenerated bindings so both apps use the same API.

This makes the connectivity handling cross-platform, removes cloud-backup-specific plumbing, and gives other features a consistent place to consume connection state later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time connectivity monitoring that automatically detects and responds to network status changes
  * Cloud backups now automatically resume when your internet connection is restored after being offline, with improved error recovery
  * Enhanced application responsiveness to network connectivity state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->