### PR TITLE
Fix ShareLink in remaining transient presenters

### DIFF
--- a/ios/Cove/Flows/SelectedWalletFlow/MoreInfoPopover.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/MoreInfoPopover.swift
@@ -46,11 +46,7 @@ struct MoreInfoPopover: View {
         Task {
             do {
                 let result = try await manager.rust.exportTransactionsCsv()
-                ShareSheet.present(data: result.content, filename: result.filename) { success in
-                    if !success {
-                        Log.warn("Transaction Export Failed: cancelled or failed")
-                    }
-                }
+                ShareSheet.presentFromMenu(data: result.content, filename: result.filename)
             } catch {
                 app.alertState = .init(.general(
                     title: "Transaction Export Failed",
@@ -79,16 +75,7 @@ struct MoreInfoPopover: View {
             let prefix = t.identFileNamePrefix()
             let filename = "\(prefix)_backup.txt"
 
-            Button(action: {
-                // Defer presentation until the Menu's dismissal animation completes.
-                // ShareLink presented directly from a Menu races the dismissal and
-                // can fail silently or surface extension errors. See issues #449 and #313.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                    ShareSheet.present(data: content, filename: filename) { success in
-                        if !success { Log.warn("Backup export cancelled or failed") }
-                    }
-                }
-            }) {
+            Button(action: { ShareSheet.presentFromMenu(data: content, filename: filename) }) {
                 Label("Download Backup", systemImage: "square.and.arrow.down")
             }
         } else if let backupError = tapSignerBackupError {

--- a/ios/Cove/Flows/SelectedWalletFlow/MoreInfoPopover.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/MoreInfoPopover.swift
@@ -79,10 +79,16 @@ struct MoreInfoPopover: View {
             let prefix = t.identFileNamePrefix()
             let filename = "\(prefix)_backup.txt"
 
-            ShareLink(
-                item: BackupExport(content: content, filename: filename),
-                preview: SharePreview(filename)
-            ) {
+            Button(action: {
+                // Defer presentation until the Menu's dismissal animation completes.
+                // ShareLink presented directly from a Menu races the dismissal and
+                // can fail silently or surface extension errors. See issues #449 and #313.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    ShareSheet.present(data: content, filename: filename) { success in
+                        if !success { Log.warn("Backup export cancelled or failed") }
+                    }
+                }
+            }) {
                 Label("Download Backup", systemImage: "square.and.arrow.down")
             }
         } else if let backupError = tapSignerBackupError {

--- a/ios/Cove/Flows/SendFlow/SendFlowHardwareScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowHardwareScreen.swift
@@ -442,17 +442,7 @@ struct SendFlowHardwareScreen: View {
         }
 
         Button("More...") {
-            // Defer presentation until the confirmationDialog's dismissal
-            // animation completes. A SwiftUI `ShareLink` presented directly
-            // from a confirmationDialog action races the dialog's dismissal
-            // and either fails silently (Save to Files) or surfaces extension
-            // errors (Signal). See issues #449 and #313.
-            let psbtBytes = details.psbtBytes()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                ShareSheet.present(data: psbtBytes, filename: "transaction.psbt") { success in
-                    if !success { Log.warn("PSBT export cancelled or failed") }
-                }
-            }
+            ShareSheet.presentFromMenu(data: details.psbtBytes(), filename: "transaction.psbt")
         }
     }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerSetupSuccessView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerSetupSuccessView.swift
@@ -74,13 +74,13 @@ struct TapSignerSetupSuccess: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
 
-            ShareLink(
-                item: BackupExport(
-                    content: hexEncode(bytes: setup.backup),
-                    filename: "\(tapSigner.identFileNamePrefix())_backup.txt"
-                ),
-                preview: SharePreview("\(tapSigner.identFileNamePrefix())_backup.txt")
-            ) {
+            Button(action: {
+                let content = hexEncode(bytes: setup.backup)
+                let filename = "\(tapSigner.identFileNamePrefix())_backup.txt"
+                ShareSheet.present(data: content, filename: filename) { success in
+                    if !success { Log.warn("Backup export cancelled or failed") }
+                }
+            }) {
                 HStack {
                     VStack(spacing: 4) {
                         HStack {

--- a/ios/Cove/ShareSheet.swift
+++ b/ios/Cove/ShareSheet.swift
@@ -97,6 +97,29 @@ enum ShareSheet {
         presenter.present(activityViewController, animated: true)
     }
 
+    /// Like `present(data:filename:completion:)` but defers by 400ms so that a
+    /// transient presenter (Menu, confirmationDialog) can finish its dismissal
+    /// animation before the share sheet appears. Centralises the magic delay and
+    /// failure-logging so callers don't repeat them.
+    @MainActor
+    static func presentFromMenu(data: String, filename: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            present(data: data, filename: filename) { success in
+                if !success { Log.warn("Share sheet cancelled or failed: \(filename)") }
+            }
+        }
+    }
+
+    /// Binary-data variant of `presentFromMenu`.
+    @MainActor
+    static func presentFromMenu(data: Data, filename: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            present(data: data, filename: filename) { success in
+                if !success { Log.warn("Share sheet cancelled or failed: \(filename)") }
+            }
+        }
+    }
+
     /// Presents share sheet with arbitrary data by writing to a temporary file
     /// - Parameters:
     ///   - data: the data to share


### PR DESCRIPTION
Apply the same fix from #631 to the two remaining ShareLink sites that present from transient contexts.

**MoreInfoPopover (high risk):** `DownloadBackupButton` used a `ShareLink` inside a toolbar `Menu`. Menus are transient presenters — the same dialog-dismissal race from #449/#313 applies. Replaced with a `Button` that calls `ShareSheet.present` deferred by 400ms, matching the pattern from #631.

**TapSignerSetupSuccessView (lower risk):** The Download Backup button also used `ShareLink`. This screen is not a dialog, so the race is less likely, but replacing with `ShareSheet.present` eliminates the fragile path and keeps the sharing behaviour consistent across the app.

`SendFlowHardwareScreen:444` was already fixed in #631.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backup sharing functionality to improve reliability and stability when accessing share options from menu interfaces
  * Improved error handling for share operations to better report any issues during backup export

<!-- end of auto-generated comment: release notes by coderabbit.ai -->