### PR TITLE
Add missing test coverage for nested multisig descriptors

### DIFF
--- a/rust/crates/cove-bdk/src/descriptor_ext.rs
+++ b/rust/crates/cove-bdk/src/descriptor_ext.rs
@@ -319,4 +319,24 @@ mod tests {
             "expected MultisigNotSupported, got {result:?}"
         );
     }
+
+    #[test]
+    fn sh_wsh_sortedmulti_full_origin_returns_multisig_not_supported() {
+        let desc = sh_wsh_sortedmulti_desc();
+        let result = desc.full_origin();
+        assert!(
+            matches!(result, Err(Error::MultisigNotSupported)),
+            "expected MultisigNotSupported, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sh_wsh_sortedmulti_origin_returns_multisig_not_supported() {
+        let desc = sh_wsh_sortedmulti_desc();
+        let result = desc.origin();
+        assert!(
+            matches!(result, Err(Error::MultisigNotSupported)),
+            "expected MultisigNotSupported, got {result:?}"
+        );
+    }
 }


### PR DESCRIPTION

## Description

While top-level `wsh(sortedmulti)` descriptors had comprehensive verification, the nested `sh(wsh(sortedmulti))` variant was missing `full_origin` and `origin` test cases.

### Changes:
- Added `sh_wsh_sortedmulti_full_origin_returns_multisig_not_supported` to `descriptor_ext.rs`
- Added `sh_wsh_sortedmulti_origin_returns_multisig_not_supported` to `descriptor_ext.rs`

## Verification Results

### Automated Tests
Ran `cargo test --package cove-bdk` locally.
Result: **11 passed; 0 failed**

```text
test descriptor_ext::tests::sh_wsh_sortedmulti_origin_returns_multisig_not_supported ... ok
test descriptor_ext::tests::sh_wsh_sortedmulti_descriptor_public_key_returns_multisig_not_supported ... ok
test descriptor_ext::tests::sh_wsh_sortedmulti_full_origin_returns_multisig_not_supported ... ok
...
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Related
Relates to #621 (Multi-Sig wallet support).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for descriptor validation on multisig configurations, ensuring consistent error handling across related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->