### PR TITLE
 fix: skip unrecognized BIP329 label entries instead of failing the w…

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
@@ -68,8 +68,18 @@ class ScanManager private constructor() {
                     }
 
                     try {
-                        LabelManager(id = selectedWallet).use { it.importLabels(multiFormat.v1) }
-                        app.alertState = TaggedItem(AppAlertState.ImportedLabelsSuccessfully)
+                        val result = LabelManager(id = selectedWallet).use { it.importLabels(multiFormat.v1) }
+                        if (result.skipped > 0u) {
+                            val noun = if (result.skipped == 1u) "label" else "labels"
+                            app.alertState = TaggedItem(
+                                AppAlertState.General(
+                                    title = "Labels Imported",
+                                    message = "Could not import ${result.skipped} $noun"
+                                )
+                            )
+                        } else {
+                            app.alertState = TaggedItem(AppAlertState.ImportedLabelsSuccessfully)
+                        }
 
                         app.walletManager?.let { wm ->
                             mainScope.launch {

--- a/android/app/src/main/java/org/bitcoinppl/cove/nfc/NfcLabelImportSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/nfc/NfcLabelImportSheet.kt
@@ -45,6 +45,7 @@ fun NfcLabelImportSheet(
     labelManager: LabelManager,
     onDismiss: () -> Unit,
     onSuccess: () -> Unit,
+    onPartialSuccess: (skipped: UInt) -> Unit,
     onError: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -86,11 +87,13 @@ fun NfcLabelImportSheet(
                     // try to parse the NFC data as BIP329 labels
                     try {
                         result.text?.let { text ->
-                            // try to import the labels
-                            labelManager.import(text.trim())
-                            // success! dismiss and notify
+                            val importResult = labelManager.import(text.trim())
                             nfcReader.reset()
-                            onSuccess()
+                            if (importResult.skipped > 0u) {
+                                onPartialSuccess(importResult.skipped)
+                            } else {
+                                onSuccess()
+                            }
                             return@collect
                         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/MoreInfoPopover.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/MoreInfoPopover.kt
@@ -65,20 +65,32 @@ fun rememberWalletExportLaunchers(
                         }
 
                         // refresh transactions with updated labels
-                        try {
+                        val refreshFailed = try {
                             currentManager.rust.getTransactions()
+                            false
                         } catch (refreshError: Exception) {
                             android.util.Log.e(tag, "failed to refresh transactions after label import", refreshError)
-                            snackbarHostState.showSnackbar("Labels imported successfully, but transaction list may need manual refresh")
-                            return@launch
+                            true
                         }
 
-                        if (result.skipped > 0u) {
+                        val skippedMsg = if (result.skipped > 0u) {
                             val noun = if (result.skipped == 1u) "label" else "labels"
-                            snackbarHostState.showSnackbar("Labels imported. Could not import ${result.skipped} $noun")
+                            "Could not import ${result.skipped} $noun"
                         } else {
-                            snackbarHostState.showSnackbar("Labels imported successfully")
+                            null
                         }
+
+                        val msg = when {
+                            skippedMsg != null && refreshFailed ->
+                                "Labels imported. $skippedMsg. Transaction list may need manual refresh"
+                            skippedMsg != null ->
+                                "Labels imported. $skippedMsg"
+                            refreshFailed ->
+                                "Labels imported successfully, but transaction list may need manual refresh"
+                            else ->
+                                "Labels imported successfully"
+                        }
+                        snackbarHostState.showSnackbar(msg)
                     } catch (e: Exception) {
                         android.util.Log.e(tag, "error importing labels", e)
                         snackbarHostState.showSnackbar("Unable to import labels: ${e.localizedMessage ?: e.message}")

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/MoreInfoPopover.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/MoreInfoPopover.kt
@@ -60,8 +60,7 @@ fun rememberWalletExportLaunchers(
                                 }
                             } ?: throw Exception("Unable to read file")
 
-                        // validate import was successful before showing success message
-                        currentManager.rust.labelManager().use { labelManager ->
+                        val result = currentManager.rust.labelManager().use { labelManager ->
                             labelManager.import(fileContents.trim())
                         }
 
@@ -74,7 +73,12 @@ fun rememberWalletExportLaunchers(
                             return@launch
                         }
 
-                        snackbarHostState.showSnackbar("Labels imported successfully")
+                        if (result.skipped > 0u) {
+                            val noun = if (result.skipped == 1u) "label" else "labels"
+                            snackbarHostState.showSnackbar("Labels imported. Could not import ${result.skipped} $noun")
+                        } else {
+                            snackbarHostState.showSnackbar("Labels imported successfully")
+                        }
                     } catch (e: Exception) {
                         android.util.Log.e(tag, "error importing labels", e)
                         snackbarHostState.showSnackbar("Unable to import labels: ${e.localizedMessage ?: e.message}")

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
@@ -298,14 +298,15 @@ internal fun WalletSheetsHost(
                 onPartialSuccess = { skipped ->
                     onDismissNfcScanner()
                     scope.launch {
-                        val noun = if (skipped == 1u) "entry" else "entries"
-                        val msg = "Labels imported ($skipped $noun skipped)"
+                        val noun = if (skipped == 1u) "label" else "labels"
+                        val skippedMsg = "Labels imported. Could not import $skipped $noun"
                         try {
                             manager.rust.getTransactions()
+                            snackbarHostState.showSnackbar(skippedMsg)
                         } catch (e: Exception) {
                             android.util.Log.e(tag, "Failed to refresh transactions after partial NFC label import")
+                            snackbarHostState.showSnackbar("$skippedMsg. Transaction list may need manual refresh")
                         }
-                        snackbarHostState.showSnackbar(msg)
                     }
                 },
                 onError = { errorMsg ->

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
@@ -295,6 +295,19 @@ internal fun WalletSheetsHost(
                         }
                     }
                 },
+                onPartialSuccess = { skipped ->
+                    onDismissNfcScanner()
+                    scope.launch {
+                        val noun = if (skipped == 1u) "entry" else "entries"
+                        val msg = "Labels imported ($skipped $noun skipped)"
+                        try {
+                            manager.rust.getTransactions()
+                        } catch (e: Exception) {
+                            android.util.Log.e(tag, "Failed to refresh transactions after partial NFC label import")
+                        }
+                        snackbarHostState.showSnackbar(msg)
+                    }
+                },
                 onError = { errorMsg ->
                     onDismissNfcScanner()
                     scope.launch {

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
@@ -304,7 +304,7 @@ internal fun WalletSheetsHost(
                             manager.rust.getTransactions()
                             snackbarHostState.showSnackbar(skippedMsg)
                         } catch (e: Exception) {
-                            android.util.Log.e(tag, "Failed to refresh transactions after partial NFC label import")
+                            android.util.Log.e(tag, "Failed to refresh transactions after partial NFC label import", e)
                             snackbarHostState.showSnackbar("$skippedMsg. Transaction list may need manual refresh")
                         }
                     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -2388,9 +2388,9 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_labelmanager_has_labels(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_cove_fn_method_labelmanager_import(`ptr`: Long,`jsonl`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): Unit
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_labelmanager_importlabels(`ptr`: Long,`labels`: Long,uniffi_out_err: UniffiRustCallStatus, 
-    ): Unit
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_labelmanager_insert_or_update_labels_for_txn(`ptr`: Long,`details`: Long,`label`: RustBuffer.ByValue,`origin`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     external fun uniffi_cove_fn_method_labelmanager_transaction_label(`ptr`: Long,`txId`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -4004,10 +4004,10 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_labelmanager_has_labels() != 29517.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_labelmanager_import() != 37462.toShort()) {
+    if (lib.uniffi_cove_checksum_method_labelmanager_import() != 57006.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_labelmanager_importlabels() != 52503.toShort()) {
+    if (lib.uniffi_cove_checksum_method_labelmanager_importlabels() != 8041.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_labelmanager_insert_or_update_labels_for_txn() != 51703.toShort()) {
@@ -14001,9 +14001,9 @@ public interface LabelManagerInterface {
     
     fun `hasLabels`(): kotlin.Boolean
     
-    fun `import`(`jsonl`: kotlin.String)
+    fun `import`(`jsonl`: kotlin.String): LabelParseReport
     
-    fun `importLabels`(`labels`: Bip329Labels)
+    fun `importLabels`(`labels`: Bip329Labels): LabelParseReport
     
     fun `insertOrUpdateLabelsForTxn`(`details`: TransactionDetails, `label`: kotlin.String, `origin`: kotlin.String?)
     
@@ -14210,8 +14210,8 @@ open class LabelManager: Disposable, AutoCloseable, LabelManagerInterface
     
 
     
-    @Throws(LabelManagerException::class)override fun `import`(`jsonl`: kotlin.String)
-        = 
+    @Throws(LabelManagerException::class)override fun `import`(`jsonl`: kotlin.String): LabelParseReport {
+            return FfiConverterTypeLabelParseReport.lift(
     callWithHandle {
     uniffiRustCallWithError(LabelManagerException) { _status ->
     UniffiLib.uniffi_cove_fn_method_labelmanager_import(
@@ -14220,12 +14220,13 @@ open class LabelManager: Disposable, AutoCloseable, LabelManagerInterface
         FfiConverterString.lower(`jsonl`),_status)
 }
     }
-    
+    )
+    }
     
 
     
-    @Throws(LabelManagerException::class)override fun `importLabels`(`labels`: Bip329Labels)
-        = 
+    @Throws(LabelManagerException::class)override fun `importLabels`(`labels`: Bip329Labels): LabelParseReport {
+            return FfiConverterTypeLabelParseReport.lift(
     callWithHandle {
     uniffiRustCallWithError(LabelManagerException) { _status ->
     UniffiLib.uniffi_cove_fn_method_labelmanager_importlabels(
@@ -14234,7 +14235,8 @@ open class LabelManager: Disposable, AutoCloseable, LabelManagerInterface
         FfiConverterTypeBip329Labels.lower(`labels`),_status)
 }
     }
-    
+    )
+    }
     
 
     
@@ -27736,6 +27738,8 @@ data class BackupImportReport (
     , 
     var `walletsWithLabelsImported`: kotlin.UInt
     , 
+    var `labelsSkipped`: kotlin.UInt
+    , 
     var `labelsFailedWalletNames`: List<kotlin.String>
     , 
     var `labelsFailedErrors`: List<kotlin.String>
@@ -27777,6 +27781,7 @@ public object FfiConverterTypeBackupImportReport: FfiConverterRustBuffer<BackupI
             FfiConverterSequenceString.read(buf),
             FfiConverterSequenceString.read(buf),
             FfiConverterUInt.read(buf),
+            FfiConverterUInt.read(buf),
             FfiConverterSequenceString.read(buf),
             FfiConverterSequenceString.read(buf),
             FfiConverterBoolean.read(buf),
@@ -27795,6 +27800,7 @@ public object FfiConverterTypeBackupImportReport: FfiConverterRustBuffer<BackupI
             FfiConverterSequenceString.allocationSize(value.`failedWalletNames`) +
             FfiConverterSequenceString.allocationSize(value.`failedWalletErrors`) +
             FfiConverterUInt.allocationSize(value.`walletsWithLabelsImported`) +
+            FfiConverterUInt.allocationSize(value.`labelsSkipped`) +
             FfiConverterSequenceString.allocationSize(value.`labelsFailedWalletNames`) +
             FfiConverterSequenceString.allocationSize(value.`labelsFailedErrors`) +
             FfiConverterBoolean.allocationSize(value.`settingsRestored`) +
@@ -27812,6 +27818,7 @@ public object FfiConverterTypeBackupImportReport: FfiConverterRustBuffer<BackupI
             FfiConverterSequenceString.write(value.`failedWalletNames`, buf)
             FfiConverterSequenceString.write(value.`failedWalletErrors`, buf)
             FfiConverterUInt.write(value.`walletsWithLabelsImported`, buf)
+            FfiConverterUInt.write(value.`labelsSkipped`, buf)
             FfiConverterSequenceString.write(value.`labelsFailedWalletNames`, buf)
             FfiConverterSequenceString.write(value.`labelsFailedErrors`, buf)
             FfiConverterBoolean.write(value.`settingsRestored`, buf)
@@ -29430,6 +29437,44 @@ public object FfiConverterTypeLabelExportResult: FfiConverterRustBuffer<LabelExp
     override fun write(value: LabelExportResult, buf: ByteBuffer) {
             FfiConverterString.write(value.`content`, buf)
             FfiConverterString.write(value.`filename`, buf)
+    }
+}
+
+
+
+data class LabelParseReport (
+    var `imported`: kotlin.UInt
+    , 
+    var `skipped`: kotlin.UInt
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeLabelParseReport: FfiConverterRustBuffer<LabelParseReport> {
+    override fun read(buf: ByteBuffer): LabelParseReport {
+        return LabelParseReport(
+            FfiConverterUInt.read(buf),
+            FfiConverterUInt.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: LabelParseReport) = (
+            FfiConverterUInt.allocationSize(value.`imported`) +
+            FfiConverterUInt.allocationSize(value.`skipped`)
+    )
+
+    override fun write(value: LabelParseReport, buf: ByteBuffer) {
+            FfiConverterUInt.write(value.`imported`, buf)
+            FfiConverterUInt.write(value.`skipped`, buf)
     }
 }
 

--- a/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
@@ -448,13 +448,24 @@ struct SelectedWalletScreen: View {
         }
 
         do {
-            try labelManager.importLabels(labels: labels)
-            app.alertState = .init(
-                .general(
-                    title: "Success!",
-                    message: "Labels have been imported successfully."
+            let result = try labelManager.importLabels(labels: labels)
+            if result.skipped > 0 {
+                app.alertState = .init(
+                    .general(
+                        title: "Labels Imported",
+                        message: "Could not import \(result.skipped) labels"
+                    )
                 )
-            )
+            } else {
+                app.alertState = .init(
+                    .general(
+                        title: "Success!",
+                        message: "Labels have been imported successfully."
+                    )
+                )
+            }
+
+            Task { await manager.rust.getTransactions() }
 
         } catch {
             app.alertState = .init(

--- a/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
@@ -368,14 +368,24 @@ struct SelectedWalletScreen: View {
             do {
                 let file = try result.get()
                 let fileContents = try FileReader(for: file).read()
-                try labelManager.import(jsonl: fileContents)
+                let result = try labelManager.import(jsonl: fileContents)
 
-                app.alertState = .init(
-                    .general(
-                        title: "Success!",
-                        message: "Labels have been imported successfully."
+                if result.skipped > 0 {
+                    let noun = result.skipped == 1 ? "label" : "labels"
+                    app.alertState = .init(
+                        .general(
+                            title: "Labels Imported",
+                            message: "Could not import \(result.skipped) \(noun)"
+                        )
                     )
-                )
+                } else {
+                    app.alertState = .init(
+                        .general(
+                            title: "Success!",
+                            message: "Labels have been imported successfully."
+                        )
+                    )
+                }
 
                 // when labels are imported, we need to get the transactions again with the updated labels
                 Task { await manager.rust.getTransactions() }
@@ -450,10 +460,11 @@ struct SelectedWalletScreen: View {
         do {
             let result = try labelManager.importLabels(labels: labels)
             if result.skipped > 0 {
+                let noun = result.skipped == 1 ? "label" : "labels"
                 app.alertState = .init(
                     .general(
                         title: "Labels Imported",
-                        message: "Could not import \(result.skipped) labels"
+                        message: "Could not import \(result.skipped) \(noun)"
                     )
                 )
             } else {

--- a/ios/Cove/ScanManager.swift
+++ b/ios/Cove/ScanManager.swift
@@ -35,8 +35,16 @@ import SwiftUI
                     return setInvalidLabels()
                 }
 
-                try LabelManager(id: selectedWallet).import(labels: labels)
-                app.alertState = .init(.importedLabelsSuccessfully)
+                let report = try LabelManager(id: selectedWallet).import(labels: labels)
+                if report.skipped > 0 {
+                    let noun = report.skipped == 1 ? "label" : "labels"
+                    app.alertState = .init(.general(
+                        title: "Labels Imported",
+                        message: "Could not import \(report.skipped) \(noun)"
+                    ))
+                } else {
+                    app.alertState = .init(.importedLabelsSuccessfully)
+                }
                 Task { await manager.rust.getTransactions() }
             }
         } catch {
@@ -97,7 +105,18 @@ import SwiftUI
                 Log.error(panic)
             case let .bip329Labels(labels):
                 if let selectedWallet = Database().globalConfig().selectedWallet() {
-                    return try LabelManager(id: selectedWallet).import(labels: labels)
+                    let report = try LabelManager(id: selectedWallet).import(labels: labels)
+                    if report.skipped > 0 {
+                        let noun = report.skipped == 1 ? "label" : "labels"
+                        app.alertState = TaggedItem(.general(
+                            title: "Labels Imported",
+                            message: "Could not import \(report.skipped) \(noun)"
+                        ))
+                    } else {
+                        app.alertState = TaggedItem(.importedLabelsSuccessfully)
+                    }
+                    Task { await app.walletManager?.rust.getTransactions() }
+                    return
                 }
 
                 app.alertState = TaggedItem(

--- a/ios/CoveCore/Sources/CoveCore/CoveCore.swift
+++ b/ios/CoveCore/Sources/CoveCore/CoveCore.swift
@@ -83,7 +83,7 @@ public extension FiatOrBtc {
 }
 
 public extension LabelManager {
-    func `import`(labels: Bip329Labels) throws {
+    func `import`(labels: Bip329Labels) throws -> LabelParseReport {
         try importLabels(labels: labels)
     }
 }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -5093,9 +5093,9 @@ public protocol LabelManagerProtocol: AnyObject, Sendable {
     
     func hasLabels()  -> Bool
     
-    func `import`(jsonl: String) throws 
+    func `import`(jsonl: String) throws  -> LabelParseReport
     
-    func importLabels(labels: Bip329Labels) throws 
+    func importLabels(labels: Bip329Labels) throws  -> LabelParseReport
     
     func insertOrUpdateLabelsForTxn(details: TransactionDetails, label: String, origin: String?) throws 
     
@@ -5229,22 +5229,24 @@ open func hasLabels() -> Bool  {
 })
 }
     
-open func `import`(jsonl: String)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
+open func `import`(jsonl: String)throws  -> LabelParseReport  {
+    return try  FfiConverterTypeLabelParseReport_lift(try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
         uniffiCallStatus in
     uniffi_cove_fn_method_labelmanager_import(
             self.uniffiCloneHandle(),
         FfiConverterString.lower(jsonl),uniffiCallStatus
     )
-}
+})
 }
     
-open func importLabels(labels: Bip329Labels)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
+open func importLabels(labels: Bip329Labels)throws  -> LabelParseReport  {
+    return try  FfiConverterTypeLabelParseReport_lift(try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
         uniffiCallStatus in
     uniffi_cove_fn_method_labelmanager_importlabels(
             self.uniffiCloneHandle(),
         FfiConverterTypeBip329Labels_lower(labels),uniffiCallStatus
     )
-}
+})
 }
     
 open func insertOrUpdateLabelsForTxn(details: TransactionDetails, label: String, origin: String?)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
@@ -13102,6 +13104,7 @@ public struct BackupImportReport: Equatable, Hashable {
     public var failedWalletNames: [String]
     public var failedWalletErrors: [String]
     public var walletsWithLabelsImported: UInt32
+    public var labelsSkipped: UInt32
     public var labelsFailedWalletNames: [String]
     public var labelsFailedErrors: [String]
     public var settingsRestored: Bool
@@ -13117,7 +13120,7 @@ public struct BackupImportReport: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(walletsImported: UInt32, importedWalletNames: [String], walletsSkipped: UInt32, skippedWalletNames: [String], walletsFailed: UInt32, failedWalletNames: [String], failedWalletErrors: [String], walletsWithLabelsImported: UInt32, labelsFailedWalletNames: [String], labelsFailedErrors: [String], settingsRestored: Bool, settingsError: String?, 
+    public init(walletsImported: UInt32, importedWalletNames: [String], walletsSkipped: UInt32, skippedWalletNames: [String], walletsFailed: UInt32, failedWalletNames: [String], failedWalletErrors: [String], walletsWithLabelsImported: UInt32, labelsSkipped: UInt32, labelsFailedWalletNames: [String], labelsFailedErrors: [String], settingsRestored: Bool, settingsError: String?, 
         /**
          * Wallets imported with degraded functionality (e.g. unknown secret type)
          */degradedWalletNames: [String], 
@@ -13132,6 +13135,7 @@ public struct BackupImportReport: Equatable, Hashable {
         self.failedWalletNames = failedWalletNames
         self.failedWalletErrors = failedWalletErrors
         self.walletsWithLabelsImported = walletsWithLabelsImported
+        self.labelsSkipped = labelsSkipped
         self.labelsFailedWalletNames = labelsFailedWalletNames
         self.labelsFailedErrors = labelsFailedErrors
         self.settingsRestored = settingsRestored
@@ -13164,6 +13168,7 @@ public struct FfiConverterTypeBackupImportReport: FfiConverterRustBuffer {
                 failedWalletNames: FfiConverterSequenceString.read(from: &buf), 
                 failedWalletErrors: FfiConverterSequenceString.read(from: &buf), 
                 walletsWithLabelsImported: FfiConverterUInt32.read(from: &buf), 
+                labelsSkipped: FfiConverterUInt32.read(from: &buf), 
                 labelsFailedWalletNames: FfiConverterSequenceString.read(from: &buf), 
                 labelsFailedErrors: FfiConverterSequenceString.read(from: &buf), 
                 settingsRestored: FfiConverterBool.read(from: &buf), 
@@ -13182,6 +13187,7 @@ public struct FfiConverterTypeBackupImportReport: FfiConverterRustBuffer {
         FfiConverterSequenceString.write(value.failedWalletNames, into: &buf)
         FfiConverterSequenceString.write(value.failedWalletErrors, into: &buf)
         FfiConverterUInt32.write(value.walletsWithLabelsImported, into: &buf)
+        FfiConverterUInt32.write(value.labelsSkipped, into: &buf)
         FfiConverterSequenceString.write(value.labelsFailedWalletNames, into: &buf)
         FfiConverterSequenceString.write(value.labelsFailedErrors, into: &buf)
         FfiConverterBool.write(value.settingsRestored, into: &buf)
@@ -15274,6 +15280,60 @@ public func FfiConverterTypeLabelExportResult_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeLabelExportResult_lower(_ value: LabelExportResult) -> RustBuffer {
     return FfiConverterTypeLabelExportResult.lower(value)
+}
+
+
+public struct LabelParseReport: Equatable, Hashable {
+    public var imported: UInt32
+    public var skipped: UInt32
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(imported: UInt32, skipped: UInt32) {
+        self.imported = imported
+        self.skipped = skipped
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension LabelParseReport: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeLabelParseReport: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LabelParseReport {
+        return
+            try LabelParseReport(
+                imported: FfiConverterUInt32.read(from: &buf), 
+                skipped: FfiConverterUInt32.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: LabelParseReport, into buf: inout [UInt8]) {
+        FfiConverterUInt32.write(value.imported, into: &buf)
+        FfiConverterUInt32.write(value.skipped, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLabelParseReport_lift(_ buf: RustBuffer) throws -> LabelParseReport {
+    return try FfiConverterTypeLabelParseReport.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLabelParseReport_lower(_ value: LabelParseReport) -> RustBuffer {
+    return FfiConverterTypeLabelParseReport.lower(value)
 }
 
 
@@ -38585,10 +38645,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_labelmanager_has_labels() != 29517) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_labelmanager_import() != 37462) {
+    if (uniffi_cove_checksum_method_labelmanager_import() != 57006) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_labelmanager_importlabels() != 52503) {
+    if (uniffi_cove_checksum_method_labelmanager_importlabels() != 8041) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_labelmanager_insert_or_update_labels_for_txn() != 51703) {

--- a/rust/src/backup/import.rs
+++ b/rust/src/backup/import.rs
@@ -534,7 +534,14 @@ pub(crate) fn cleanup_failed_wallet(metadata: &WalletMetadata) -> Vec<String> {
 
 fn import_labels(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
     let manager = LabelManager::new(id.clone());
-    manager.import(jsonl).map(|_| ()).map_err_str(BackupError::Restore)
+    manager.import(jsonl).map_err_str(BackupError::Restore)?;
+    Ok(())
+}
+
+fn import_labels_preserve_backup(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
+    let manager = LabelManager::new(id.clone());
+    manager.import_without_cloud_backup_dirty(jsonl).map_err_str(BackupError::Restore)?;
+    Ok(())
 }
 
 pub(crate) fn restore_wallet_labels(
@@ -547,13 +554,11 @@ pub(crate) fn restore_wallet_labels(
         return LabelRestoreOutcome::default();
     };
 
-    let manager = LabelManager::new(wallet_id.clone());
     let import_result = match behavior {
         LabelRestoreBehavior::MarkCloudBackupDirty => import_labels(wallet_id, jsonl),
-        LabelRestoreBehavior::PreserveCloudBackupClean => manager
-            .import_without_cloud_backup_dirty(jsonl)
-            .map(|_| ())
-            .map_err_str(BackupError::Restore),
+        LabelRestoreBehavior::PreserveCloudBackupClean => {
+            import_labels_preserve_backup(wallet_id, jsonl)
+        }
     };
 
     match import_result {

--- a/rust/src/backup/import.rs
+++ b/rust/src/backup/import.rs
@@ -533,7 +533,7 @@ pub(crate) fn cleanup_failed_wallet(metadata: &WalletMetadata) -> Vec<String> {
 
 fn import_labels(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
     let manager = LabelManager::new(id.clone());
-    manager.import(jsonl).map_err(|e| BackupError::Restore(e.to_string()))
+    manager.import(jsonl).map(drop).map_err(|e| BackupError::Restore(e.to_string()))
 }
 
 pub(crate) fn restore_wallet_labels(
@@ -551,6 +551,7 @@ pub(crate) fn restore_wallet_labels(
         LabelRestoreBehavior::MarkCloudBackupDirty => import_labels(wallet_id, jsonl),
         LabelRestoreBehavior::PreserveCloudBackupClean => manager
             .import_without_cloud_backup_dirty(jsonl)
+            .map(drop)
             .map_err(|error| BackupError::Restore(error.to_string())),
     };
 

--- a/rust/src/backup/import.rs
+++ b/rust/src/backup/import.rs
@@ -11,7 +11,7 @@ use cove_types::network::Network;
 
 use crate::database::Database;
 use crate::database::global_config::GlobalConfigKey;
-use crate::label_manager::LabelManager;
+use crate::label_manager::{LabelManager, LabelParseReport};
 use crate::mnemonic::MnemonicExt as _;
 use crate::wallet::fingerprint::Fingerprint;
 use crate::wallet::metadata::{WalletId, WalletMetadata, WalletMode, WalletType};
@@ -43,6 +43,7 @@ pub async fn import_all(
             Ok(RestoreResult::Imported {
                 name,
                 labels_imported,
+                labels_skipped,
                 labels_failure,
                 fingerprint,
                 degraded,
@@ -51,6 +52,7 @@ pub async fn import_all(
                 if labels_imported {
                     report.wallets_with_labels_imported += 1;
                 }
+                report.labels_skipped += labels_skipped;
                 if let Some((name, error)) = labels_failure {
                     report.labels_failed_wallet_names.push(name);
                     report.labels_failed_errors.push(error);
@@ -121,6 +123,7 @@ enum RestoreResult {
     Imported {
         name: String,
         labels_imported: bool,
+        labels_skipped: u32,
         labels_failure: Option<(String, String)>,
         fingerprint: Option<(Fingerprint, Network, WalletMode)>,
         degraded: bool,
@@ -271,6 +274,7 @@ pub(crate) struct LabelRestoreWarning {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct LabelRestoreOutcome {
     pub imported: bool,
+    pub skipped: u32,
     pub warning: Option<LabelRestoreWarning>,
 }
 
@@ -331,12 +335,20 @@ async fn restore_wallet(
         LabelRestoreBehavior::MarkCloudBackupDirty,
     );
     let labels_imported = labels_outcome.imported;
+    let labels_skipped = labels_outcome.skipped;
     if let Some(warning) = labels_outcome.warning {
         warn!("Failed to import labels for wallet {name}: {}", warning.error);
         labels_failure = Some((warning.wallet_name, warning.error));
     }
 
-    Ok(RestoreResult::Imported { name, labels_imported, labels_failure, fingerprint, degraded })
+    Ok(RestoreResult::Imported {
+        name,
+        labels_imported,
+        labels_skipped,
+        labels_failure,
+        fingerprint,
+        degraded,
+    })
 }
 
 /// Run a restore operation, cleaning up on failure
@@ -532,16 +544,17 @@ pub(crate) fn cleanup_failed_wallet(metadata: &WalletMetadata) -> Vec<String> {
     failures
 }
 
-fn import_labels(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
+fn import_labels(id: &WalletId, jsonl: &str) -> Result<LabelParseReport, BackupError> {
     let manager = LabelManager::new(id.clone());
-    manager.import(jsonl).map_err_str(BackupError::Restore)?;
-    Ok(())
+    manager.import(jsonl).map_err_str(BackupError::Restore)
 }
 
-fn import_labels_preserve_backup(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
+fn import_labels_preserve_backup(
+    id: &WalletId,
+    jsonl: &str,
+) -> Result<LabelParseReport, BackupError> {
     let manager = LabelManager::new(id.clone());
-    manager.import_without_cloud_backup_dirty(jsonl).map_err_str(BackupError::Restore)?;
-    Ok(())
+    manager.import_without_cloud_backup_dirty(jsonl).map_err_str(BackupError::Restore)
 }
 
 pub(crate) fn restore_wallet_labels(
@@ -562,9 +575,14 @@ pub(crate) fn restore_wallet_labels(
     };
 
     match import_result {
-        Ok(()) => LabelRestoreOutcome { imported: true, warning: None },
+        Ok(report) => LabelRestoreOutcome {
+            imported: report.imported > 0,
+            skipped: report.skipped,
+            warning: None,
+        },
         Err(error) => LabelRestoreOutcome {
             imported: false,
+            skipped: 0,
             warning: Some(LabelRestoreWarning {
                 wallet_name: wallet_name.to_string(),
                 error: error.to_string(),

--- a/rust/src/backup/import.rs
+++ b/rust/src/backup/import.rs
@@ -533,7 +533,8 @@ pub(crate) fn cleanup_failed_wallet(metadata: &WalletMetadata) -> Vec<String> {
 
 fn import_labels(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
     let manager = LabelManager::new(id.clone());
-    manager.import(jsonl).map(drop).map_err(|e| BackupError::Restore(e.to_string()))
+    manager.import(jsonl).map_err(|e| BackupError::Restore(e.to_string()))?;
+    Ok(())
 }
 
 pub(crate) fn restore_wallet_labels(
@@ -551,8 +552,8 @@ pub(crate) fn restore_wallet_labels(
         LabelRestoreBehavior::MarkCloudBackupDirty => import_labels(wallet_id, jsonl),
         LabelRestoreBehavior::PreserveCloudBackupClean => manager
             .import_without_cloud_backup_dirty(jsonl)
-            .map(drop)
-            .map_err(|error| BackupError::Restore(error.to_string())),
+            .map_err(|error| BackupError::Restore(error.to_string()))
+            .map(|_| ()),
     };
 
     match import_result {

--- a/rust/src/backup/import.rs
+++ b/rust/src/backup/import.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr as _;
 
 use bip39::Mnemonic;
+use cove_util::result_ext::ResultExt as _;
 use strum::IntoEnumIterator as _;
 use tracing::{error, info, warn};
 use zeroize::Zeroizing;
@@ -533,8 +534,7 @@ pub(crate) fn cleanup_failed_wallet(metadata: &WalletMetadata) -> Vec<String> {
 
 fn import_labels(id: &WalletId, jsonl: &str) -> Result<(), BackupError> {
     let manager = LabelManager::new(id.clone());
-    manager.import(jsonl).map_err(|e| BackupError::Restore(e.to_string()))?;
-    Ok(())
+    manager.import(jsonl).map(|_| ()).map_err_str(BackupError::Restore)
 }
 
 pub(crate) fn restore_wallet_labels(
@@ -552,8 +552,8 @@ pub(crate) fn restore_wallet_labels(
         LabelRestoreBehavior::MarkCloudBackupDirty => import_labels(wallet_id, jsonl),
         LabelRestoreBehavior::PreserveCloudBackupClean => manager
             .import_without_cloud_backup_dirty(jsonl)
-            .map_err(|error| BackupError::Restore(error.to_string()))
-            .map(|_| ()),
+            .map(|_| ())
+            .map_err_str(BackupError::Restore),
     };
 
     match import_result {

--- a/rust/src/backup/model.rs
+++ b/rust/src/backup/model.rs
@@ -144,6 +144,7 @@ pub struct BackupImportReport {
     pub failed_wallet_names: Vec<String>,
     pub failed_wallet_errors: Vec<String>,
     pub wallets_with_labels_imported: u32,
+    pub labels_skipped: u32,
     pub labels_failed_wallet_names: Vec<String>,
     pub labels_failed_errors: Vec<String>,
     pub settings_restored: bool,

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use cove_util::result_ext::ResultExt as _;
+use tracing::{debug, warn};
 
 use crate::{
     database::{InsertOrUpdate, Record, record::Timestamps, wallet_data::WalletDataDb},
@@ -55,6 +56,12 @@ pub enum LabelManagerError {
 
 pub type Error = LabelManagerError;
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct LabelParseReport {
+    pub imported: u32,
+    pub skipped: u32,
+}
 
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct AddressArgs {
@@ -231,13 +238,17 @@ impl LabelManager {
     }
 
     #[uniffi::method(name = "importLabels")]
-    pub fn _import_labels(&self, labels: Arc<Bip329Labels>) -> Result<(), LabelManagerError> {
+    pub fn _import_labels(
+        &self,
+        labels: Arc<Bip329Labels>,
+    ) -> Result<LabelParseReport, LabelManagerError> {
         let labels = Arc::unwrap_or_clone(labels);
         self.import_labels(labels.0)
     }
 
-    pub fn import(&self, jsonl: &str) -> Result<(), LabelManagerError> {
-        self.save_imported_labels(parse_labels(jsonl)?, true)
+    pub fn import(&self, jsonl: &str) -> Result<LabelParseReport, LabelManagerError> {
+        let (labels, report) = parse_labels(jsonl)?;
+        self.save_imported_labels(labels, report, true)
     }
 
     pub async fn export(&self) -> Result<String, LabelManagerError> {
@@ -299,28 +310,47 @@ impl LabelManager {
         Ok(Self { db })
     }
 
-    pub fn import_labels(&self, labels: impl Into<Labels>) -> Result<(), LabelManagerError> {
-        self.save_imported_labels(labels.into(), true)
+    pub fn import_labels(
+        &self,
+        labels: impl Into<Labels>,
+    ) -> Result<LabelParseReport, LabelManagerError> {
+        let labels = labels.into();
+        // Count only supported variants — insert_label_with_write_txn silently drops
+        // PublicKey and ExtendedPublicKey, so labels.len() would overstate the import count.
+        let supported = labels
+            .iter()
+            .filter(|l| {
+                matches!(
+                    l,
+                    Label::Transaction(_) | Label::Address(_) | Label::Input(_) | Label::Output(_)
+                )
+            })
+            .count() as u32;
+        let skipped = labels.len() as u32 - supported;
+        let report = LabelParseReport { imported: supported, skipped };
+        self.save_imported_labels(labels, report, true)
     }
 
     pub(crate) fn import_without_cloud_backup_dirty(
         &self,
         jsonl: &str,
-    ) -> Result<(), LabelManagerError> {
-        self.save_imported_labels(parse_labels(jsonl)?, false)
+    ) -> Result<LabelParseReport, LabelManagerError> {
+        let (labels, report) = parse_labels(jsonl)?;
+        self.save_imported_labels(labels, report, false)
     }
 
     fn save_imported_labels(
         &self,
         labels: Labels,
+        report: LabelParseReport,
         mark_cloud_backup_dirty: bool,
-    ) -> Result<(), LabelManagerError> {
+    ) -> Result<LabelParseReport, LabelManagerError> {
         self.db.labels.insert_labels(labels).map_err_str(LabelManagerError::Save)?;
         if mark_cloud_backup_dirty {
             self.mark_cloud_backup_dirty();
         }
 
-        Ok(())
+        Ok(report)
     }
 
     fn mark_cloud_backup_dirty(&self) {
@@ -524,6 +554,105 @@ impl LabelManager {
     }
 }
 
-fn parse_labels(jsonl: &str) -> Result<Labels, LabelManagerError> {
-    Labels::try_from_str(jsonl).map_err_str(LabelManagerError::Parse)
+fn parse_labels(jsonl: &str) -> Result<(Labels, LabelParseReport), LabelManagerError> {
+    let lines: Vec<&str> = jsonl.trim().lines().filter(|line| !line.trim().is_empty()).collect();
+
+    if lines.is_empty() {
+        return Ok((Labels::new(vec![]), LabelParseReport { imported: 0, skipped: 0 }));
+    }
+
+    let mut parsed = Vec::with_capacity(lines.len());
+    let mut first_error: Option<String> = None;
+    let mut skipped = 0u32;
+
+    for line in &lines {
+        match serde_json::from_str::<Label>(line) {
+            Ok(label) => {
+                if matches!(
+                    label,
+                    Label::Transaction(_) | Label::Address(_) | Label::Input(_) | Label::Output(_)
+                ) {
+                    parsed.push(label);
+                } else {
+                    debug!("skipping unsupported label type");
+                    skipped += 1;
+                }
+            }
+            Err(e) => {
+                if first_error.is_none() {
+                    first_error = Some(e.to_string());
+                }
+                debug!("skipping unrecognized label entry: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    if parsed.is_empty() {
+        return Err(LabelManagerError::Parse(first_error.unwrap_or_default()));
+    }
+
+    if skipped > 0 {
+        warn!(
+            "imported {} of {} labels, skipped {skipped} unrecognized entries",
+            parsed.len(),
+            lines.len()
+        );
+    }
+
+    let report = LabelParseReport { imported: parsed.len() as u32, skipped };
+    Ok((Labels::new(parsed), report))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_TX: &str = r#"{"type":"tx","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd","label":"test tx"}"#;
+    const VALID_OUTPUT: &str = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:0","label":"test output"}"#;
+    const VALID_INPUT: &str = r#"{"type":"input","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"test input"}"#;
+
+    // Nunchuk-style invalid output ref: vout contains non-numeric characters
+    const BAD_VOUT_OUTPUT: &str = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:bad","label":"broken"}"#;
+
+    #[test]
+    fn test_parse_labels_valid() {
+        let jsonl = format!("{VALID_TX}\n{VALID_OUTPUT}\n{VALID_INPUT}");
+        let (labels, report) = parse_labels(&jsonl).unwrap();
+        assert_eq!(labels.len(), 3);
+        assert_eq!(report.imported, 3);
+        assert_eq!(report.skipped, 0);
+    }
+
+    #[test]
+    fn test_parse_labels_skips_bad_vout_line() {
+        let jsonl = format!("{VALID_TX}\n{BAD_VOUT_OUTPUT}\n{VALID_OUTPUT}");
+        let (labels, report) = parse_labels(&jsonl).unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(report.imported, 2);
+        assert_eq!(report.skipped, 1);
+    }
+
+    #[test]
+    fn test_parse_labels_all_invalid_returns_error() {
+        let jsonl = format!("{BAD_VOUT_OUTPUT}\n{BAD_VOUT_OUTPUT}");
+        assert!(parse_labels(&jsonl).is_err());
+    }
+
+    #[test]
+    fn test_parse_labels_empty_returns_empty() {
+        let (labels, report) = parse_labels("").unwrap();
+        assert!(labels.is_empty());
+        assert_eq!(report.imported, 0);
+        assert_eq!(report.skipped, 0);
+    }
+
+    #[test]
+    fn test_parse_labels_ignores_blank_lines() {
+        let jsonl = format!("{VALID_TX}\n\n   \n{VALID_OUTPUT}");
+        let (labels, report) = parse_labels(&jsonl).unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(report.imported, 2);
+        assert_eq!(report.skipped, 0);
+    }
 }

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -243,7 +243,10 @@ impl LabelManager {
         labels: Arc<Bip329Labels>,
     ) -> Result<LabelParseReport, LabelManagerError> {
         let labels = Arc::unwrap_or_clone(labels);
-        self.import_labels(labels.0)
+        let parse_skipped = labels.parse_skipped;
+        let mut report = self.import_labels(labels.labels)?;
+        report.skipped += parse_skipped;
+        Ok(report)
     }
 
     pub fn import(&self, jsonl: &str) -> Result<LabelParseReport, LabelManagerError> {
@@ -327,6 +330,9 @@ impl LabelManager {
             )
         };
         let supported = labels.iter().filter(is_supported).count() as u32;
+        if supported == 0 {
+            return Err(LabelManagerError::Parse("no supported labels found".to_string()));
+        }
         let skipped = labels.len() as u32 - supported;
         let report = LabelParseReport { imported: supported, skipped };
         self.save_imported_labels(labels, report, true)

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -238,7 +238,7 @@ impl LabelManager {
     }
 
     #[uniffi::method(name = "importLabels")]
-    pub fn _import_labels(
+    pub fn ffi_import_labels(
         &self,
         labels: Arc<Bip329Labels>,
     ) -> Result<LabelParseReport, LabelManagerError> {
@@ -248,6 +248,9 @@ impl LabelManager {
 
     pub fn import(&self, jsonl: &str) -> Result<LabelParseReport, LabelManagerError> {
         let (labels, report) = parse_labels(jsonl)?;
+        if labels.is_empty() {
+            return Ok(report);
+        }
         self.save_imported_labels(labels, report, true)
     }
 
@@ -315,17 +318,15 @@ impl LabelManager {
         labels: impl Into<Labels>,
     ) -> Result<LabelParseReport, LabelManagerError> {
         let labels = labels.into();
-        // Count only supported variants — insert_label_with_write_txn silently drops
+        // count only supported variants — insert_label_with_write_txn silently drops
         // PublicKey and ExtendedPublicKey, so labels.len() would overstate the import count.
-        let supported = labels
-            .iter()
-            .filter(|l| {
-                matches!(
-                    l,
-                    Label::Transaction(_) | Label::Address(_) | Label::Input(_) | Label::Output(_)
-                )
-            })
-            .count() as u32;
+        let is_supported = |l: &&Label| {
+            matches!(
+                l,
+                Label::Transaction(_) | Label::Address(_) | Label::Input(_) | Label::Output(_)
+            )
+        };
+        let supported = labels.iter().filter(is_supported).count() as u32;
         let skipped = labels.len() as u32 - supported;
         let report = LabelParseReport { imported: supported, skipped };
         self.save_imported_labels(labels, report, true)
@@ -589,7 +590,9 @@ fn parse_labels(jsonl: &str) -> Result<(Labels, LabelParseReport), LabelManagerE
     }
 
     if parsed.is_empty() {
-        return Err(LabelManagerError::Parse(first_error.unwrap_or_default()));
+        return Err(LabelManagerError::Parse(
+            first_error.unwrap_or_else(|| "no supported label types found".to_string()),
+        ));
     }
 
     if skipped > 0 {

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -144,13 +144,22 @@ impl MultiFormat {
 
         // try and parse bip329 labels — tolerant: skip unparseable lines so a single
         // malformed entry doesn't discard all valid labels in the file
-        let parsed_labels: Vec<bip329::Label> = string
-            .trim()
-            .lines()
-            .filter_map(|line| bip329::Label::try_from_str(line.trim()).ok())
+        let lines: Vec<&str> = string.lines().map(str::trim).filter(|l| !l.is_empty()).collect();
+        let total = lines.len();
+        let parsed_labels: Vec<bip329::Label> = lines
+            .into_iter()
+            .filter_map(|line| {
+                bip329::Label::try_from_str(line)
+                    .inspect_err(|e| debug!("skipping bip329 line: {e}"))
+                    .ok()
+            })
             .collect();
         if !parsed_labels.is_empty() {
-            return Ok(Self::Bip329Labels(Arc::new(bip329::Labels::new(parsed_labels).into())));
+            let parse_skipped = (total - parsed_labels.len()) as u32;
+            return Ok(Self::Bip329Labels(Arc::new(Bip329Labels {
+                labels: bip329::Labels::new(parsed_labels),
+                parse_skipped,
+            })));
         }
 
         if string.contains("tapsigner.com/start") {
@@ -350,19 +359,36 @@ impl StringOrData {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    uniffi::Object,
-    derive_more::Into,
-    derive_more::From,
-    derive_more::Deref,
-    derive_more::AsRef,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+pub struct Bip329Labels {
+    pub labels: bip329::Labels,
+    pub parse_skipped: u32,
+}
 
-pub struct Bip329Labels(pub bip329::Labels);
+impl From<bip329::Labels> for Bip329Labels {
+    fn from(labels: bip329::Labels) -> Self {
+        Self { labels, parse_skipped: 0 }
+    }
+}
+
+impl From<Bip329Labels> for bip329::Labels {
+    fn from(b: Bip329Labels) -> Self {
+        b.labels
+    }
+}
+
+impl std::ops::Deref for Bip329Labels {
+    type Target = bip329::Labels;
+    fn deref(&self) -> &Self::Target {
+        &self.labels
+    }
+}
+
+impl AsRef<bip329::Labels> for Bip329Labels {
+    fn as_ref(&self) -> &bip329::Labels {
+        &self.labels
+    }
+}
 
 impl From<cove_tap_card::TapSigner> for MultiFormat {
     fn from(tap_signer: cove_tap_card::TapSigner) -> Self {
@@ -688,5 +714,20 @@ mod tests {
             "Base64 path and UR path produce different PSBT bytes"
         );
         assert_eq!(original_bytes, path1_bytes, "Parsed PSBT differs from original bytes");
+    }
+
+    #[test]
+    fn bip329_mixed_payload_tracks_skipped_count() {
+        const VALID: &str = r#"{"type":"tx","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd","label":"test"}"#;
+        const INVALID: &str = "this is not valid jsonl";
+        let payload = format!("{VALID}\n{INVALID}\n{VALID}");
+
+        let result = MultiFormat::try_from_string(&payload).expect("should parse with skipped");
+        let MultiFormat::Bip329Labels(labels) = result else {
+            panic!("expected Bip329Labels");
+        };
+
+        assert_eq!(labels.labels.len(), 2, "two valid labels parsed");
+        assert_eq!(labels.parse_skipped, 1, "one malformed line skipped");
     }
 }

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -142,9 +142,15 @@ impl MultiFormat {
             return Ok(Self::Transaction(Arc::new(txn)));
         }
 
-        // try and parse bip329 labels
-        if let Ok(labels) = bip329::Labels::try_from_str(string) {
-            return Ok(Self::Bip329Labels(Arc::new(labels.into())));
+        // try and parse bip329 labels — tolerant: skip unparseable lines so a single
+        // malformed entry doesn't discard all valid labels in the file
+        let parsed_labels: Vec<bip329::Label> = string
+            .trim()
+            .lines()
+            .filter_map(|line| bip329::Label::try_from_str(line.trim()).ok())
+            .collect();
+        if !parsed_labels.is_empty() {
+            return Ok(Self::Bip329Labels(Arc::new(bip329::Labels::new(parsed_labels).into())));
         }
 
         if string.contains("tapsigner.com/start") {


### PR DESCRIPTION
## Summary

Fixes #277

When importing BIP329 labels from Nunchuck, a single entry with an unrecognized ref format (e.g. non-numeric `vout`) caused the entire import to fail with `"Unable to parse file: error parsing vout"`, resulting in all labels being lost.

`parse_labels` now processes input line-by-line: valid entries are imported, invalid ones are logged and skipped. The import only fails if every line is unrecognized.

## Testing

5 unit tests added covering:

* all valid
* mixed valid/invalid
* all invalid
* empty input
* blank lines

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Label import now returns a parsed report (imported vs skipped) and UIs surface partial-import details.
  * Backup import reports now include skipped label counts.

* **Bug Fixes**
  * Import parsing tolerates blank lines and skips malformed/unsupported entries instead of failing the whole import.
  * Transaction refresh after imports remains intact.

* **Tests**
  * Added tests for partial success, full failure, empty input, and blank-line handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitcoinppl/cove/pull/670)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->