### PR TITLE
fix: Enhance error handling for connection issues in TapSigner flow NFC interactions

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -124,6 +124,8 @@ class CoinControlManager(
      * called when user presses continue button
      * navigates forward to CoinControlSetAmount screen with selected UTXOs
      */
+
+    @MainActor
     fun continuePressed(app: AppManager) {
         val walletId = rust.id()
         val selectedUtxos = utxos.filter { selected.contains(it.outpoint.hashToUint()) }
@@ -133,6 +135,7 @@ class CoinControlManager(
         app.pushRoute(Route.Send(sendRoute))
     }
 
+    @MainActor
     private fun updateSendFlowManager() {
         val sfm = AppManager.getInstance().sendFlowManager ?: return
         updateSendFlowManagerTask?.cancel()

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerEnterPinView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerEnterPinView.kt
@@ -252,6 +252,9 @@ private suspend fun deriveAction(
         if (isAuthError(e)) {
             Log.w("TapSignerEnterPin", "TapSigner auth failed - likely wrong PIN")
             manager.errorMessage = "Wrong PIN, please try again"
+        } else if (isConnectionError(e)) {
+            Log.w("TapSignerEnterPin", "TapSigner connection lost")
+            manager.errorMessage = "Tag connection lost, please hold your phone still"
         } else {
             manager.errorMessage = "Connection failed, please try again"
         }
@@ -317,6 +320,9 @@ private suspend fun backupAction(
         if (isAuthError(e)) {
             Log.w("TapSignerEnterPin", "TapSigner auth failed - likely wrong PIN")
             manager.errorMessage = "Wrong PIN, please try again"
+        } else if (isConnectionError(e)) {
+            Log.w("TapSignerEnterPin", "TapSigner connection lost")
+            manager.errorMessage = "Tag connection lost, please hold your phone still"
         } else {
             manager.errorMessage = "Connection failed, please try again"
         }
@@ -374,6 +380,9 @@ private suspend fun signAction(
         if (isAuthError(e)) {
             Log.w("TapSignerEnterPin", "TapSigner auth failed - likely wrong PIN")
             manager.errorMessage = "Wrong PIN, please try again"
+        } else if (isConnectionError(e)) {
+            Log.w("TapSignerEnterPin", "TapSigner connection lost")
+            manager.errorMessage = "Tag connection lost, please hold your phone still"
         } else {
             manager.errorMessage = "Connection failed, please try again"
         }
@@ -384,4 +393,10 @@ private fun isAuthError(error: Exception): Boolean {
     // check if error is a bad auth error using type-safe FFI function
     return error is org.bitcoinppl.cove_core.TapSignerReaderException &&
         error.isAuthError()
+}
+
+private fun isConnectionError(error: Exception): Boolean {
+    // check if error is a connection error using type-safe FFI function
+    return error is org.bitcoinppl.cove_core.TapSignerReaderException &&
+        error.isConnectionError()
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/nfc/TapCardNfcManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/nfc/TapCardNfcManager.kt
@@ -283,9 +283,7 @@ private class TapCardTransport(
             response
         } catch (e: Exception) {
             Log.e(tag, "APDU error", e)
-            throw TransportException.UnknownException(
-                "Tag connection lost, please hold your phone still and try again"
-            )
+            throw TransportException.ConnectionException("Tag connection lost, please hold your phone still")
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -3256,6 +3256,8 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_tapsignerreadererror_isautherror(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
+    external fun uniffi_cove_fn_method_tapsignerreadererror_isconnectionerror(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
     external fun uniffi_cove_fn_method_tapsignerreadererror_isnobackuperror(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_cove_fn_method_tapsignerreadererror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -46884,6 +46886,16 @@ sealed class TapSignerReaderException: kotlin.Exception() {
     }
     
 
+     fun `isConnectionError`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_tapsignerreadererror_isconnectionerror(FfiConverterTypeTapSignerReaderError.lower(this),
+        _status)
+}
+    )
+    }
+    
+
      fun `isNoBackupError`(): kotlin.Boolean {
             return FfiConverterBoolean.lift(
     uniffiRustCall() { _status ->
@@ -48008,6 +48020,14 @@ sealed class TransportException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
     
+    class ConnectionException(
+        
+        val v1: kotlin.String
+        ) : TransportException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+    
     class UnknownException(
         
         val v1: kotlin.String
@@ -48062,7 +48082,10 @@ public object FfiConverterTypeTransportError : FfiConverterRustBuffer<TransportE
             6 -> TransportException.CvcChangeException(
                 FfiConverterString.read(buf),
                 )
-            7 -> TransportException.UnknownException(
+            7 -> TransportException.ConnectionException(
+                FfiConverterString.read(buf),
+                )
+            8 -> TransportException.UnknownException(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
@@ -48097,6 +48120,11 @@ public object FfiConverterTypeTransportError : FfiConverterRustBuffer<TransportE
                 + FfiConverterString.allocationSize(value.v1)
             )
             is TransportException.CvcChangeException -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+            is TransportException.ConnectionException -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
@@ -48141,8 +48169,13 @@ public object FfiConverterTypeTransportError : FfiConverterRustBuffer<TransportE
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is TransportException.UnknownException -> {
+            is TransportException.ConnectionException -> {
                 buf.putInt(7)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is TransportException.UnknownException -> {
+                buf.putInt(8)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -5,7 +5,9 @@ import SwiftUI
 private let walletModeChangeDelayMs = 250
 private let sidebarNavigationDelayMs = 250
 
-@Observable final class AppManager: FfiReconcile {
+@MainActor
+@Observable
+final class AppManager: FfiReconcile {
     static let shared = makeShared()
 
     private let logger = Log(id: "AppManager")
@@ -98,6 +100,7 @@ private let sidebarNavigationDelayMs = 250
         self.rust.listenForUpdates(updater: self)
     }
 
+    @MainActor
     public func getWalletManager(id: WalletId) throws -> WalletManager {
         if let walletvm = walletManager, walletvm.id == id {
             logger.debug("found and using vm for \(id)")
@@ -112,6 +115,7 @@ private let sidebarNavigationDelayMs = 250
         return walletManager!
     }
 
+    @MainActor
     public func getSendFlowManager(_ wm: WalletManager, presenter: SendFlowPresenter) -> SendFlowManager {
         let id = wm.id
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerConfirmPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerConfirmPinView.swift
@@ -81,6 +81,7 @@ struct TapSignerConfirmPinView: View {
             case let .failure(error):
                 if error.isAuthError() { return app.alertState = .init(.tapSignerInvalidAuth) }
                 if error.isNoBackupError() { return app.alertState = .init(.tapSignerNoBackup(tapSigner: args.tapSigner)) }
+                if error.isConnectionError() { return app.alertState = .init(.general(title: "Connection Lost", message: "Tag connection lost, please hold your phone still")) }
                 app.alertState = .init(.general(title: "Error", message: error.description))
             }
         }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerEnterPinView.swift
@@ -54,6 +54,8 @@ struct TapSignerEnterPin: View {
                 if error.isAuthError() {
                     app.sheetState = nil
                     app.alertState = .init(.tapSignerWrongPin(tapSigner: tapSigner, action: .derive))
+                } else if error.isConnectionError() {
+                    app.alertState = .init(.general(title: "Connection Lost", message: "Tag connection lost, please hold your phone still"))
                 } else {
                     app.alertState = .init(.tapSignerDeriveFailed(message: error.description))
                 }
@@ -83,6 +85,8 @@ struct TapSignerEnterPin: View {
                 if error.isAuthError() {
                     app.sheetState = nil
                     app.alertState = .init(.tapSignerWrongPin(tapSigner: tapSigner, action: .backup))
+                } else if error.isConnectionError() {
+                    app.alertState = .init(.general(title: "Connection Lost", message: "Tag connection lost, please hold your phone still"))
                 } else {
                     app.alertState = .init(
                         .general(title: "Backup Failed!", message: error.description)
@@ -128,6 +132,8 @@ struct TapSignerEnterPin: View {
                 if error.isAuthError() {
                     app.sheetState = nil
                     app.alertState = .init(.tapSignerWrongPin(tapSigner: tapSigner, action: .sign(psbt)))
+                } else if error.isConnectionError() {
+                    app.alertState = .init(.general(title: "Connection Lost", message: "Tag connection lost, please hold your phone still"))
                 } else {
                     app.alertState = .init(
                         .general(title: "Signing Failed!", message: error.description)

--- a/ios/Cove/ImportWalletManager.swift
+++ b/ios/Cove/ImportWalletManager.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
-@Observable class ImportWalletManager: ImportWalletManagerReconciler {
+@MainActor
+@Observable
+final class ImportWalletManager: ImportWalletManagerReconciler {
     private let logger = Log(id: "ImportWalletManager")
     var rust: RustImportWalletManager
 

--- a/ios/Cove/Security.swift
+++ b/ios/Cove/Security.swift
@@ -8,7 +8,8 @@
 import Foundation
 import KeychainSwift
 
-class KeychainAccessor: KeychainAccess {
+@MainActor
+final class KeychainAccessor: KeychainAccess {
     let keychain: KeychainSwift
 
     init() {

--- a/ios/Cove/ShareSheet.swift
+++ b/ios/Cove/ShareSheet.swift
@@ -2,8 +2,7 @@ import LinkPresentation
 import SwiftUI
 import UIKit
 
-@MainActor
-private class ShareableFile: NSObject, UIActivityItemSource {
+private final class ShareableFile: NSObject, UIActivityItemSource {
     let url: URL
     let iconImage: UIImage?
 

--- a/ios/Cove/TapSignerNFC.swift
+++ b/ios/Cove/TapSignerNFC.swift
@@ -360,8 +360,11 @@ private class TapCardNFC: NSObject, NFCTagReaderSessionDelegate {
         } catch let error as TapSignerReaderError {
             logger.error("TAPSIGNER error: \(error)")
             tapSignerError = error
-            if case .TapSignerError(.CkTap(.BadAuth)) = error {
+            if error.isAuthError() {
                 return session.invalidate(errorMessage: "Wrong PIN, please try again")
+            }
+            if error.isConnectionError() {
+                return session.invalidate(errorMessage: "Tag connection lost, please hold your phone still")
             }
             session.invalidate(errorMessage: "TapSigner error: \(error.description)")
         } catch {
@@ -439,9 +442,18 @@ class TapCardTransport: TapcardTransportProtocol, @unchecked Sendable {
 
                 if let error {
                     logger.error("APDU error: \(error)")
-                    continuation.resume(
-                        throwing: TransportError.UnknownError(error.localizedDescription)
-                    )
+                    // Check if this is a connection error
+                    if let nfcError = error as? NFCReaderError,
+                       nfcError.code == .readerTransceiveErrorTagConnectionLost
+                    {
+                        continuation.resume(
+                            throwing: TransportError.ConnectionError(error.localizedDescription)
+                        )
+                    } else {
+                        continuation.resume(
+                            throwing: TransportError.UnknownError(error.localizedDescription)
+                        )
+                    }
                     return
                 }
 

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 extension WeakReconciler: WalletManagerReconciler where Reconciler == WalletManager {}
 
-@Observable final class WalletManager: AnyReconciler, WalletManagerReconciler {
+@MainActor
+@Observable
+final class WalletManager: AnyReconciler, WalletManagerReconciler {
     typealias Message = WalletManagerReconcileMessage
     typealias Action = WalletManagerAction
 
@@ -241,7 +243,7 @@ extension WeakReconciler: WalletManagerReconciler where Reconciler == WalletMana
         }
     }
 
-    func reconcile(message: Message) {
+    nonisolated func reconcile(message: Message) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             logger.debug("reconcile \(message)")
@@ -249,7 +251,7 @@ extension WeakReconciler: WalletManagerReconciler where Reconciler == WalletMana
         }
     }
 
-    func reconcileMany(messages: [Message]) {
+    nonisolated func reconcileMany(messages: [Message]) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             logger.debug("reconcile_messages: \(messages)")

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -28825,6 +28825,14 @@ public func isAuthError() -> Bool  {
 })
 }
     
+public func isConnectionError() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_cove_fn_method_tapsignerreadererror_isconnectionerror(
+            FfiConverterTypeTapSignerReaderError_lower(self),$0
+    )
+})
+}
+    
 public func isNoBackupError() -> Bool  {
     return try!  FfiConverterBool.lift(try! rustCall() {
     uniffi_cove_fn_method_tapsignerreadererror_isnobackuperror(
@@ -29536,6 +29544,8 @@ enum TransportError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError
     )
     case CvcChangeError(String
     )
+    case ConnectionError(String
+    )
     case UnknownError(String
     )
 
@@ -29595,7 +29605,10 @@ public struct FfiConverterTypeTransportError: FfiConverterRustBuffer {
         case 6: return .CvcChangeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 7: return .UnknownError(
+        case 7: return .ConnectionError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 8: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -29640,8 +29653,13 @@ public struct FfiConverterTypeTransportError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
             
         
-        case let .UnknownError(v1):
+        case let .ConnectionError(v1):
             writeInt(&buf, Int32(7))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case let .UnknownError(v1):
+            writeInt(&buf, Int32(8))
             FfiConverterString.write(v1, into: &buf)
             
         }

--- a/rust/src/tap_card.rs
+++ b/rust/src/tap_card.rs
@@ -25,6 +25,9 @@ pub enum TransportError {
     #[error("CvcChangeError: {0}")]
     CvcChangeError(String),
 
+    #[error("ConnectionError: {0}")]
+    ConnectionError(String),
+
     #[error("UnknownError: {0}")]
     UnknownError(String),
 }
@@ -108,6 +111,7 @@ impl From<TransportError> for ApduError {
             TransportError::IncorrectSignature(msg) => Self::IncorrectSignature(msg),
             TransportError::UnknownCardType(msg) => Self::UnknownCardType(msg),
             TransportError::CvcChangeError(_) => Self::CkTap(CkTapError::BadArguments.into()),
+            TransportError::ConnectionError(_) => Self::CkTap(CkTapError::BadArguments.into()),
             TransportError::UnknownError(_) => Self::CkTap(CkTapError::BadArguments.into()),
         }
     }

--- a/rust/src/tap_card/tap_signer_reader.rs
+++ b/rust/src/tap_card/tap_signer_reader.rs
@@ -562,6 +562,10 @@ impl TapSignerReaderError {
     pub const fn is_no_backup_error(&self) -> bool {
         matches!(self, Self::TapSignerError(TransportError::CkTap(CkTapError::BackupFirst)))
     }
+
+    pub const fn is_connection_error(&self) -> bool {
+        matches!(self, Self::TapSignerError(TransportError::ConnectionError(_)))
+    }
 }
 
 mod ffi {
@@ -645,6 +649,11 @@ impl TapSignerReaderError {
     #[uniffi::method(name = "isNoBackupError")]
     fn ffi_is_no_backup_error(&self) -> bool {
         self.is_no_backup_error()
+    }
+
+    #[uniffi::method(name = "isConnectionError")]
+    fn ffi_is_connection_error(&self) -> bool {
+        self.is_connection_error()
     }
 }
 


### PR DESCRIPTION

## Summary
Replace string-based connection error checking with type-safe error handling across Rust, iOS, and Android platforms.
<!-- describe what changed and why -->
fixes #439 
## Testing
- cargo check
- cargo test --no-run
- just ci
- just fmt
<!-- list the commands you ran or explain why testing was not needed -->

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NFC connection failures are now distinguished from authentication errors and show a dedicated "Connection Lost" alert with clearer messaging across platforms.
  * Transmission errors during NFC operations map more accurately to connection failures, improving error clarity.

* **New Features**
  * Added user guidance to "hold your phone still" when a tag connection is lost during PIN entry, backup, or signing flows.

* **Refactor**
  * Several manager and security classes updated to run on the main thread for improved UI consistency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->