### PR TITLE
Add RBF fee bump chain: guard, actor, wallet manager, and send flow

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -251,6 +251,10 @@ class SendFlowManager(
             is SendFlowManagerReconcileMessage.RefreshPresenters -> {
                 refreshPresenters()
             }
+
+            is SendFlowManagerReconcileMessage.FeeBumpConfirmDetails -> {
+                // fee bump confirmation screen wired in follow-up
+            }
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1768,6 +1768,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_block_number_fmt(
     ): Short
+    external fun uniffi_cove_checksum_method_transactiondetails_can_rbf_bump(
+    ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_confirmation_date_time(
     ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt(
@@ -1935,6 +1937,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_constructor_transactiondetails_preview_new_confirmed(
     ): Short
     external fun uniffi_cove_checksum_constructor_transactiondetails_preview_new_with_label(
+    ): Short
+    external fun uniffi_cove_checksum_constructor_transactiondetails_preview_pending_rbf(
     ): Short
     external fun uniffi_cove_checksum_constructor_transactiondetails_preview_pending_received(
     ): Short
@@ -2940,6 +2944,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_constructor_transactiondetails_preview_new_with_label(`label`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
+    external fun uniffi_cove_fn_constructor_transactiondetails_preview_pending_rbf(uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
     external fun uniffi_cove_fn_constructor_transactiondetails_preview_pending_received(uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_constructor_transactiondetails_preview_pending_sent(uniffi_out_err: UniffiRustCallStatus, 
@@ -2962,6 +2968,8 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_transactiondetails_block_number_fmt(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_transactiondetails_can_rbf_bump(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
     external fun uniffi_cove_fn_method_transactiondetails_confirmation_date_time(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt(`ptr`: Long,
@@ -4607,6 +4615,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_transactiondetails_block_number_fmt() != 8381.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_transactiondetails_can_rbf_bump() != 57738.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4857,6 +4868,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_constructor_transactiondetails_preview_new_with_label() != 51427.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_constructor_transactiondetails_preview_pending_rbf() != 25399.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_constructor_transactiondetails_preview_pending_received() != 18117.toShort()) {
@@ -23265,6 +23279,14 @@ public interface TransactionDetailsInterface {
     
     fun `blockNumberFmt`(): kotlin.String?
     
+    /**
+     * Whether this transaction can currently be fee-bumped via RBF.
+     *
+     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Use this to gate the "Speed Up" action in the UI.
+     */
+    fun `canRbfBump`(): kotlin.Boolean
+    
     fun `confirmationDateTime`(): kotlin.String?
     
     suspend fun `feeFiatFmt`(): kotlin.String
@@ -23538,6 +23560,25 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_method_transactiondetails_block_number_fmt(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Whether this transaction can currently be fee-bumped via RBF.
+     *
+     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Use this to gate the "Speed Up" action in the UI.
+     */override fun `canRbfBump`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_transactiondetails_can_rbf_bump(
         it,
         _status)
 }
@@ -23836,6 +23877,17 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     UniffiLib.uniffi_cove_fn_constructor_transactiondetails_preview_new_with_label(
     
         FfiConverterString.lower(`label`),_status)
+}
+    )
+    }
+    
+
+         fun `previewPendingRbf`(): TransactionDetails {
+            return FfiConverterTypeTransactionDetails.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_constructor_transactiondetails_preview_pending_rbf(
+    
+        _status)
 }
     )
     }
@@ -44199,6 +44251,16 @@ sealed class SendFlowManagerAction: Disposable  {
     object FinalizeAndGoToNextScreen : SendFlowManagerAction()
     
     
+    data class ConfirmFeeBump(
+        val `txid`: org.bitcoinppl.cove_core.types.TxId, 
+        val `feeRate`: org.bitcoinppl.cove_core.types.FeeRate) : SendFlowManagerAction()
+        
+    {
+        
+
+        companion object
+    }
+    
 
     
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -44338,6 +44400,14 @@ sealed class SendFlowManagerAction: Disposable  {
             }
             is SendFlowManagerAction.FinalizeAndGoToNextScreen -> {// Nothing to destroy
             }
+            is SendFlowManagerAction.ConfirmFeeBump -> {
+                
+    Disposable.destroy(
+        this.`txid`,
+        this.`feeRate`
+    )
+                
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
@@ -44416,6 +44486,10 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
                 FfiConverterTypeFeeRateOptionsWithTotalFee.read(buf),
                 )
             22 -> SendFlowManagerAction.FinalizeAndGoToNextScreen
+            23 -> SendFlowManagerAction.ConfirmFeeBump(
+                FfiConverterTypeTxId.read(buf),
+                FfiConverterTypeFeeRate.read(buf),
+                )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -44575,6 +44649,14 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
                 4UL
             )
         }
+        is SendFlowManagerAction.ConfirmFeeBump -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeTxId.allocationSize(value.`txid`)
+                + FfiConverterTypeFeeRate.allocationSize(value.`feeRate`)
+            )
+        }
     }
 
     override fun write(value: SendFlowManagerAction, buf: ByteBuffer) {
@@ -44687,6 +44769,12 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
             }
             is SendFlowManagerAction.FinalizeAndGoToNextScreen -> {
                 buf.putInt(22)
+                Unit
+            }
+            is SendFlowManagerAction.ConfirmFeeBump -> {
+                buf.putInt(23)
+                FfiConverterTypeTxId.write(value.`txid`, buf)
+                FfiConverterTypeFeeRate.write(value.`feeRate`, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -44807,6 +44895,15 @@ sealed class SendFlowManagerReconcileMessage: Disposable  {
     object ClearAlert : SendFlowManagerReconcileMessage()
     
     
+    data class FeeBumpConfirmDetails(
+        val v1: org.bitcoinppl.cove_core.types.ConfirmDetails) : SendFlowManagerReconcileMessage()
+        
+    {
+        
+
+        companion object
+    }
+    
 
     
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -44895,6 +44992,13 @@ sealed class SendFlowManagerReconcileMessage: Disposable  {
             }
             is SendFlowManagerReconcileMessage.ClearAlert -> {// Nothing to destroy
             }
+            is SendFlowManagerReconcileMessage.FeeBumpConfirmDetails -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     
@@ -44948,6 +45052,9 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
                 FfiConverterTypeSendFlowAlertState.read(buf),
                 )
             14 -> SendFlowManagerReconcileMessage.ClearAlert
+            15 -> SendFlowManagerReconcileMessage.FeeBumpConfirmDetails(
+                FfiConverterTypeConfirmDetails.read(buf),
+                )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -45048,6 +45155,13 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
                 4UL
             )
         }
+        is SendFlowManagerReconcileMessage.FeeBumpConfirmDetails -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeConfirmDetails.allocationSize(value.v1)
+            )
+        }
     }
 
     override fun write(value: SendFlowManagerReconcileMessage, buf: ByteBuffer) {
@@ -45117,6 +45231,11 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
             }
             is SendFlowManagerReconcileMessage.ClearAlert -> {
                 buf.putInt(14)
+                Unit
+            }
+            is SendFlowManagerReconcileMessage.FeeBumpConfirmDetails -> {
+                buf.putInt(15)
+                FfiConverterTypeConfirmDetails.write(value.v1, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -4615,7 +4615,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_transactiondetails_block_number_fmt() != 8381.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_transactiondetails_can_rbf_bump() != 57738.toShort()) {
+    if (lib.uniffi_cove_checksum_method_transactiondetails_can_rbf_bump() != 5315.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432.toShort()) {
@@ -23282,7 +23282,7 @@ public interface TransactionDetailsInterface {
     /**
      * Whether this transaction can currently be fee-bumped via RBF.
      *
-     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Requires the transaction to be outgoing, unconfirmed, and signaling opt-in RBF.
      * Use this to gate the "Speed Up" action in the UI.
      */
     fun `canRbfBump`(): kotlin.Boolean
@@ -23572,7 +23572,7 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     /**
      * Whether this transaction can currently be fee-bumped via RBF.
      *
-     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Requires the transaction to be outgoing, unconfirmed, and signaling opt-in RBF.
      * Use this to gate the "Speed Up" action in the UI.
      */override fun `canRbfBump`(): kotlin.Boolean {
             return FfiConverterBoolean.lift(

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -170,6 +170,9 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
 
         case .refreshPresenters:
             self.refreshPresenters()
+
+        case .feeBumpConfirmDetails:
+            break
         }
     }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -10372,7 +10372,7 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
     /**
      * Whether this transaction can currently be fee-bumped via RBF.
      *
-     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Requires the transaction to be outgoing, unconfirmed, and signaling opt-in RBF.
      * Use this to gate the "Speed Up" action in the UI.
      */
     func canRbfBump()  -> Bool
@@ -10619,7 +10619,7 @@ open func blockNumberFmt() -> String?  {
     /**
      * Whether this transaction can currently be fee-bumped via RBF.
      *
-     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Requires the transaction to be outgoing, unconfirmed, and signaling opt-in RBF.
      * Use this to gate the "Speed Up" action in the UI.
      */
 open func canRbfBump() -> Bool  {
@@ -37118,7 +37118,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_transactiondetails_block_number_fmt() != 8381) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_transactiondetails_can_rbf_bump() != 57738) {
+    if (uniffi_cove_checksum_method_transactiondetails_can_rbf_bump() != 5315) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -10369,6 +10369,14 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
     
     func blockNumberFmt()  -> String?
     
+    /**
+     * Whether this transaction can currently be fee-bumped via RBF.
+     *
+     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Use this to gate the "Speed Up" action in the UI.
+     */
+    func canRbfBump()  -> Bool
+    
     func confirmationDateTime()  -> String?
     
     func feeFiatFmt() async throws  -> String
@@ -10494,6 +10502,13 @@ public static func previewNewWithLabel(label: String = "bike payment") -> Transa
 })
 }
     
+public static func previewPendingRbf() -> TransactionDetails  {
+    return try!  FfiConverterTypeTransactionDetails_lift(try! rustCall() {
+    uniffi_cove_fn_constructor_transactiondetails_preview_pending_rbf($0
+    )
+})
+}
+    
 public static func previewPendingReceived() -> TransactionDetails  {
     return try!  FfiConverterTypeTransactionDetails_lift(try! rustCall() {
     uniffi_cove_fn_constructor_transactiondetails_preview_pending_received($0
@@ -10596,6 +10611,20 @@ open func blockNumber() -> UInt32?  {
 open func blockNumberFmt() -> String?  {
     return try!  FfiConverterOptionString.lift(try! rustCall() {
     uniffi_cove_fn_method_transactiondetails_block_number_fmt(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * Whether this transaction can currently be fee-bumped via RBF.
+     *
+     * Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+     * Use this to gate the "Speed Up" action in the UI.
+     */
+open func canRbfBump() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_cove_fn_method_transactiondetails_can_rbf_bump(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -27078,6 +27107,8 @@ public enum SendFlowManagerAction {
     case changeFeeRateOptions(FeeRateOptionsWithTotalFee
     )
     case finalizeAndGoToNextScreen
+    case confirmFeeBump(txid: TxId, feeRate: FeeRate
+    )
 
 
 
@@ -27159,6 +27190,9 @@ public struct FfiConverterTypeSendFlowManagerAction: FfiConverterRustBuffer {
         )
         
         case 22: return .finalizeAndGoToNextScreen
+        
+        case 23: return .confirmFeeBump(txid: try FfiConverterTypeTxId.read(from: &buf), feeRate: try FfiConverterTypeFeeRate.read(from: &buf)
+        )
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -27277,6 +27311,12 @@ public struct FfiConverterTypeSendFlowManagerAction: FfiConverterRustBuffer {
         case .finalizeAndGoToNextScreen:
             writeInt(&buf, Int32(22))
         
+        
+        case let .confirmFeeBump(txid,feeRate):
+            writeInt(&buf, Int32(23))
+            FfiConverterTypeTxId.write(txid, into: &buf)
+            FfiConverterTypeFeeRate.write(feeRate, into: &buf)
+            
         }
     }
 }
@@ -27326,6 +27366,8 @@ public enum SendFlowManagerReconcileMessage {
     case setAlert(SendFlowAlertState
     )
     case clearAlert
+    case feeBumpConfirmDetails(ConfirmDetails
+    )
 
 
 
@@ -27385,6 +27427,9 @@ public struct FfiConverterTypeSendFlowManagerReconcileMessage: FfiConverterRustB
         )
         
         case 14: return .clearAlert
+        
+        case 15: return .feeBumpConfirmDetails(try FfiConverterTypeConfirmDetails.read(from: &buf)
+        )
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -27460,6 +27505,11 @@ public struct FfiConverterTypeSendFlowManagerReconcileMessage: FfiConverterRustB
         case .clearAlert:
             writeInt(&buf, Int32(14))
         
+        
+        case let .feeBumpConfirmDetails(v1):
+            writeInt(&buf, Int32(15))
+            FfiConverterTypeConfirmDetails.write(v1, into: &buf)
+            
         }
     }
 }
@@ -37068,6 +37118,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_transactiondetails_block_number_fmt() != 8381) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_transactiondetails_can_rbf_bump() != 57738) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -37318,6 +37371,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_constructor_transactiondetails_preview_new_with_label() != 51427) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_constructor_transactiondetails_preview_pending_rbf() != 25399) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_constructor_transactiondetails_preview_pending_received() != 18117) {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,7 +17,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::implicit_clone)]
-#![allow(clippy::unchecked_duration_subtraction)]
+#![allow(clippy::unchecked_time_subtraction)]
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::assigning_clones)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,7 +17,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::implicit_clone)]
-#![allow(clippy::unchecked_time_subtraction)]
+#![allow(clippy::unchecked_duration_subtraction)]
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::assigning_clones)]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -1681,6 +1681,14 @@ impl RustSendFlowManager {
 
             me.reconciler.send_async(Message::FeeBumpConfirmDetails(details.clone())).await;
 
+            // save unsigned transaction for hardware wallets before routing
+            if matches!(wallet_type, WalletType::Cold | WalletType::XpubOnly)
+                && let Err(e) = manager.save_unsigned_transaction(details.clone())
+            {
+                let error = SendFlowError::UnableToSaveUnsignedTransaction(e.to_string());
+                return me.send_alert_async(error).await;
+            }
+
             let next_route = match wallet_type {
                 WalletType::Hot => RouteFactory::new().send_confirm(wallet_id, details, None, None),
                 WalletType::Cold | WalletType::XpubOnly => {

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -1666,6 +1666,10 @@ impl RustSendFlowManager {
             (state.metadata.wallet_type, state.metadata.id.clone())
         };
 
+        if matches!(wallet_type, WalletType::WatchOnly) {
+            return self.send_alert(SendFlowError::UnableToBuildTxn("watch only".to_string()));
+        }
+
         cove_tokio::task::spawn(async move {
             let raw_txid = *txid;
 
@@ -1678,12 +1682,6 @@ impl RustSendFlowManager {
                     return me.send_alert_async(error).await;
                 }
             };
-
-            // reject watch-only before touching UI state
-            if matches!(wallet_type, WalletType::WatchOnly) {
-                let error = SendFlowError::UnableToBuildTxn("watch only".to_string());
-                return me.send_alert_async(error).await;
-            }
 
             // save unsigned transaction for hardware wallets before routing
             if matches!(wallet_type, WalletType::Cold | WalletType::XpubOnly)

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -1679,7 +1679,11 @@ impl RustSendFlowManager {
                 }
             };
 
-            me.reconciler.send_async(Message::FeeBumpConfirmDetails(details.clone())).await;
+            // reject watch-only before touching UI state
+            if matches!(wallet_type, WalletType::WatchOnly) {
+                let error = SendFlowError::UnableToBuildTxn("watch only".to_string());
+                return me.send_alert_async(error).await;
+            }
 
             // save unsigned transaction for hardware wallets before routing
             if matches!(wallet_type, WalletType::Cold | WalletType::XpubOnly)
@@ -1689,15 +1693,14 @@ impl RustSendFlowManager {
                 return me.send_alert_async(error).await;
             }
 
+            me.reconciler.send_async(Message::FeeBumpConfirmDetails(details.clone())).await;
+
             let next_route = match wallet_type {
                 WalletType::Hot => RouteFactory::new().send_confirm(wallet_id, details, None, None),
                 WalletType::Cold | WalletType::XpubOnly => {
                     RouteFactory::new().send_hardware_export(wallet_id, details)
                 }
-                WalletType::WatchOnly => {
-                    let error = SendFlowError::UnableToBuildTxn("watch only".to_string());
-                    return me.send_alert_async(error).await;
-                }
+                WalletType::WatchOnly => unreachable!("rejected above"),
             };
 
             let mut deferred = DeferredDispatch::<AppAction>::new();

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -16,7 +16,7 @@ use crate::{
     fee_client::FEE_CLIENT,
     fiat::client::PriceResponse,
     router::RouteFactory,
-    transaction::FeeRate,
+    transaction::{FeeRate, TxId},
     wallet::{
         Address,
         balance::Balance,
@@ -33,6 +33,7 @@ use cove_types::{
     WalletId,
     address::AddressWithNetwork,
     amount::Amount,
+    confirm::ConfirmDetails,
     fees::{FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee, FeeSpeed},
     psbt::Psbt,
     unit::BitcoinUnit,
@@ -111,6 +112,9 @@ pub enum SendFlowManagerReconcileMessage {
     // side effects
     SetAlert(SendFlowAlertState),
     ClearAlert,
+
+    // fee bump
+    FeeBumpConfirmDetails(Arc<ConfirmDetails>),
 }
 
 #[derive(Debug, Clone, PartialEq, uniffi::Enum)]
@@ -152,6 +156,9 @@ pub enum SendFlowManagerAction {
     ChangeFeeRateOptions(Arc<FeeRateOptionsWithTotalFee>),
 
     FinalizeAndGoToNextScreen,
+
+    // fee bump: replace a pending RBF transaction with a higher fee rate
+    ConfirmFeeBump { txid: Arc<TxId>, fee_rate: Arc<FeeRate> },
 }
 
 impl RustSendFlowManager {
@@ -669,6 +676,10 @@ impl RustSendFlowManager {
             }
             Action::NotifyCoinControlEnteredAmountChanged(amount, is_focused) => {
                 self.handle_coin_control_entered_amount_changed(amount, is_focused);
+            }
+
+            Action::ConfirmFeeBump { txid, fee_rate } => {
+                self.confirm_fee_bump(*txid, *fee_rate);
             }
         }
     }
@@ -1636,6 +1647,48 @@ impl RustSendFlowManager {
                     return me
                         .send_alert_async(SendFlowError::UnableToBuildTxn("watch only".to_string()))
                         .await;
+                }
+            };
+
+            let mut deferred = DeferredDispatch::<AppAction>::new();
+            deferred.queue(AppAction::PushRoute(next_route));
+        });
+    }
+}
+
+/// MARK: fee bump
+impl RustSendFlowManager {
+    fn confirm_fee_bump(self: &Arc<Self>, txid: TxId, fee_rate: FeeRate) {
+        let me = self.clone();
+        let manager = self.wallet_manager.clone();
+        let (wallet_type, wallet_id) = {
+            let state = self.state.lock();
+            (state.metadata.wallet_type, state.metadata.id.clone())
+        };
+
+        cove_tokio::task::spawn(async move {
+            let raw_txid = *txid;
+
+            let confirm_details = manager.confirm_fee_bump_txn(raw_txid, fee_rate).await;
+
+            let details = match confirm_details {
+                Ok(details) => Arc::new(details),
+                Err(error) => {
+                    let error = SendFlowError::UnableToBuildTxn(error.to_string());
+                    return me.send_alert_async(error).await;
+                }
+            };
+
+            me.reconciler.send_async(Message::FeeBumpConfirmDetails(details.clone())).await;
+
+            let next_route = match wallet_type {
+                WalletType::Hot => RouteFactory::new().send_confirm(wallet_id, details, None, None),
+                WalletType::Cold | WalletType::XpubOnly => {
+                    RouteFactory::new().send_hardware_export(wallet_id, details)
+                }
+                WalletType::WatchOnly => {
+                    let error = SendFlowError::UnableToBuildTxn("watch only".to_string());
+                    return me.send_alert_async(error).await;
                 }
             };
 

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -1355,6 +1355,21 @@ impl RustWalletManager {
         let details = call!(self.actor.get_confirm_details(psbt, fee_rate)).await.unwrap()?;
         Ok(details)
     }
+
+    pub async fn confirm_fee_bump_txn(
+        &self,
+        txid: bitcoin::Txid,
+        fee_rate: FeeRate,
+    ) -> Result<ConfirmDetails, Error> {
+        debug!("confirm_fee_bump_txn txid: {txid}  fee_rate: {:?}", fee_rate.sat_per_vb());
+        let actor = self.actor.clone();
+        let fee_rate = fee_rate.into();
+
+        let psbt = call!(actor.build_fee_bump_tx(txid, fee_rate)).await.unwrap()?;
+        let details = call!(self.actor.get_confirm_details(psbt, fee_rate)).await.unwrap()?;
+
+        Ok(details)
+    }
 }
 
 #[uniffi::export]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -289,6 +289,24 @@ impl WalletActor {
         Ok(psbt)
     }
 
+    /// Build a replacement transaction for an unconfirmed RBF-signaling transaction.
+    ///
+    /// Reuses the original inputs and outputs; caller supplies a higher fee rate.
+    /// BDK validates that `txid` is unconfirmed and signals opt-in RBF (BIP 125).
+    #[into_actor_result]
+    pub async fn build_fee_bump_tx(
+        &mut self,
+        txid: Txid,
+        fee_rate: impl Into<BdkFeeRate>,
+    ) -> Result<Psbt, Error> {
+        debug!("build_fee_bump_tx: {txid}");
+        let mut builder =
+            self.wallet.bdk.build_fee_bump(txid).map_err(|e| Error::BuildTxError(e.to_string()))?;
+        builder.fee_rate(fee_rate.into());
+        let psbt = builder.finish().map_err(|e| Error::BuildTxError(e.to_string()))?;
+        Ok(psbt)
+    }
+
     // cancel a transaction, reset the address & change address index
     pub async fn cancel_txn(&mut self, txn: BdkTransaction) {
         self.wallet.bdk.cancel_tx(&txn);

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -300,10 +300,9 @@ impl WalletActor {
         fee_rate: impl Into<BdkFeeRate>,
     ) -> Result<Psbt, Error> {
         debug!("build_fee_bump_tx: {txid}");
-        let mut builder =
-            self.wallet.bdk.build_fee_bump(txid).map_err(|e| Error::BuildTxError(e.to_string()))?;
+        let mut builder = self.wallet.bdk.build_fee_bump(txid).map_err_str(Error::BuildTxError)?;
         builder.fee_rate(fee_rate.into());
-        let psbt = builder.finish().map_err(|e| Error::BuildTxError(e.to_string()))?;
+        let psbt = builder.finish().map_err_str(Error::BuildTxError)?;
         Ok(psbt)
     }
 

--- a/rust/src/transaction/transaction_details.rs
+++ b/rust/src/transaction/transaction_details.rs
@@ -352,11 +352,11 @@ impl TransactionDetails {
 
     /// Whether this transaction can currently be fee-bumped via RBF.
     ///
-    /// Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+    /// Requires the transaction to be outgoing, unconfirmed, and signaling opt-in RBF.
     /// Use this to gate the "Speed Up" action in the UI.
     #[uniffi::method]
     pub fn can_rbf_bump(&self) -> bool {
-        self.is_rbf_signaling && !self.is_confirmed()
+        self.is_sent() && self.is_rbf_signaling && !self.is_confirmed()
     }
 
     #[uniffi::method]

--- a/rust/src/transaction/transaction_details.rs
+++ b/rust/src/transaction/transaction_details.rs
@@ -350,6 +350,15 @@ impl TransactionDetails {
         self.is_rbf_signaling
     }
 
+    /// Whether this transaction can currently be fee-bumped via RBF.
+    ///
+    /// Requires the transaction to be both unconfirmed and signaling opt-in RBF.
+    /// Use this to gate the "Speed Up" action in the UI.
+    #[uniffi::method]
+    pub fn can_rbf_bump(&self) -> bool {
+        self.is_rbf_signaling && !self.is_confirmed()
+    }
+
     #[uniffi::method]
     pub fn confirmation_date_time(&self) -> Option<String> {
         let confirm_time = match &self.pending_or_confirmed {
@@ -517,6 +526,13 @@ impl TransactionDetails {
         me
     }
 
+    #[uniffi::constructor]
+    pub fn preview_pending_rbf() -> Self {
+        let mut me = Self::preview_pending_sent();
+        me.is_rbf_signaling = true;
+        me
+    }
+
     #[uniffi::constructor(default(label = "bike payment"))]
     pub fn preview_new_with_label(label: String) -> Self {
         let mut me = Self::preview_new_confirmed();
@@ -608,5 +624,24 @@ mod tests {
     fn preview_constructors_default_to_not_rbf() {
         assert!(!TransactionDetails::preview_new_confirmed().is_rbf_signaling);
         assert!(!TransactionDetails::preview_pending_sent().is_rbf_signaling);
+    }
+
+    #[test]
+    fn can_rbf_bump_requires_pending_and_rbf_signaling() {
+        let rbf_pending = TransactionDetails::preview_pending_rbf();
+        assert!(rbf_pending.can_rbf_bump());
+    }
+
+    #[test]
+    fn can_rbf_bump_false_when_confirmed() {
+        let mut confirmed = TransactionDetails::preview_new_confirmed();
+        confirmed.is_rbf_signaling = true;
+        assert!(!confirmed.can_rbf_bump());
+    }
+
+    #[test]
+    fn can_rbf_bump_false_when_pending_without_rbf() {
+        let pending_no_rbf = TransactionDetails::preview_pending_sent();
+        assert!(!pending_no_rbf.can_rbf_bump());
     }
 }


### PR DESCRIPTION
## Summary

  Builds the RBF fee bump action chain on top of #663 (`is_rbf_signaling`).                   
                                                                                              
  **Problem:** Cove can detect RBF-signaling transactions but has no way to                   
  actually replace them with a higher fee. A stuck pending transaction has                    
  no "Speed Up" path.                         
                                                                                              
  **What this adds:**                                             
                                                                                              
  - `can_rbf_bump()` on `TransactionDetails` combined guard     
    (`is_pending && is_rbf_signaling`) for the mobile UI to gate a                            
    "Speed Up" action. Prevents showing fee bump on confirmed transactions.
  - `preview_pending_rbf()` constructor lets iOS/Android devs build                         
    SwiftUI/Compose previews for the Speed Up UI without a live wallet.
  - `build_fee_bump_tx(txid, fee_rate)` on `WalletActor` wraps BDK's                        
    `build_fee_bump`, which validates the tx is unconfirmed and                               
    RBF-signaling, then returns a replacement PSBT at the new fee rate.                       
  - `confirm_fee_bump_txn(txid, fee_rate)` on `RustWalletManager`                           
    mirrors `confirm_txn`: builds the bump PSBT and returns                                   
    `ConfirmDetails`, reusing the existing confirm screen unchanged.                          
  - `ConfirmFeeBump { txid, fee_rate }` action + handler in                                   
    `SendFlowManager` dispatched by iOS/Android when the user confirms                      
    a fee bump. Routes to `send_confirm` (hot wallet) or                                      
    `send_hardware_export` (cold wallet), same as a normal send.                              
  - `FeeBumpConfirmDetails` reconcile message notifies the frontend                         
    when confirm details are ready. 

## Testing

  cargo test transaction_details

  10 tests pass, including 3 new ones covering all `can_rbf_bump` states:                     
  - pending + rbf-signaling ---> `true`                              
  - confirmed + rbf-signaling ---> `false`                                                       
  - pending + no rbf-signaling --->`false`  

  cargo check
  No warnings or errors. Rust-only changes UniFFI bindings regenerate on
  next `just build-ios` / `just build-android`.


### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [x] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Speed Up" (fee-bump) end-to-end flow: confirmation dialog with fee details, alerts for unsupported watch-only wallets, routing to hot-wallet confirm or hardware-export for cold/xpub wallets, and saving unsigned TXs when required. Surfaces failures to the user.
  * Exposed RBF eligibility check and a preview for pending RBF transactions to Android/iOS.

* **Tests**
  * Added unit tests covering RBF eligibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->