### PR TITLE
Add typed MultisigNotSupported error for wsh descriptors

### DIFF
--- a/rust/crates/cove-bdk/src/descriptor_ext.rs
+++ b/rust/crates/cove-bdk/src/descriptor_ext.rs
@@ -141,6 +141,9 @@ impl DescriptorExt for Descriptor<DescriptorPublicKey> {
             D::Tr(pk) => pk.internal_key(),
             D::Sh(pk) => match pk.as_inner() {
                 ShInner::Wpkh(pk) => pk.as_inner(),
+                ShInner::Wsh(_) => {
+                    return Err(Error::MultisigNotSupported);
+                }
                 _ => {
                     return Err(Error::UnsupportedDescriptor(
                         "unsupported wallet bare descriptor not wpkh".to_string(),
@@ -299,5 +302,21 @@ mod tests {
         assert_eq!(lines.len(), 2, "mismatched pair should produce two lines");
         assert_eq!(lines[0], ext.to_normalized_string());
         assert_eq!(lines[1], int.to_normalized_string());
+    }
+
+    fn sh_wsh_sortedmulti_desc() -> ExtendedDescriptor {
+        "sh(wsh(sortedmulti(2,02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5,03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb)))"
+            .parse()
+            .expect("valid sh(wsh(sortedmulti)) descriptor")
+    }
+
+    #[test]
+    fn sh_wsh_sortedmulti_descriptor_public_key_returns_multisig_not_supported() {
+        let desc = sh_wsh_sortedmulti_desc();
+        let result = DescriptorExt::descriptor_public_key(&desc);
+        assert!(
+            matches!(result, Err(Error::MultisigNotSupported)),
+            "expected MultisigNotSupported, got {result:?}"
+        );
     }
 }

--- a/rust/crates/cove-bdk/src/descriptor_ext.rs
+++ b/rust/crates/cove-bdk/src/descriptor_ext.rs
@@ -17,6 +17,9 @@ pub enum Error {
 
     #[error("descriptors are not a matching external/internal pair")]
     NotMatchingPair,
+
+    #[error("multisig descriptors are not yet supported")]
+    MultisigNotSupported,
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -154,9 +157,7 @@ impl DescriptorExt for Descriptor<DescriptorPublicKey> {
 
             // multi-sig
             D::Wsh(_pk) => {
-                return Err(Error::UnsupportedDescriptor(
-                    "unsupported wallet, multisig".to_string(),
-                ));
+                return Err(Error::MultisigNotSupported);
             }
         };
 
@@ -170,6 +171,10 @@ impl DescriptorExt for Descriptor<DescriptorPublicKey> {
             DescriptorType::Wpkh => "wpkh",
             DescriptorType::Tr => "tr",
             DescriptorType::Sh => "sh",
+            DescriptorType::Wsh
+            | DescriptorType::ShWsh
+            | DescriptorType::WshSortedMulti
+            | DescriptorType::ShWshSortedMulti => return Err(Error::MultisigNotSupported),
             other => Err(Error::UnsupportedDescriptorType(other))?,
         };
 
@@ -247,6 +252,43 @@ mod tests {
         let export = DescriptorExt::to_export_string(&ext, &int);
         assert!(export.contains("/<0;1>/*"));
         assert!(!export.contains('\n'), "matching pair should be a single line");
+    }
+
+    fn wsh_sortedmulti_desc() -> ExtendedDescriptor {
+        // 2-of-2 wsh(sortedmulti) using bare compressed public keys (no xpub derivation)
+        "wsh(sortedmulti(2,02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5,03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb))"
+            .parse()
+            .expect("valid wsh(sortedmulti) descriptor")
+    }
+
+    #[test]
+    fn wsh_sortedmulti_descriptor_public_key_returns_multisig_not_supported() {
+        let desc = wsh_sortedmulti_desc();
+        let result = DescriptorExt::descriptor_public_key(&desc);
+        assert!(
+            matches!(result, Err(Error::MultisigNotSupported)),
+            "expected MultisigNotSupported, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn wsh_sortedmulti_full_origin_returns_multisig_not_supported() {
+        let desc = wsh_sortedmulti_desc();
+        let result = desc.full_origin();
+        assert!(
+            matches!(result, Err(Error::MultisigNotSupported)),
+            "expected MultisigNotSupported, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn wsh_sortedmulti_origin_returns_multisig_not_supported() {
+        let desc = wsh_sortedmulti_desc();
+        let result = desc.origin();
+        assert!(
+            matches!(result, Err(Error::MultisigNotSupported)),
+            "expected MultisigNotSupported, got {result:?}"
+        );
     }
 
     #[test]

--- a/rust/src/keys.rs
+++ b/rust/src/keys.rs
@@ -278,6 +278,9 @@ impl From<cove_bdk::descriptor_ext::Error> for DescriptorKeyParseError {
             E::NotMatchingPair => Self::UnsupportedDescriptor(
                 "descriptors are not a matching external/internal pair".to_string(),
             ),
+            E::MultisigNotSupported => {
+                Self::UnsupportedDescriptor("multisig descriptors are not yet supported".to_string())
+            }
         }
     }
 }

--- a/rust/src/keys.rs
+++ b/rust/src/keys.rs
@@ -5,12 +5,12 @@ use bdk_wallet::keys::bip39::Mnemonic;
 use bdk_wallet::keys::{
     DerivableKey as _, DescriptorSecretKey as BdkDescriptorSecretKey, ExtendedKey,
 };
+use bdk_wallet::{CreateParams, KeychainKind};
 use bdk_wallet::{
     keys::{DescriptorPublicKey as BdkDescriptorPublicKey, KeyMap},
     miniscript::descriptor::{DescriptorXKey, Wildcard},
     template::{Bip44, Bip49, Bip84, DescriptorTemplate as _},
 };
-use bdk_wallet::{CreateParams, KeychainKind};
 use bitcoin::bip32::Xpub;
 use cove_bdk::descriptor_ext::DescriptorExt as _;
 
@@ -76,9 +76,9 @@ impl Descriptors {
 
     pub fn new_from_tap_signer(derive: &DeriveInfo) -> Result<Self, Error> {
         use bitcoin::{
+            NetworkKind,
             bip32::{ChainCode, ChildNumber, Xpub},
             secp256k1::PublicKey,
-            NetworkKind,
         };
 
         // dept is always 3 and always the first (0) child, derives the standard derivation path

--- a/rust/src/keys.rs
+++ b/rust/src/keys.rs
@@ -5,12 +5,12 @@ use bdk_wallet::keys::bip39::Mnemonic;
 use bdk_wallet::keys::{
     DerivableKey as _, DescriptorSecretKey as BdkDescriptorSecretKey, ExtendedKey,
 };
-use bdk_wallet::{CreateParams, KeychainKind};
 use bdk_wallet::{
     keys::{DescriptorPublicKey as BdkDescriptorPublicKey, KeyMap},
     miniscript::descriptor::{DescriptorXKey, Wildcard},
     template::{Bip44, Bip49, Bip84, DescriptorTemplate as _},
 };
+use bdk_wallet::{CreateParams, KeychainKind};
 use bitcoin::bip32::Xpub;
 use cove_bdk::descriptor_ext::DescriptorExt as _;
 
@@ -34,6 +34,9 @@ pub enum DescriptorKeyParseError {
 
     #[error("unsupported descriptor type: {0:?}")]
     UnsupportedDescriptorType(DescriptorType),
+
+    #[error("multisig descriptors are not yet supported")]
+    MultisigNotSupported,
 
     #[error("no origin found")]
     NoOrigin,
@@ -73,9 +76,9 @@ impl Descriptors {
 
     pub fn new_from_tap_signer(derive: &DeriveInfo) -> Result<Self, Error> {
         use bitcoin::{
-            NetworkKind,
             bip32::{ChainCode, ChildNumber, Xpub},
             secp256k1::PublicKey,
+            NetworkKind,
         };
 
         // dept is always 3 and always the first (0) child, derives the standard derivation path
@@ -278,9 +281,7 @@ impl From<cove_bdk::descriptor_ext::Error> for DescriptorKeyParseError {
             E::NotMatchingPair => Self::UnsupportedDescriptor(
                 "descriptors are not a matching external/internal pair".to_string(),
             ),
-            E::MultisigNotSupported => {
-                Self::UnsupportedDescriptor("multisig descriptors are not yet supported".to_string())
-            }
+            E::MultisigNotSupported => Self::MultisigNotSupported,
         }
     }
 }


### PR DESCRIPTION
Relates to #491 

Multisig descriptors (like `wsh(sortedmulti(...))`) were rejected with a generic string error, and different code paths returned different errors for the same case.

Added a dedicated `MultisigNotSupported` error variant and used it consistently across `descriptor_public_key()`, `origin()`, and `full_origin()`. No changes to the single-sig flow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for multisig descriptors: explicitly reject them with a clear "multisig descriptors are not yet supported" error message.
* **Tests**
  * Added unit tests verifying multisig descriptors are consistently rejected across public descriptor APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->