### PR TITLE
Feat cache receive addresses with `5m timeout`

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -3,6 +3,7 @@ package org.bitcoinppl.cove
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
@@ -89,6 +90,13 @@ class WalletManager :
 
     val accentColor: Color
         get() = walletMetadata?.color?.toComposeColor() ?: Color.Blue
+
+    var addressGeneratedTime by mutableLongStateOf(0L)
+        private set
+
+    suspend fun getReceiveAddress(forceNew: Boolean = false): AddressInfoWithDerivation {
+        return rust.getReceiveAddress(forceNew)
+    }
 
     // private constructor - use companion factory methods
     private constructor(
@@ -300,6 +308,10 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
                 AppManager.getInstance().alertState = TaggedItem(AppAlertState.HotWalletKeyMissing(message.v1))
+            }
+
+            is WalletManagerReconcileMessage.AddressGeneratedTime -> {
+                addressGeneratedTime = message.v1.toLong() * 1000L
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/ReceiveAddressSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/ReceiveAddressSheet.kt
@@ -67,18 +67,20 @@ fun ReceiveAddressSheet(
     var addressInfo by remember { mutableStateOf<AddressInfoWithDerivation?>(null) }
     var isLoading by remember { mutableStateOf(true) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+    var initialLoadComplete by remember { mutableStateOf(false) }
 
-    // load initial address on mount
-    LaunchedEffect(manager) {
+    // load initial address on mount, re-fetch safely on state changes
+    LaunchedEffect(manager, manager.loadState) {
         try {
             isLoading = true
-            addressInfo = manager.rust.nextAddress()
+            addressInfo = manager.getReceiveAddress(forceNew = false)
             errorMessage = null
         } catch (e: Exception) {
             Log.e(tag, "Unable to get next address", e)
             errorMessage = e.message ?: "Unable to get address"
         } finally {
             isLoading = false
+            initialLoadComplete = true
         }
     }
 
@@ -87,7 +89,7 @@ fun ReceiveAddressSheet(
         scope.launch {
             try {
                 isLoading = true
-                addressInfo = manager.rust.nextAddress()
+                addressInfo = manager.getReceiveAddress(forceNew = true)
                 errorMessage = null
             } catch (e: Exception) {
                 Log.e(tag, "Unable to get next address", e)
@@ -133,8 +135,10 @@ fun ReceiveAddressSheet(
             addressRaw = addressInfo?.addressUnformatted(),
             derivationPath = addressInfo?.derivationPath(),
             isLoading = isLoading,
+            addressGeneratedTime = manager.addressGeneratedTime,
             onCopyAddress = ::copyAddress,
             onCreateNewAddress = ::createNewAddress,
+            initialLoadComplete = initialLoadComplete,
         )
     }
 }
@@ -146,10 +150,39 @@ private fun ReceiveAddressSheetContent(
     addressRaw: String?,
     derivationPath: String?,
     isLoading: Boolean,
+    addressGeneratedTime: Long,
+    initialLoadComplete: Boolean,
     onCopyAddress: () -> Unit,
     onCreateNewAddress: () -> Unit,
 ) {
     val isDarkTheme = !MaterialTheme.colorScheme.isLight
+    var timeLeftStr by remember { mutableStateOf("") }
+
+    LaunchedEffect(addressGeneratedTime, initialLoadComplete) {
+        if (!initialLoadComplete) return@LaunchedEffect
+        while(true) {
+            if (addressGeneratedTime == 0L) {
+                timeLeftStr = ""
+            } else {
+                val elapsed = System.currentTimeMillis() - addressGeneratedTime
+                val remaining = (5 * 60 * 1000L) - elapsed
+                
+                if (remaining > 0) {
+                    if (remaining <= 60_000L) {
+                        val seconds = (remaining / 1000)
+                        timeLeftStr = String.format("Auto-refresh in %02d", seconds)
+                    } else {
+                        timeLeftStr = ""
+                    }
+                } else {
+                    timeLeftStr = "Refreshing..."
+                    onCreateNewAddress()
+                    break
+                }
+            }
+            kotlinx.coroutines.delay(1000)
+        }
+    }
 
     Column(
         modifier =
@@ -278,7 +311,18 @@ private fun ReceiveAddressSheetContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(64.dp))
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (timeLeftStr.isNotEmpty() && !isLoading) {
+            Text(
+                text = timeLeftStr,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
 
         // copy address button
         Button(
@@ -330,6 +374,8 @@ private fun ReceiveAddressSheetPreview() {
             isLoading = false,
             onCopyAddress = {},
             onCreateNewAddress = {},
+            addressGeneratedTime = System.currentTimeMillis(),
+            initialLoadComplete = false,
         )
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1576,6 +1576,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_get_fee_options(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_get_receive_address(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_get_transactions(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_get_unsigned_transactions(
@@ -2665,6 +2667,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_rustwalletmanager_force_wallet_scan(`ptr`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_get_fee_options(`ptr`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_get_receive_address(`ptr`: Long,`forceNew`: Byte,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_get_transactions(`ptr`: Long,
     ): Long
@@ -4317,6 +4321,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_get_fee_options() != 42115.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_get_receive_address() != 38137.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_get_transactions() != 27342.toShort()) {
@@ -20712,6 +20719,11 @@ public interface RustWalletManagerInterface {
     suspend fun `getFeeOptions`(): FeeRateOptions
     
     /**
+     * Get the receive address for the wallet, deduplicated and persistently cached
+     */
+    suspend fun `getReceiveAddress`(`forceNew`: kotlin.Boolean): AddressInfoWithDerivation
+    
+    /**
      * gets the transactions for the wallet that are currently available
      */
     suspend fun `getTransactions`()
@@ -21455,6 +21467,30 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
         { future -> UniffiLib.ffi_cove_rust_future_free_u64(future) },
         // lift function
         { FfiConverterTypeFeeRateOptions.lift(it) },
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
+
+    
+    /**
+     * Get the receive address for the wallet, deduplicated and persistently cached
+     */
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `getReceiveAddress`(`forceNew`: kotlin.Boolean) : AddressInfoWithDerivation {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_get_receive_address(
+                uniffiHandle,
+                FfiConverterBoolean.lower(`forceNew`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_u64(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_u64(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_u64(future) },
+        // lift function
+        { FfiConverterTypeAddressInfoWithDerivation.lift(it) },
         // Error FFI converter
         WalletManagerException.ErrorHandler,
     )
@@ -50874,6 +50910,15 @@ sealed class WalletManagerReconcileMessage: Disposable  {
         companion object
     }
     
+    data class AddressGeneratedTime(
+        val v1: kotlin.ULong) : WalletManagerReconcileMessage()
+        
+    {
+        
+
+        companion object
+    }
+    
 
     
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -50967,6 +51012,13 @@ sealed class WalletManagerReconcileMessage: Disposable  {
     )
                 
             }
+            is WalletManagerReconcileMessage.AddressGeneratedTime -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
@@ -51021,6 +51073,9 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 )
             14 -> WalletManagerReconcileMessage.HotWalletKeyMissing(
                 FfiConverterTypeWalletId.read(buf),
+                )
+            15 -> WalletManagerReconcileMessage.AddressGeneratedTime(
+                FfiConverterULong.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
@@ -51123,6 +51178,13 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 + FfiConverterTypeWalletId.allocationSize(value.v1)
             )
         }
+        is WalletManagerReconcileMessage.AddressGeneratedTime -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterULong.allocationSize(value.v1)
+            )
+        }
     }
 
     override fun write(value: WalletManagerReconcileMessage, buf: ByteBuffer) {
@@ -51193,6 +51255,11 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
                 buf.putInt(14)
                 FfiConverterTypeWalletId.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerReconcileMessage.AddressGeneratedTime -> {
+                buf.putInt(15)
+                FfiConverterULong.write(value.v1, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/ios/Cove/Flows/SelectedWalletFlow/ReceiveView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/ReceiveView.swift
@@ -20,6 +20,39 @@ struct ReceiveView: View {
     private let pasteboard = UIPasteboard.general
     @State private var addressInfo: AddressInfoWithDerivation?
 
+    @State private var timeRemainingString: String = ""
+    @State private var timerTask: Task<Void, Never>? = nil
+
+    func startTimer() {
+        timerTask?.cancel()
+        timerTask = Task { @MainActor in
+            while !Task.isCancelled {
+                guard let generatedTime = manager.addressGeneratedTime else {
+                    timeRemainingString = ""
+                    try? await Task.sleep(for: .seconds(1))
+                    continue
+                }
+
+                let elapsed = Date().timeIntervalSince(generatedTime)
+                let remaining = (5 * 60) - elapsed
+
+                if remaining > 0 {
+                    if remaining <= 60 {
+                        let seconds = Int(remaining)
+                        timeRemainingString = String(format: "Auto-refresh in %02d", seconds)
+                    } else {
+                        timeRemainingString = ""
+                    }
+                } else {
+                    timeRemainingString = "Refreshing..."
+                    nextAddressSync()
+                    break
+                }
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
     var addressLoaded: Bool {
         addressInfo != nil
     }
@@ -38,13 +71,16 @@ struct ReceiveView: View {
     }
 
     func nextAddressSync() {
-        Task { await nextAddress() }
+        Task { await nextAddress(forceNew: true) }
     }
 
-    func nextAddress() async {
+    func nextAddress(forceNew: Bool = false) async {
         do {
-            let addressInfo = try await manager.rust.nextAddress()
-            await MainActor.run { self.addressInfo = addressInfo }
+            let addressInfo = try await manager.getReceiveAddress(forceNew: forceNew)
+            await MainActor.run {
+                self.addressInfo = addressInfo
+                self.startTimer()
+            }
         } catch {
             Log.error("Unable to get next address: \(error)")
             dismiss()
@@ -110,7 +146,16 @@ struct ReceiveView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .padding(.horizontal)
 
-                Spacer(minLength: 32)
+                Spacer(minLength: 4)
+
+                if !timeRemainingString.isEmpty, addressLoaded {
+                    Text(timeRemainingString)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 2)
+                }
+
+                Spacer(minLength: 12)
 
                 // ----- Copy button -----
                 Button(action: copyText) {
@@ -133,6 +178,17 @@ struct ReceiveView: View {
         .background(Color(.systemBackground))
         .task {
             await nextAddress()
+        }
+        .onChange(of: manager.loadState) { _, _ in
+            Task { await nextAddress() }
+        }
+        .onChange(of: manager.addressGeneratedTime) { _, _ in
+            if addressLoaded {
+                startTimer()
+            }
+        }
+        .onDisappear {
+            timerTask?.cancel()
         }
     }
 }

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -30,6 +30,12 @@ extension WeakReconciler: WalletManagerReconciler where Reconciler == WalletMana
     /// scroll position for transaction list (persists across navigation)
     var scrolledTransactionId: String?
 
+    private(set) var addressGeneratedTime: Date? = nil
+
+    func getReceiveAddress(forceNew: Bool = false) async throws -> AddressInfoWithDerivation {
+        try await rust.getReceiveAddress(forceNew: forceNew)
+    }
+
     init(id: WalletId) throws {
         self.id = id
         let rust = try RustWalletManager(id: id)
@@ -220,6 +226,10 @@ extension WeakReconciler: WalletManagerReconciler where Reconciler == WalletMana
 
         case let .hotWalletKeyMissing(walletId):
             AppManager.shared.alertState = .init(.hotWalletKeyMissing(walletId: walletId))
+
+        case let .addressGeneratedTime(timestamp):
+            let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+            withAnimation { self.addressGeneratedTime = date }
         }
     }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -8771,6 +8771,11 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
     func getFeeOptions() async throws  -> FeeRateOptions
     
     /**
+     * Get the receive address for the wallet, deduplicated and persistently cached
+     */
+    func getReceiveAddress(forceNew: Bool) async throws  -> AddressInfoWithDerivation
+    
+    /**
      * gets the transactions for the wallet that are currently available
      */
     func getTransactions() async 
@@ -9384,6 +9389,26 @@ open func getFeeOptions()async throws  -> FeeRateOptions  {
             completeFunc: ffi_cove_rust_future_complete_u64,
             freeFunc: ffi_cove_rust_future_free_u64,
             liftFunc: FfiConverterTypeFeeRateOptions_lift,
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
+}
+    
+    /**
+     * Get the receive address for the wallet, deduplicated and persistently cached
+     */
+open func getReceiveAddress(forceNew: Bool)async throws  -> AddressInfoWithDerivation  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_get_receive_address(
+                    self.uniffiCloneHandle(),
+                    FfiConverterBool.lower(forceNew)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_u64,
+            completeFunc: ffi_cove_rust_future_complete_u64,
+            freeFunc: ffi_cove_rust_future_free_u64,
+            liftFunc: FfiConverterTypeAddressInfoWithDerivation_lift,
             errorHandler: FfiConverterTypeWalletManagerError_lift
         )
 }
@@ -31484,6 +31509,8 @@ public enum WalletManagerReconcileMessage {
     )
     case hotWalletKeyMissing(WalletId
     )
+    case addressGeneratedTime(UInt64
+    )
 
 
 
@@ -31543,6 +31570,9 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         )
         
         case 14: return .hotWalletKeyMissing(try FfiConverterTypeWalletId.read(from: &buf)
+        )
+        
+        case 15: return .addressGeneratedTime(try FfiConverterUInt64.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -31619,6 +31649,11 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         case let .hotWalletKeyMissing(v1):
             writeInt(&buf, Int32(14))
             FfiConverterTypeWalletId.write(v1, into: &buf)
+            
+        
+        case let .addressGeneratedTime(v1):
+            writeInt(&buf, Int32(15))
+            FfiConverterUInt64.write(v1, into: &buf)
             
         }
     }
@@ -36778,6 +36813,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_get_fee_options() != 42115) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_get_receive_address() != 38137) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_get_transactions() != 27342) {

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -49,7 +49,9 @@ pub struct Address(BdkAddress);
 )]
 pub struct AddressInfo(BdkAddressInfo);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Object)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, uniffi::Object, serde::Serialize, serde::Deserialize,
+)]
 pub struct AddressInfoWithDerivation {
     pub info: AddressInfo,
     pub derivation_path: Option<String>,
@@ -320,38 +322,38 @@ impl Address {
 
 #[uniffi::export]
 impl AddressInfo {
-    fn address_unformatted(&self) -> String {
+    pub fn address_unformatted(&self) -> String {
         self.address.to_string()
     }
 
-    fn address(&self) -> Address {
+    pub fn address(&self) -> Address {
         self.address.clone().into()
     }
 
-    fn index(&self) -> u32 {
+    pub fn index(&self) -> u32 {
         self.index
     }
 }
 
 #[uniffi::export]
 impl AddressInfoWithDerivation {
-    fn address_unformatted(&self) -> String {
+    pub fn address_unformatted(&self) -> String {
         self.info.address.to_string()
     }
 
-    fn address_spaced_out(&self) -> String {
+    pub fn address_spaced_out(&self) -> String {
         address_string_spaced_out(self.info.address.to_string())
     }
 
-    fn address(&self) -> Address {
+    pub fn address(&self) -> Address {
         self.info.address.clone().into()
     }
 
-    fn index(&self) -> u32 {
+    pub fn index(&self) -> u32 {
         self.info.index
     }
 
-    fn derivation_path(&self) -> Option<String> {
+    pub fn derivation_path(&self) -> Option<String> {
         self.derivation_path.clone()
     }
 }
@@ -404,6 +406,50 @@ impl<'de> Deserialize<'de> for Address {
             BdkAddress::from_str(&s).map_err(serde::de::Error::custom)?.assume_checked();
 
         Ok(Self(bdk_address))
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AddressInfoShadow {
+    address: String,
+    index: u32,
+    keychain: String,
+}
+
+impl serde::Serialize for AddressInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let shadow = AddressInfoShadow {
+            address: self.0.address.to_string(),
+            index: self.0.index,
+            keychain: match self.0.keychain {
+                bdk_wallet::KeychainKind::External => "External".to_string(),
+                bdk_wallet::KeychainKind::Internal => "Internal".to_string(),
+            },
+        };
+        shadow.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AddressInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let shadow = AddressInfoShadow::deserialize(deserializer)?;
+        let address = BdkAddress::from_str(&shadow.address)
+            .map_err(serde::de::Error::custom)?
+            .assume_checked();
+
+        let keychain = match shadow.keychain.as_str() {
+            "External" => bdk_wallet::KeychainKind::External,
+            "Internal" => bdk_wallet::KeychainKind::Internal,
+            _ => return Err(serde::de::Error::custom("invalid keychain kind")),
+        };
+
+        Ok(AddressInfo(BdkAddressInfo { address, index: shadow.index, keychain }))
     }
 }
 

--- a/rust/src/database/global_cache.rs
+++ b/rust/src/database/global_cache.rs
@@ -14,6 +14,9 @@ use crate::{
 use super::Error;
 use cove_types::redb::Json;
 
+use crate::wallet::metadata::WalletId;
+use cove_types::address::AddressInfoWithDerivation;
+
 pub const TABLE: TableDefinition<&'static str, Json<GlobalCacheData>> =
     TableDefinition::new("global_cache");
 
@@ -29,10 +32,18 @@ pub struct PricesKey;
 #[derive(Debug, Clone, Copy)]
 pub struct FeesKey;
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReceiveAddressCache {
+    pub address_info: AddressInfoWithDerivation,
+    pub generated_at: u64,
+    pub tx_count: usize,
+}
+
 #[derive(Debug, Clone, derive_more::From, serde::Serialize, serde::Deserialize)]
 pub enum GlobalCacheData {
     Prices(PriceResponse),
     Fees(FeeResponse),
+    ReceiveAddress(ReceiveAddressCache),
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +71,43 @@ pub enum GlobalCacheTableError {
 }
 
 impl GlobalCacheTable {
+    pub fn get_receive_address(&self, id: &WalletId) -> Result<Option<ReceiveAddressCache>, Error> {
+        let read_txn = self.db.begin_read().map_err_str(Error::DatabaseAccess)?;
+        let table = read_txn.open_table(TABLE).map_err_str(Error::TableAccess)?;
+
+        let id_str: &str = id.as_ref();
+        let key = format!("receive_address_{}", id_str);
+
+        let value = table
+            .get(key.as_str())
+            .map_err_str(GlobalCacheTableError::Read)?
+            .map(|value| value.value());
+        if let Some(GlobalCacheData::ReceiveAddress(data)) = value {
+            Ok(Some(data))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn set_receive_address(
+        &self,
+        id: &WalletId,
+        data: ReceiveAddressCache,
+    ) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err_str(Error::DatabaseAccess)?;
+        {
+            let mut table = write_txn.open_table(TABLE).map_err_str(Error::TableAccess)?;
+            let id_str: &str = id.as_ref();
+            let key = format!("receive_address_{}", id_str);
+
+            table
+                .insert(key.as_str(), GlobalCacheData::ReceiveAddress(data))
+                .map_err_str(GlobalCacheTableError::Save)?;
+        }
+        write_txn.commit().map_err_str(Error::DatabaseAccess)?;
+        Ok(())
+    }
+
     pub fn get_prices(&self) -> Result<Option<PriceResponse>, Error> {
         let key = GlobalCacheKey::Prices(PricesKey);
         if let Some(GlobalCacheData::Prices(prices)) = self.get(key)? {

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -15,6 +15,7 @@ use tracing::{debug, error, warn};
 use cove_common::consts::MAX_RESCAN_GAP_LIMIT;
 use cove_tokio::task::{self, spawn_actor};
 use cove_util::{format::NumberFormatter as _, result_ext::ResultExt as _};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::{
     app::FfiApp,
@@ -85,6 +86,7 @@ pub enum WalletManagerReconcileMessage {
 
     SendFlowError(SendFlowErrorAlert),
     HotWalletKeyMissing(WalletId),
+    AddressGeneratedTime(u64),
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
@@ -164,6 +166,7 @@ pub struct RustWalletManager {
 
     #[allow(dead_code)]
     scanner: Option<Addr<WalletScanner>>,
+    address_generation_lock: Arc<AsyncMutex<()>>,
 }
 
 pub type Error = WalletManagerError;
@@ -314,6 +317,7 @@ impl RustWalletManager {
             label_manager,
             initial_load_state,
             scanner,
+            address_generation_lock: Arc::new(AsyncMutex::new(())),
         })
     }
 
@@ -385,6 +389,7 @@ impl RustWalletManager {
             label_manager,
             initial_load_state: WalletLoadState::Loading,
             scanner,
+            address_generation_lock: Arc::new(AsyncMutex::new(())),
         })
     }
 
@@ -415,6 +420,7 @@ impl RustWalletManager {
             label_manager,
             initial_load_state: WalletLoadState::Loading,
             scanner: None,
+            address_generation_lock: Arc::new(AsyncMutex::new(())),
         })
     }
 
@@ -878,6 +884,63 @@ impl RustWalletManager {
     pub async fn number_of_confirmations_fmt(&self, block_height: u32) -> Result<String, Error> {
         let number_of_confirmations = self.number_of_confirmations(block_height).await?;
         Ok(number_of_confirmations.thousands_int())
+    }
+
+    /// Get the receive address for the wallet, deduplicated and persistently cached
+    #[uniffi::method]
+    pub async fn get_receive_address(
+        &self,
+        force_new: bool,
+    ) -> Result<AddressInfoWithDerivation, Error> {
+        let _guard = self.address_generation_lock.lock().await;
+        let db = Database::global();
+
+        let txns = call!(self.actor.transactions()).await.unwrap_or_default();
+        let current_tx_count = txns.len();
+
+        if !force_new && let Ok(Some(cache)) = db.global_cache.get_receive_address(&self.id) {
+            let now = jiff::Timestamp::now().as_second() as u64;
+            let time_elapsed = now.saturating_sub(cache.generated_at) > (5 * 60);
+
+            let mut address_was_used = false;
+            if current_tx_count != cache.tx_count {
+                let cached_index = cache.address_info.index();
+                let is_cached_still_unused = call!(self.actor.is_address_unused(cached_index))
+                    .await
+                    .map_err_str(Error::NextAddressError)?;
+
+                // If cached address is no longer in the unused list, then it's used
+                address_was_used = !is_cached_still_unused;
+            }
+
+            if !time_elapsed && !address_was_used {
+                if current_tx_count != cache.tx_count {
+                    // Cache's tx_count is outdated, but the address was not used
+                    // Update the tx_count to skip the checks on subsequent UI updates
+                    let mut updated_cache = cache.clone();
+                    updated_cache.tx_count = current_tx_count;
+                    let _ = db.global_cache.set_receive_address(&self.id, updated_cache);
+                }
+
+                self.reconciler.send(Message::AddressGeneratedTime(cache.generated_at));
+                return Ok(cache.address_info);
+            }
+        }
+
+        let new_address =
+            call!(self.actor.next_address()).await.map_err_str(Error::NextAddressError)?;
+        let now = jiff::Timestamp::now().as_second() as u64;
+
+        let cache = crate::database::global_cache::ReceiveAddressCache {
+            address_info: new_address.clone(),
+            generated_at: now,
+            tx_count: current_tx_count,
+        };
+
+        let _ = db.global_cache.set_receive_address(&self.id, cache);
+        self.reconciler.send(Message::AddressGeneratedTime(now));
+
+        Ok(new_address)
     }
 
     /// Get the next address for the wallet
@@ -1384,6 +1447,7 @@ impl RustWalletManager {
             label_manager,
             initial_load_state: WalletLoadState::Loading,
             scanner: None,
+            address_generation_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 }

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -734,6 +734,11 @@ impl WalletActor {
         Produces::ok(address)
     }
 
+    pub async fn is_address_unused(&mut self, index: u32) -> ActorResult<bool> {
+        let is_unused = self.wallet.is_address_unused(index)?;
+        Produces::ok(is_unused)
+    }
+
     #[into_actor_result]
     pub async fn check_node_connection(&mut self) {
         let node = Database::global().global_config.selected_node();

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -603,6 +603,13 @@ impl Wallet {
         Ok(address_info_with_derivation)
     }
 
+    /// Check if the address at the given index is still in the unused addresses list
+    pub fn is_address_unused(&mut self, index: u32) -> Result<bool, WalletError> {
+        let is_unused =
+            self.bdk.list_unused_addresses(KeychainKind::External).any(|addr| addr.index == index);
+        Ok(is_unused)
+    }
+
     pub fn persist(&mut self) -> Result<(), WalletError> {
         self.bdk.persist(&mut self.db.lock()).map_err_str(WalletError::PersistError)?;
 


### PR DESCRIPTION
## Summary
1. Previously, the receive address refreshed every time the view was opened or the address was copied.
2. Closes: #386  

This commit introduces address caching to the WalletManager on both platforms:
1. Addresses are now cached for `5 minutes` before a new one is requested.
2. The cache is automatically invalidated if the wallet's `transaction count changes`, ensuring a genuinely new address is shown if the current one receives pending or confirmed funds.
3. Users can still `manually force a new address` generation via the "Create New Address" button.

## Testing
|IOS|Android|
|-|-|
|<img height="692" alt="Screenshot 2026-04-16 at 21 37 18" src="https://github.com/user-attachments/assets/704adaeb-2ee7-47a0-87e6-b0d5f986e907" />|<img height="692" alt="WhatsApp Image 2026-04-17 at 00 01 52" src="https://github.com/user-attachments/assets/ae700539-60c4-497e-b514-faacff4a61cb" />|

### Platform Coverage

- [x] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on iOS simulator
- [x] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receive addresses auto-refresh and expire after 5 minutes on Android and iOS.
  * Live countdown in the UI: shows "Auto-refresh in XX" during the final minute, then "Refreshing..." and requests a new address.
  * "Create new address" forces an immediate refresh.
  * Intelligent caching limits unnecessary regenerations while ensuring timely updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->