### PR TITLE
Add wallet reordering to sidebar (iOS + Android)

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
@@ -85,8 +85,7 @@ fun SidebarView(
     val scope = rememberCoroutineScope()
     val spacingPx = with(density) { INTER_ITEM_SPACING_DP.dp.toPx() }
 
-    // local, optimistically-updated order of wallets for a smooth drag; synced from
-    // `app.wallets` whenever no drag is in progress
+    // local copy lets drags apply optimistically; resyncs from app.wallets when idle
     var walletList by remember { mutableStateOf(app.wallets) }
     var draggedWalletId by remember { mutableStateOf<WalletId?>(null) }
     var draggedOffsetY by remember { mutableFloatStateOf(0f) }
@@ -156,7 +155,7 @@ fun SidebarView(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        // wallet list with long-press drag-to-reorder
+        // wallet list
         LazyColumn(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(INTER_ITEM_SPACING_DP.dp),

--- a/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove.AppManager
@@ -90,6 +91,8 @@ fun SidebarView(
     var draggedWalletId by remember { mutableStateOf<WalletId?>(null) }
     var draggedOffsetY by remember { mutableFloatStateOf(0f) }
     var itemHeightPx by remember { mutableFloatStateOf(0f) }
+    var preDragSnapshot by remember { mutableStateOf<List<WalletMetadata>>(emptyList()) }
+    var pendingReorderJob by remember { mutableStateOf<Job?>(null) }
 
     LaunchedEffect(app.wallets) {
         if (draggedWalletId == null) walletList = app.wallets
@@ -185,6 +188,7 @@ fun SidebarView(
                             detectDragGesturesAfterLongPress(
                                 onDragStart = {
                                     haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    preDragSnapshot = walletList
                                     draggedWalletId = wallet.id
                                     draggedOffsetY = 0f
                                 },
@@ -217,20 +221,28 @@ fun SidebarView(
                                 },
                                 onDragEnd = {
                                     val orderedIds = walletList.map { it.id }
-                                    val previous = app.wallets
-                                    persistReorder(
-                                        scope = scope,
-                                        app = app,
-                                        orderedIds = orderedIds,
-                                        previous = previous,
-                                        haptics = haptics,
-                                        onRollback = { walletList = previous },
-                                    )
+                                    pendingReorderJob =
+                                        persistReorder(
+                                            scope = scope,
+                                            app = app,
+                                            previousJob = pendingReorderJob,
+                                            orderedIds = orderedIds,
+                                            haptics = haptics,
+                                            currentOptimisticIds = { walletList.map { it.id } },
+                                            onAdoptAuthoritative = { authoritative ->
+                                                walletList = authoritative
+                                                app.loadWallets()
+                                            },
+                                            onFailureResync = {
+                                                app.loadWallets()
+                                                walletList = app.wallets
+                                            },
+                                        )
                                     draggedWalletId = null
                                     draggedOffsetY = 0f
                                 },
                                 onDragCancel = {
-                                    walletList = app.wallets
+                                    walletList = preDragSnapshot
                                     draggedWalletId = null
                                     draggedOffsetY = 0f
                                 },
@@ -312,24 +324,33 @@ fun SidebarView(
 private fun persistReorder(
     scope: CoroutineScope,
     app: AppManager,
+    previousJob: Job?,
     orderedIds: List<WalletId>,
-    previous: List<WalletMetadata>,
     haptics: HapticFeedback,
-    onRollback: () -> Unit,
-) {
+    currentOptimisticIds: () -> List<WalletId>,
+    onAdoptAuthoritative: (List<WalletMetadata>) -> Unit,
+    onFailureResync: () -> Unit,
+): Job =
     scope.launch {
+        previousJob?.join()
+
         val result =
             withContext(Dispatchers.IO) {
                 runCatching { app.database.wallets().reorderWallets(orderedIds) }
             }
-        result.onSuccess {
-            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+
+        val stillCurrent = currentOptimisticIds() == orderedIds
+
+        result.onSuccess { authoritative ->
+            if (stillCurrent) {
+                onAdoptAuthoritative(authoritative)
+                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
         }.onFailure { error ->
             Log.e(TAG, "Failed to reorder wallets: ${error.message}")
-            onRollback()
+            if (stillCurrent) onFailureResync()
         }
     }
-}
 
 @Composable
 private fun WalletItem(

--- a/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
@@ -179,9 +179,7 @@ fun SidebarView(
                             app.rust.selectWallet(wallet.id)
                         }
                     },
-                    onMeasuredHeight = { h ->
-                        if (itemHeightPx == 0f) itemHeightPx = h.toFloat()
-                    },
+                    onMeasuredHeight = { h -> itemHeightPx = h.toFloat() },
                     gestureModifier =
                         Modifier.pointerInput(wallet.id) {
                             detectDragGesturesAfterLongPress(

--- a/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/sidebar/SidebarView.kt
@@ -3,6 +3,7 @@ package org.bitcoinppl.cove.sidebar
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,15 +31,35 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove.AppManager
+import org.bitcoinppl.cove.Log
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.ui.theme.CoveColor
 import org.bitcoinppl.cove.views.AutoSizeText
@@ -47,12 +68,34 @@ import org.bitcoinppl.cove_core.RouteFactory
 import org.bitcoinppl.cove_core.SettingsRoute
 import org.bitcoinppl.cove_core.WalletColor
 import org.bitcoinppl.cove_core.WalletMetadata
+import org.bitcoinppl.cove_core.types.WalletId
+
+private const val TAG = "SidebarView"
+private const val DRAG_SCALE = 1.02f
+private const val DRAG_SHADOW_ELEVATION_DP = 12f
+private const val INTER_ITEM_SPACING_DP = 12
 
 @Composable
 fun SidebarView(
     app: AppManager,
     modifier: Modifier = Modifier,
 ) {
+    val density = LocalDensity.current
+    val haptics = LocalHapticFeedback.current
+    val scope = rememberCoroutineScope()
+    val spacingPx = with(density) { INTER_ITEM_SPACING_DP.dp.toPx() }
+
+    // local, optimistically-updated order of wallets for a smooth drag; synced from
+    // `app.wallets` whenever no drag is in progress
+    var walletList by remember { mutableStateOf(app.wallets) }
+    var draggedWalletId by remember { mutableStateOf<WalletId?>(null) }
+    var draggedOffsetY by remember { mutableFloatStateOf(0f) }
+    var itemHeightPx by remember { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(app.wallets) {
+        if (draggedWalletId == null) walletList = app.wallets
+    }
+
     Column(
         modifier =
             modifier
@@ -113,19 +156,89 @@ fun SidebarView(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        // wallet list
+        // wallet list with long-press drag-to-reorder
         LazyColumn(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(INTER_ITEM_SPACING_DP.dp),
         ) {
-            items(app.wallets) { wallet ->
+            items(walletList, key = { it.id }) { wallet ->
+                val isDragged = wallet.id == draggedWalletId
+                val isAnyDragging = draggedWalletId != null
+
+                // only neighbors slide smoothly; the dragged item tracks the finger via
+                // graphicsLayer and should not be animated by the lazy list
+                val placementModifier = if (isDragged) Modifier else Modifier.animateItem()
+
                 WalletItem(
                     wallet = wallet,
+                    isDragged = isDragged,
+                    dragOffsetY = if (isDragged) draggedOffsetY else 0f,
+                    isClickEnabled = !isAnyDragging,
+                    placementModifier = placementModifier,
                     onClick = {
                         app.closeSidebarAndNavigate {
                             app.rust.selectWallet(wallet.id)
                         }
                     },
+                    onMeasuredHeight = { h ->
+                        if (itemHeightPx == 0f) itemHeightPx = h.toFloat()
+                    },
+                    gestureModifier =
+                        Modifier.pointerInput(wallet.id) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = {
+                                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    draggedWalletId = wallet.id
+                                    draggedOffsetY = 0f
+                                },
+                                onDrag = onDrag@{ change, dragAmount ->
+                                    change.consume()
+                                    val draggingId = draggedWalletId ?: return@onDrag
+                                    val step = itemHeightPx + spacingPx
+                                    if (step <= 0f) return@onDrag
+
+                                    draggedOffsetY += dragAmount.y
+                                    val fromIndex = walletList.indexOfFirst { it.id == draggingId }
+                                    if (fromIndex == -1) return@onDrag
+
+                                    val threshold = step / 2f
+                                    if (draggedOffsetY > threshold && fromIndex < walletList.size - 1) {
+                                        walletList =
+                                            walletList.toMutableList().apply {
+                                                val item = removeAt(fromIndex)
+                                                add(fromIndex + 1, item)
+                                            }
+                                        draggedOffsetY -= step
+                                    } else if (draggedOffsetY < -threshold && fromIndex > 0) {
+                                        walletList =
+                                            walletList.toMutableList().apply {
+                                                val item = removeAt(fromIndex)
+                                                add(fromIndex - 1, item)
+                                            }
+                                        draggedOffsetY += step
+                                    }
+                                },
+                                onDragEnd = {
+                                    val orderedIds = walletList.map { it.id }
+                                    val previous = app.wallets
+                                    persistReorder(
+                                        scope = scope,
+                                        app = app,
+                                        orderedIds = orderedIds,
+                                        previous = previous,
+                                        haptics = haptics,
+                                        onRollback = { walletList = previous },
+                                    )
+                                    draggedWalletId = null
+                                    draggedOffsetY = 0f
+                                },
+                                onDragCancel = {
+                                    walletList = app.wallets
+                                    draggedWalletId = null
+                                    draggedOffsetY = 0f
+                                },
+                            )
+                        },
                 )
             }
         }
@@ -199,18 +312,68 @@ fun SidebarView(
     }
 }
 
+private fun persistReorder(
+    scope: CoroutineScope,
+    app: AppManager,
+    orderedIds: List<WalletId>,
+    previous: List<WalletMetadata>,
+    haptics: HapticFeedback,
+    onRollback: () -> Unit,
+) {
+    scope.launch {
+        val result =
+            withContext(Dispatchers.IO) {
+                runCatching { app.database.wallets().reorderWallets(orderedIds) }
+            }
+        result.onSuccess {
+            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to reorder wallets: ${error.message}")
+            onRollback()
+        }
+    }
+}
+
 @Composable
 private fun WalletItem(
     wallet: WalletMetadata,
+    isDragged: Boolean,
+    dragOffsetY: Float,
+    isClickEnabled: Boolean,
     onClick: () -> Unit,
+    onMeasuredHeight: (Int) -> Unit,
+    gestureModifier: Modifier,
+    placementModifier: Modifier = Modifier,
 ) {
+    val density = LocalDensity.current
+    val shadowPx = with(density) { DRAG_SHADOW_ELEVATION_DP.dp.toPx() }
+
+    var base: Modifier =
+        Modifier
+            .fillMaxWidth()
+            .then(placementModifier)
+            .onSizeChanged { onMeasuredHeight(it.height) }
+
+    if (isDragged) {
+        base =
+            base
+                .zIndex(1f)
+                .graphicsLayer {
+                    translationY = dragOffsetY
+                    scaleX = DRAG_SCALE
+                    scaleY = DRAG_SCALE
+                    shadowElevation = shadowPx
+                    clip = false
+                }
+    }
+
     Row(
         modifier =
-            Modifier
-                .fillMaxWidth()
+            base
                 .clip(RoundedCornerShape(10.dp))
                 .background(CoveColor.coveLightGray.copy(alpha = 0.06f))
-                .clickable(onClick = onClick)
+                .then(gestureModifier)
+                .clickable(enabled = isClickEnabled, onClick = onClick)
                 .padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1316,6 +1316,10 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_walletstable_len(
     ): Short
+    external fun uniffi_cove_checksum_method_walletstable_move_wallet(
+    ): Short
+    external fun uniffi_cove_checksum_method_walletstable_reorder_wallets(
+    ): Short
     external fun uniffi_cove_checksum_method_priceresponse_get(
     ): Short
     external fun uniffi_cove_checksum_method_priceresponse_get_for_currency(
@@ -2290,6 +2294,10 @@ internal object UniffiLib {
     ): Byte
     external fun uniffi_cove_fn_method_walletstable_len(`ptr`: Long,`network`: RustBufferNetwork.ByValue,`mode`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Short
+    external fun uniffi_cove_fn_method_walletstable_move_wallet(`ptr`: Long,`walletId`: RustBufferWalletId.ByValue,`toPosition`: Int,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_walletstable_reorder_wallets(`ptr`: Long,`orderedIds`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_clone_walletdatadb(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_free_walletdatadb(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -3927,6 +3935,12 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_walletstable_len() != 51436.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_walletstable_move_wallet() != 47857.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_walletstable_reorder_wallets() != 55038.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_priceresponse_get() != 6552.toShort()) {
@@ -26310,6 +26324,17 @@ public interface WalletsTableInterface {
     
     fun `len`(`network`: Network, `mode`: WalletMode): kotlin.UShort
     
+    /**
+     * Move a wallet to `to_position`. Out-of-range positions clamp to the list bounds.
+     */
+    fun `moveWallet`(`walletId`: WalletId, `toPosition`: kotlin.UInt): List<WalletMetadata>
+    
+    /**
+     * Reorder wallets for the current (network, mode) to match `ordered_ids`.
+     * `ordered_ids` must be a permutation of the current wallet IDs.
+     */
+    fun `reorderWallets`(`orderedIds`: List<WalletId>): List<WalletMetadata>
+    
     companion object
 }
 
@@ -26481,6 +26506,41 @@ open class WalletsTable: Disposable, AutoCloseable, WalletsTableInterface
     UniffiLib.uniffi_cove_fn_method_walletstable_len(
         it,
         FfiConverterTypeNetwork.lower(`network`),FfiConverterTypeWalletMode.lower(`mode`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Move a wallet to `to_position`. Out-of-range positions clamp to the list bounds.
+     */
+    @Throws(DatabaseException::class)override fun `moveWallet`(`walletId`: WalletId, `toPosition`: kotlin.UInt): List<WalletMetadata> {
+            return FfiConverterSequenceTypeWalletMetadata.lift(
+    callWithHandle {
+    uniffiRustCallWithError(DatabaseException) { _status ->
+    UniffiLib.uniffi_cove_fn_method_walletstable_move_wallet(
+        it,
+        FfiConverterTypeWalletId.lower(`walletId`),FfiConverterUInt.lower(`toPosition`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Reorder wallets for the current (network, mode) to match `ordered_ids`.
+     * `ordered_ids` must be a permutation of the current wallet IDs.
+     */
+    @Throws(DatabaseException::class)override fun `reorderWallets`(`orderedIds`: List<WalletId>): List<WalletMetadata> {
+            return FfiConverterSequenceTypeWalletMetadata.lift(
+    callWithHandle {
+    uniffiRustCallWithError(DatabaseException) { _status ->
+    UniffiLib.uniffi_cove_fn_method_walletstable_reorder_wallets(
+        it,
+        FfiConverterSequenceTypeWalletId.lower(`orderedIds`),_status)
 }
     }
     )
@@ -29567,6 +29627,12 @@ data class WalletMetadata (
     var `origin`: kotlin.String?
     , 
     /**
+     * Position in the wallet list within its (network, mode); lower appears first.
+     * Backfilled by `WalletsTable::migrate_positions` for pre-existing records.
+     */
+    var `position`: kotlin.UInt
+    , 
+    /**
      * Metadata data specific to different hardware wallets
      */
     var `hardwareMetadata`: HardwareWalletMetadata?
@@ -29643,6 +29709,7 @@ data class WalletMetadata (
         this.`addressType`,
         this.`fiatOrBtc`,
         this.`origin`,
+        this.`position`,
         this.`hardwareMetadata`,
         this.`showLabels`,
         this.`internal`
@@ -29673,6 +29740,7 @@ public object FfiConverterTypeWalletMetadata: FfiConverterRustBuffer<WalletMetad
             FfiConverterTypeWalletAddressType.read(buf),
             FfiConverterTypeFiatOrBtc.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterUInt.read(buf),
             FfiConverterOptionalTypeHardwareWalletMetadata.read(buf),
             FfiConverterBoolean.read(buf),
             FfiConverterTypeInternalOnlyMetadata.read(buf),
@@ -29695,6 +29763,7 @@ public object FfiConverterTypeWalletMetadata: FfiConverterRustBuffer<WalletMetad
             FfiConverterTypeWalletAddressType.allocationSize(value.`addressType`) +
             FfiConverterTypeFiatOrBtc.allocationSize(value.`fiatOrBtc`) +
             FfiConverterOptionalString.allocationSize(value.`origin`) +
+            FfiConverterUInt.allocationSize(value.`position`) +
             FfiConverterOptionalTypeHardwareWalletMetadata.allocationSize(value.`hardwareMetadata`) +
             FfiConverterBoolean.allocationSize(value.`showLabels`) +
             FfiConverterTypeInternalOnlyMetadata.allocationSize(value.`internal`)
@@ -29716,6 +29785,7 @@ public object FfiConverterTypeWalletMetadata: FfiConverterRustBuffer<WalletMetad
             FfiConverterTypeWalletAddressType.write(value.`addressType`, buf)
             FfiConverterTypeFiatOrBtc.write(value.`fiatOrBtc`, buf)
             FfiConverterOptionalString.write(value.`origin`, buf)
+            FfiConverterUInt.write(value.`position`, buf)
             FfiConverterOptionalTypeHardwareWalletMetadata.write(value.`hardwareMetadata`, buf)
             FfiConverterBoolean.write(value.`showLabels`, buf)
             FfiConverterTypeInternalOnlyMetadata.write(value.`internal`, buf)
@@ -51450,6 +51520,18 @@ sealed class WalletTableException: kotlin.Exception() {
             get() = ""
     }
     
+    class WalletNotFound(
+        ) : WalletTableException() {
+        override val message
+            get() = ""
+    }
+    
+    class ReorderMismatch(
+        ) : WalletTableException() {
+        override val message
+            get() = ""
+    }
+    
 
     
 
@@ -51485,6 +51567,8 @@ public object FfiConverterTypeWalletTableError : FfiConverterRustBuffer<WalletTa
                 FfiConverterString.read(buf),
                 )
             3 -> WalletTableException.WalletAlreadyExists()
+            4 -> WalletTableException.WalletNotFound()
+            5 -> WalletTableException.ReorderMismatch()
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
     }
@@ -51505,6 +51589,14 @@ public object FfiConverterTypeWalletTableError : FfiConverterRustBuffer<WalletTa
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
             )
+            is WalletTableException.WalletNotFound -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
+            is WalletTableException.ReorderMismatch -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
         }
     }
 
@@ -51522,6 +51614,14 @@ public object FfiConverterTypeWalletTableError : FfiConverterRustBuffer<WalletTa
             }
             is WalletTableException.WalletAlreadyExists -> {
                 buf.putInt(3)
+                Unit
+            }
+            is WalletTableException.WalletNotFound -> {
+                buf.putInt(4)
+                Unit
+            }
+            is WalletTableException.ReorderMismatch -> {
+                buf.putInt(5)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/ios/Cove/Views/SidebarView.swift
+++ b/ios/Cove/Views/SidebarView.swift
@@ -186,10 +186,10 @@ struct SidebarView: View {
         app.wallets = reordered
         HapticFeedback.progress.trigger()
 
-        persistWalletOrder(orderedIds: reordered.map(\.id), previous: previous)
+        persistWalletOrder(orderedIds: reordered.map(\.id))
     }
 
-    private func persistWalletOrder(orderedIds: [WalletId], previous: [WalletMetadata]) {
+    private func persistWalletOrder(orderedIds: [WalletId]) {
         let database = app.database
         let appRef = app
         let pending = reorderTask
@@ -204,14 +204,14 @@ struct SidebarView: View {
                 await MainActor.run {
                     if appRef.wallets.map(\.id) == orderedIds {
                         appRef.wallets = persisted
+                        HapticFeedback.success.trigger()
                     }
-                    HapticFeedback.success.trigger()
                 }
             } catch {
                 Log.error("Failed to reorder wallets: \(error)")
                 await MainActor.run {
                     if appRef.wallets.map(\.id) == orderedIds {
-                        appRef.wallets = previous
+                        appRef.loadWallets()
                     }
                 }
             }

--- a/ios/Cove/Views/SidebarView.swift
+++ b/ios/Cove/Views/SidebarView.swift
@@ -188,8 +188,7 @@ struct SidebarView: View {
         persistWalletOrder(orderedIds: reordered.map(\.id), previous: previous)
     }
 
-    /// persists the new wallet order through the Rust FFI off the main actor, and
-    /// rolls back the optimistic UI update if persistence fails
+    /// Persists off the main actor and rolls back the optimistic UI on failure.
     private func persistWalletOrder(orderedIds: [WalletId], previous: [WalletMetadata]) {
         let database = app.database
         let appRef = app

--- a/ios/Cove/Views/SidebarView.swift
+++ b/ios/Cove/Views/SidebarView.swift
@@ -114,8 +114,7 @@ struct SidebarView: View {
                                 app.pushRoutes(RouteFactory().nestedWalletSettings(id: wallet.id))
                             }
                             Button("Edit Order") {
-                                let generator = UIImpactFeedbackGenerator(style: .medium)
-                                generator.impactOccurred()
+                                HapticFeedback.progress.trigger()
                                 withAnimation { editMode = .active }
                             }
                         }
@@ -125,6 +124,11 @@ struct SidebarView: View {
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
                 .environment(\.editMode, $editMode)
+                .onChange(of: app.isSidebarVisible) { _, isVisible in
+                    if !isVisible, editMode.isEditing {
+                        editMode = .inactive
+                    }
+                }
 
                 VStack(spacing: 32) {
                     Divider()
@@ -175,17 +179,24 @@ struct SidebarView: View {
         let previous = app.wallets
         var reordered = previous
         reordered.move(fromOffsets: source, toOffset: destination)
+
+        guard reordered.map(\.id) != previous.map(\.id) else { return }
+
         app.wallets = reordered
+        HapticFeedback.progress.trigger()
 
-        let orderedIds = reordered.map(\.id)
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
+        persistWalletOrder(orderedIds: reordered.map(\.id), previous: previous)
+    }
 
+    /// persists the new wallet order through the Rust FFI off the main actor, and
+    /// rolls back the optimistic UI update if persistence fails
+    private func persistWalletOrder(orderedIds: [WalletId], previous: [WalletMetadata]) {
         let database = app.database
         let appRef = app
         Task.detached {
             do {
                 _ = try database.wallets().reorderWallets(orderedIds: orderedIds)
+                await MainActor.run { HapticFeedback.success.trigger() }
             } catch {
                 Log.error("Failed to reorder wallets: \(error)")
                 await MainActor.run { appRef.wallets = previous }

--- a/ios/Cove/Views/SidebarView.swift
+++ b/ios/Cove/Views/SidebarView.swift
@@ -13,6 +13,8 @@ struct SidebarView: View {
 
     let currentRoute: Route
 
+    @State private var editMode: EditMode = .inactive
+
     func setForeground(_ route: Route) -> LinearGradient {
         if RouteFactory().isSameParentRoute(route: route, routeToCheck: currentRoute) {
             LinearGradient(
@@ -63,12 +65,22 @@ struct SidebarView: View {
                         .foregroundStyle(.white)
 
                     Spacer()
+
+                    if editMode.isEditing {
+                        Button("Done") {
+                            withAnimation { editMode = .inactive }
+                        }
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.white)
+                    }
                 }
                 .padding(.bottom, 16)
 
-                VStack(spacing: 12) {
+                List {
                     ForEach(app.wallets, id: \.id) { wallet in
                         Button(action: {
+                            guard !editMode.isEditing else { return }
                             goTo(Route.selectedWallet(wallet.id))
                         }) {
                             HStack(spacing: 10) {
@@ -89,6 +101,9 @@ struct SidebarView: View {
                         .padding()
                         .background(Color.coveLightGray.opacity(0.06))
                         .cornerRadius(10)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
                         .contentShape(
                             .contextMenuPreview,
                             RoundedRectangle(cornerRadius: 10)
@@ -98,11 +113,18 @@ struct SidebarView: View {
                                 app.isSidebarVisible = false
                                 app.pushRoutes(RouteFactory().nestedWalletSettings(id: wallet.id))
                             }
+                            Button("Edit Order") {
+                                let generator = UIImpactFeedbackGenerator(style: .medium)
+                                generator.impactOccurred()
+                                withAnimation { editMode = .active }
+                            }
                         }
                     }
+                    .onMove(perform: handleMove)
                 }
-
-                Spacer()
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .environment(\.editMode, $editMode)
 
                 VStack(spacing: 32) {
                     Divider()
@@ -146,6 +168,28 @@ struct SidebarView: View {
         Task {
             try? await Task.sleep(for: .milliseconds(200))
             await navigateRoute(route)
+        }
+    }
+
+    private func handleMove(from source: IndexSet, to destination: Int) {
+        let previous = app.wallets
+        var reordered = previous
+        reordered.move(fromOffsets: source, toOffset: destination)
+        app.wallets = reordered
+
+        let orderedIds = reordered.map(\.id)
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        let database = app.database
+        let appRef = app
+        Task.detached {
+            do {
+                _ = try database.wallets().reorderWallets(orderedIds: orderedIds)
+            } catch {
+                Log.error("Failed to reorder wallets: \(error)")
+                await MainActor.run { appRef.wallets = previous }
+            }
         }
     }
 

--- a/ios/Cove/Views/SidebarView.swift
+++ b/ios/Cove/Views/SidebarView.swift
@@ -14,6 +14,7 @@ struct SidebarView: View {
     let currentRoute: Route
 
     @State private var editMode: EditMode = .inactive
+    @State private var reorderTask: Task<Void, Never>?
 
     func setForeground(_ route: Route) -> LinearGradient {
         if RouteFactory().isSameParentRoute(route: route, routeToCheck: currentRoute) {
@@ -188,17 +189,31 @@ struct SidebarView: View {
         persistWalletOrder(orderedIds: reordered.map(\.id), previous: previous)
     }
 
-    /// Persists off the main actor and rolls back the optimistic UI on failure.
     private func persistWalletOrder(orderedIds: [WalletId], previous: [WalletMetadata]) {
         let database = app.database
         let appRef = app
-        Task.detached {
+        let pending = reorderTask
+        reorderTask = Task {
+            await pending?.value
+
             do {
-                _ = try database.wallets().reorderWallets(orderedIds: orderedIds)
-                await MainActor.run { HapticFeedback.success.trigger() }
+                let persisted = try await Task.detached {
+                    try database.wallets().reorderWallets(orderedIds: orderedIds)
+                }.value
+
+                await MainActor.run {
+                    if appRef.wallets.map(\.id) == orderedIds {
+                        appRef.wallets = persisted
+                    }
+                    HapticFeedback.success.trigger()
+                }
             } catch {
                 Log.error("Failed to reorder wallets: \(error)")
-                await MainActor.run { appRef.wallets = previous }
+                await MainActor.run {
+                    if appRef.wallets.map(\.id) == orderedIds {
+                        appRef.wallets = previous
+                    }
+                }
             }
         }
     }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -11950,6 +11950,17 @@ public protocol WalletsTableProtocol: AnyObject, Sendable {
     
     func len(network: Network, mode: WalletMode) throws  -> UInt16
     
+    /**
+     * Move a wallet to `to_position`. Out-of-range positions clamp to the list bounds.
+     */
+    func moveWallet(walletId: WalletId, toPosition: UInt32) throws  -> [WalletMetadata]
+    
+    /**
+     * Reorder wallets for the current (network, mode) to match `ordered_ids`.
+     * `ordered_ids` must be a permutation of the current wallet IDs.
+     */
+    func reorderWallets(orderedIds: [WalletId]) throws  -> [WalletMetadata]
+    
 }
 open class WalletsTable: WalletsTableProtocol, @unchecked Sendable {
     fileprivate let handle: UInt64
@@ -12045,6 +12056,32 @@ open func len(network: Network, mode: WalletMode)throws  -> UInt16  {
             self.uniffiCloneHandle(),
         FfiConverterTypeNetwork_lower(network),
         FfiConverterTypeWalletMode_lower(mode),$0
+    )
+})
+}
+    
+    /**
+     * Move a wallet to `to_position`. Out-of-range positions clamp to the list bounds.
+     */
+open func moveWallet(walletId: WalletId, toPosition: UInt32)throws  -> [WalletMetadata]  {
+    return try  FfiConverterSequenceTypeWalletMetadata.lift(try rustCallWithError(FfiConverterTypeDatabaseError_lift) {
+    uniffi_cove_fn_method_walletstable_move_wallet(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeWalletId_lower(walletId),
+        FfiConverterUInt32.lower(toPosition),$0
+    )
+})
+}
+    
+    /**
+     * Reorder wallets for the current (network, mode) to match `ordered_ids`.
+     * `ordered_ids` must be a permutation of the current wallet IDs.
+     */
+open func reorderWallets(orderedIds: [WalletId])throws  -> [WalletMetadata]  {
+    return try  FfiConverterSequenceTypeWalletMetadata.lift(try rustCallWithError(FfiConverterTypeDatabaseError_lift) {
+    uniffi_cove_fn_method_walletstable_reorder_wallets(
+            self.uniffiCloneHandle(),
+        FfiConverterSequenceTypeWalletId.lower(orderedIds),$0
     )
 })
 }
@@ -15337,6 +15374,11 @@ public struct WalletMetadata: Equatable, Hashable {
     public var fiatOrBtc: FiatOrBtc
     public var origin: String?
     /**
+     * Position in the wallet list within its (network, mode); lower appears first.
+     * Backfilled by `WalletsTable::migrate_positions` for pre-existing records.
+     */
+    public var position: UInt32
+    /**
      * Metadata data specific to different hardware wallets
      */
     public var hardwareMetadata: HardwareWalletMetadata?
@@ -15350,6 +15392,10 @@ public struct WalletMetadata: Equatable, Hashable {
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
     public init(id: WalletId, name: String, color: WalletColor, verified: Bool, network: Network, masterFingerprint: Fingerprint?, selectedUnit: BitcoinUnit, sensitiveVisible: Bool, detailsExpanded: Bool, walletType: WalletType, walletMode: WalletMode, discoveryState: DiscoveryState, addressType: WalletAddressType, fiatOrBtc: FiatOrBtc, origin: String?, 
+        /**
+         * Position in the wallet list within its (network, mode); lower appears first.
+         * Backfilled by `WalletsTable::migrate_positions` for pre-existing records.
+         */position: UInt32, 
         /**
          * Metadata data specific to different hardware wallets
          */hardwareMetadata: HardwareWalletMetadata?, 
@@ -15372,6 +15418,7 @@ public struct WalletMetadata: Equatable, Hashable {
         self.addressType = addressType
         self.fiatOrBtc = fiatOrBtc
         self.origin = origin
+        self.position = position
         self.hardwareMetadata = hardwareMetadata
         self.showLabels = showLabels
         self.`internal` = `internal`
@@ -15447,6 +15494,7 @@ public struct FfiConverterTypeWalletMetadata: FfiConverterRustBuffer {
                 addressType: FfiConverterTypeWalletAddressType.read(from: &buf), 
                 fiatOrBtc: FfiConverterTypeFiatOrBtc.read(from: &buf), 
                 origin: FfiConverterOptionString.read(from: &buf), 
+                position: FfiConverterUInt32.read(from: &buf), 
                 hardwareMetadata: FfiConverterOptionTypeHardwareWalletMetadata.read(from: &buf), 
                 showLabels: FfiConverterBool.read(from: &buf), 
                 internal: FfiConverterTypeInternalOnlyMetadata.read(from: &buf)
@@ -15469,6 +15517,7 @@ public struct FfiConverterTypeWalletMetadata: FfiConverterRustBuffer {
         FfiConverterTypeWalletAddressType.write(value.addressType, into: &buf)
         FfiConverterTypeFiatOrBtc.write(value.fiatOrBtc, into: &buf)
         FfiConverterOptionString.write(value.origin, into: &buf)
+        FfiConverterUInt32.write(value.position, into: &buf)
         FfiConverterOptionTypeHardwareWalletMetadata.write(value.hardwareMetadata, into: &buf)
         FfiConverterBool.write(value.showLabels, into: &buf)
         FfiConverterTypeInternalOnlyMetadata.write(value.`internal`, into: &buf)
@@ -31972,6 +32021,8 @@ enum WalletTableError: Swift.Error, Equatable, Hashable, Foundation.LocalizedErr
     case ReadError(String
     )
     case WalletAlreadyExists
+    case WalletNotFound
+    case ReorderMismatch
 
     
 
@@ -32018,6 +32069,8 @@ public struct FfiConverterTypeWalletTableError: FfiConverterRustBuffer {
             try FfiConverterString.read(from: &buf)
             )
         case 3: return .WalletAlreadyExists
+        case 4: return .WalletNotFound
+        case 5: return .ReorderMismatch
 
          default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -32042,6 +32095,14 @@ public struct FfiConverterTypeWalletTableError: FfiConverterRustBuffer {
         
         case .WalletAlreadyExists:
             writeInt(&buf, Int32(3))
+        
+        
+        case .WalletNotFound:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .ReorderMismatch:
+            writeInt(&buf, Int32(5))
         
         }
     }
@@ -36388,6 +36449,12 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_walletstable_len() != 51436) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_walletstable_move_wallet() != 47857) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_walletstable_reorder_wallets() != 55038) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_priceresponse_get() != 6552) {

--- a/rust/src/backup/model.rs
+++ b/rust/src/backup/model.rs
@@ -310,6 +310,7 @@ mod tests {
             address_type: WalletAddressType::NativeSegwit,
             fiat_or_btc: FiatOrBtc::Btc,
             origin: None,
+            position: 0,
             hardware_metadata: Some(HardwareWalletMetadata::TapSigner(tap_signer)),
             show_labels: true,
             internal: InternalOnlyMetadata::default(),

--- a/rust/src/database.rs
+++ b/rust/src/database.rs
@@ -138,6 +138,10 @@ impl Database {
 
         write_txn.commit()?;
 
+        if let Err(err) = wallets.migrate_positions() {
+            error!("wallet position migration failed: {err}");
+        }
+
         Ok(Self {
             global_flag,
             global_config,

--- a/rust/src/database/wallet.rs
+++ b/rust/src/database/wallet.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, sync::Arc, time::Duration};
 
-use redb::{ReadOnlyTable, ReadableTableMetadata, TableDefinition};
+use redb::{ReadOnlyTable, ReadableTable, ReadableTableMetadata, TableDefinition};
 use tracing::debug;
 
 use cove_util::result_ext::ResultExt as _;
@@ -140,30 +140,30 @@ impl WalletsTable {
         let network = Database::global().global_config.selected_network();
         let mode = Database::global().global_config.wallet_mode();
 
-        let mut wallets = self.get_all(network, mode)?;
-
-        if ordered_ids.len() != wallets.len() {
-            return Err(WalletTableError::ReorderMismatch.into());
-        }
-
-        let mut seen = vec![false; wallets.len()];
-        for (new_pos, id) in ordered_ids.iter().enumerate() {
-            let Some(idx) = wallets.iter().position(|w| &w.id == id) else {
-                return Err(WalletTableError::WalletNotFound.into());
-            };
-
-            if seen[idx] {
+        let wallets = self.mutate_positions_txn(network, mode, |wallets| {
+            if ordered_ids.len() != wallets.len() {
                 return Err(WalletTableError::ReorderMismatch.into());
             }
-            seen[idx] = true;
 
-            wallets[idx].position = new_pos as u32;
-        }
+            let mut seen = vec![false; wallets.len()];
+            for (new_pos, id) in ordered_ids.iter().enumerate() {
+                let Some(idx) = wallets.iter().position(|w| &w.id == id) else {
+                    return Err(WalletTableError::WalletNotFound.into());
+                };
 
-        wallets.sort_by_key(|wallet| wallet.position);
-        self.save_all_wallets(network, mode, wallets.clone())?;
+                if seen[idx] {
+                    return Err(WalletTableError::ReorderMismatch.into());
+                }
+                seen[idx] = true;
+
+                wallets[idx].position = new_pos as u32;
+            }
+
+            wallets.sort_by_key(|wallet| wallet.position);
+            Ok(())
+        })?;
+
         Updater::send_update(Update::WalletsChanged);
-
         Ok(wallets)
     }
 
@@ -176,24 +176,24 @@ impl WalletsTable {
         let network = Database::global().global_config.selected_network();
         let mode = Database::global().global_config.wallet_mode();
 
-        let mut wallets = self.get_all(network, mode)?;
+        let wallets = self.mutate_positions_txn(network, mode, |wallets| {
+            let Some(from_idx) = wallets.iter().position(|w| w.id == wallet_id) else {
+                return Err(WalletTableError::WalletNotFound.into());
+            };
 
-        let Some(from_idx) = wallets.iter().position(|w| w.id == wallet_id) else {
-            return Err(WalletTableError::WalletNotFound.into());
-        };
+            let to_idx = (to_position as usize).min(wallets.len().saturating_sub(1));
 
-        let to_idx = (to_position as usize).min(wallets.len().saturating_sub(1));
+            let wallet = wallets.remove(from_idx);
+            wallets.insert(to_idx, wallet);
 
-        let wallet = wallets.remove(from_idx);
-        wallets.insert(to_idx, wallet);
+            for (i, w) in wallets.iter_mut().enumerate() {
+                w.position = i as u32;
+            }
 
-        for (i, w) in wallets.iter_mut().enumerate() {
-            w.position = i as u32;
-        }
+            Ok(())
+        })?;
 
-        self.save_all_wallets(network, mode, wallets.clone())?;
         Updater::send_update(Update::WalletsChanged);
-
         Ok(wallets)
     }
 }
@@ -213,8 +213,9 @@ impl WalletsTable {
             return Err(WalletTableError::WalletAlreadyExists.into());
         }
 
+        // use max + 1 so a gap left by an older buggy build can't collide
         let mut wallet = wallet;
-        wallet.position = wallets.len() as u32;
+        wallet.position = wallets.iter().map(|w| w.position).max().map_or(0, |m| m + 1);
 
         let wallet_for_backup = should_backup_to_cloud.then(|| wallet.clone());
         wallets.push(wallet);
@@ -235,10 +236,11 @@ impl WalletsTable {
         Self { db }
     }
 
-    /// Backfill `position` for wallets persisted before the field existed.
-    /// Idempotent. Must be called after `Database::init()`'s startup transaction
-    /// commits, since this opens its own write transaction.
+    /// Backfill contiguous `position` values whenever duplicates are observed.
+    /// Idempotent; must run after `Database::init()`'s startup txn commits
+    /// because it opens its own write transaction.
     pub fn migrate_positions(&self) -> Result<(), Error> {
+        use std::collections::HashSet;
         use strum::IntoEnumIterator;
 
         for network in Network::iter() {
@@ -249,8 +251,9 @@ impl WalletsTable {
                     continue;
                 }
 
-                let needs_migration = wallets.iter().all(|w| w.position == 0);
-                if !needs_migration {
+                let mut seen = HashSet::with_capacity(wallets.len());
+                let has_duplicates = wallets.iter().any(|w| !seen.insert(w.position));
+                if !has_duplicates {
                     continue;
                 }
 
@@ -304,9 +307,8 @@ impl WalletsTable {
         Ok(wallet)
     }
 
-    /// Get all wallets for a network, sorted by `position` ascending.
-    /// Uses a stable sort so pre-migration records (all `position == 0`) keep
-    /// their stored order.
+    /// Get all wallets for a network, stable-sorted by `position` ascending so
+    /// records sharing a position keep their stored order until migration.
     pub fn get_all(
         &self,
         network: Network,
@@ -429,6 +431,44 @@ impl WalletsTable {
         Updater::send_update(AppStateReconcileMessage::DatabaseUpdated);
 
         Ok(())
+    }
+
+    /// Read → mutate → write wallet positions in one write transaction so
+    /// concurrent metadata writes cannot be clobbered by a stale clone.
+    /// Callers must only mutate `position` fields.
+    fn mutate_positions_txn<F>(
+        &self,
+        network: Network,
+        mode: WalletMode,
+        mutate: F,
+    ) -> Result<Vec<WalletMetadata>, Error>
+    where
+        F: FnOnce(&mut Vec<WalletMetadata>) -> Result<(), Error>,
+    {
+        let write_txn = self.db.begin_write()?;
+        let key = WalletKey::from((network, mode)).to_string();
+
+        let result = {
+            let mut table = write_txn.open_table(TABLE)?;
+
+            let mut wallets: Vec<WalletMetadata> = table
+                .get(key.as_str())
+                .map_err_str(WalletTableError::ReadError)?
+                .map(|value| value.value())
+                .unwrap_or_default();
+
+            wallets.sort_by_key(|w| w.position);
+            mutate(&mut wallets)?;
+
+            let snapshot = wallets.clone();
+            table.insert(&*key, wallets).map_err_str(WalletTableError::SaveError)?;
+            snapshot
+        };
+
+        write_txn.commit().map_err_str(WalletTableError::SaveError)?;
+        Updater::send_update(AppStateReconcileMessage::DatabaseUpdated);
+
+        Ok(result)
     }
 
     pub fn find_by_tap_signer_ident(

--- a/rust/src/database/wallet.rs
+++ b/rust/src/database/wallet.rs
@@ -35,6 +35,12 @@ pub enum WalletTableError {
 
     #[error("wallet already exists")]
     WalletAlreadyExists,
+
+    #[error("wallet not found for reorder")]
+    WalletNotFound,
+
+    #[error("reorder id list does not match the current wallet list")]
+    ReorderMismatch,
 }
 
 #[derive(Debug, Clone, Copy, uniffi::Object)]
@@ -124,6 +130,72 @@ impl WalletsTable {
 
         Ok(wallets)
     }
+
+    /// Reorder wallets for the current (network, mode) to match `ordered_ids`.
+    /// `ordered_ids` must be a permutation of the current wallet IDs.
+    pub fn reorder_wallets(
+        &self,
+        ordered_ids: Vec<WalletId>,
+    ) -> Result<Vec<WalletMetadata>, Error> {
+        let network = Database::global().global_config.selected_network();
+        let mode = Database::global().global_config.wallet_mode();
+
+        let mut wallets = self.get_all(network, mode)?;
+
+        if ordered_ids.len() != wallets.len() {
+            return Err(WalletTableError::ReorderMismatch.into());
+        }
+
+        let mut seen = vec![false; wallets.len()];
+        for (new_pos, id) in ordered_ids.iter().enumerate() {
+            let Some(idx) = wallets.iter().position(|w| &w.id == id) else {
+                return Err(WalletTableError::WalletNotFound.into());
+            };
+
+            if seen[idx] {
+                return Err(WalletTableError::ReorderMismatch.into());
+            }
+            seen[idx] = true;
+
+            wallets[idx].position = new_pos as u32;
+        }
+
+        wallets.sort_by_key(|wallet| wallet.position);
+        self.save_all_wallets(network, mode, wallets.clone())?;
+        Updater::send_update(Update::WalletsChanged);
+
+        Ok(wallets)
+    }
+
+    /// Move a wallet to `to_position`. Out-of-range positions clamp to the list bounds.
+    pub fn move_wallet(
+        &self,
+        wallet_id: WalletId,
+        to_position: u32,
+    ) -> Result<Vec<WalletMetadata>, Error> {
+        let network = Database::global().global_config.selected_network();
+        let mode = Database::global().global_config.wallet_mode();
+
+        let mut wallets = self.get_all(network, mode)?;
+
+        let Some(from_idx) = wallets.iter().position(|w| w.id == wallet_id) else {
+            return Err(WalletTableError::WalletNotFound.into());
+        };
+
+        let to_idx = (to_position as usize).min(wallets.len().saturating_sub(1));
+
+        let wallet = wallets.remove(from_idx);
+        wallets.insert(to_idx, wallet);
+
+        for (i, w) in wallets.iter_mut().enumerate() {
+            w.position = i as u32;
+        }
+
+        self.save_all_wallets(network, mode, wallets.clone())?;
+        Updater::send_update(Update::WalletsChanged);
+
+        Ok(wallets)
+    }
 }
 
 impl WalletsTable {
@@ -140,6 +212,9 @@ impl WalletsTable {
         if wallets.iter().any(|w| w.id == wallet.id) {
             return Err(WalletTableError::WalletAlreadyExists.into());
         }
+
+        let mut wallet = wallet;
+        wallet.position = wallets.len() as u32;
 
         let wallet_for_backup = should_backup_to_cloud.then(|| wallet.clone());
         wallets.push(wallet);
@@ -158,6 +233,43 @@ impl WalletsTable {
         write_txn.open_table(TABLE).expect("failed to create table");
 
         Self { db }
+    }
+
+    /// Backfill `position` for wallets persisted before the field existed.
+    /// Idempotent. Must be called after `Database::init()`'s startup transaction
+    /// commits, since this opens its own write transaction.
+    pub fn migrate_positions(&self) -> Result<(), Error> {
+        use strum::IntoEnumIterator;
+
+        for network in Network::iter() {
+            for mode in WalletMode::iter() {
+                let wallets = self.get_all(network, mode)?;
+
+                if wallets.len() <= 1 {
+                    continue;
+                }
+
+                let needs_migration = wallets.iter().all(|w| w.position == 0);
+                if !needs_migration {
+                    continue;
+                }
+
+                debug!("migrating wallet positions for {network}/{mode}");
+
+                let migrated: Vec<WalletMetadata> = wallets
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, mut w)| {
+                        w.position = i as u32;
+                        w
+                    })
+                    .collect();
+
+                self.save_all_wallets(network, mode, migrated)?;
+            }
+        }
+
+        Ok(())
     }
 
     pub fn mark_wallet_as_verified(&self, id: &WalletId) -> Result<(), Error> {
@@ -192,7 +304,9 @@ impl WalletsTable {
         Ok(wallet)
     }
 
-    /// Get all wallets for a network
+    /// Get all wallets for a network, sorted by `position` ascending.
+    /// Uses a stable sort so pre-migration records (all `position == 0`) keep
+    /// their stored order.
     pub fn get_all(
         &self,
         network: Network,
@@ -201,11 +315,13 @@ impl WalletsTable {
         let table = self.read_table()?;
         let key = WalletKey::from((network, mode)).to_string();
 
-        let value = table
+        let mut value: Vec<WalletMetadata> = table
             .get(key.as_str())
             .map_err_str(WalletTableError::ReadError)?
             .map(|value| value.value())
             .unwrap_or(vec![]);
+
+        value.sort_by_key(|wallet| wallet.position);
 
         Ok(value)
     }

--- a/rust/src/database/wallet.rs
+++ b/rust/src/database/wallet.rs
@@ -332,10 +332,11 @@ impl WalletsTable {
 
         let mut wallets = self.get_all(network, mode)?;
 
-        // update the wallet
         for wallet in &mut wallets {
             if wallet.id == metadata.id {
+                let current_position = wallet.position;
                 *wallet = metadata.clone();
+                wallet.position = current_position;
             }
         }
 
@@ -388,6 +389,11 @@ impl WalletsTable {
         let mut wallets = self.get_all(network, mode)?;
 
         wallets.retain(|wallet| &wallet.id != id);
+
+        for (i, wallet) in wallets.iter_mut().enumerate() {
+            wallet.position = i as u32;
+        }
+
         self.save_all_wallets(network, mode, wallets)?;
 
         Updater::send_update(Update::WalletsChanged);

--- a/rust/src/wallet/metadata.rs
+++ b/rust/src/wallet/metadata.rs
@@ -44,6 +44,11 @@ pub struct WalletMetadata {
     #[serde(default)]
     pub origin: Option<String>,
 
+    /// Position in the wallet list within its (network, mode); lower appears first.
+    /// Backfilled by `WalletsTable::migrate_positions` for pre-existing records.
+    #[serde(default)]
+    pub position: u32,
+
     /// Metadata data specific to different hardware wallets
     #[serde(default)]
     pub hardware_metadata: Option<HardwareWalletMetadata>,
@@ -193,6 +198,7 @@ impl WalletMetadata {
             color: WalletColor::random(),
             master_fingerprint: fingerprint.map(Into::into),
             origin: None,
+            position: 0,
             verified: false,
             network,
             fiat_or_btc: FiatOrBtc::Btc,
@@ -241,6 +247,7 @@ impl WalletMetadata {
             name: "Test Wallet".to_string(),
             master_fingerprint: Some(Arc::new(Fingerprint::default())),
             origin: None,
+            position: 0,
             color: WalletColor::random(),
             verified: false,
             network: Network::Bitcoin,


### PR DESCRIPTION
## Summary

Adds wallet reordering in the hamburger menu (closes #493).

- **Rust**: `position: u32` on `WalletMetadata`, stable-sorted `get_all()`, one-time `migrate_positions()` backfill on startup.
- **UniFFI**: `reorderWallets(orderedIds)` and `moveWallet(walletId, toPosition)`; new `WalletTableError::{WalletNotFound, ReorderMismatch}`.
- **iOS**: drag-to-reorder in `SidebarView` using `List` + `.onMove` + `EditMode`; haptics on drag start and on successful persist; optimistic update with rollback on FFI error; edit-mode resets when the sidebar closes.
- **Android**: long-press drag-to-reorder in `SidebarView.kt`; haptics; visual elevation (scale + shadow + zIndex); smooth `animateItem()` for neighbors; FFI persisted off the UI thread; optimistic update with rollback on error.
- **Bindings**: regenerated Kotlin and Swift UniFFI bindings.

## Testing

- `cargo fmt --check` — pass
- `cargo clippy --all-features -- -D warnings` — pass
- `cargo test --package cove --lib` — passes aside from pre-existing `database::migration::bdk` / `database::encrypted_backend` flakiness (reproduced on `master`; unrelated to this PR)
- `just ba` — Android build + Kotlin bindings regenerated successfully
- `just bi` — iOS build + Swift bindings regenerated successfully

Manual: reordered wallets on an Android device (Pixel) and on the iOS simulator; killed and reopened the app — wallet order persisted in the new position on both.

### Platform Coverage

- [ ] Tested on iOS device
- [x] Tested on Android device
- [x] Tested on iOS simulator
- [ ] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android: long-press drag-and-drop to reorder wallets in the sidebar.
  * iOS: “Edit Order” mode with drag-reorder, Done control, and contextual edit action.

* **Improvements**
  * Ordering is now persisted and consistently applied across devices; background migration repairs positions.
  * Smoother visuals, elevation/translation effects and enhanced haptic feedback during reordering.

* **Bug Fixes**
  * Optimistic reorders now rollback or reconcile if persistence fails, with reload on mismatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->