### PR TITLE
Tighten cloud backup cleanup

### DIFF
--- a/ios/Cove/CoveApp.swift
+++ b/ios/Cove/CoveApp.swift
@@ -289,9 +289,7 @@ extension CoveApp {
             let isICloudAvailable = await MainActor.run { FileManager.default.ubiquityIdentityToken != nil }
             guard isICloudAvailable else { return }
 
-            let warning = await Task.detached {
-                await CloudBackupManager.shared.rust.verifyBackupIntegrity()
-            }.value
+            let warning = await CloudBackupManager.shared.rust.verifyBackupIntegrity()
             if let warning { Log.error("[STARTUP] backup integrity warning: \(warning)") }
         }
     }

--- a/ios/Cove/FFI/CloudStorageAccessImpl.swift
+++ b/ios/Cove/FFI/CloudStorageAccessImpl.swift
@@ -5,7 +5,8 @@ final class CloudStorageAccessImpl: CloudStorageAccess, @unchecked Sendable {
     private let helper = ICloudDriveHelper.shared
     private let queue = DispatchQueue(
         label: "cove.CloudStorageAccessImpl",
-        qos: .userInitiated
+        qos: .userInitiated,
+        attributes: .concurrent
     )
 
     private func run<T: Sendable>(
@@ -68,7 +69,7 @@ final class CloudStorageAccessImpl: CloudStorageAccess, @unchecked Sendable {
 
     func deleteWalletBackup(namespace: String, recordId: String) async throws {
         try await run {
-            let url = try self.helper.walletFileReadURL(namespace: namespace, recordId: recordId)
+            let url = try self.helper.backupFileReadURL(namespace: namespace, recordId: recordId)
             if FileManager.default.fileExists(atPath: url.path) {
                 try self.helper.coordinatedDelete(at: url, missingItemID: recordId)
                 return

--- a/ios/Cove/FFI/ICloudDriveHelper.swift
+++ b/ios/Cove/FFI/ICloudDriveHelper.swift
@@ -212,6 +212,14 @@ final class ICloudDriveHelper: @unchecked Sendable {
         return try walletFileURL(namespace: namespace, recordId: recordId)
     }
 
+    func backupFileReadURL(namespace: String, recordId: String) throws -> URL {
+        if recordId == csppMasterKeyRecordId() {
+            return try masterKeyFileReadURL(namespace: namespace)
+        }
+
+        return try walletFileReadURL(namespace: namespace, recordId: recordId)
+    }
+
     // MARK: - File coordination
 
     /// Coordinates iCloud-backed filesystem access because ubiquitous items may

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ arc-swap = "1.7"
 
 # async
 tokio = { version = "1.43" }
+async-trait = "0.1.81"
 
 # encoding / decoding 
 hex = "0.4.3"
@@ -151,7 +152,7 @@ act-zero-ext = "0.2.0"
 
 # async 
 tokio = { workspace = true, features = ["rt"] }
-async-trait = "0.1.81"
+async-trait = { workspace = true }
 futures = "0.3.30"
 backon = "1.6"
 

--- a/rust/crates/cove-device/Cargo.toml
+++ b/rust/crates/cove-device/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # async
-async-trait = "0.1.81"
+async-trait = { workspace = true }
 
 # uniffi
 uniffi = { workspace = true }

--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -17,6 +17,7 @@ use cove_device::cloud_storage::{CloudStorage, CloudSyncHealth};
 use cove_tokio::task::spawn_actor;
 use cove_util::ResultExt as _;
 use flume::{Receiver, Sender};
+use futures::stream::{self, StreamExt as _};
 use parking_lot::RwLock;
 use tracing::{error, info, warn};
 use zeroize::Zeroizing;
@@ -51,6 +52,7 @@ use super::connectivity_manager::CONNECTIVITY_MANAGER;
 type LocalWalletSecret = crate::backup::model::WalletSecret;
 
 const PASSKEY_RP_ID: &str = "covebitcoinwallet.com";
+pub(super) const CLOUD_BACKUP_IO_CONCURRENCY: usize = 4;
 type Message = CloudBackupReconcileMessage;
 
 pub static CLOUD_BACKUP_MANAGER: LazyLock<Arc<RustCloudBackupManager>> =
@@ -1241,18 +1243,27 @@ impl RustCloudBackupManager {
             });
         };
 
-        let cloud = CloudStorage::global();
-        let reader = WalletBackupReader::new(
-            cloud.clone(),
-            namespace.clone(),
-            Zeroizing::new(master_key.critical_data_key()),
-        );
+        let cloud = CloudStorage::global().clone();
+        let critical_key = master_key.critical_data_key();
         let mut remote_wallet_truth = RemoteWalletTruth::default();
 
-        for wallet in local_wallets {
-            let record_id = wallet_record_id(wallet.id.as_ref());
+        let mut summaries = stream::iter(local_wallets)
+            .map(|wallet| {
+                let cloud = cloud.clone();
+                let namespace = namespace.clone();
 
-            match reader.summary(&record_id).await {
+                async move {
+                    let record_id = wallet_record_id(wallet.id.as_ref());
+                    let reader =
+                        WalletBackupReader::new(cloud, namespace, Zeroizing::new(critical_key));
+                    let result = reader.summary(&record_id).await;
+                    (record_id, result)
+                }
+            })
+            .buffer_unordered(CLOUD_BACKUP_IO_CONCURRENCY);
+
+        while let Some((record_id, result)) = summaries.next().await {
+            match result {
                 Ok(WalletBackupLookup::Found(summary)) => {
                     remote_wallet_truth.summaries_by_record_id.insert(record_id, summary);
                 }
@@ -1528,8 +1539,22 @@ impl RustCloudBackupManager {
 
     /// Dismiss staged enable state for the existing-backup confirmation flow
     pub(crate) fn discard_pending_enable_cloud_backup(&self) {
-        if self.take_pending_enable_session().is_some() {
+        if let Some(pending) = self.take_pending_enable_session() {
+            let should_delete_remote = pending.is_retry_upload();
+            let namespace_id = pending.master_key.namespace_id();
+
             cove_cspp::Cspp::new(Keychain::global().clone()).delete_master_key();
+
+            if should_delete_remote {
+                cove_tokio::task::spawn(async move {
+                    if let Err(error) = CloudStorage::global()
+                        .delete_wallet_backup(namespace_id, MASTER_KEY_RECORD_ID.to_string())
+                        .await
+                    {
+                        warn!("Discard pending enable failed to delete remote master key: {error}");
+                    }
+                });
+            }
         }
         self.clear_existing_backup_found_prompt();
     }
@@ -1754,13 +1779,9 @@ pub(crate) fn ensure_cloud_backup_test_tokio_runtime() {
 #[cfg(test)]
 impl RustCloudBackupManager {
     pub(crate) async fn clear_wallet_upload_debouncers_for_test(&self) {
-        let runtime = self.runtime.clone();
-        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
-        let _task = cove_tokio::task::spawn(async move {
-            let result = send!(runtime.clear_upload_runtime_state());
-            sender.send(result).expect("send clear upload runtime state result");
-        });
-        receiver.recv().expect("receive clear upload runtime state result");
+        act_zero::call!(self.runtime.clear_upload_runtime_state())
+            .await
+            .expect("clear upload runtime state");
     }
 
     pub(crate) async fn verify_pending_uploads_once_for_test(&self) -> bool {

--- a/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
+++ b/rust/src/manager/cloud_backup_manager/cloud_inventory.rs
@@ -1,9 +1,13 @@
 use std::collections::{HashMap, HashSet};
 
 use cove_util::ResultExt as _;
+use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 
 use super::wallets::{RemoteWalletBackupSummary, all_local_wallets, prepare_wallet_backup};
-use super::{CloudBackupDetail, CloudBackupError, CloudBackupWalletItem, CloudBackupWalletStatus};
+use super::{
+    CLOUD_BACKUP_IO_CONCURRENCY, CloudBackupDetail, CloudBackupError, CloudBackupWalletItem,
+    CloudBackupWalletStatus,
+};
 use crate::database::Database;
 use crate::database::cloud_backup::{
     CloudBlobFailedState, PersistedCloudBackupStatus, PersistedCloudBlobState,
@@ -231,19 +235,19 @@ fn wallet_item_bucket(item: &CloudBackupWalletItem) -> Option<WalletItemBucket> 
 async fn all_local_wallet_snapshots(
     db: &Database,
 ) -> Result<Vec<LocalWalletSnapshot>, CloudBackupError> {
-    let mut snapshots = Vec::new();
-
-    for wallet in all_local_wallets(db)? {
-        let prepared = prepare_wallet_backup(&wallet, wallet.wallet_mode).await?;
-        snapshots.push(LocalWalletSnapshot {
-            metadata: wallet,
-            record_id: prepared.record_id,
-            revision_hash: prepared.revision_hash,
-            local_label_count: prepared.entry.labels_count,
-        });
-    }
-
-    Ok(snapshots)
+    stream::iter(all_local_wallets(db)?)
+        .map(|wallet| async move {
+            let prepared = prepare_wallet_backup(&wallet, wallet.wallet_mode).await?;
+            Ok(LocalWalletSnapshot {
+                metadata: wallet,
+                record_id: prepared.record_id,
+                revision_hash: prepared.revision_hash,
+                local_label_count: prepared.entry.labels_count,
+            })
+        })
+        .buffered(CLOUD_BACKUP_IO_CONCURRENCY)
+        .try_collect()
+        .await
 }
 
 fn sync_status_from_state(

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -3,6 +3,7 @@ use cove_device::cloud_storage::CloudStorage;
 use cove_device::keychain::{CSPP_NAMESPACE_ID_KEY, Keychain};
 use cove_device::passkey::PasskeyAccess;
 use cove_util::ResultExt as _;
+use futures::stream::{self, StreamExt as _};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
@@ -16,9 +17,10 @@ use super::wallets::{
 };
 
 use super::{
-    BlockingCloudStep, CloudBackupError, CloudBackupPasskeyChoiceFlow, CloudBackupRestoreProgress,
-    CloudBackupRestoreReport, CloudBackupRestoreStage, CloudBackupStatus, CloudBackupWalletItem,
-    CloudBackupWalletStatus, PendingEnableSession, RestoreOperation, RustCloudBackupManager,
+    BlockingCloudStep, CLOUD_BACKUP_IO_CONCURRENCY, CloudBackupError, CloudBackupPasskeyChoiceFlow,
+    CloudBackupRestoreProgress, CloudBackupRestoreReport, CloudBackupRestoreStage,
+    CloudBackupStatus, CloudBackupWalletItem, CloudBackupWalletStatus, PendingEnableSession,
+    RestoreOperation, RustCloudBackupManager,
 };
 use crate::database::Database;
 use crate::database::cloud_backup::{PersistedCloudBackupState, PersistedCloudBackupStatus};
@@ -42,6 +44,14 @@ enum EnablePasskeyAcquisition {
 }
 
 impl RustCloudBackupManager {
+    async fn lookup_wallet_backup(
+        reader: WalletBackupReader,
+        record_id: String,
+    ) -> (String, Result<WalletBackupLookup<DownloadedWalletBackup>, CloudBackupError>) {
+        let lookup = reader.lookup(&record_id).await;
+        (record_id, lookup)
+    }
+
     fn clear_enable_progress(&self, status: CloudBackupStatus) {
         self.set_progress(None);
         self.set_restore_progress(None);
@@ -189,6 +199,7 @@ impl RustCloudBackupManager {
         let orphan_ids: Vec<_> = wallet_record_ids
             .iter()
             .filter(|record_id| !local_record_ids.contains(*record_id))
+            .cloned()
             .collect();
 
         if orphan_ids.is_empty() {
@@ -211,9 +222,15 @@ impl RustCloudBackupManager {
             Zeroizing::new(master_key.critical_data_key()),
         );
         let mut items = Vec::new();
+        let mut lookups = stream::iter(
+            orphan_ids
+                .into_iter()
+                .map(|record_id| Self::lookup_wallet_backup(reader.clone(), record_id)),
+        )
+        .buffered(CLOUD_BACKUP_IO_CONCURRENCY);
 
-        for record_id in orphan_ids {
-            let wallet = match reader.lookup(record_id).await {
+        while let Some((record_id, lookup)) = lookups.next().await {
+            let wallet = match lookup {
                 Ok(WalletBackupLookup::Found(wallet)) => wallet,
                 Ok(WalletBackupLookup::UnsupportedVersion(version)) => {
                     warn!(
@@ -835,10 +852,18 @@ impl RustCloudBackupManager {
         )?;
 
         let mut downloaded_wallets = Vec::with_capacity(wallet_record_ids.len());
+        let mut lookups = stream::iter(
+            wallet_record_ids
+                .iter()
+                .cloned()
+                .map(|record_id| Self::lookup_wallet_backup(reader.clone(), record_id)),
+        )
+        .buffered(CLOUD_BACKUP_IO_CONCURRENCY);
+        let mut completed = 0;
 
-        for (index, record_id) in wallet_record_ids.iter().enumerate() {
+        while let Some((record_id, lookup)) = lookups.next().await {
             self.ensure_current_restore_operation(operation)?;
-            match reader.lookup(record_id).await {
+            match lookup {
                 Ok(WalletBackupLookup::Found(wallet)) => {
                     downloaded_wallets.push((record_id.clone(), wallet));
                 }
@@ -866,11 +891,12 @@ impl RustCloudBackupManager {
                     report.failed_wallet_errors.push(error.to_string());
                 }
             }
+            completed += 1;
 
             self.send_restore_progress(
                 operation,
                 CloudBackupRestoreStage::Downloading,
-                (index + 1) as u32,
+                completed,
                 Some(total),
             )?;
         }
@@ -3160,6 +3186,37 @@ mod tests {
         manager.discard_pending_enable_cloud_backup();
 
         assert!(manager.take_pending_enable_session().is_none());
+        assert!(cspp.load_master_key_from_store().unwrap().is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn discard_pending_enable_retry_upload_deletes_remote_master_key() {
+        let _guard = test_lock().lock();
+        cove_tokio::init();
+        let globals = test_globals();
+        let manager = RustCloudBackupManager::init();
+
+        reset_cloud_backup_test_state(&manager, globals);
+
+        let master_key = cove_cspp::master_key::MasterKey::generate();
+        let namespace = master_key.namespace_id();
+        let cspp = cove_cspp::Cspp::new(Keychain::global().clone());
+        cspp.save_master_key(&master_key).unwrap();
+        globals.cloud.set_master_key_backup(namespace.clone(), vec![1, 2, 3]);
+        manager.replace_pending_enable_session(PendingEnableSession::retry_upload(
+            master_key,
+            UnpersistedPrfKey { prf_key: [7; 32], prf_salt: [9; 32], credential_id: vec![1, 2, 3] },
+        ));
+
+        manager.discard_pending_enable_cloud_backup();
+
+        wait_for_test_condition(
+            Duration::from_secs(1),
+            "remote master key backup should be deleted",
+            || !globals.cloud.has_master_key_backup(&namespace),
+        )
+        .await;
+
         assert!(cspp.load_master_key_from_store().unwrap().is_none());
     }
 

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -6,7 +6,8 @@ use act_zero::call;
 use bip39::Mnemonic;
 use cove_cspp::CsppStore;
 use cove_cspp::backup_data::{
-    WalletEntry, WalletMode as CloudWalletMode, WalletSecret, wallet_filename_from_record_id,
+    MASTER_KEY_RECORD_ID, WalletEntry, WalletMode as CloudWalletMode, WalletSecret,
+    wallet_filename_from_record_id,
 };
 use cove_device::cloud_storage::{
     CloudStorage, CloudStorageAccess, CloudStorageError, CloudSyncHealth,
@@ -178,6 +179,10 @@ impl MockCloudStorage {
         self.state.lock().uploaded_wallet_backups.len()
     }
 
+    pub(crate) fn has_master_key_backup(&self, namespace: &str) -> bool {
+        self.state.lock().master_key_backups.contains_key(namespace)
+    }
+
     pub(crate) fn wallet_backup_upload_attempt_count(&self) -> usize {
         self.state.lock().wallet_backup_upload_attempts
     }
@@ -281,9 +286,19 @@ impl CloudStorageAccess for MockCloudStorage {
 
     async fn delete_wallet_backup(
         &self,
-        _namespace: String,
-        _record_id: String,
+        namespace: String,
+        record_id: String,
     ) -> Result<(), CloudStorageError> {
+        let mut state = self.state.lock();
+        if record_id == MASTER_KEY_RECORD_ID {
+            state.master_key_backups.remove(&namespace);
+            return Ok(());
+        }
+
+        state.wallet_backups.remove(&(namespace.clone(), record_id.clone()));
+        state.uploaded_wallet_backups.retain(|(uploaded_namespace, uploaded_record_id)| {
+            uploaded_namespace != &namespace || uploaded_record_id != &record_id
+        });
         Ok(())
     }
 

--- a/rust/src/manager/cloud_backup_manager/pending/detail.rs
+++ b/rust/src/manager/cloud_backup_manager/pending/detail.rs
@@ -33,7 +33,7 @@ impl RustCloudBackupManager {
 
         info!("refresh_cloud_backup_detail: listing wallets for namespace {namespace}");
         let cloud = CloudStorage::global();
-        let wallet_record_ids = match cloud.list_wallet_backups(namespace).await {
+        let wallet_record_ids = match cloud.list_wallet_backups(namespace.clone()).await {
             Ok(ids) => ids,
             Err(CloudStorageError::NotFound(_)) => {
                 info!("No wallet backups found in namespace, re-uploading all wallets");
@@ -43,10 +43,7 @@ impl RustCloudBackupManager {
                     )));
                 }
 
-                match cloud
-                    .list_wallet_backups(self.current_namespace_id().unwrap_or_default())
-                    .await
-                {
+                match cloud.list_wallet_backups(namespace.clone()).await {
                     Ok(ids) => ids,
                     Err(error) => {
                         return Some(CloudBackupDetailResult::AccessError(error.to_string()));

--- a/rust/src/manager/cloud_backup_manager/verify/session.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/session.rs
@@ -5,12 +5,13 @@ use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
 use cove_device::keychain::Keychain;
 use cove_device::passkey::{PasskeyAccess, PasskeyCredentialPresence};
 use cove_util::ResultExt as _;
+use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 use super::super::{
-    CloudBackupDetail, CloudBackupError, DeepVerificationFailure, DeepVerificationReport,
-    DeepVerificationResult, PASSKEY_RP_ID, PendingVerificationCompletion,
+    CLOUD_BACKUP_IO_CONCURRENCY, CloudBackupDetail, CloudBackupError, DeepVerificationFailure,
+    DeepVerificationReport, DeepVerificationResult, PASSKEY_RP_ID, PendingVerificationCompletion,
     PendingVerificationUpload, RustCloudBackupManager, VerificationFailureKind,
     cloud_inventory::CloudWalletInventory,
     wallets::{WalletBackupLookup, WalletBackupReader, prepare_wallet_backup},
@@ -368,15 +369,18 @@ impl VerificationSession {
                 self.retry_result(format!("failed to auto-sync missing wallet backups: {error}")),
             );
         }
-        let mut pending_uploads = Vec::with_capacity(unsynced.len());
-        for wallet in &unsynced {
-            let prepared = match prepare_wallet_backup(wallet, wallet.wallet_mode).await {
-                Ok(prepared) => prepared,
-                Err(error) => return Some(self.local_inventory_retry_result(&error)),
-            };
-            pending_uploads
-                .push(PendingVerificationUpload::new(prepared.record_id, prepared.revision_hash));
-        }
+        let pending_uploads = match stream::iter(unsynced.iter().cloned())
+            .map(|wallet| async move {
+                let prepared = prepare_wallet_backup(&wallet, wallet.wallet_mode).await?;
+                Ok(PendingVerificationUpload::new(prepared.record_id, prepared.revision_hash))
+            })
+            .buffered(CLOUD_BACKUP_IO_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await
+        {
+            Ok(pending_uploads) => pending_uploads,
+            Err(error) => return Some(self.local_inventory_retry_result(&error)),
+        };
 
         let updated_ids = match self.cloud.list_wallet_backups(self.namespace.clone()).await {
             Ok(updated_ids) => updated_ids,

--- a/rust/src/manager/cloud_backup_manager/verify/wrapper_repair.rs
+++ b/rust/src/manager/cloud_backup_manager/verify/wrapper_repair.rs
@@ -203,7 +203,6 @@ impl WrapperRepairOperation {
         match strategy {
             WrapperRepairStrategy::CreateNew => {
                 let new_prf = create_prf_key_without_persisting(&self.passkey).await?;
-                info!("Creating new passkey for wrapper repair");
 
                 Ok(WrapperRepairCredentials {
                     prf_key: new_prf.prf_key,

--- a/rust/src/manager/cloud_backup_manager/wallets/payload.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/payload.rs
@@ -268,7 +268,7 @@ async fn export_wallet_labels_jsonl(
     let manager = LabelManager::try_new(wallet_id.clone())
         .map_err(|error| CloudBackupError::Internal(format!("open labels db: {error}")))?;
 
-    manager.export().await.map_err(|error| CloudBackupError::Internal(error.to_string()))
+    manager.export().await.map_err_str(CloudBackupError::Internal)
 }
 
 pub fn decode_cloud_labels_jsonl(entry: &WalletEntry) -> Result<Option<String>, CloudBackupError> {

--- a/rust/src/manager/cloud_backup_manager/wallets/restore.rs
+++ b/rust/src/manager/cloud_backup_manager/wallets/restore.rs
@@ -22,6 +22,7 @@ pub(crate) enum WalletBackupLookup<T> {
 
 type ExistingFingerprints = Vec<(Fingerprint, cove_types::network::Network, LocalWalletMode)>;
 
+#[derive(Clone)]
 pub(crate) struct WalletBackupReader {
     cloud: CloudStorage,
     namespace: String,

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -1473,44 +1473,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use bip39::Mnemonic;
 
     use super::*;
-
-    fn determine_cloud_check_outcome<F, S>(
-        retry_delays: &[u64],
-        mut has_any_cloud_backup: F,
-        mut sleep: S,
-    ) -> CloudCheckOutcome
-    where
-        F: FnMut() -> Result<bool, CloudStorageError>,
-        S: FnMut(Duration),
-    {
-        for (attempt, delay) in retry_delays.iter().enumerate() {
-            info!(
-                "Onboarding: checking cloud backup attempt={}/{}",
-                attempt + 1,
-                retry_delays.len() + 1
-            );
-
-            match has_any_cloud_backup() {
-                Ok(true) => return CloudCheckOutcome::BackupFound,
-                Ok(false) => return CloudCheckOutcome::NoBackupConfirmed,
-                Err(error) => warn!("Onboarding: cloud backup check failed: {error}"),
-            }
-
-            sleep(Duration::from_secs(*delay));
-        }
-
-        match has_any_cloud_backup() {
-            Ok(true) => CloudCheckOutcome::BackupFound,
-            Ok(false) => CloudCheckOutcome::NoBackupConfirmed,
-            Err(error) => {
-                warn!("Onboarding: final cloud backup check failed: {error}");
-                CloudCheckOutcome::Inconclusive(classify_cloud_check_error(&error))
-            }
-        }
-    }
 
     #[test]
     fn continue_from_backup_requires_a_saved_backup_method() {
@@ -2168,30 +2135,44 @@ mod tests {
         assert_eq!(classify_cloud_check_error(&error), CloudCheckIssue::CloudUnavailable);
     }
 
-    #[test]
-    fn cloud_check_false_short_circuits_without_sleeping() {
-        let mut slept = Vec::new();
-        let outcome = determine_cloud_check_outcome(
+    #[tokio::test(flavor = "current_thread")]
+    async fn cloud_check_false_short_circuits_without_sleeping() {
+        let slept = Arc::new(Mutex::new(Vec::new()));
+        let sleep_log = Arc::clone(&slept);
+        let outcome = determine_cloud_check_outcome_async(
             &[1, 2, 3],
-            || Ok(false),
-            |duration| slept.push(duration),
-        );
+            || async { Ok(false) },
+            move |duration| {
+                let sleep_log = Arc::clone(&sleep_log);
+                async move {
+                    sleep_log.lock().unwrap().push(duration);
+                }
+            },
+        )
+        .await;
 
         assert_eq!(outcome, CloudCheckOutcome::NoBackupConfirmed);
-        assert!(slept.is_empty());
+        assert!(slept.lock().unwrap().is_empty());
     }
 
-    #[test]
-    fn cloud_check_retries_errors_and_returns_inconclusive() {
-        let mut slept = Vec::new();
-        let outcome = determine_cloud_check_outcome(
+    #[tokio::test(flavor = "current_thread")]
+    async fn cloud_check_retries_errors_and_returns_inconclusive() {
+        let slept = Arc::new(Mutex::new(Vec::new()));
+        let sleep_log = Arc::clone(&slept);
+        let outcome = determine_cloud_check_outcome_async(
             &[1, 2],
-            || Err(CloudStorageError::NotAvailable("network timed out".into())),
-            |duration| slept.push(duration),
-        );
+            || async { Err(CloudStorageError::NotAvailable("network timed out".into())) },
+            move |duration| {
+                let sleep_log = Arc::clone(&sleep_log);
+                async move {
+                    sleep_log.lock().unwrap().push(duration);
+                }
+            },
+        )
+        .await;
 
         assert_eq!(outcome, CloudCheckOutcome::Inconclusive(CloudCheckIssue::CloudUnavailable));
-        assert_eq!(slept, vec![Duration::from_secs(1), Duration::from_secs(2)]);
+        assert_eq!(*slept.lock().unwrap(), vec![Duration::from_secs(1), Duration::from_secs(2)]);
     }
 
     #[test]


### PR DESCRIPTION
Clean up retry-upload state more completely by removing the remote master-key backup when a staged enable session is discarded.

Speed up cloud backup detail, restore, and verification flows by running bounded cloud lookups and wallet preparation work concurrently.

Also align onboarding tests with the production async helper, use workspace async-trait dependencies, and simplify the iOS backup integrity and cloud storage paths.
