### PR TITLE
feat: add canonical outpoint lock state and APIs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ upload_certificate.pem
 /.jjconflict-base-*
 *.o
 /ios/build
+.DS_Store

--- a/rust/src/database/wallet_data.rs
+++ b/rust/src/database/wallet_data.rs
@@ -1,4 +1,5 @@
 pub mod label;
+pub mod locked_outpoints;
 
 use std::{
     path::{Path, PathBuf},
@@ -6,6 +7,7 @@ use std::{
 };
 
 use label::LabelsTable;
+use locked_outpoints::LockedOutpointsTable;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use redb::{ReadOnlyTable, TableDefinition};
@@ -63,6 +65,7 @@ pub struct WalletDataDb {
     pub id: WalletId,
     pub db: Arc<redb::Database>,
     pub labels: LabelsTable,
+    pub locked_outpoints: LockedOutpointsTable,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -105,6 +108,7 @@ impl WalletDataDb {
             .open_table(TABLE)
             .map_err(|e| WalletDataError::TableAccess { id: id.clone(), error: e.to_string() })?;
         let labels = LabelsTable::new(db.clone(), &write_txn);
+        let locked_outpoints = LockedOutpointsTable::new(db.clone(), &write_txn);
 
         // commit the write transaction
         write_txn.commit().map_err(|e| WalletDataError::DatabaseAccess {
@@ -112,7 +116,7 @@ impl WalletDataDb {
             error: e.to_string(),
         })?;
 
-        Ok(Self { id, db, labels })
+        Ok(Self { id, db, labels, locked_outpoints })
     }
 
     pub fn get_scan_state(&self, address_type: WalletAddressType) -> Result<Option<ScanState>> {

--- a/rust/src/database/wallet_data/locked_outpoints.rs
+++ b/rust/src/database/wallet_data/locked_outpoints.rs
@@ -1,0 +1,443 @@
+use std::sync::Arc;
+
+use redb::{ReadOnlyTable, ReadableTable as _, ReadableTableMetadata as _, TableDefinition};
+
+use crate::database::key::OutPointKey;
+
+use super::Error;
+
+/// Stores locked outpoints as `OutPointKey -> ()`.
+///
+/// An outpoint present in this table is locked.
+/// Absent means unlocked.
+pub(crate) const LOCKED_OUTPOINTS_TABLE: TableDefinition<OutPointKey, ()> =
+    TableDefinition::new("locked_outpoints");
+
+/// 3-state aggregate lock state for a set of outpoints.
+///
+/// Used by the Transaction Details UI to render the correct bulk toggle:
+/// - `Unlocked`: none locked → tap locks all
+/// - `Mixed`: some locked → tap locks all remaining
+/// - `Locked`: all locked → tap unlocks all
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, uniffi::Enum)]
+pub enum UtxoLockState {
+    /// No wallet-owned unspent outputs are locked.
+    Unlocked,
+    /// Some (but not all) wallet-owned unspent outputs are locked.
+    Mixed,
+    /// All wallet-owned unspent outputs are locked.
+    Locked,
+}
+
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct LockedOutpointsTable {
+    db: Arc<redb::Database>,
+}
+
+impl LockedOutpointsTable {
+    /// Create a new `LockedOutpointsTable`, ensuring the table exists.
+    pub fn new(db: Arc<redb::Database>, write_txn: &redb::WriteTransaction) -> Self {
+        write_txn
+            .open_table(LOCKED_OUTPOINTS_TABLE)
+            .expect("failed to create locked outpoints table");
+
+        Self { db }
+    }
+
+    // MARK: READ
+
+    /// Check whether a single outpoint is locked.
+    pub fn is_locked(&self, outpoint: impl Into<OutPointKey>) -> Result<bool, Error> {
+        let key = outpoint.into();
+        let table = self.read_table()?;
+        let locked = table
+            .get(key)
+            .map_err(|error| Error::Read(error.to_string()))?
+            .is_some();
+
+        Ok(locked)
+    }
+
+    /// Return the set of all currently locked outpoints.
+    pub fn all_locked(&self) -> Result<Vec<OutPointKey>, Error> {
+        let table = self.read_table()?;
+        let locked = table
+            .iter()
+            .map_err(|error| Error::Read(error.to_string()))?
+            .filter_map(Result::ok)
+            .map(|(key, _)| key.value())
+            .collect();
+
+        Ok(locked)
+    }
+
+    /// Number of locked outpoints.
+    pub fn count(&self) -> Result<u64, Error> {
+        let table = self.read_table()?;
+        table.len().map_err(|error| Error::Read(error.to_string()))
+    }
+
+    /// Compute the aggregate lock state for a set of wallet-owned unspent outpoints.
+    ///
+    /// `outpoints` should contain only wallet-owned unspent outputs for a transaction.
+    /// Spent outputs and external outputs must be filtered out by the caller.
+    ///
+    /// Returns `None` if the slice is empty (no wallet-owned unspent outputs).
+    pub fn aggregate_lock_state(
+        &self,
+        outpoints: &[OutPointKey],
+    ) -> Result<Option<UtxoLockState>, Error> {
+        if outpoints.is_empty() {
+            return Ok(None);
+        }
+
+        let mut locked_count = 0u64;
+        for outpoint in outpoints {
+            if self.is_locked(outpoint.clone())? {
+                locked_count += 1;
+            }
+        }
+
+        let total = outpoints.len() as u64;
+        let state = if locked_count == 0 {
+            UtxoLockState::Unlocked
+        } else if locked_count == total {
+            UtxoLockState::Locked
+        } else {
+            UtxoLockState::Mixed
+        };
+
+        Ok(Some(state))
+    }
+
+    // MARK: WRITE
+
+    /// Lock a single outpoint.
+    pub fn lock(&self, outpoint: impl Into<OutPointKey>) -> Result<(), Error> {
+        let key = outpoint.into();
+        self.set(key)
+    }
+
+    /// Unlock a single outpoint.
+    pub fn unlock(&self, outpoint: impl Into<OutPointKey>) -> Result<(), Error> {
+        let key = outpoint.into();
+        self.remove(key)
+    }
+
+    /// Lock all given outpoints in a single write transaction.
+    pub fn lock_all(&self, outpoints: &[OutPointKey]) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err(|e| Error::Save(e.to_string()))?;
+
+        {
+            let mut table = write_txn
+                .open_table(LOCKED_OUTPOINTS_TABLE)
+                .map_err(|e| Error::Save(e.to_string()))?;
+
+            for key in outpoints {
+                table.insert(key, ()).map_err(|error| Error::Save(error.to_string()))?;
+            }
+        }
+
+        write_txn.commit().map_err(|e| Error::Save(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Unlock all given outpoints in a single write transaction.
+    pub fn unlock_all(&self, outpoints: &[OutPointKey]) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err(|e| Error::Save(e.to_string()))?;
+
+        {
+            let mut table = write_txn
+                .open_table(LOCKED_OUTPOINTS_TABLE)
+                .map_err(|e| Error::Save(e.to_string()))?;
+
+            for key in outpoints {
+                table.remove(key).map_err(|error| Error::Save(error.to_string()))?;
+            }
+        }
+
+        write_txn.commit().map_err(|e| Error::Save(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Toggle the bulk lock state for a transaction's wallet-owned unspent outpoints.
+    ///
+    /// - If current state is `Unlocked` or `Mixed` → lock all
+    /// - If current state is `Locked` → unlock all
+    ///
+    /// Returns the new aggregate state, or `None` if the slice is empty.
+    pub fn toggle_transaction_lock(
+        &self,
+        outpoints: &[OutPointKey],
+    ) -> Result<Option<UtxoLockState>, Error> {
+        let current = self.aggregate_lock_state(outpoints)?;
+
+        match current {
+            None => Ok(None),
+            Some(UtxoLockState::Locked) => {
+                self.unlock_all(outpoints)?;
+                Ok(Some(UtxoLockState::Unlocked))
+            }
+            Some(UtxoLockState::Unlocked | UtxoLockState::Mixed) => {
+                self.lock_all(outpoints)?;
+                Ok(Some(UtxoLockState::Locked))
+            }
+        }
+    }
+
+    // MARK: PRIVATE
+
+    fn set(&self, key: OutPointKey) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err(|e| Error::Save(e.to_string()))?;
+
+        {
+            let mut table = write_txn
+                .open_table(LOCKED_OUTPOINTS_TABLE)
+                .map_err(|e| Error::Save(e.to_string()))?;
+
+            table.insert(key, ()).map_err(|error| Error::Save(error.to_string()))?;
+        }
+
+        write_txn.commit().map_err(|e| Error::Save(e.to_string()))?;
+        Ok(())
+    }
+
+    fn remove(&self, key: OutPointKey) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err(|e| Error::Save(e.to_string()))?;
+
+        {
+            let mut table = write_txn
+                .open_table(LOCKED_OUTPOINTS_TABLE)
+                .map_err(|e| Error::Save(e.to_string()))?;
+
+            table.remove(key).map_err(|error| Error::Save(error.to_string()))?;
+        }
+
+        write_txn.commit().map_err(|e| Error::Save(e.to_string()))?;
+        Ok(())
+    }
+
+    fn read_table(&self) -> Result<ReadOnlyTable<OutPointKey, ()>, Error> {
+        let read_txn = self.db.begin_read().map_err(|e| Error::Read(e.to_string()))?;
+        let table =
+            read_txn.open_table(LOCKED_OUTPOINTS_TABLE).map_err(|e| Error::Read(e.to_string()))?;
+
+        Ok(table)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{database::wallet_data::WalletDataDb, wallet::metadata::WalletId};
+
+    fn outpoint_key(txid_byte: u8, vout: u32) -> OutPointKey {
+        OutPointKey { id: [txid_byte; 32], index: vout }
+    }
+
+    #[test]
+    fn lock_and_query_single_outpoint() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op = outpoint_key(0xAA, 0);
+
+        assert!(!table.is_locked(op.clone()).unwrap());
+        table.lock(op.clone()).unwrap();
+        assert!(table.is_locked(op.clone()).unwrap());
+    }
+
+    #[test]
+    fn unlock_removes_outpoint() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op = outpoint_key(0xBB, 1);
+
+        table.lock(op.clone()).unwrap();
+        assert!(table.is_locked(op.clone()).unwrap());
+
+        table.unlock(op.clone()).unwrap();
+        assert!(!table.is_locked(op.clone()).unwrap());
+    }
+
+    #[test]
+    fn all_locked_returns_only_locked() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op1 = outpoint_key(0x01, 0);
+        let op2 = outpoint_key(0x02, 0);
+        let op3 = outpoint_key(0x03, 0);
+
+        table.lock(op1.clone()).unwrap();
+        table.lock(op2.clone()).unwrap();
+        // op3 not locked
+
+        let locked = table.all_locked().unwrap();
+        assert_eq!(locked.len(), 2);
+        assert!(locked.contains(&op1));
+        assert!(locked.contains(&op2));
+        assert!(!locked.contains(&op3));
+    }
+
+    #[test]
+    fn aggregate_empty_returns_none() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        assert_eq!(table.aggregate_lock_state(&[]).unwrap(), None);
+    }
+
+    #[test]
+    fn aggregate_all_unlocked() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let ops = vec![outpoint_key(0x01, 0), outpoint_key(0x01, 1)];
+
+        assert_eq!(
+            table.aggregate_lock_state(&ops).unwrap(),
+            Some(UtxoLockState::Unlocked)
+        );
+    }
+
+    #[test]
+    fn aggregate_all_locked() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let ops = vec![outpoint_key(0x01, 0), outpoint_key(0x01, 1)];
+        table.lock_all(&ops).unwrap();
+
+        assert_eq!(
+            table.aggregate_lock_state(&ops).unwrap(),
+            Some(UtxoLockState::Locked)
+        );
+    }
+
+    #[test]
+    fn aggregate_mixed_state() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op1 = outpoint_key(0x01, 0);
+        let op2 = outpoint_key(0x01, 1);
+
+        table.lock(op1.clone()).unwrap();
+        // op2 not locked
+
+        assert_eq!(
+            table.aggregate_lock_state(&[op1, op2]).unwrap(),
+            Some(UtxoLockState::Mixed)
+        );
+    }
+
+    #[test]
+    fn bulk_lock_all() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let ops = vec![outpoint_key(0x01, 0), outpoint_key(0x01, 1), outpoint_key(0x01, 2)];
+        table.lock_all(&ops).unwrap();
+
+        for op in &ops {
+            assert!(table.is_locked(op.clone()).unwrap());
+        }
+    }
+
+    #[test]
+    fn bulk_unlock_all() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let ops = vec![outpoint_key(0x01, 0), outpoint_key(0x01, 1)];
+        table.lock_all(&ops).unwrap();
+        table.unlock_all(&ops).unwrap();
+
+        for op in &ops {
+            assert!(!table.is_locked(op.clone()).unwrap());
+        }
+    }
+
+    #[test]
+    fn toggle_from_unlocked_locks_all() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let ops = vec![outpoint_key(0x01, 0), outpoint_key(0x01, 1)];
+
+        let result = table.toggle_transaction_lock(&ops).unwrap();
+        assert_eq!(result, Some(UtxoLockState::Locked));
+
+        for op in &ops {
+            assert!(table.is_locked(op.clone()).unwrap());
+        }
+    }
+
+    #[test]
+    fn toggle_from_mixed_locks_all() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op1 = outpoint_key(0x01, 0);
+        let op2 = outpoint_key(0x01, 1);
+
+        table.lock(op1.clone()).unwrap();
+        // op2 unlocked → mixed
+
+        let ops = vec![op1.clone(), op2.clone()];
+        let result = table.toggle_transaction_lock(&ops).unwrap();
+        assert_eq!(result, Some(UtxoLockState::Locked));
+
+        assert!(table.is_locked(op1).unwrap());
+        assert!(table.is_locked(op2).unwrap());
+    }
+
+    #[test]
+    fn toggle_from_locked_unlocks_all() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let ops = vec![outpoint_key(0x01, 0), outpoint_key(0x01, 1)];
+        table.lock_all(&ops).unwrap();
+
+        let result = table.toggle_transaction_lock(&ops).unwrap();
+        assert_eq!(result, Some(UtxoLockState::Unlocked));
+
+        for op in &ops {
+            assert!(!table.is_locked(op.clone()).unwrap());
+        }
+    }
+
+    #[test]
+    fn toggle_empty_returns_none() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let result = table.toggle_transaction_lock(&[]).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn lock_is_idempotent() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op = outpoint_key(0xCC, 0);
+        table.lock(op.clone()).unwrap();
+        table.lock(op.clone()).unwrap();
+        assert!(table.is_locked(op).unwrap());
+    }
+
+    #[test]
+    fn unlock_nonexistent_is_noop() {
+        let (db, _tmp) = WalletDataDb::new_test(WalletId::preview_new());
+        let table = &db.locked_outpoints;
+
+        let op = outpoint_key(0xDD, 0);
+        // should not error
+        table.unlock(op.clone()).unwrap();
+        assert!(!table.is_locked(op).unwrap());
+    }
+}


### PR DESCRIPTION
Add LockedOutpointsTable backed by redb for per-outpoint lock storage, using a presence/absence pattern (OutPointKey -> ()) where key present means locked and key absent means unlocked.

Includes:
- CRUD: lock, unlock, is_locked, all_locked, count
- Bulk ops: lock_all, unlock_all (single write txn)
- Aggregate: aggregate_lock_state -> Option<UtxoLockState>
- Toggle: toggle_transaction_lock for Transaction Details UI
- UtxoLockState enum (Unlocked/Mixed/Locked) exposed via UniFFI
- 13 unit tests covering all acceptance criteria

Wired into WalletDataDb as pub locked_outpoints field.
## Closes #657 

## Summary

This is the foundation for the UTXO locking feature track (#168). It adds a new redb table (locked_outpoints) and a LockedOutpointsTable API that stores which outpoints are locked. The table uses a presence/absence pattern — an outpoint key existing in the table means it's locked, absence means unlocked. A UtxoLockState enum provides three-state aggregation (Unlocked/Mixed/Locked) for the Transaction Details UI bulk toggle. All bulk operations (lock_all, unlock_all) use a single write transaction for atomicity.

## Testing

cargo check --lib        # clean
cargo check --tests      # clean
cargo clippy --lib       # zero warnings

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [X] Not tested (Rust-only change, no UI impact yet)


## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [X] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added outpoint locking functionality to manage wallet outputs.
  * Bulk lock/unlock operations available for multiple outputs.
  * Visual lock state aggregation displaying Locked, Unlocked, or Mixed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->