### PR TITLE
Fix fiat amount paste stripping non-numeric characters (#314)

### DIFF
--- a/rust/src/manager/send_flow_manager/btc_on_change.rs
+++ b/rust/src/manager/send_flow_manager/btc_on_change.rs
@@ -43,15 +43,23 @@ impl BtcOnChangeHandler {
         }
 
         let old = old_value.trim();
+        let new_value_trimmed = new_value.trim();
 
         // strip BTC-unit tokens from pasted input (e.g. "100 SATS" → "100"). #314
-        let Some(new) = sanitize::sanitize_btc_amount(new_value.trim()) else {
+        let Some(new) = sanitize::sanitize_btc_amount(new_value_trimmed) else {
             return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() };
         };
 
+        // If sanitization stripped tokens (e.g. "100 BTC" → "100"), early exits must still
+        // emit the cleaned string so the raw pasted text doesn't stay visible in the UI.
+        let sanitization_changed = new != new_value_trimmed;
+
         // early exit if nothing changed
         if old == new {
-            return Changeset::default();
+            return Changeset {
+                entering_amount_btc: sanitization_changed.then_some(old.into()),
+                ..Default::default()
+            };
         }
 
         if new == "00" {
@@ -102,7 +110,10 @@ impl BtcOnChangeHandler {
 
         // if the unformatted is the same as the old value, then we don't need to do anything
         if old.replace(',', "") == unformatted {
-            return Changeset::default();
+            return Changeset {
+                entering_amount_btc: sanitization_changed.then_some(old.into()),
+                ..Default::default()
+            };
         }
 
         // ---------------------------------------------------------------------

--- a/rust/src/manager/send_flow_manager/btc_on_change.rs
+++ b/rust/src/manager/send_flow_manager/btc_on_change.rs
@@ -47,8 +47,13 @@ impl BtcOnChangeHandler {
         // strip currency tokens from pasted input (e.g. "100 SATS" → "100"). #314
         let sanitized;
         let new = match sanitize::sanitize_amount(new_value.trim()) {
-            Some(s) => { sanitized = s; sanitized.as_str() }
-            None => return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() },
+            Some(s) => {
+                sanitized = s;
+                sanitized.as_str()
+            }
+            None => {
+                return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() };
+            }
         };
 
         // early exit if nothing changed

--- a/rust/src/manager/send_flow_manager/btc_on_change.rs
+++ b/rust/src/manager/send_flow_manager/btc_on_change.rs
@@ -44,8 +44,8 @@ impl BtcOnChangeHandler {
 
         let old = old_value.trim();
 
-        // strip currency tokens from pasted input (e.g. "100 SATS" → "100"). #314
-        let Some(new) = sanitize::sanitize_amount(new_value.trim()) else {
+        // strip BTC-unit tokens from pasted input (e.g. "100 SATS" → "100"). #314
+        let Some(new) = sanitize::sanitize_btc_amount(new_value.trim()) else {
             return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() };
         };
 

--- a/rust/src/manager/send_flow_manager/btc_on_change.rs
+++ b/rust/src/manager/send_flow_manager/btc_on_change.rs
@@ -45,15 +45,8 @@ impl BtcOnChangeHandler {
         let old = old_value.trim();
 
         // strip currency tokens from pasted input (e.g. "100 SATS" → "100"). #314
-        let sanitized;
-        let new = match sanitize::sanitize_amount(new_value.trim()) {
-            Some(s) => {
-                sanitized = s;
-                sanitized.as_str()
-            }
-            None => {
-                return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() };
-            }
+        let Some(new) = sanitize::sanitize_amount(new_value.trim()) else {
+            return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() };
         };
 
         // early exit if nothing changed

--- a/rust/src/manager/send_flow_manager/btc_on_change.rs
+++ b/rust/src/manager/send_flow_manager/btc_on_change.rs
@@ -5,6 +5,7 @@ use cove_types::{amount::Amount, unit::BitcoinUnit};
 use cove_util::format::{self, NumberFormatter as _};
 use tracing::debug;
 
+use super::sanitize;
 use super::state::State;
 
 #[derive(Debug, Clone)]
@@ -43,7 +44,29 @@ impl BtcOnChangeHandler {
         }
 
         let old = old_value.trim();
-        let new = new_value.trim();
+
+        // strip known currency tokens from pasted input (e.g. "100 SATS" → "100"). #314
+        let stripped_buf;
+        let new = {
+            let raw = new_value.trim();
+            if raw.chars().any(|c| c.is_alphabetic()) {
+                match sanitize::strip_currency_suffix(raw) {
+                    Some(s) => {
+                        stripped_buf = s;
+                        stripped_buf.as_str()
+                    }
+                    // alphabetic chars survived — reject (e.g. a bech32 address)
+                    None => {
+                        return Changeset {
+                            entering_amount_btc: Some(old.to_string()),
+                            ..Default::default()
+                        };
+                    }
+                }
+            } else {
+                raw
+            }
+        };
 
         // early exit if nothing changed
         if old == new {

--- a/rust/src/manager/send_flow_manager/btc_on_change.rs
+++ b/rust/src/manager/send_flow_manager/btc_on_change.rs
@@ -5,8 +5,7 @@ use cove_types::{amount::Amount, unit::BitcoinUnit};
 use cove_util::format::{self, NumberFormatter as _};
 use tracing::debug;
 
-use super::sanitize;
-use super::state::State;
+use super::{sanitize, state::State};
 
 #[derive(Debug, Clone)]
 pub struct BtcOnChangeHandler {
@@ -45,27 +44,11 @@ impl BtcOnChangeHandler {
 
         let old = old_value.trim();
 
-        // strip known currency tokens from pasted input (e.g. "100 SATS" → "100"). #314
-        let stripped_buf;
-        let new = {
-            let raw = new_value.trim();
-            if raw.chars().any(|c| c.is_alphabetic()) {
-                match sanitize::strip_currency_suffix(raw) {
-                    Some(s) => {
-                        stripped_buf = s;
-                        stripped_buf.as_str()
-                    }
-                    // alphabetic chars survived — reject (e.g. a bech32 address)
-                    None => {
-                        return Changeset {
-                            entering_amount_btc: Some(old.to_string()),
-                            ..Default::default()
-                        };
-                    }
-                }
-            } else {
-                raw
-            }
+        // strip currency tokens from pasted input (e.g. "100 SATS" → "100"). #314
+        let sanitized;
+        let new = match sanitize::sanitize_amount(new_value.trim()) {
+            Some(s) => { sanitized = s; sanitized.as_str() }
+            None => return Changeset { entering_amount_btc: Some(old.into()), ..Default::default() },
         };
 
         // early exit if nothing changed

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -63,28 +63,14 @@ impl FiatOnChangeHandler {
         let old_value = old_value.trim();
         let new_value = new_value.trim();
 
-        let symbol = self.selected_currency.symbol();
-
-        // If the pasted text contains letters, try stripping known currency tokens
-        // (e.g. "100 CHF" → "100", "BTC 0.5" → "0.5"). Only reject if alphabetic
-        // characters survive that cleanup — a bech32 address always will. #314
-        let stripped_buf;
-        let new_value = if new_value.chars().any(|c| c.is_alphabetic()) {
-            match sanitize::strip_currency_suffix(new_value) {
-                Some(s) => {
-                    stripped_buf = s;
-                    stripped_buf.as_str()
-                }
-                None => {
-                    return Ok(Changeset {
-                        entering_fiat_amount: Some(old_value.to_string()),
-                        ..Default::default()
-                    });
-                }
-            }
-        } else {
-            new_value
+        // strip currency tokens from pasted amounts (e.g. "$12.50", "12.50 USD")
+        let sanitized_fiat;
+        let new_value = match sanitize::sanitize_amount(new_value) {
+            Some(s) => { sanitized_fiat = s; sanitized_fiat.as_str() }
+            None => return Ok(Changeset { entering_fiat_amount: Some(old_value.to_string()), ..Default::default() }),
         };
+
+        let symbol = self.selected_currency.symbol();
 
         let number_of_decimal_points = new_value.chars().filter(|c| *c == '.').count();
 

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -65,15 +65,26 @@ impl FiatOnChangeHandler {
 
         let symbol = self.selected_currency.symbol();
 
-        // reject input containing alphabetic characters so pasted bitcoin
-        // addresses (and similar mixed-alphanumeric strings) aren't silently
-        // stripped down to just their digits and treated as a fiat amount. #314
-        if new_value.chars().any(|c| c.is_alphabetic()) {
-            return Ok(Changeset {
-                entering_fiat_amount: Some(old_value.to_string()),
-                ..Default::default()
-            });
-        }
+        // If the pasted text contains letters, try stripping known currency tokens
+        // (e.g. "100 CHF" → "100", "BTC 0.5" → "0.5"). Only reject if alphabetic
+        // characters survive that cleanup — a bech32 address always will. #314
+        let stripped_buf;
+        let new_value = if new_value.chars().any(|c| c.is_alphabetic()) {
+            match sanitize::strip_currency_suffix(new_value) {
+                Some(s) => {
+                    stripped_buf = s;
+                    stripped_buf.as_str()
+                }
+                None => {
+                    return Ok(Changeset {
+                        entering_fiat_amount: Some(old_value.to_string()),
+                        ..Default::default()
+                    });
+                }
+            }
+        } else {
+            new_value
+        };
 
         let number_of_decimal_points = new_value.chars().filter(|c| *c == '.').count();
 
@@ -258,5 +269,35 @@ mod tests {
         let result = h.on_change("$100", "").unwrap();
         assert_eq!(result.entering_fiat_amount.as_deref(), Some("$"));
         assert_eq!(result.fiat_value, Some(0.0));
+    }
+
+    #[test]
+    fn pasting_amount_with_chf_suffix_is_accepted() {
+        let h = handler();
+        let result = h.on_change("$0", "100 CHF").unwrap();
+        assert!(result.fiat_value.is_some(), "100 CHF should parse as a fiat amount");
+        assert!(result.btc_amount.is_some());
+    }
+
+    #[test]
+    fn pasting_amount_with_btc_suffix_is_accepted() {
+        let h = handler();
+        let result = h.on_change("$0", "0.5 BTC").unwrap();
+        assert!(result.fiat_value.is_some(), "0.5 BTC should parse as a numeric amount");
+    }
+
+    #[test]
+    fn pasting_amount_with_sats_suffix_is_accepted() {
+        let h = handler();
+        let result = h.on_change("$0", "1000 SATS").unwrap();
+        assert!(result.fiat_value.is_some(), "1000 SATS should parse after stripping suffix");
+    }
+
+    #[test]
+    fn pasting_bech32_address_still_rejected_after_suffix_strip() {
+        let h = handler();
+        let result = h.on_change("$0", "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$0"));
+        assert!(result.btc_amount.is_none());
     }
 }

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -61,15 +61,19 @@ impl FiatOnChangeHandler {
 
     pub fn on_change(&self, old_value: &str, new_value: &str) -> Result<Changeset> {
         let old_value = old_value.trim();
-        let new_value = new_value.trim();
+        let new_value_trimmed = new_value.trim();
 
         // strip fiat tokens from pasted amounts (e.g. "$12.50", "12.50 USD"); rejects BTC/SATS
-        let Some(new_value) = sanitize::sanitize_fiat_amount(new_value) else {
+        let Some(new_value) = sanitize::sanitize_fiat_amount(new_value_trimmed) else {
             return Ok(Changeset {
                 entering_fiat_amount: Some(old_value.to_string()),
                 ..Default::default()
             });
         };
+
+        // If sanitization stripped tokens (e.g. "100 CHF" → "100"), early exits must still
+        // emit the cleaned string so the raw pasted text doesn't stay visible in the UI.
+        let sanitization_changed = new_value != new_value_trimmed;
 
         let symbol = self.selected_currency.symbol();
 
@@ -88,11 +92,17 @@ impl FiatOnChangeHandler {
 
         // early exit if same value is passed in
         if old_value == new_value {
-            return Ok(Changeset::default());
+            return Ok(Changeset {
+                entering_fiat_amount: sanitization_changed.then_some(old_value.to_string()),
+                ..Default::default()
+            });
         }
 
         if old_value_raw == new_value_raw {
-            return Ok(Changeset::default());
+            return Ok(Changeset {
+                entering_fiat_amount: sanitization_changed.then_some(old_value.to_string()),
+                ..Default::default()
+            });
         }
 
         // start entering with a period
@@ -105,7 +115,10 @@ impl FiatOnChangeHandler {
 
         // if old value is the same as the new value, then we don't need to do anything
         if old_value == new_value {
-            return Ok(Changeset::default());
+            return Ok(Changeset {
+                entering_fiat_amount: sanitization_changed.then_some(old_value.to_string()),
+                ..Default::default()
+            });
         }
 
         // don't allow adding more than 1 decimal point
@@ -118,7 +131,10 @@ impl FiatOnChangeHandler {
 
         // if the only change was formatting (adding ,) then we don't need to do anything
         if old_value_raw == new_value_raw {
-            return Ok(Changeset::default());
+            return Ok(Changeset {
+                entering_fiat_amount: sanitization_changed.then_some(old_value.to_string()),
+                ..Default::default()
+            });
         }
 
         // convert the fiat amount to btc amount
@@ -285,6 +301,20 @@ mod tests {
         assert_eq!(result.entering_fiat_amount.as_deref(), Some("$0"));
         assert!(result.fiat_value.is_none());
         assert!(result.btc_amount.is_none());
+    }
+
+    #[test]
+    fn pasting_fiat_code_over_same_numeric_value_rewrites_field() {
+        let h = handler();
+        // "100 CHF" over "$100" — numeric value unchanged, but display must be rewritten
+        let result = h.on_change("$100", "100 CHF").unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$100"));
+        assert!(result.fiat_value.is_none()); // amount didn't change, no re-parse needed
+
+        // "USD 100" over "$100" — same case with prefix code
+        let result = h.on_change("$100", "USD 100").unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$100"));
+        assert!(result.fiat_value.is_none());
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -63,8 +63,8 @@ impl FiatOnChangeHandler {
         let old_value = old_value.trim();
         let new_value = new_value.trim();
 
-        // strip currency tokens from pasted amounts (e.g. "$12.50", "12.50 USD")
-        let Some(new_value) = sanitize::sanitize_amount(new_value) else {
+        // strip fiat tokens from pasted amounts (e.g. "$12.50", "12.50 USD"); rejects BTC/SATS
+        let Some(new_value) = sanitize::sanitize_fiat_amount(new_value) else {
             return Ok(Changeset {
                 entering_fiat_amount: Some(old_value.to_string()),
                 ..Default::default()
@@ -262,22 +262,29 @@ mod tests {
     fn pasting_amount_with_chf_suffix_is_accepted() {
         let h = handler();
         let result = h.on_change("$0", "100 CHF").unwrap();
-        assert!(result.fiat_value.is_some(), "100 CHF should parse as a fiat amount");
+        // CHF is a fiat token — strips to "100", treated as 100 USD
+        assert_eq!(result.fiat_value, Some(100.0));
         assert!(result.btc_amount.is_some());
     }
 
     #[test]
-    fn pasting_amount_with_btc_suffix_is_accepted() {
+    fn pasting_amount_with_btc_suffix_is_rejected() {
         let h = handler();
         let result = h.on_change("$0", "0.5 BTC").unwrap();
-        assert!(result.fiat_value.is_some(), "0.5 BTC should parse as a numeric amount");
+        // BTC is not a fiat token — should revert to old value
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$0"));
+        assert!(result.fiat_value.is_none());
+        assert!(result.btc_amount.is_none());
     }
 
     #[test]
-    fn pasting_amount_with_sats_suffix_is_accepted() {
+    fn pasting_amount_with_sats_suffix_is_rejected() {
         let h = handler();
         let result = h.on_change("$0", "1000 SATS").unwrap();
-        assert!(result.fiat_value.is_some(), "1000 SATS should parse after stripping suffix");
+        // SATS is not a fiat token — should revert to old value
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$0"));
+        assert!(result.fiat_value.is_none());
+        assert!(result.btc_amount.is_none());
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -64,18 +64,11 @@ impl FiatOnChangeHandler {
         let new_value = new_value.trim();
 
         // strip currency tokens from pasted amounts (e.g. "$12.50", "12.50 USD")
-        let sanitized_fiat;
-        let new_value = match sanitize::sanitize_amount(new_value) {
-            Some(s) => {
-                sanitized_fiat = s;
-                sanitized_fiat.as_str()
-            }
-            None => {
-                return Ok(Changeset {
-                    entering_fiat_amount: Some(old_value.to_string()),
-                    ..Default::default()
-                });
-            }
+        let Some(new_value) = sanitize::sanitize_amount(new_value) else {
+            return Ok(Changeset {
+                entering_fiat_amount: Some(old_value.to_string()),
+                ..Default::default()
+            });
         };
 
         let symbol = self.selected_currency.symbol();

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -66,8 +66,16 @@ impl FiatOnChangeHandler {
         // strip currency tokens from pasted amounts (e.g. "$12.50", "12.50 USD")
         let sanitized_fiat;
         let new_value = match sanitize::sanitize_amount(new_value) {
-            Some(s) => { sanitized_fiat = s; sanitized_fiat.as_str() }
-            None => return Ok(Changeset { entering_fiat_amount: Some(old_value.to_string()), ..Default::default() }),
+            Some(s) => {
+                sanitized_fiat = s;
+                sanitized_fiat.as_str()
+            }
+            None => {
+                return Ok(Changeset {
+                    entering_fiat_amount: Some(old_value.to_string()),
+                    ..Default::default()
+                });
+            }
         };
 
         let symbol = self.selected_currency.symbol();

--- a/rust/src/manager/send_flow_manager/fiat_on_change.rs
+++ b/rust/src/manager/send_flow_manager/fiat_on_change.rs
@@ -65,6 +65,16 @@ impl FiatOnChangeHandler {
 
         let symbol = self.selected_currency.symbol();
 
+        // reject input containing alphabetic characters so pasted bitcoin
+        // addresses (and similar mixed-alphanumeric strings) aren't silently
+        // stripped down to just their digits and treated as a fiat amount. #314
+        if new_value.chars().any(|c| c.is_alphabetic()) {
+            return Ok(Changeset {
+                entering_fiat_amount: Some(old_value.to_string()),
+                ..Default::default()
+            });
+        }
+
         let number_of_decimal_points = new_value.chars().filter(|c| *c == '.').count();
 
         let new_value_raw =
@@ -169,5 +179,84 @@ impl FiatOnChangeHandler {
         }
 
         Ok(changes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handler() -> FiatOnChangeHandler {
+        let prices = PriceResponse {
+            time: 0,
+            fetched_at: 0,
+            usd: 100_000,
+            eur: 100_000,
+            gbp: 100_000,
+            cad: 100_000,
+            chf: 100_000,
+            aud: 100_000,
+            jpy: 100_000,
+        };
+        FiatOnChangeHandler::new(prices, FiatCurrency::Usd, None)
+    }
+
+    #[test]
+    fn pasting_bech32_bitcoin_address_is_rejected() {
+        let h = handler();
+        let old = "$100";
+        let new = "$100bc1qxyz0123456789abcdef";
+        let result = h.on_change(old, new).unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$100"));
+        assert!(result.btc_amount.is_none());
+        assert!(result.fiat_value.is_none());
+    }
+
+    #[test]
+    fn pasting_legacy_bitcoin_address_is_rejected() {
+        let h = handler();
+        let old = "$0";
+        let new = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2";
+        let result = h.on_change(old, new).unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$0"));
+        assert!(result.btc_amount.is_none());
+    }
+
+    #[test]
+    fn typing_a_single_letter_is_rejected() {
+        let h = handler();
+        let old = "$1";
+        let new = "$1a";
+        let result = h.on_change(old, new).unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$1"));
+        assert!(result.btc_amount.is_none());
+    }
+
+    #[test]
+    fn plain_digits_are_still_accepted() {
+        let h = handler();
+        let old = "$";
+        let new = "$123";
+        let result = h.on_change(old, new).unwrap();
+        assert!(result.fiat_value.is_some());
+        assert!(result.btc_amount.is_some());
+    }
+
+    #[test]
+    fn decimal_input_still_accepted() {
+        let h = handler();
+        let old = "$1";
+        let new = "$1.5";
+        let result = h.on_change(old, new).unwrap();
+        assert!(result.fiat_value.is_some());
+        assert!(result.btc_amount.is_some());
+    }
+
+    #[test]
+    fn empty_input_still_works() {
+        let h = handler();
+        let result = h.on_change("$100", "").unwrap();
+        assert_eq!(result.entering_fiat_amount.as_deref(), Some("$"));
+        assert_eq!(result.fiat_value, Some(0.0));
     }
 }

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -1,3 +1,41 @@
+/// Known currency tokens that can appear as a prefix or suffix when pasting
+/// formatted amounts (e.g. "100 CHF", "BTC 0.5", "100 SATS").
+const CURRENCY_TOKENS: &[&str] =
+    &["SATS", "SAT", "BTC", "CHF", "USD", "EUR", "GBP", "CAD", "AUD", "JPY"];
+
+/// Strip leading/trailing currency tokens and whitespace from `s` (case-insensitive).
+///
+/// Returns `Some(cleaned)` if no alphabetic characters remain after stripping,
+/// or `None` if letters survive (e.g. a bech32 address or free-form text).
+pub fn strip_currency_suffix(s: &str) -> Option<String> {
+    let mut work = s.trim();
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for token in CURRENCY_TOKENS {
+            let upper_work = work.to_ascii_uppercase();
+            if let Some(rest) = upper_work.strip_prefix(token) {
+                // advance past the token in the original (same byte length since ASCII)
+                work = work[token.len()..].trim();
+                let _ = rest;
+                changed = true;
+                continue;
+            }
+            if let Some(rest) = upper_work.strip_suffix(token) {
+                work = work[..rest.len()].trim();
+                changed = true;
+            }
+        }
+    }
+
+    if work.chars().any(|c| c.is_alphabetic()) {
+        return None;
+    }
+
+    Some(work.to_string())
+}
+
 // returns the dollars and the cents (with the decimal point) as a string
 pub fn seperate_and_limit_dollars_and_cents(
     amount: &str,
@@ -19,4 +57,39 @@ pub fn seperate_and_limit_dollars_and_cents(
     let dollars = &amount[..decimal_index];
     let cents_with_decimal_point = &amount[decimal_index..=decimal_index + decimal_places];
     (dollars, cents_with_decimal_point)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_trailing_chf() {
+        assert_eq!(strip_currency_suffix("100 CHF").unwrap(), "100");
+    }
+
+    #[test]
+    fn strips_leading_btc() {
+        assert_eq!(strip_currency_suffix("BTC 0.5").unwrap(), "0.5");
+    }
+
+    #[test]
+    fn strips_sats_suffix_case_insensitive() {
+        assert_eq!(strip_currency_suffix("1000 sats").unwrap(), "1000");
+    }
+
+    #[test]
+    fn plain_number_passes_through() {
+        assert_eq!(strip_currency_suffix("123.45").unwrap(), "123.45");
+    }
+
+    #[test]
+    fn bech32_address_returns_none() {
+        assert!(strip_currency_suffix("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
+    }
+
+    #[test]
+    fn legacy_address_returns_none() {
+        assert!(strip_currency_suffix("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").is_none());
+    }
 }

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -9,7 +9,7 @@ fn fiat_tokens() -> Vec<&'static str> {
     tokens
 }
 
-const BTC_TOKENS: &[&str] = &["BTC", "SAT", "SATS"];
+const BTC_TOKENS: &[&str] = &["SATS", "SAT", "BTC"];
 
 fn strip_prefix_ignore_ascii_case<'a>(input: &'a str, token: &str) -> Option<&'a str> {
     input
@@ -145,5 +145,12 @@ mod tests {
     #[test]
     fn sanitize_btc_rejects_address() {
         assert!(sanitize_btc_amount("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
+    }
+
+    #[test]
+    fn sanitize_btc_sats_prefix_not_mis_stripped_as_sat() {
+        // "SATS" must be matched before "SAT" to avoid leaving a stray "S"
+        assert_eq!(sanitize_btc_amount("SATS 0.1").unwrap(), "0.1");
+        assert_eq!(sanitize_btc_amount("sats 1000").unwrap(), "1000");
     }
 }

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -6,13 +6,6 @@ const FIAT_TOKENS: &[&str] = &[
 
 const BTC_TOKENS: &[&str] = &["BTC", "SAT", "SATS"];
 
-const CURRENCY_TOKENS: &[&str] = &[
-    // fiat symbols
-    "$", "€", "£", "¥", "₹", // fiat codes
-    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN", // bitcoin units
-    "BTC", "SAT", "SATS",
-];
-
 fn strip_prefix_ignore_ascii_case<'a>(input: &'a str, token: &str) -> Option<&'a str> {
     input
         .get(..token.len())
@@ -50,14 +43,6 @@ fn strip_tokens(input: &str, tokens: &[&str]) -> Option<String> {
     Some(work.to_string())
 }
 
-/// Strip leading/trailing currency tokens from `input` (case-insensitive).
-///
-/// Returns `Some(cleaned)` if no alphabetic characters remain after stripping,
-/// or `None` if letters survive (e.g. a bech32 address or free-form text).
-pub fn strip_currency_suffix(input: &str) -> Option<String> {
-    strip_tokens(input, CURRENCY_TOKENS)
-}
-
 /// Sanitizes a raw amount string for the fiat field.
 ///
 /// Strips recognized fiat tokens (symbols and codes). Returns `None` if
@@ -82,28 +67,11 @@ pub fn sanitize_btc_amount(input: &str) -> Option<String> {
     strip_tokens(input, BTC_TOKENS)
 }
 
-/// Sanitizes a raw amount string by stripping recognized currency tokens.
-///
-/// Returns `Some(sanitized)` when the input is usable — either no alphabetic
-/// characters were present (pass-through), or all alphabetic characters were
-/// recognized currency tokens and successfully stripped.
-///
-/// Returns `None` when the input contains alphabetic characters that are not a
-/// recognized currency token. The caller should reject the input and revert to
-/// the previous value.
-pub fn sanitize_amount(input: &str) -> Option<String> {
-    if !input.chars().any(|c| c.is_alphabetic()) {
-        return Some(input.to_string());
-    }
-    strip_currency_suffix(input)
-}
-
 // returns the dollars and the cents (with the decimal point) as a string
 pub fn seperate_and_limit_dollars_and_cents(
     amount: &str,
     max_decimal_places: usize,
 ) -> (&str, &str) {
-    // get how many decimals there are after the decimal point
     let last_index = amount.len().saturating_sub(1);
 
     let decimal_index = match memchr::memchr(b'.', amount.as_bytes()) {
@@ -112,8 +80,6 @@ pub fn seperate_and_limit_dollars_and_cents(
     };
 
     let current_decimal_places = last_index - decimal_index;
-
-    // get the number of decimals after the decimal point
     let decimal_places = current_decimal_places.min(max_decimal_places);
 
     let dollars = &amount[..decimal_index];
@@ -124,56 +90,6 @@ pub fn seperate_and_limit_dollars_and_cents(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn strips_trailing_chf() {
-        assert_eq!(strip_currency_suffix("100 CHF").unwrap(), "100");
-    }
-
-    #[test]
-    fn strips_leading_btc() {
-        assert_eq!(strip_currency_suffix("BTC 0.5").unwrap(), "0.5");
-    }
-
-    #[test]
-    fn strips_sats_suffix_case_insensitive() {
-        assert_eq!(strip_currency_suffix("1000 sats").unwrap(), "1000");
-    }
-
-    #[test]
-    fn strips_dollar_prefix() {
-        assert_eq!(strip_currency_suffix("$12.50").unwrap(), "12.50");
-    }
-
-    #[test]
-    fn plain_number_passes_through() {
-        assert_eq!(strip_currency_suffix("123.45").unwrap(), "123.45");
-    }
-
-    #[test]
-    fn bech32_address_returns_none() {
-        assert!(strip_currency_suffix("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
-    }
-
-    #[test]
-    fn legacy_address_returns_none() {
-        assert!(strip_currency_suffix("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").is_none());
-    }
-
-    #[test]
-    fn sanitize_amount_plain_number_passes_through() {
-        assert_eq!(sanitize_amount("100").unwrap(), "100");
-    }
-
-    #[test]
-    fn sanitize_amount_strips_currency() {
-        assert_eq!(sanitize_amount("100 sats").unwrap(), "100");
-    }
-
-    #[test]
-    fn sanitize_amount_rejects_address() {
-        assert!(sanitize_amount("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
-    }
 
     #[test]
     fn sanitize_fiat_strips_fiat_tokens() {
@@ -196,6 +112,12 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_fiat_rejects_address() {
+        assert!(sanitize_fiat_amount("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
+        assert!(sanitize_fiat_amount("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").is_none());
+    }
+
+    #[test]
     fn sanitize_btc_strips_btc_tokens() {
         assert_eq!(sanitize_btc_amount("0.5 BTC").unwrap(), "0.5");
         assert_eq!(sanitize_btc_amount("1000 SATS").unwrap(), "1000");
@@ -213,5 +135,10 @@ mod tests {
     #[test]
     fn sanitize_btc_plain_number_passes_through() {
         assert_eq!(sanitize_btc_amount("1000").unwrap(), "1000");
+    }
+
+    #[test]
+    fn sanitize_btc_rejects_address() {
+        assert!(sanitize_btc_amount("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
     }
 }

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -1,7 +1,6 @@
 const FIAT_TOKENS: &[&str] = &[
     // fiat symbols
-    "$", "€", "£", "¥", "₹",
-    // fiat codes
+    "$", "€", "£", "¥", "₹", // fiat codes
     "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
 ];
 
@@ -9,10 +8,8 @@ const BTC_TOKENS: &[&str] = &["BTC", "SAT", "SATS"];
 
 const CURRENCY_TOKENS: &[&str] = &[
     // fiat symbols
-    "$", "€", "£", "¥", "₹",
-    // fiat codes
-    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
-    // bitcoin units
+    "$", "€", "£", "¥", "₹", // fiat codes
+    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN", // bitcoin units
     "BTC", "SAT", "SATS",
 ];
 

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -1,31 +1,45 @@
 /// Known currency tokens that can appear as a prefix or suffix when pasting
-/// formatted amounts (e.g. "100 CHF", "BTC 0.5", "100 SATS").
-const CURRENCY_TOKENS: &[&str] =
-    &["SATS", "SAT", "BTC", "CHF", "USD", "EUR", "GBP", "CAD", "AUD", "JPY"];
+/// formatted amounts (e.g. "100 CHF", "BTC 0.5", "$12.50", "100 SATS").
+const CURRENCY_TOKENS: &[&str] = &[
+    // fiat symbols
+    "$", "€", "£", "¥", "₹",
+    // fiat codes
+    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
+    // bitcoin units
+    "BTC", "SAT", "SATS",
+];
 
-/// Strip leading/trailing currency tokens and whitespace from `s` (case-insensitive).
+fn strip_prefix_ignore_ascii_case<'a>(input: &'a str, token: &str) -> Option<&'a str> {
+    input
+        .get(..token.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(token))
+        .map(|_| input[token.len()..].trim())
+}
+
+fn strip_suffix_ignore_ascii_case<'a>(input: &'a str, token: &str) -> Option<&'a str> {
+    let start = input.len().checked_sub(token.len())?;
+    input
+        .get(start..)
+        .filter(|suffix| suffix.eq_ignore_ascii_case(token))
+        .map(|_| input[..start].trim())
+}
+
+/// Strip leading/trailing currency tokens from `input` (case-insensitive).
 ///
 /// Returns `Some(cleaned)` if no alphabetic characters remain after stripping,
 /// or `None` if letters survive (e.g. a bech32 address or free-form text).
-pub fn strip_currency_suffix(s: &str) -> Option<String> {
-    let mut work = s.trim();
+pub fn strip_currency_suffix(input: &str) -> Option<String> {
+    let mut work = input.trim();
 
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for token in CURRENCY_TOKENS {
-            let upper_work = work.to_ascii_uppercase();
-            if let Some(rest) = upper_work.strip_prefix(token) {
-                // advance past the token in the original (same byte length since ASCII)
-                work = work[token.len()..].trim();
-                let _ = rest;
-                changed = true;
-                continue;
-            }
-            if let Some(rest) = upper_work.strip_suffix(token) {
-                work = work[..rest.len()].trim();
-                changed = true;
-            }
+    loop {
+        let next = CURRENCY_TOKENS.iter().find_map(|token| {
+            strip_prefix_ignore_ascii_case(work, token)
+                .or_else(|| strip_suffix_ignore_ascii_case(work, token))
+        });
+
+        match next {
+            Some(stripped) => work = stripped,
+            None => break,
         }
     }
 
@@ -34,6 +48,22 @@ pub fn strip_currency_suffix(s: &str) -> Option<String> {
     }
 
     Some(work.to_string())
+}
+
+/// Sanitizes a raw amount string by stripping recognized currency tokens.
+///
+/// Returns `Some(sanitized)` when the input is usable — either no alphabetic
+/// characters were present (pass-through), or all alphabetic characters were
+/// recognized currency tokens and successfully stripped.
+///
+/// Returns `None` when the input contains alphabetic characters that are not a
+/// recognized currency token. The caller should reject the input and revert to
+/// the previous value.
+pub fn sanitize_amount(input: &str) -> Option<String> {
+    if !input.chars().any(|c| c.is_alphabetic()) {
+        return Some(input.to_string());
+    }
+    strip_currency_suffix(input)
 }
 
 // returns the dollars and the cents (with the decimal point) as a string
@@ -79,6 +109,11 @@ mod tests {
     }
 
     #[test]
+    fn strips_dollar_prefix() {
+        assert_eq!(strip_currency_suffix("$12.50").unwrap(), "12.50");
+    }
+
+    #[test]
     fn plain_number_passes_through() {
         assert_eq!(strip_currency_suffix("123.45").unwrap(), "123.45");
     }
@@ -91,5 +126,20 @@ mod tests {
     #[test]
     fn legacy_address_returns_none() {
         assert!(strip_currency_suffix("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").is_none());
+    }
+
+    #[test]
+    fn sanitize_amount_plain_number_passes_through() {
+        assert_eq!(sanitize_amount("100").unwrap(), "100");
+    }
+
+    #[test]
+    fn sanitize_amount_strips_currency() {
+        assert_eq!(sanitize_amount("100 sats").unwrap(), "100");
+    }
+
+    #[test]
+    fn sanitize_amount_rejects_address() {
+        assert!(sanitize_amount("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
     }
 }

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -1,9 +1,18 @@
-/// Known currency tokens that can appear as a prefix or suffix when pasting
-/// formatted amounts (e.g. "100 CHF", "BTC 0.5", "$12.50", "100 SATS").
+const FIAT_TOKENS: &[&str] = &[
+    // fiat symbols
+    "$", "€", "£", "¥", "₹",
+    // fiat codes
+    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
+];
+
+const BTC_TOKENS: &[&str] = &["BTC", "SAT", "SATS"];
+
 const CURRENCY_TOKENS: &[&str] = &[
     // fiat symbols
-    "$", "€", "£", "¥", "₹", // fiat codes
-    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN", // bitcoin units
+    "$", "€", "£", "¥", "₹",
+    // fiat codes
+    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
+    // bitcoin units
     "BTC", "SAT", "SATS",
 ];
 
@@ -22,15 +31,11 @@ fn strip_suffix_ignore_ascii_case<'a>(input: &'a str, token: &str) -> Option<&'a
         .map(|_| input[..start].trim())
 }
 
-/// Strip leading/trailing currency tokens from `input` (case-insensitive).
-///
-/// Returns `Some(cleaned)` if no alphabetic characters remain after stripping,
-/// or `None` if letters survive (e.g. a bech32 address or free-form text).
-pub fn strip_currency_suffix(input: &str) -> Option<String> {
+fn strip_tokens(input: &str, tokens: &[&str]) -> Option<String> {
     let mut work = input.trim();
 
     loop {
-        let next = CURRENCY_TOKENS.iter().find_map(|token| {
+        let next = tokens.iter().find_map(|token| {
             strip_prefix_ignore_ascii_case(work, token)
                 .or_else(|| strip_suffix_ignore_ascii_case(work, token))
         });
@@ -46,6 +51,38 @@ pub fn strip_currency_suffix(input: &str) -> Option<String> {
     }
 
     Some(work.to_string())
+}
+
+/// Strip leading/trailing currency tokens from `input` (case-insensitive).
+///
+/// Returns `Some(cleaned)` if no alphabetic characters remain after stripping,
+/// or `None` if letters survive (e.g. a bech32 address or free-form text).
+pub fn strip_currency_suffix(input: &str) -> Option<String> {
+    strip_tokens(input, CURRENCY_TOKENS)
+}
+
+/// Sanitizes a raw amount string for the fiat field.
+///
+/// Strips recognized fiat tokens (symbols and codes). Returns `None` if
+/// BTC/SAT/SATS or other unrecognized alphabetic characters are present —
+/// those should not be accepted into a fiat amount field.
+pub fn sanitize_fiat_amount(input: &str) -> Option<String> {
+    if !input.chars().any(|c| c.is_alphabetic()) {
+        return Some(input.to_string());
+    }
+    strip_tokens(input, FIAT_TOKENS)
+}
+
+/// Sanitizes a raw amount string for the BTC/sats field.
+///
+/// Strips recognized BTC tokens (BTC, SAT, SATS). Returns `None` if fiat
+/// symbols/codes or other unrecognized alphabetic characters are present —
+/// those should not be accepted into a BTC amount field.
+pub fn sanitize_btc_amount(input: &str) -> Option<String> {
+    if !input.chars().any(|c| c.is_alphabetic()) {
+        return Some(input.to_string());
+    }
+    strip_tokens(input, BTC_TOKENS)
 }
 
 /// Sanitizes a raw amount string by stripping recognized currency tokens.
@@ -139,5 +176,45 @@ mod tests {
     #[test]
     fn sanitize_amount_rejects_address() {
         assert!(sanitize_amount("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").is_none());
+    }
+
+    #[test]
+    fn sanitize_fiat_strips_fiat_tokens() {
+        assert_eq!(sanitize_fiat_amount("100 CHF").unwrap(), "100");
+        assert_eq!(sanitize_fiat_amount("EUR 50").unwrap(), "50");
+        // $ is not alphabetic — no stripping needed, passes through
+        assert_eq!(sanitize_fiat_amount("$12.50").unwrap(), "$12.50");
+    }
+
+    #[test]
+    fn sanitize_fiat_rejects_btc_tokens() {
+        assert!(sanitize_fiat_amount("0.5 BTC").is_none());
+        assert!(sanitize_fiat_amount("1000 SATS").is_none());
+        assert!(sanitize_fiat_amount("500 sat").is_none());
+    }
+
+    #[test]
+    fn sanitize_fiat_plain_number_passes_through() {
+        assert_eq!(sanitize_fiat_amount("100").unwrap(), "100");
+    }
+
+    #[test]
+    fn sanitize_btc_strips_btc_tokens() {
+        assert_eq!(sanitize_btc_amount("0.5 BTC").unwrap(), "0.5");
+        assert_eq!(sanitize_btc_amount("1000 SATS").unwrap(), "1000");
+        assert_eq!(sanitize_btc_amount("BTC 0.1").unwrap(), "0.1");
+    }
+
+    #[test]
+    fn sanitize_btc_rejects_fiat_tokens() {
+        assert!(sanitize_btc_amount("100 USD").is_none());
+        assert!(sanitize_btc_amount("100 CHF").is_none());
+        // $ is not alphabetic — passes through; downstream parser rejects it
+        assert_eq!(sanitize_btc_amount("$100").unwrap(), "$100");
+    }
+
+    #[test]
+    fn sanitize_btc_plain_number_passes_through() {
+        assert_eq!(sanitize_btc_amount("1000").unwrap(), "1000");
     }
 }

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -1,8 +1,13 @@
-const FIAT_TOKENS: &[&str] = &[
-    // fiat symbols
-    "$", "€", "£", "¥", "₹", // fiat codes
-    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
-];
+use crate::fiat::FiatCurrency;
+use strum::IntoEnumIterator as _;
+
+fn fiat_tokens() -> Vec<&'static str> {
+    let mut tokens: Vec<&'static str> = FiatCurrency::all_symbols().to_vec();
+    for currency in FiatCurrency::iter() {
+        tokens.push(currency.into());
+    }
+    tokens
+}
 
 const BTC_TOKENS: &[&str] = &["BTC", "SAT", "SATS"];
 
@@ -52,7 +57,7 @@ pub fn sanitize_fiat_amount(input: &str) -> Option<String> {
     if !input.chars().any(|c| c.is_alphabetic()) {
         return Some(input.to_string());
     }
-    strip_tokens(input, FIAT_TOKENS)
+    strip_tokens(input, &fiat_tokens())
 }
 
 /// Sanitizes a raw amount string for the BTC/sats field.

--- a/rust/src/manager/send_flow_manager/sanitize.rs
+++ b/rust/src/manager/send_flow_manager/sanitize.rs
@@ -2,10 +2,8 @@
 /// formatted amounts (e.g. "100 CHF", "BTC 0.5", "$12.50", "100 SATS").
 const CURRENCY_TOKENS: &[&str] = &[
     // fiat symbols
-    "$", "€", "£", "¥", "₹",
-    // fiat codes
-    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN",
-    // bitcoin units
+    "$", "€", "£", "¥", "₹", // fiat codes
+    "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "MXN", // bitcoin units
     "BTC", "SAT", "SATS",
 ];
 


### PR DESCRIPTION
Pasting a Bitcoin address into the send-flow amount field while in fiat mode caused the address to be silently stripped down to just its digits and treated as a send value, as described in #314. The fiat `on_change` handler filtered characters through `c.is_numeric() || c == '.'`, so input like `bc1qxyz0123456789abc` collapsed to `0123456789` and was parsed as a fiat amount. The BTC handler was already safe because it uses strict `parse::<u64>` / `parse::<f64>` and falls back to the previous value on failure.

This change rejects any input containing an alphabetic character at the top of the fiat handler, returning the previous value unchanged so the text field does not accept addresses or other alphanumeric pastes. Tests cover bech32 addresses, legacy P2PKH addresses, a single stray letter, plain digits, decimals, and empty input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paste sanitization for fiat and BTC amounts; common currency/unit tokens are stripped and public sanitization utilities added.

* **Bug Fixes**
  * Cleaned pasted values are preserved instead of being lost by early-exit logic.
  * Malformed pastes (addresses, lone letters, unsupported tokens, or mixed currency tokens) now revert to the previous valid value.

* **Tests**
  * Added tests covering accepted/rejected paste cases, suffix stripping, edge inputs, and BTC/fiat mixing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitcoinppl/cove/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->