### PR TITLE
add rescan with custom gap limit to recover missed addresses

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1602,6 +1602,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_required_deletion_confirmations(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_rescan_wallet_with_gap_limit(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_save_unsigned_transaction(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_selected_fiat_currency(
@@ -2690,6 +2692,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_required_deletion_confirmations(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
+    external fun uniffi_cove_fn_method_rustwalletmanager_rescan_wallet_with_gap_limit(`ptr`: Long,`gapLimit`: Int,
+    ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_save_unsigned_transaction(`ptr`: Long,`details`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     external fun uniffi_cove_fn_method_rustwalletmanager_selected_fiat_currency(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -4352,6 +4356,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_required_deletion_confirmations() != 30427.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_rescan_wallet_with_gap_limit() != 28630.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_save_unsigned_transaction() != 43358.toShort()) {
@@ -20741,6 +20748,8 @@ public interface RustWalletManagerInterface {
      */
     fun `requiredDeletionConfirmations`(): kotlin.UByte
     
+    suspend fun `rescanWalletWithGapLimit`(`gapLimit`: kotlin.UInt)
+    
     fun `saveUnsignedTransaction`(`details`: ConfirmDetails)
     
     fun `selectedFiatCurrency`(): FiatCurrency
@@ -21669,6 +21678,28 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
     )
     }
     
+
+    
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `rescanWalletWithGapLimit`(`gapLimit`: kotlin.UInt) {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_rescan_wallet_with_gap_limit(
+                uniffiHandle,
+                FfiConverterUInt.lower(`gapLimit`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+        
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
 
     
     @Throws(WalletManagerException::class)override fun `saveUnsignedTransaction`(`details`: ConfirmDetails)

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -8807,6 +8807,8 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
      */
     func requiredDeletionConfirmations()  -> UInt8
     
+    func rescanWalletWithGapLimit(gapLimit: UInt32) async throws 
+    
     func saveUnsignedTransaction(details: ConfirmDetails) throws 
     
     func selectedFiatCurrency()  -> FiatCurrency
@@ -9546,6 +9548,23 @@ open func requiredDeletionConfirmations() -> UInt8  {
             self.uniffiCloneHandle(),$0
     )
 })
+}
+    
+open func rescanWalletWithGapLimit(gapLimit: UInt32)async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_rescan_wallet_with_gap_limit(
+                    self.uniffiCloneHandle(),
+                    FfiConverterUInt32.lower(gapLimit)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_void,
+            completeFunc: ffi_cove_rust_future_complete_void,
+            freeFunc: ffi_cove_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
 }
     
 open func saveUnsignedTransaction(details: ConfirmDetails)throws   {try rustCallWithError(FfiConverterTypeWalletManagerError_lift) {
@@ -36798,6 +36817,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_required_deletion_confirmations() != 30427) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_rescan_wallet_with_gap_limit() != 28630) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_save_unsigned_transaction() != 43358) {

--- a/rust/crates/cove-common/src/consts.rs
+++ b/rust/crates/cove-common/src/consts.rs
@@ -9,6 +9,7 @@ static CUSTOM_ROOT_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 pub static ROOT_DATA_DIR: LazyLock<PathBuf> = LazyLock::new(data_dir_init);
 pub static WALLET_DATA_DIR: LazyLock<PathBuf> = LazyLock::new(wallet_data_dir_init);
 pub static GAP_LIMIT: u8 = 30;
+pub static MAX_RESCAN_GAP_LIMIT: u32 = 2000;
 
 pub static MIN_SEND_SATS: u64 = 5000;
 pub static MIN_SEND_AMOUNT: Amount = Amount::from_sat(MIN_SEND_SATS);

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -12,6 +12,7 @@ use parking_lot::RwLock;
 use tap::TapFallible as _;
 use tracing::{debug, error, warn};
 
+use cove_common::consts::MAX_RESCAN_GAP_LIMIT;
 use cove_tokio::task::{self, spawn_actor};
 use cove_util::{format::NumberFormatter as _, result_ext::ResultExt as _};
 
@@ -1001,6 +1002,24 @@ impl RustWalletManager {
         tokio::spawn(async move {
             send!(actor.wallet_scan_and_notify(true));
         });
+    }
+
+    #[uniffi::method]
+    pub async fn rescan_wallet_with_gap_limit(&self, gap_limit: u32) -> Result<(), Error> {
+        debug!("rescan_wallet_with_gap_limit: {} gap_limit={}", self.id, gap_limit);
+
+        if gap_limit == 0 || gap_limit > MAX_RESCAN_GAP_LIMIT {
+            return Err(Error::WalletScanError(format!(
+                "gap_limit must be between 1 and {MAX_RESCAN_GAP_LIMIT}",
+            )));
+        }
+
+        let actor = self.actor.clone();
+        task::spawn(async move {
+            send!(actor.perform_rescan_full_scan(gap_limit));
+        });
+
+        Ok(())
     }
 
     #[uniffi::method]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -101,13 +101,24 @@ pub enum FullScanType {
     Initial,
     /// Expanded scan scans for 150 addresses GAP_LIMIT
     Expanded,
+    Rescan(u32),
 }
 
 impl FullScanType {
-    const fn stop_gap(&self) -> usize {
+    fn stop_gap(&self) -> usize {
         match self {
             Self::Initial => 20,
             Self::Expanded => 150,
+            Self::Rescan(gap) => *gap as usize,
+        }
+    }
+
+    /// Whether this scan covers at least as many addresses as the expanded scan.
+    fn covers_expanded(&self) -> bool {
+        match self {
+            Self::Initial => false,
+            Self::Expanded => true,
+            Self::Rescan(gap) => *gap as usize >= Self::Expanded.stop_gap(),
         }
     }
 }
@@ -1122,9 +1133,12 @@ impl WalletActor {
     // this is slower, but we want to be able to see all transactions in the UI, so scan the next
     // 150 addresses
     async fn maybe_perform_expanded_full_scan(&mut self) -> ActorResult<()> {
-        if self.state == ActorState::FullScanComplete(FullScanType::Expanded)
-            || self.state == ActorState::IncrementalScanComplete
-        {
+        let already_covered = matches!(
+            self.state,
+            ActorState::FullScanComplete(t) if t.covers_expanded(),
+        ) || self.state == ActorState::IncrementalScanComplete;
+
+        if already_covered {
             debug!("already scanned skipping expanded full scan ({:?})", self.state);
             return Produces::ok(());
         }
@@ -1194,6 +1208,48 @@ impl WalletActor {
         Produces::ok(())
     }
 
+    /// Perform a full scan with a user-supplied gap limit to recover missed addresses.
+    pub async fn perform_rescan_full_scan(&mut self, gap_limit: u32) -> ActorResult<()> {
+        debug!("perform_rescan_full_scan with gap_limit={gap_limit}");
+
+        if matches!(
+            self.state,
+            ActorState::PerformingFullScan(_) | ActorState::PerformingIncrementalScan
+        ) {
+            warn!("scan already in progress, rejecting rescan ({:?})", self.state);
+            return Err(
+                Error::WalletScanError("wallet scan already in progress".to_string()).into()
+            );
+        }
+
+        let scan_type = FullScanType::Rescan(gap_limit);
+
+        let (full_scan_request, graph, node_client) = self.get_for_full_scan().await?;
+
+        let txns = self.transactions().await?.await?;
+        self.reconciler
+            .send(WalletManagerReconcileMessage::StartedExpandedFullScan(txns).into())
+            .unwrap();
+
+        self.state = ActorState::PerformingFullScan(scan_type);
+
+        let addr = self.addr.clone();
+        self.addr.send_fut(async move {
+            let start = UNIX_EPOCH.elapsed().unwrap().as_secs();
+
+            let full_scan_result = node_client
+                .start_wallet_scan(&graph, full_scan_request, scan_type.stop_gap())
+                .await;
+
+            let now = UNIX_EPOCH.elapsed().unwrap().as_secs();
+            debug!("[rescan] done rescan full scan in {}s", now - start);
+
+            send!(addr.handle_full_scan_complete(full_scan_result, scan_type));
+        });
+
+        Produces::ok(())
+    }
+
     async fn get_for_full_scan(
         &mut self,
     ) -> Result<(FullScanRequest<KeychainKind>, TxGraph, NodeClient)> {
@@ -1249,8 +1305,10 @@ impl WalletActor {
             }
         }
 
-        // only mark as scan complete when the expanded full scan is complete
-        if full_scan_type == FullScanType::Expanded {
+        // only mark as scan complete when the scan covered at least the
+        // expanded 150-address gap; smaller rescans must not persist this
+        // or the automatic expanded scan will be skipped next boot.
+        if full_scan_type.covers_expanded() {
             let now = jiff::Timestamp::now().as_second() as u64;
             self.wallet.metadata.internal.performed_full_scan_at = Some(now);
             Database::global().wallets.update_internal_metadata(&self.wallet.metadata)?;


### PR DESCRIPTION
Adds a rescan action that takes a user-chosen gap limit, so wallets can find addresses with balances that were skipped past the default 30/150 limit. No ui yet, just the Rust hook (rescan_wallet_with_gap_limit) that the iOS and Android settings screens can wire up next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous wallet rescan with a configurable gap limit that returns immediately and runs in background.
  * Rescans won't start if another full or incremental scan is already running.

* **Bug Fixes / Improvements**
  * Enforced gap-limit validation (must be within allowed range).
  * Wallet is marked as scanned when a rescan covers the expanded scan range.
  * Added debug logging for rescan requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->