### PR TITLE
Add Tor proxy support for node connections

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -60,6 +61,7 @@ import org.bitcoinppl.cove_core.ApiType
 import org.bitcoinppl.cove_core.NodeSelection
 import org.bitcoinppl.cove_core.NodeSelector
 import org.bitcoinppl.cove_core.NodeSelectorException
+import org.bitcoinppl.cove_core.TorConfig
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,6 +81,14 @@ fun NodeSettingsScreen(
 
     var customUrl by remember { mutableStateOf("") }
     var customNodeName by remember { mutableStateOf("") }
+    var torEnabled by remember {
+        val savedNode = selectedNodeSelection.toNode()
+        mutableStateOf(savedNode.tor.enabled)
+    }
+    var torProxyAddress by remember {
+        val savedNode = selectedNodeSelection.toNode()
+        mutableStateOf(savedNode.tor.proxyAddress)
+    }
 
     var isLoading by remember { mutableStateOf(false) }
     var showErrorDialog by remember { mutableStateOf(false) }
@@ -118,6 +128,8 @@ fun NodeSettingsScreen(
                 if (matchesType) {
                     customUrl = node.url
                     customNodeName = node.name
+                    torEnabled = node.tor.enabled
+                    torProxyAddress = node.tor.proxyAddress
                 }
             }
         }
@@ -176,9 +188,19 @@ fun NodeSettingsScreen(
         scope.launch {
             isLoading = true
             try {
+                val torConfig = TorConfig(
+                    enabled = torEnabled,
+                    proxyAddress = torProxyAddress.ifEmpty { "127.0.0.1:9050" },
+                )
+
                 val node =
                     withContext(Dispatchers.IO) {
-                        nodeSelector.parseCustomNode(customUrl, selectedNodeName, customNodeName)
+                        nodeSelector.parseCustomNodeWithTor(
+                            customUrl,
+                            selectedNodeName,
+                            customNodeName,
+                            torConfig,
+                        )
                     }
 
                 // update fields with parsed values
@@ -350,6 +372,56 @@ fun NodeSettingsScreen(
                                 modifier = Modifier.fillMaxWidth(),
                             ) {
                                 Text(stringResource(R.string.node_save_button))
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(MaterialSpacing.medium))
+
+                    SectionHeader("Tor Proxy")
+                    MaterialSection {
+                        Column(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(MaterialSpacing.medium),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "Use Tor",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                )
+                                Switch(
+                                    checked = torEnabled,
+                                    onCheckedChange = { torEnabled = it },
+                                )
+                            }
+
+                            if (torEnabled) {
+                                OutlinedTextField(
+                                    value = torProxyAddress,
+                                    onValueChange = { torProxyAddress = it },
+                                    label = { Text("Proxy Address") },
+                                    placeholder = { Text("127.0.0.1:9050") },
+                                    keyboardOptions =
+                                        KeyboardOptions(
+                                            keyboardType = KeyboardType.Uri,
+                                            capitalization = KeyboardCapitalization.None,
+                                        ),
+                                    singleLine = true,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+
+                                Text(
+                                    text = "Ensure a Tor proxy (e.g. Orbot) is running on this address.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
                             }
                         }
                     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1633,6 +1633,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_nodeselector_parse_custom_node(
     ): Short
+    external fun uniffi_cove_checksum_method_nodeselector_parse_custom_node_with_tor(
+    ): Short
     external fun uniffi_cove_checksum_method_nodeselector_select_preset_node(
     ): Short
     external fun uniffi_cove_checksum_method_nodeselector_selected_node(
@@ -2722,6 +2724,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_nodeselector_node_list(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_nodeselector_parse_custom_node(`ptr`: Long,`url`: RustBuffer.ByValue,`name`: RustBuffer.ByValue,`enteredName`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_nodeselector_parse_custom_node_with_tor(`ptr`: Long,`url`: RustBuffer.ByValue,`name`: RustBuffer.ByValue,`enteredName`: RustBuffer.ByValue,`tor`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_nodeselector_select_preset_node(`ptr`: Long,`name`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -4376,6 +4380,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_nodeselector_parse_custom_node() != 62414.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_nodeselector_parse_custom_node_with_tor() != 43875.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_nodeselector_select_preset_node() != 59069.toShort()) {
@@ -15069,6 +15076,11 @@ public interface NodeSelectorInterface {
      */
     fun `parseCustomNode`(`url`: kotlin.String, `name`: kotlin.String, `enteredName`: kotlin.String): Node
     
+    /**
+     * Use the url and name of the custom node to set it as the selected node, with TOR config
+     */
+    fun `parseCustomNodeWithTor`(`url`: kotlin.String, `name`: kotlin.String, `enteredName`: kotlin.String, `tor`: TorConfig): Node
+    
     fun `selectPresetNode`(`name`: kotlin.String): Node
     
     fun `selectedNode`(): NodeSelection
@@ -15256,6 +15268,23 @@ open class NodeSelector: Disposable, AutoCloseable, NodeSelectorInterface
     UniffiLib.uniffi_cove_fn_method_nodeselector_parse_custom_node(
         it,
         FfiConverterString.lower(`url`),FfiConverterString.lower(`name`),FfiConverterString.lower(`enteredName`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Use the url and name of the custom node to set it as the selected node, with TOR config
+     */
+    @Throws(NodeSelectorException::class)override fun `parseCustomNodeWithTor`(`url`: kotlin.String, `name`: kotlin.String, `enteredName`: kotlin.String, `tor`: TorConfig): Node {
+            return FfiConverterTypeNode.lift(
+    callWithHandle {
+    uniffiRustCallWithError(NodeSelectorException) { _status ->
+    UniffiLib.uniffi_cove_fn_method_nodeselector_parse_custom_node_with_tor(
+        it,
+        FfiConverterString.lower(`url`),FfiConverterString.lower(`name`),FfiConverterString.lower(`enteredName`),FfiConverterTypeTorConfig.lower(`tor`),_status)
 }
     }
     )
@@ -28420,6 +28449,8 @@ data class Node (
     var `apiType`: ApiType
     , 
     var `url`: kotlin.String
+    , 
+    var `tor`: TorConfig
     
 ){
     
@@ -28440,6 +28471,7 @@ public object FfiConverterTypeNode: FfiConverterRustBuffer<Node> {
             FfiConverterTypeNetwork.read(buf),
             FfiConverterTypeApiType.read(buf),
             FfiConverterString.read(buf),
+            FfiConverterTypeTorConfig.read(buf),
         )
     }
 
@@ -28447,7 +28479,8 @@ public object FfiConverterTypeNode: FfiConverterRustBuffer<Node> {
             FfiConverterString.allocationSize(value.`name`) +
             FfiConverterTypeNetwork.allocationSize(value.`network`) +
             FfiConverterTypeApiType.allocationSize(value.`apiType`) +
-            FfiConverterString.allocationSize(value.`url`)
+            FfiConverterString.allocationSize(value.`url`) +
+            FfiConverterTypeTorConfig.allocationSize(value.`tor`)
     )
 
     override fun write(value: Node, buf: ByteBuffer) {
@@ -28455,6 +28488,7 @@ public object FfiConverterTypeNode: FfiConverterRustBuffer<Node> {
             FfiConverterTypeNetwork.write(value.`network`, buf)
             FfiConverterTypeApiType.write(value.`apiType`, buf)
             FfiConverterString.write(value.`url`, buf)
+            FfiConverterTypeTorConfig.write(value.`tor`, buf)
     }
 }
 
@@ -29027,6 +29061,50 @@ public object FfiConverterTypeTapSignerSetupComplete: FfiConverterRustBuffer<Tap
     override fun write(value: TapSignerSetupComplete, buf: ByteBuffer) {
             FfiConverterByteArray.write(value.`backup`, buf)
             FfiConverterTypeDeriveInfo.write(value.`deriveInfo`, buf)
+    }
+}
+
+
+
+data class TorConfig (
+    /**
+     * Whether TOR proxy is enabled
+     */
+    var `enabled`: kotlin.Boolean
+    , 
+    /**
+     * SOCKS5 proxy address (e.g. "127.0.0.1:9050")
+     */
+    var `proxyAddress`: kotlin.String
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTorConfig: FfiConverterRustBuffer<TorConfig> {
+    override fun read(buf: ByteBuffer): TorConfig {
+        return TorConfig(
+            FfiConverterBoolean.read(buf),
+            FfiConverterString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: TorConfig) = (
+            FfiConverterBoolean.allocationSize(value.`enabled`) +
+            FfiConverterString.allocationSize(value.`proxyAddress`)
+    )
+
+    override fun write(value: TorConfig, buf: ByteBuffer) {
+            FfiConverterBoolean.write(value.`enabled`, buf)
+            FfiConverterString.write(value.`proxyAddress`, buf)
     }
 }
 

--- a/ios/Cove/Flows/SettingsFlow/SettingsScreen/NodeSelectionView.swift
+++ b/ios/Cove/Flows/SettingsFlow/SettingsScreen/NodeSelectionView.swift
@@ -19,14 +19,24 @@ struct NodeSelectionView: View {
     @State private var customNodeName: String = ""
     @State private var customUrl: String = ""
 
+    @State private var torEnabled: Bool = false
+    @State private var torProxyAddress: String = "127.0.0.1:9050"
+
     @State private var showParseUrlAlert = false
     @State private var parseUrlMessage = ""
 
     @State private var checkUrlTask: Task<Void, Never>?
 
     init() {
-        selectedNodeName = nodeSelector.selectedNode().name
+        let selected = nodeSelector.selectedNode()
+        selectedNodeName = selected.name
         nodeList = nodeSelector.nodeList()
+
+        // restore TOR settings from the currently selected node
+        if case let .custom(savedNode) = selected {
+            _torEnabled = State(initialValue: savedNode.tor.enabled)
+            _torProxyAddress = State(initialValue: savedNode.tor.proxyAddress)
+        }
     }
 
     var showCustomUrlField: Bool {
@@ -95,14 +105,45 @@ struct NodeSelectionView: View {
                 Button("Save Custom Node", action: checkAndSaveNode)
                     .disabled(customUrl.isEmpty)
             }
+
+            Section("Tor Proxy") {
+                Toggle("Use Tor", isOn: $torEnabled)
+                    .font(.subheadline)
+
+                if torEnabled {
+                    HStack {
+                        Text("Proxy")
+                            .frame(width: 60, alignment: .leading)
+
+                        TextField("127.0.0.1:9050", text: $torProxyAddress)
+                            .keyboardType(.numbersAndPunctuation)
+                            .textInputAutocapitalization(.never)
+                    }
+                    .font(.subheadline)
+
+                    Text("Ensure a Tor proxy (e.g. Orbot) is running on this address.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 
     func checkAndSaveNode() {
         var node: Node? = nil
 
+        let torConfig = TorConfig(
+            enabled: torEnabled,
+            proxyAddress: torProxyAddress.isEmpty ? "127.0.0.1:9050" : torProxyAddress
+        )
+
         do {
-            node = try nodeSelector.parseCustomNode(url: customUrl, name: selectedNodeName, enteredName: customNodeName)
+            node = try nodeSelector.parseCustomNodeWithTor(
+                url: customUrl,
+                name: selectedNodeName,
+                enteredName: customNodeName,
+                tor: torConfig
+            )
             customUrl = node?.url ?? customUrl
             customNodeName = node?.name ?? customNodeName
         } catch {
@@ -195,11 +236,15 @@ struct NodeSelectionView: View {
                     if savedSelectedNode.apiType == .electrum, selectedNodeName.contains("Electrum") {
                         customUrl = savedSelectedNode.url
                         customNodeName = savedSelectedNode.name
+                        torEnabled = savedSelectedNode.tor.enabled
+                        torProxyAddress = savedSelectedNode.tor.proxyAddress
                     }
 
                     if savedSelectedNode.apiType == .esplora, selectedNodeName.contains("Esplora") {
                         customUrl = savedSelectedNode.url
                         customNodeName = savedSelectedNode.name
+                        torEnabled = savedSelectedNode.tor.enabled
+                        torProxyAddress = savedSelectedNode.tor.proxyAddress
                     }
                 }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -5580,6 +5580,11 @@ public protocol NodeSelectorProtocol: AnyObject, Sendable {
      */
     func parseCustomNode(url: String, name: String, enteredName: String) throws  -> Node
     
+    /**
+     * Use the url and name of the custom node to set it as the selected node, with TOR config
+     */
+    func parseCustomNodeWithTor(url: String, name: String, enteredName: String, tor: TorConfig) throws  -> Node
+    
     func selectPresetNode(name: String) throws  -> Node
     
     func selectedNode()  -> NodeSelection
@@ -5700,6 +5705,21 @@ open func parseCustomNode(url: String, name: String, enteredName: String)throws 
         FfiConverterString.lower(url),
         FfiConverterString.lower(name),
         FfiConverterString.lower(enteredName),$0
+    )
+})
+}
+    
+    /**
+     * Use the url and name of the custom node to set it as the selected node, with TOR config
+     */
+open func parseCustomNodeWithTor(url: String, name: String, enteredName: String, tor: TorConfig)throws  -> Node  {
+    return try  FfiConverterTypeNode_lift(try rustCallWithError(FfiConverterTypeNodeSelectorError_lift) {
+    uniffi_cove_fn_method_nodeselector_parse_custom_node_with_tor(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(url),
+        FfiConverterString.lower(name),
+        FfiConverterString.lower(enteredName),
+        FfiConverterTypeTorConfig_lower(tor),$0
     )
 })
 }
@@ -14237,14 +14257,16 @@ public struct Node: Equatable, Hashable {
     public var network: Network
     public var apiType: ApiType
     public var url: String
+    public var tor: TorConfig
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(name: String, network: Network, apiType: ApiType, url: String) {
+    public init(name: String, network: Network, apiType: ApiType, url: String, tor: TorConfig) {
         self.name = name
         self.network = network
         self.apiType = apiType
         self.url = url
+        self.tor = tor
     }
 
     
@@ -14266,7 +14288,8 @@ public struct FfiConverterTypeNode: FfiConverterRustBuffer {
                 name: FfiConverterString.read(from: &buf), 
                 network: FfiConverterTypeNetwork.read(from: &buf), 
                 apiType: FfiConverterTypeApiType.read(from: &buf), 
-                url: FfiConverterString.read(from: &buf)
+                url: FfiConverterString.read(from: &buf), 
+                tor: FfiConverterTypeTorConfig.read(from: &buf)
         )
     }
 
@@ -14275,6 +14298,7 @@ public struct FfiConverterTypeNode: FfiConverterRustBuffer {
         FfiConverterTypeNetwork.write(value.network, into: &buf)
         FfiConverterTypeApiType.write(value.apiType, into: &buf)
         FfiConverterString.write(value.url, into: &buf)
+        FfiConverterTypeTorConfig.write(value.tor, into: &buf)
     }
 }
 
@@ -14970,6 +14994,72 @@ public func FfiConverterTypeTapSignerSetupComplete_lift(_ buf: RustBuffer) throw
 #endif
 public func FfiConverterTypeTapSignerSetupComplete_lower(_ value: TapSignerSetupComplete) -> RustBuffer {
     return FfiConverterTypeTapSignerSetupComplete.lower(value)
+}
+
+
+public struct TorConfig: Equatable, Hashable {
+    /**
+     * Whether TOR proxy is enabled
+     */
+    public var enabled: Bool
+    /**
+     * SOCKS5 proxy address (e.g. "127.0.0.1:9050")
+     */
+    public var proxyAddress: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Whether TOR proxy is enabled
+         */enabled: Bool, 
+        /**
+         * SOCKS5 proxy address (e.g. "127.0.0.1:9050")
+         */proxyAddress: String) {
+        self.enabled = enabled
+        self.proxyAddress = proxyAddress
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension TorConfig: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeTorConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TorConfig {
+        return
+            try TorConfig(
+                enabled: FfiConverterBool.read(from: &buf), 
+                proxyAddress: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: TorConfig, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.enabled, into: &buf)
+        FfiConverterString.write(value.proxyAddress, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTorConfig_lift(_ buf: RustBuffer) throws -> TorConfig {
+    return try FfiConverterTypeTorConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTorConfig_lower(_ value: TorConfig) -> RustBuffer {
+    return FfiConverterTypeTorConfig.lower(value)
 }
 
 
@@ -36760,6 +36850,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_nodeselector_parse_custom_node() != 62414) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_nodeselector_parse_custom_node_with_tor() != 43875) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_nodeselector_select_preset_node() != 59069) {

--- a/rust/crates/cove-http/Cargo.toml
+++ b/rust/crates/cove-http/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["socks"] }
 rustls = { version = "0.23", features = ["ring"], default-features = false }
 webpki-roots = "1.0"

--- a/rust/crates/cove-http/src/lib.rs
+++ b/rust/crates/cove-http/src/lib.rs
@@ -3,15 +3,30 @@ use std::time::Duration;
 /// Build a reqwest Client that uses webpki-roots for TLS cert verification,
 /// bypassing rustls-platform-verifier (which requires Android JNI init)
 pub fn new_client() -> Result<reqwest::Client, reqwest::Error> {
+    build_client(None)
+}
+
+/// Build a reqwest Client with an optional SOCKS5 proxy for TOR support.
+/// The `socks5_url` should be in the format "socks5://127.0.0.1:9050".
+pub fn new_client_with_proxy(socks5_url: &str) -> Result<reqwest::Client, reqwest::Error> {
+    build_client(Some(socks5_url))
+}
+
+fn build_client(socks5_url: Option<&str>) -> Result<reqwest::Client, reqwest::Error> {
     let root_store =
         rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
     let tls_config =
         rustls::ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
 
-    reqwest::ClientBuilder::new()
+    let mut builder = reqwest::ClientBuilder::new()
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(30))
-        .tls_backend_preconfigured(tls_config)
-        .build()
+        .tls_backend_preconfigured(tls_config);
+
+    if let Some(proxy_url) = socks5_url {
+        builder = builder.proxy(reqwest::Proxy::all(proxy_url)?);
+    }
+
+    builder.build()
 }

--- a/rust/src/fee_client.rs
+++ b/rust/src/fee_client.rs
@@ -9,7 +9,6 @@ use std::{
 use arc_swap::ArcSwap;
 use backon::{ExponentialBuilder, Retryable as _};
 use eyre::{Context as _, Result};
-use once_cell::sync::OnceCell;
 use tracing::{debug, error, warn};
 
 /// Guard to prevent multiple concurrent background refresh tasks
@@ -37,7 +36,6 @@ pub static FEES: LazyLock<ArcSwap<Option<CachedFeeResponse>>> =
 
 pub struct FeeClient {
     url: String,
-    client: OnceCell<reqwest::Client>,
 }
 
 impl FeeClient {
@@ -46,7 +44,7 @@ impl FeeClient {
     }
 
     pub fn new_with_url(url: String) -> Self {
-        Self { url, client: OnceCell::new() }
+        Self { url }
     }
 
     /// Get cached fees, will trigger background refresh if stale
@@ -111,13 +109,19 @@ impl FeeClient {
 
     /// Always gets new fees from the server
     async fn get_new_fees(&self) -> Result<FeeResponse, reqwest::Error> {
-        let response = self.client()?.get(&self.url).send().await?;
+        let client = Self::build_client()?;
+        let response = client.get(&self.url).send().await?;
         let fees: FeeResponse = response.json().await?;
         Ok(fees)
     }
 
-    fn client(&self) -> Result<&reqwest::Client, reqwest::Error> {
-        self.client.get_or_try_init(cove_http::new_client)
+    fn build_client() -> Result<reqwest::Client, reqwest::Error> {
+        let node = Database::global().global_config.selected_node();
+        if node.tor.enabled {
+            cove_http::new_client_with_proxy(&node.tor.socks5_url())
+        } else {
+            cove_http::new_client()
+        }
     }
 }
 

--- a/rust/src/fiat/client.rs
+++ b/rust/src/fiat/client.rs
@@ -7,7 +7,6 @@ use arc_swap::ArcSwap;
 use backon::{ExponentialBuilder, Retryable as _};
 use eyre::{Context as _, Result};
 use jiff::Timestamp;
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, trace, warn};
 
@@ -34,7 +33,6 @@ pub static PRICES: LazyLock<ArcSwap<Option<PriceResponse>>> =
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct FiatClient {
     url: String,
-    client: OnceCell<reqwest::Client>,
 }
 
 #[derive(
@@ -81,7 +79,7 @@ impl_default_for!(FiatClient);
 
 impl FiatClient {
     fn new() -> Self {
-        Self { url: CURRENCY_URL.to_string(), client: OnceCell::new() }
+        Self { url: CURRENCY_URL.to_string() }
     }
     /// Sync method using cached prices only, returns None if no cache
     pub fn value_in_currency_cached(&self, amount: Amount, currency: FiatCurrency) -> Option<f64> {
@@ -105,7 +103,7 @@ impl FiatClient {
     ) -> Result<HistoricalPricesResponse, reqwest::Error> {
         let url = format!("{HISTORICAL_PRICES_URL}?timestamp={timestamp}");
 
-        let response = self.client()?.get(&url).send().await?;
+        let response = Self::build_client()?.get(&url).send().await?;
         let historical_prices: HistoricalPricesResponse = response.json().await?;
 
         Ok(historical_prices)
@@ -146,7 +144,7 @@ impl FiatClient {
         }
 
         debug!("fetching prices");
-        let response = self.client()?.get(&self.url).send().await?;
+        let response = Self::build_client()?.get(&self.url).send().await?;
         let prices: PriceResponse = response.json().await?;
 
         // saved prices are the same as the new ones don't need to update
@@ -194,8 +192,13 @@ impl FiatClient {
         Ok(value_in_currency)
     }
 
-    fn client(&self) -> Result<&reqwest::Client, reqwest::Error> {
-        self.client.get_or_try_init(cove_http::new_client)
+    fn build_client() -> Result<reqwest::Client, reqwest::Error> {
+        let node = crate::database::Database::global().global_config.selected_node();
+        if node.tor.enabled {
+            cove_http::new_client_with_proxy(&node.tor.socks5_url())
+        } else {
+            cove_http::new_client()
+        }
     }
 }
 

--- a/rust/src/node.rs
+++ b/rust/src/node.rs
@@ -2,7 +2,7 @@ pub mod client;
 pub mod client_builder;
 
 use crate::node_connect::{
-    BITCOIN_ELECTRUM, NodeSelection, SIGNET_ESPLORA, TESTNET_ESPLORA, TESTNET4_ESPLORA,
+    BITCOIN_ELECTRUM, NodeSelection, SIGNET_ESPLORA, TESTNET_ELECTRUM, TESTNET4_ESPLORA,
 };
 
 use client::NodeClient;
@@ -30,11 +30,38 @@ pub enum ApiType {
 #[derive(
     Debug, Clone, Hash, Eq, PartialEq, uniffi::Record, serde::Serialize, serde::Deserialize,
 )]
+pub struct TorConfig {
+    /// Whether TOR proxy is enabled
+    pub enabled: bool,
+    /// SOCKS5 proxy address (e.g. "127.0.0.1:9050")
+    pub proxy_address: String,
+}
+
+impl Default for TorConfig {
+    fn default() -> Self {
+        Self { enabled: false, proxy_address: "127.0.0.1:9050".to_string() }
+    }
+}
+
+impl TorConfig {
+    /// Returns the SOCKS5 proxy URL with remote DNS resolution (socks5h).
+    /// The 'h' variant resolves hostnames through the proxy, which is
+    /// required for .onion addresses that cannot be resolved locally.
+    pub fn socks5_url(&self) -> String {
+        format!("socks5h://{}", self.proxy_address)
+    }
+}
+
+#[derive(
+    Debug, Clone, Hash, Eq, PartialEq, uniffi::Record, serde::Serialize, serde::Deserialize,
+)]
 pub struct Node {
     pub name: String,
     pub network: Network,
     pub api_type: ApiType,
     pub url: String,
+    #[serde(default)]
+    pub tor: TorConfig,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -48,52 +75,31 @@ impl Node {
         match network {
             Network::Bitcoin => {
                 let (name, url) = BITCOIN_ELECTRUM[0];
-
-                Self {
-                    name: name.to_string(),
-                    network,
-                    api_type: ApiType::Electrum,
-                    url: url.to_string(),
-                }
+                Self::new_electrum(name.to_string(), url.to_string(), network)
             }
             Network::Testnet => {
-                let (name, url) = TESTNET_ESPLORA[0];
-                Self {
-                    name: name.to_string(),
-                    network,
-                    api_type: ApiType::Electrum,
-                    url: url.to_string(),
-                }
+                let (name, url) = TESTNET_ELECTRUM[0];
+                Self::new_electrum(name.to_string(), url.to_string(), network)
             }
 
             Network::Signet => {
                 let (name, url) = SIGNET_ESPLORA[0];
-                Self {
-                    name: name.to_string(),
-                    network,
-                    api_type: ApiType::Esplora,
-                    url: url.to_string(),
-                }
+                Self::new_esplora(name.to_string(), url.to_string(), network)
             }
 
             Network::Testnet4 => {
                 let (name, url) = TESTNET4_ESPLORA[0];
-                Self {
-                    name: name.to_string(),
-                    network,
-                    api_type: ApiType::Esplora,
-                    url: url.to_string(),
-                }
+                Self::new_esplora(name.to_string(), url.to_string(), network)
             }
         }
     }
 
-    pub const fn new_electrum(name: String, url: String, network: Network) -> Self {
-        Self { name, network, api_type: ApiType::Electrum, url }
+    pub fn new_electrum(name: String, url: String, network: Network) -> Self {
+        Self { name, network, api_type: ApiType::Electrum, url, tor: TorConfig::default() }
     }
 
-    pub const fn new_esplora(name: String, url: String, network: Network) -> Self {
-        Self { name, network, api_type: ApiType::Esplora, url }
+    pub fn new_esplora(name: String, url: String, network: Network) -> Self {
+        Self { name, network, api_type: ApiType::Esplora, url, tor: TorConfig::default() }
     }
 
     pub async fn check_url(&self) -> Result<(), Error> {

--- a/rust/src/node/client/electrum.rs
+++ b/rust/src/node/client/electrum.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bdk_electrum::{
     BdkElectrumClient,
-    electrum_client::{self, Client, ElectrumApi as _, Param},
+    electrum_client::{self, Client, ConfigBuilder, ElectrumApi as _, Param, Socks5Config},
 };
 use bdk_wallet::chain::{
     BlockId, ConfirmationBlockTime, TxGraph,
@@ -57,11 +57,21 @@ impl ElectrumClient {
         options: NodeClientOptions,
     ) -> Result<Self, Error> {
         let url = node.url.strip_suffix('/').unwrap_or(&node.url).to_string();
+        let tor = node.tor.clone();
 
         // use spawn_blocking for the synchronous TCP connection to avoid blocking the async runtime
-        let inner_client = cove_tokio::unblock::run_blocking(move || Client::new(&url))
-            .await
-            .map_err(Error::CreateElectrumClient)?;
+        let inner_client = cove_tokio::unblock::run_blocking(move || {
+            if tor.enabled {
+                let socks5 = Socks5Config::new(&tor.proxy_address);
+                let config = ConfigBuilder::new().socks5(Some(socks5)).timeout(Some(30)).build();
+
+                Client::from_config(&url, config)
+            } else {
+                Client::new(&url)
+            }
+        })
+        .await
+        .map_err(Error::CreateElectrumClient)?;
 
         let bdk_client = BdkElectrumClient::new(inner_client);
         let client = Arc::new(bdk_client);
@@ -303,6 +313,7 @@ mod tests {
             name: "blockstream".to_string(),
             api_type: crate::node::ApiType::Electrum,
             network: cove_types::network::Network::Bitcoin,
+            tor: crate::node::TorConfig::default(),
         })
         .await
         .unwrap();

--- a/rust/src/node/client/esplora.rs
+++ b/rust/src/node/client/esplora.rs
@@ -29,10 +29,12 @@ impl EsploraClient {
     }
 
     pub fn new_from_node(node: &Node) -> Result<Self, Error> {
-        let client = esplora_client::Builder::new(&node.url)
-            .build_async()
-            .map_err(Error::CreateEsploraClient)?
-            .into();
+        let mut builder = esplora_client::Builder::new(&node.url);
+        if node.tor.enabled {
+            builder = builder.proxy(&node.tor.socks5_url());
+        }
+
+        let client = builder.build_async().map_err(Error::CreateEsploraClient)?.into();
 
         Ok(Self::new(client))
     }
@@ -41,10 +43,12 @@ impl EsploraClient {
         node: &Node,
         options: NodeClientOptions,
     ) -> Result<Self, Error> {
-        let client = esplora_client::Builder::new(&node.url)
-            .build_async()
-            .map_err(Error::CreateEsploraClient)?
-            .into();
+        let mut builder = esplora_client::Builder::new(&node.url);
+        if node.tor.enabled {
+            builder = builder.proxy(&node.tor.socks5_url());
+        }
+
+        let client = builder.build_async().map_err(Error::CreateEsploraClient)?.into();
 
         Ok(Self::new_with_options(client, options))
     }

--- a/rust/src/node_connect.rs
+++ b/rust/src/node_connect.rs
@@ -1,7 +1,11 @@
 use tracing::error;
 use url::Url;
 
-use crate::{database::Database, network::Network, node::Node};
+use crate::{
+    database::Database,
+    network::Network,
+    node::{Node, TorConfig},
+};
 use cove_macros::impl_default_for;
 use eyre::{Context, eyre};
 
@@ -137,10 +141,24 @@ impl NodeSelector {
         name: String,
         entered_name: String,
     ) -> Result<Node, Error> {
-        let node_type = name.to_ascii_lowercase();
+        self.parse_custom_node_with_tor(url, name, entered_name, TorConfig::default())
+    }
 
-        let url =
-            parse_node_url(&url).map_err(|error| Error::ParseNodeUrlError(error.to_string()))?;
+    #[uniffi::method]
+    /// Use the url and name of the custom node to set it as the selected node, with TOR config
+    pub fn parse_custom_node_with_tor(
+        &self,
+        url: String,
+        name: String,
+        entered_name: String,
+        tor: TorConfig,
+    ) -> Result<Node, Error> {
+        let node_type = name.to_ascii_lowercase();
+        let is_onion = url.contains(".onion");
+        let is_esplora = node_type.contains("esplora");
+
+        let url = parse_node_url(&url, is_onion, is_esplora)
+            .map_err(|error| Error::ParseNodeUrlError(error.to_string()))?;
 
         if !url.domain().unwrap_or_default().contains('.') {
             return Err(Error::ParseNodeUrlError("invalid url, no domain".to_string()));
@@ -154,7 +172,7 @@ impl NodeSelector {
             entered_name
         };
 
-        let node = if node_type.contains("electrum") {
+        let mut node = if node_type.contains("electrum") {
             Node::new_electrum(name, url_string, self.network)
         } else if node_type.contains("esplora") {
             Node::new_esplora(name, url_string, self.network)
@@ -162,6 +180,8 @@ impl NodeSelector {
             error!("invalid node type: {node_type}");
             Node::default(self.network)
         };
+
+        node.tor = tor;
 
         Ok(node)
     }
@@ -237,36 +257,62 @@ fn node_list(network: Network) -> Vec<Node> {
     }
 }
 
-fn parse_node_url(url: &str) -> eyre::Result<Url> {
-    let url = url.replace("http://", "tcp://");
-    let url = url.replace("https://", "ssl://");
+fn parse_node_url(url: &str, is_onion: bool, is_esplora: bool) -> eyre::Result<Url> {
+    // Esplora uses HTTP URLs — don't convert http/https to tcp/ssl
+    // Electrum uses tcp/ssl schemes
+    let url = if is_esplora {
+        url.to_string()
+    } else {
+        let url = url.replace("http://", "tcp://");
+        url.replace("https://", "ssl://")
+    };
 
     let mut url = if url.contains("://") {
         Url::parse(&url)?
+    } else if is_esplora {
+        // Esplora defaults to http
+        let url_str = format!("http://{url}/");
+        Url::parse(&url_str)?
     } else {
         let url_str = format!("none://{url}/");
         Url::parse(&url_str)?
     };
 
-    // set the scheme properly, use the port as a hint
-    match (url.scheme(), url.port()) {
-        ("none", Some(50002)) => url
-            .set_scheme("ssl")
-            .map_err(|()| eyre!("can't set scheme to ssl"))
-            .context("original: none, port is 50002")?,
-        ("none", Some(50001)) => url
-            .set_scheme("tcp")
-            .map_err(|()| eyre!("can't set scheme to tcp"))
-            .context("original: none, port is 50001")?,
-        ("none", port) => {
-            url.set_scheme("tcp")
-                .map_err(|()| eyre!("can't set scheme to tcp"))
-                .wrap_err_with(|| format!("original: none, port is {port:?}"))?;
-        }
-        _ => {}
+    // Esplora URLs keep their http/https scheme — skip electrum-specific scheme logic
+    if is_esplora {
+        return Ok(url);
     }
 
-    // set the port to if not set, default to 50002 for ssl and 50001 for tcp
+    // .onion addresses should always use tcp:// (TOR already provides encryption)
+    if is_onion {
+        match url.scheme() {
+            "none" | "ssl" | "https" => {
+                url.set_scheme("tcp")
+                    .map_err(|()| eyre!("can't set scheme to tcp for onion address"))?;
+            }
+            _ => {}
+        }
+    } else {
+        // set the scheme properly, use the port as a hint
+        match (url.scheme(), url.port()) {
+            ("none", Some(50002)) => url
+                .set_scheme("ssl")
+                .map_err(|()| eyre!("can't set scheme to ssl"))
+                .context("original: none, port is 50002")?,
+            ("none", Some(50001)) => url
+                .set_scheme("tcp")
+                .map_err(|()| eyre!("can't set scheme to tcp"))
+                .context("original: none, port is 50001")?,
+            ("none", port) => {
+                url.set_scheme("tcp")
+                    .map_err(|()| eyre!("can't set scheme to tcp"))
+                    .wrap_err_with(|| format!("original: none, port is {port:?}"))?;
+            }
+            _ => {}
+        }
+    }
+
+    // set the port if not set, default to 50002 for ssl and 50001 for tcp
     match (url.port(), url.scheme()) {
         (Some(_), _) => {}
         (None, "ssl") => url.set_port(Some(50002)).map_err(|()| eyre!("can't set port"))?,


### PR DESCRIPTION
Route Electrum, Esplora, and HTTP client traffic through a SOCKS5 proxy when Tor is enabled. This lets users connect to their own .onion Electrum/Esplora servers via a local Tor proxy such as Orbot.

- Add TorConfig (enabled, proxy_address) to the Node model
- Use electrum-client's Client::from_config with Socks5Config
- Pass socks5 proxy URL to esplora-client Builder::proxy
- Add reqwest socks feature to cove-http for fee/fiat clients
- Force tcp:// scheme for .onion addresses (Tor encrypts)
- Add Tor toggle and proxy address fields to iOS and Android node settings UI
- Backward-compatible: serde(default) on tor field

Closes #256

## Summary

<!-- describe what changed and why -->

## Testing

<!-- list the commands you ran or explain why testing was not needed -->

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Tor support for custom node configurations on Android and iOS, with a toggle to enable Tor and configurable proxy address settings.
  * Support for connecting to Tor hidden services (`.onion` addresses).
  * HTTP requests automatically route through SOCKS5 proxy when Tor is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->