### PR TITLE
Implement transaction watcher timer and follow-up scan logic

### DIFF
--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -14,7 +14,11 @@ use crate::{
         Address, AddressInfo, Wallet, WalletAddressType, balance::Balance, metadata::BlockSizeLast,
     },
 };
-use act_zero::{runtimes::tokio::spawn_actor, *};
+use act_zero::{
+    runtimes::tokio::{Timer, spawn_actor},
+    timer::Tick,
+    *,
+};
 use act_zero_ext::into_actor_result;
 use ahash::HashMap;
 use bdk_wallet::{
@@ -59,6 +63,13 @@ use self::mnemonic::{Mnemonic, MnemonicExt as _};
 
 use super::{SingleOrMany, WalletManagerReconcileMessage};
 
+#[derive(Debug, Default)]
+struct PendingScanState {
+    timer: Timer,
+    pending_txids: Vec<Txid>,
+    timer_armed: bool,
+}
+
 #[derive(Debug)]
 pub struct WalletActor {
     pub addr: WeakAddr<Self>,
@@ -71,6 +82,7 @@ pub struct WalletActor {
 
     seed: u64,
     transaction_watchers: HashMap<Txid, Addr<TransactionWatcher>>,
+    pending_scans: PendingScanState,
 
     // cached values, source of truth is the redb database saved with wallet metadata
     last_scan_finished: Option<Duration>,
@@ -167,6 +179,24 @@ impl Actor for WalletActor {
     }
 }
 
+#[async_trait::async_trait]
+impl Tick for WalletActor {
+    async fn tick(&mut self) -> ActorResult<()> {
+        if !self.pending_scans.timer.tick() {
+            return Produces::ok(());
+        }
+
+        self.pending_scans.timer_armed = false;
+
+        for tx_id in std::mem::take(&mut self.pending_scans.pending_txids) {
+            send!(self.addr.perform_scan_for_single_tx_id(tx_id));
+            send!(self.addr.remove_watcher_for_txn(tx_id));
+        }
+
+        Produces::ok(())
+    }
+}
+
 impl WalletActor {
     pub fn new(
         wallet: Wallet,
@@ -185,6 +215,7 @@ impl WalletActor {
             last_height_fetched: None,
             state: ActorState::Initial,
             transaction_watchers: HashMap::default(),
+            pending_scans: PendingScanState::default(),
             db,
         })
     }
@@ -933,15 +964,15 @@ impl WalletActor {
         // update the height and perform sync scan which will update the transactions
         self.perform_scan_for_single_tx_id(tx_id).await?;
 
-        // wait 30 seconds run the scan again and then remove the watcher
-        // sanity check to make sure the transaction was picked up by the wallet
-        // and no extra watchers were created in the meantime
-        let addr = self.addr.clone();
-        self.addr.send_fut(async move {
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            send!(addr.perform_scan_for_single_tx_id(tx_id));
-            send!(addr.remove_watcher_for_txn(tx_id));
-        });
+        // wait 30 seconds, run follow-up scans, then remove watcher(s).
+        self.pending_scans.pending_txids.push(tx_id);
+
+        if !self.pending_scans.timer_armed {
+            self.pending_scans.timer_armed = true;
+            self.pending_scans
+                .timer
+                .set_timeout_for_weak(self.addr.clone(), Duration::from_secs(30));
+        }
 
         Produces::ok(())
     }
@@ -952,7 +983,7 @@ impl WalletActor {
         // TODO: stop the wallet scans too, need to save the task handle when we start the scan
     }
 
-    async fn remove_watcher_for_txn(&mut self, tx_id: Txid) {
+    pub async fn remove_watcher_for_txn(&mut self, tx_id: Txid) {
         debug!("removing watcher for txn: {tx_id}");
         self.transaction_watchers.remove(&tx_id);
     }

--- a/rust/src/transaction_watcher.rs
+++ b/rust/src/transaction_watcher.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use act_zero::*;
+use act_zero::{runtimes::tokio::Timer, timer::Tick, *};
 use bitcoin::{Transaction, Txid};
 use cove_types::Network;
 use tracing::{debug, error, info};
@@ -11,13 +11,13 @@ use crate::{
 };
 
 /// Watches for a transaction to see if it is confirmed or to waits for it to be fully confirmed (3 confirmations)
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct TransactionWatcher {
     wallet_actor: WeakAddr<WalletActor>,
     addr: WeakAddr<Self>,
     tx_id: Arc<Txid>,
     client_builder: NodeClientBuilder,
+    timer: Timer,
+    client: Option<Arc<NodeClient>>,
     network: Network,
 }
 
@@ -55,60 +55,81 @@ impl TransactionWatcher {
             addr: Default::default(),
             tx_id: Arc::new(tx_id),
             client_builder,
+            timer: Timer::default(),
+            client: None,
             network,
+        }
+    }
+
+    fn normal_wait_time(&self) -> Duration {
+        match self.network {
+            Network::Bitcoin => Duration::from_secs(20),
+            Network::Testnet | Network::Testnet4 => Duration::from_secs(20),
+            Network::Signet => Duration::from_secs(10),
         }
     }
 
     pub async fn start_watching(&mut self) -> ActorResult<()> {
         debug!("start_watching for txn {}", self.tx_id);
-        let client = Arc::new(self.client_builder.build().await?);
-        let addr = self.addr.clone();
-        let manager = self.wallet_actor.clone();
-        let tx_id = self.tx_id.clone();
-
-        let normal_wait_time = match self.network {
-            Network::Bitcoin => Duration::from_secs(20),
-            Network::Testnet | Network::Testnet4 => Duration::from_secs(20),
-            Network::Signet => Duration::from_secs(10),
-        };
-
-        self.addr.send_fut(async move {
-            let client = client;
-            loop {
-                debug!("checking txn: {tx_id}");
-                let result = call!(addr.check_txn(client.clone())).await;
-
-                match result {
-                    Ok(WatchResult::Found(txn)) => {
-                        let tx_id = txn.compute_txid();
-                        info!("found txn: {}", tx_id);
-                        send!(manager.mark_transaction_found(tx_id));
-                        break;
-                    }
-
-                    // sleep for 10 seconds before checking again
-                    Ok(WatchResult::Continue) => {
-                        debug!("continue watching, waiting for {}", normal_wait_time.as_secs());
-                        tokio::time::sleep(normal_wait_time).await;
-                    }
-
-                    // sleep for 30 seconds before checking again, if we get an error
-                    Err(error) => {
-                        error!("failed to check txn: {error:?}");
-                        tokio::time::sleep(Duration::from_secs(30)).await;
-                    }
-                }
+        let client = match self.client_builder.build().await {
+            Ok(c) => Arc::new(c),
+            Err(e) => {
+                error!("failed to build client: {e:?}");
+                self.timer.set_timeout_for_weak(self.addr.clone(), Duration::from_secs(10));
+                return Produces::ok(());
             }
-        });
+        };
+        self.client = Some(client);
+
+        // Trigger the first check immediately.
+        self.timer.set_timeout_for_weak(self.addr.clone(), Duration::ZERO);
 
         Produces::ok(())
     }
 
-    async fn check_txn(&mut self, client: Arc<NodeClient>) -> ActorResult<WatchResult> {
+    async fn check_txn(&mut self) -> Result<WatchResult, Box<dyn std::error::Error>> {
+        let Some(client) = self.client.clone() else {
+            error!("transaction watcher client not initialized");
+            return Ok(WatchResult::Continue);
+        };
+
         let txn = client.get_confirmed_transaction(self.tx_id.clone()).await?;
         match txn {
-            Some(txn) => Produces::ok(WatchResult::Found(txn)),
-            None => Produces::ok(WatchResult::Continue),
+            Some(txn) => Ok(WatchResult::Found(txn)),
+            None => Ok(WatchResult::Continue),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl Tick for TransactionWatcher {
+    async fn tick(&mut self) -> ActorResult<()> {
+        if !self.timer.tick() {
+            return Produces::ok(());
+        }
+
+        debug!("checking txn: {}", self.tx_id);
+
+        match self.check_txn().await {
+            Ok(WatchResult::Found(txn)) => {
+                let tx_id = txn.compute_txid();
+                info!("found txn: {}", tx_id);
+                send!(self.wallet_actor.mark_transaction_found(tx_id));
+                send!(self.wallet_actor.remove_watcher_for_txn(tx_id));
+                self.timer.clear();
+            }
+
+            Ok(WatchResult::Continue) => {
+                debug!("continue watching, waiting for {}", self.normal_wait_time().as_secs());
+                self.timer.set_timeout_for_weak(self.addr.clone(), self.normal_wait_time());
+            }
+
+            Err(error) => {
+                error!("failed to check txn: {error:?}");
+                self.timer.set_timeout_for_weak(self.addr.clone(), Duration::from_secs(30));
+            }
+        }
+
+        Produces::ok(())
     }
 }


### PR DESCRIPTION
## Summary
Refactored actor timer implementations to use act-zero trait and Timer infrastructure instead of manual send_fut + tokio::time::sleep patterns.
<!-- describe what changed and why -->
fixes #495 
## Testing
- just fmt
- just ci
<!-- list the commands you ran or explain why testing was not needed -->

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced per-transaction delayed tasks with a single actor-level timer that batches follow-up checks, reducing concurrent timers and improving efficiency and predictability of follow-up scans.
  * Converted transaction watching to a timer/tick-driven model that caches the node client, triggers an immediate initial check, and centralizes scheduling and backoff to provide more reliable, resource-friendly monitoring and clearer retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->