### PR TITLE
Android: add visual affordance to amount input

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAmountView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAmountView.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -61,6 +63,11 @@ fun EnterAmountView(
     var showUnitMenu by remember { mutableStateOf(false) }
     var textWidth by remember { mutableStateOf(0.dp) }
     var isFocused by remember { mutableStateOf(false) }
+
+    // fall back to a local FocusRequester so the clickable wrapper can always
+    // programmatically focus the TextField even when the parent doesn't pass one
+    val localFocusRequester = remember { FocusRequester() }
+    val effectiveFocusRequester = focusRequester ?: localFocusRequester
 
     // offset to compensate for unit dropdown (matches iOS)
     val configuration = LocalConfiguration.current
@@ -98,7 +105,16 @@ fun EnterAmountView(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.Bottom,
         ) {
-            Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        // extend the tap target beyond the text glyphs and provide
+                        // a ripple; BasicTextField still consumes taps within its
+                        // own bounds, so this only fires for taps on empty space
+                        .clickable { effectiveFocusRequester.requestFocus() },
+                contentAlignment = Alignment.Center,
+            ) {
                 AutoSizeTextField(
                     value = amount,
                     onValueChange = { newValue ->
@@ -118,7 +134,14 @@ fun EnterAmountView(
                     },
                     maxFontSize = 48.sp,
                     minimumScaleFactor = 0.01f,
-                    color = if (exceedsBalance) CoveColor.WarningOrange else MaterialTheme.colorScheme.onSurface,
+                    color =
+                        when {
+                            // hide the default "0" value behind the placeholder so
+                            // we don't see both at once
+                            !isFocused && (amount.isEmpty() || amount == "0") -> Color.Transparent
+                            exceedsBalance -> CoveColor.WarningOrange
+                            else -> MaterialTheme.colorScheme.onSurface
+                        },
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp).offset(x = amountOffset),
@@ -128,8 +151,17 @@ fun EnterAmountView(
                         onFocusChanged(focused)
                     },
                     keyboardActions = KeyboardActions(onDone = { onDone() }),
-                    focusRequester = focusRequester,
+                    focusRequester = effectiveFocusRequester,
                 )
+
+                if (!isFocused && (amount.isEmpty() || amount == "0")) {
+                    Text(
+                        text = stringResource(R.string.placeholder_tap_to_enter_amount),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
             }
             // unit dropdown area (only shown when in BTC mode, matches iOS)
             if (!isFiatMode) {
@@ -173,6 +205,11 @@ fun EnterAmountView(
                 }
             }
         }
+        Spacer(Modifier.height(8.dp))
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant,
+            thickness = 1.dp,
+        )
         Spacer(Modifier.height(8.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAmountView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAmountView.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -68,6 +69,8 @@ fun EnterAmountView(
     // programmatically focus the TextField even when the parent doesn't pass one
     val localFocusRequester = remember { FocusRequester() }
     val effectiveFocusRequester = focusRequester ?: localFocusRequester
+
+    val showTapPlaceholder = !isFocused && (amount.isEmpty() || amount == "0")
 
     // offset to compensate for unit dropdown (matches iOS)
     val configuration = LocalConfiguration.current
@@ -138,13 +141,22 @@ fun EnterAmountView(
                         when {
                             // hide the default "0" value behind the placeholder so
                             // we don't see both at once
-                            !isFocused && (amount.isEmpty() || amount == "0") -> Color.Transparent
+                            showTapPlaceholder -> Color.Transparent
                             exceedsBalance -> CoveColor.WarningOrange
                             else -> MaterialTheme.colorScheme.onSurface
                         },
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp).offset(x = amountOffset),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 30.dp)
+                            .offset(x = amountOffset)
+                            // remove from accessibility tree when hidden behind
+                            // the placeholder so TalkBack doesn't announce both
+                            .then(
+                                if (showTapPlaceholder) Modifier.clearAndSetSemantics {} else Modifier,
+                            ),
                     onTextWidthChanged = { width -> textWidth = width },
                     onFocusChanged = { focused ->
                         isFocused = focused
@@ -154,12 +166,13 @@ fun EnterAmountView(
                     focusRequester = effectiveFocusRequester,
                 )
 
-                if (!isFocused && (amount.isEmpty() || amount == "0")) {
+                if (showTapPlaceholder) {
                     Text(
                         text = stringResource(R.string.placeholder_tap_to_enter_amount),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Medium,
+                        modifier = Modifier.offset(x = amountOffset),
                     )
                 }
             }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="label_balance">Balance</string>
     <string name="label_enter_amount">Enter amount</string>
     <string name="label_how_much_to_send">How much would you like to send?</string>
+    <string name="placeholder_tap_to_enter_amount">Tap to enter amount</string>
     <string name="label_enter_address">Enter address</string>
     <string name="label_where_send_to">Where do you want to send to?</string>
     <string name="label_account">Account</string>


### PR DESCRIPTION
Combines the three directions from the design discussion on #515. The amount field on Android is a BasicTextField with no Material chrome, so users had no visual cue that it was tappable.

Adds a "Tap to enter amount" placeholder centered in the Box when the value is empty or "0" and the field isn't focused. The underlying text is drawn transparent in that state so the default "0" doesn't bleed through behind the placeholder. Wraps the amount Box in .clickable { focusRequester.requestFocus() } so taps on the empty area around the glyphs give a Material ripple and focus the field BasicTextField still consumes taps within its own bounds, so the wrapper only fires for the outer area. Drops a HorizontalDivider under the amount row as a subtle bottom border, matching the conventional "this is an input" look.

Falls back to a locally-remembered FocusRequester when the caller doesn't provide one, so the clickable wrapper always has a target.

Closes #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the amount input field in the Send flow with improved interaction responsiveness and expanded tap targets for easier focus activation.
  * Added placeholder guidance text when the input field is empty.
  * Refined visual layout with a divider separating the input area from controls below.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->