### PR TITLE
Fix connectivity retry

### DIFF
--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -815,11 +815,12 @@ impl RustCloudBackupManager {
         let receiver = CONNECTIVITY_MANAGER.subscribe();
 
         std::thread::spawn(move || {
-            while let Ok(connected) = receiver.recv() {
+            while receiver.recv().is_ok() {
                 let Some(manager) = manager.upgrade() else {
                     break;
                 };
 
+                let connected = CONNECTIVITY_MANAGER.connected();
                 manager.handle_connectivity_change(connected);
             }
         });

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -2111,23 +2111,36 @@ mod tests {
         cove_tokio::init();
         let globals = test_globals();
         let manager = CLOUD_BACKUP_MANAGER.clone();
+        clear_wallet_upload_runtime_for_test_async(&manager).await;
         configure_enabled_cloud_backup(&manager, globals, 0);
 
         let metadata = xpub_only_wallet_metadata();
+        let record_id = cove_cspp::backup_data::wallet_record_id(metadata.id.as_ref());
         persist_xpub_wallets(vec![metadata.clone()]);
         persist_failed_blob_state(metadata.id.clone(), false);
         globals.cloud.fail_wallet_backup_upload_quota_exceeded();
+        let initial_attempt_count = globals.cloud.wallet_backup_upload_attempt_count();
 
         manager.resume_pending_cloud_upload_verification();
 
         assert_test_condition_stays_true(
             Duration::from_millis(250),
             "startup resume should not retry non-retryable failed uploads",
-            || globals.cloud.wallet_backup_upload_attempt_count() == 0,
+            || globals.cloud.wallet_backup_upload_attempt_count() == initial_attempt_count,
         )
         .await;
 
-        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), 0);
+        assert_eq!(globals.cloud.wallet_backup_upload_attempt_count(), initial_attempt_count);
+        assert!(matches!(
+            Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+            Some(PersistedCloudBlobSyncState {
+                state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                    retryable: false,
+                    ..
+                }),
+                ..
+            })
+        ));
 
         clear_wallet_upload_runtime_for_test_async(&manager).await;
         globals.cloud.clear_wallet_backup_upload_failure();

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -1097,6 +1097,7 @@ where
 mod test_support;
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use std::sync::Arc;
     use std::time::Duration;

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -2157,15 +2157,17 @@ mod tests {
             Duration::from_secs(1),
             "startup resume should retry interrupted uploads",
             || {
-                matches!(
+                let upload_state_is_pending_or_confirmed = matches!(
                     Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
                     Some(PersistedCloudBlobSyncState {
-                        state: PersistedCloudBlobState::Dirty(_)
-                            | PersistedCloudBlobState::UploadedPendingConfirmation(_)
+                        state: PersistedCloudBlobState::UploadedPendingConfirmation(_)
                             | PersistedCloudBlobState::Confirmed(_),
                         ..
                     })
-                )
+                );
+
+                globals.cloud.wallet_backup_upload_attempt_count() >= 1
+                    && upload_state_is_pending_or_confirmed
             },
         )
         .await;

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -452,6 +452,7 @@ impl TestGlobals {
         self.cloud.reset();
         self.passkey.reset();
         cove_cspp::Cspp::<Keychain>::clear_cached_master_key();
+        CONNECTIVITY_MANAGER.set_connection_state(true);
     }
 }
 

--- a/rust/src/manager/connectivity_manager.rs
+++ b/rust/src/manager/connectivity_manager.rs
@@ -25,7 +25,7 @@ pub struct ConnectivityState {
 #[derive(Clone, Debug, uniffi::Object)]
 pub struct RustConnectivityManager {
     is_connected: Arc<AtomicBool>,
-    subscribers: Arc<Mutex<Vec<Sender<bool>>>>,
+    subscribers: Arc<Mutex<Vec<Sender<()>>>>,
 }
 
 impl RustConnectivityManager {
@@ -46,8 +46,8 @@ impl RustConnectivityManager {
         self.is_connected.load(Ordering::Acquire)
     }
 
-    pub(crate) fn subscribe(&self) -> Receiver<bool> {
-        let (sender, receiver) = flume::bounded(16);
+    pub(crate) fn subscribe(&self) -> Receiver<()> {
+        let (sender, receiver) = flume::bounded(1);
         self.subscribers.lock().push(sender);
         receiver
     }
@@ -58,15 +58,16 @@ impl RustConnectivityManager {
             return false;
         }
 
-        self.broadcast(is_connected);
+        self.broadcast();
         true
     }
 
-    fn broadcast(&self, is_connected: bool) {
+    fn broadcast(&self) {
         let mut subscribers = self.subscribers.lock();
-        subscribers.retain(|sender| match sender.try_send(is_connected) {
+        subscribers.retain(|sender| match sender.try_send(()) {
             Ok(()) => true,
-            Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => false,
+            Err(TrySendError::Full(_)) => true,
+            Err(TrySendError::Disconnected(_)) => false,
         });
     }
 }
@@ -109,7 +110,8 @@ mod tests {
 
         manager.set_connection_state(next);
 
-        assert_eq!(receiver.recv().unwrap(), next);
+        receiver.recv().unwrap();
+        assert_eq!(manager.connected(), next);
     }
 
     #[test]
@@ -124,25 +126,55 @@ mod tests {
     }
 
     #[test]
-    fn broadcast_drops_full_and_disconnected_subscribers() {
+    fn broadcast_keeps_full_subscribers_registered() {
+        let manager = RustConnectivityManager::init();
+        let (full_sender, full_receiver) = flume::bounded(1);
+
+        full_sender.send(()).expect("fill subscriber channel");
+        manager.subscribers.lock().push(full_sender);
+
+        manager.broadcast();
+
+        assert_eq!(manager.subscribers.lock().len(), 1);
+        full_receiver.recv().unwrap();
+
+        manager.broadcast();
+
+        full_receiver.recv().unwrap();
+    }
+
+    #[test]
+    fn subscribe_coalesces_multiple_changes_and_uses_latest_state() {
+        let manager = RustConnectivityManager::init();
+        let receiver = manager.subscribe();
+
+        manager.is_connected.store(false, Ordering::Release);
+        manager.set_connection_state_internal(true);
+        manager.set_connection_state_internal(false);
+
+        receiver.recv().unwrap();
+
+        assert!(receiver.try_recv().is_err());
+        assert!(!manager.connected());
+    }
+
+    #[test]
+    fn broadcast_drops_disconnected_subscribers() {
         let manager = RustConnectivityManager::init();
         let (healthy_sender, healthy_receiver) = flume::bounded(1);
-        let (full_sender, _full_receiver) = flume::bounded(1);
         let (disconnected_sender, disconnected_receiver) = flume::bounded(1);
 
-        full_sender.send(false).expect("fill subscriber channel");
         drop(disconnected_receiver);
 
         {
             let mut subscribers = manager.subscribers.lock();
             subscribers.push(healthy_sender);
-            subscribers.push(full_sender);
             subscribers.push(disconnected_sender);
         }
 
-        manager.broadcast(true);
+        manager.broadcast();
 
-        assert_eq!(healthy_receiver.recv().unwrap(), true);
+        healthy_receiver.recv().unwrap();
         assert_eq!(manager.subscribers.lock().len(), 1);
     }
 }

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -1,4 +1,10 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
 use cove_util::ResultExt as _;
@@ -10,7 +16,10 @@ use tracing::{info, warn};
 use crate::{
     app::{App, AppAction, FfiApp},
     database::{Database, global_config::GlobalConfigKey},
-    manager::cloud_backup_manager::{CLOUD_BACKUP_MANAGER, RustCloudBackupManager},
+    manager::{
+        cloud_backup_manager::{CLOUD_BACKUP_MANAGER, RustCloudBackupManager},
+        connectivity_manager::CONNECTIVITY_MANAGER,
+    },
     mnemonic::{Mnemonic as StoredMnemonic, MnemonicExt, NumberOfBip39Words},
     network::Network,
     pending_wallet::PendingWallet,
@@ -307,6 +316,8 @@ struct InternalState {
 #[derive(Clone, Debug, uniffi::Object)]
 pub struct RustOnboardingManager {
     state: Arc<RwLock<InternalState>>,
+    cloud_check_in_flight: Arc<AtomicBool>,
+    pending_cloud_check_retry: Arc<AtomicBool>,
     reconciler: MessageSender<Message>,
     reconcile_receiver: Arc<Receiver<SingleOrMany<Message>>>,
 }
@@ -345,10 +356,13 @@ impl RustOnboardingManager {
 
         let manager = Arc::new(Self {
             state: Arc::new(RwLock::new(InternalState::new(resolution.flow))),
+            cloud_check_in_flight: Arc::new(AtomicBool::new(false)),
+            pending_cloud_check_retry: Arc::new(AtomicBool::new(false)),
             reconciler: MessageSender::new(sender),
             reconcile_receiver: Arc::new(receiver),
         });
 
+        manager.start_connectivity_listener();
         manager.maybe_advance_accepted_terms();
 
         if should_start_cloud_check {
@@ -405,7 +419,44 @@ impl RustOnboardingManager {
 }
 
 impl RustOnboardingManager {
+    fn start_connectivity_listener(self: &Arc<Self>) {
+        let manager = Arc::downgrade(self);
+        let receiver = CONNECTIVITY_MANAGER.subscribe();
+
+        std::thread::spawn(move || {
+            while receiver.recv().is_ok() {
+                let Some(manager) = manager.upgrade() else {
+                    break;
+                };
+
+                let connected = CONNECTIVITY_MANAGER.connected();
+                manager.handle_connectivity_change(connected);
+            }
+        });
+    }
+
+    fn handle_connectivity_change(self: &Arc<Self>, connected: bool) {
+        if !connected {
+            return;
+        }
+
+        if self.cloud_check_in_flight.load(Ordering::Acquire) {
+            self.pending_cloud_check_retry.store(true, Ordering::Release);
+            return;
+        }
+
+        if !self.prepare_offline_cloud_check_retry() {
+            return;
+        }
+
+        self.start_cloud_check();
+    }
+
     fn start_cloud_check(self: &Arc<Self>) {
+        if self.cloud_check_in_flight.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
         let me = Arc::clone(self);
         cove_tokio::task::spawn(async move {
             if CLOUD_BACKUP_MANAGER.is_offline() {
@@ -428,8 +479,34 @@ impl RustOnboardingManager {
         });
     }
 
-    fn finish_cloud_check(&self, outcome: CloudCheckOutcome) {
+    fn prepare_offline_cloud_check_retry(&self) -> bool {
+        self.mutate_state(|state, deferred| state.prepare_offline_cloud_check_retry(deferred))
+    }
+
+    fn finish_cloud_check(self: &Arc<Self>, outcome: CloudCheckOutcome) {
+        let should_retry =
+            self.finish_cloud_check_and_prepare_retry(outcome, CONNECTIVITY_MANAGER.connected());
+        if should_retry {
+            self.start_cloud_check();
+        }
+    }
+
+    fn finish_cloud_check_and_prepare_retry(
+        &self,
+        outcome: CloudCheckOutcome,
+        connected: bool,
+    ) -> bool {
         self.apply_event(InternalEvent::CloudCheckFinished(outcome));
+        self.cloud_check_in_flight.store(false, Ordering::Release);
+
+        if !self.pending_cloud_check_retry.swap(false, Ordering::AcqRel)
+            || outcome != CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline)
+            || !connected
+        {
+            return false;
+        }
+
+        self.prepare_offline_cloud_check_retry()
     }
 
     fn apply_event(&self, event: InternalEvent) {
@@ -622,6 +699,23 @@ impl InternalState {
         }
 
         self.flow.resolve_terms_acceptance(true)
+    }
+
+    fn prepare_offline_cloud_check_retry(
+        &mut self,
+        deferred: &mut DeferredSender<Message>,
+    ) -> bool {
+        if self.cloud_restore_discovery
+            != CloudRestoreDiscovery::Inconclusive(CloudCheckIssue::Offline)
+            || !self.flow.is_offline_cloud_check_retry_eligible()
+        {
+            return false;
+        }
+
+        self.cloud_restore_discovery = CloudRestoreDiscovery::Checking;
+        self.flow.prepare_for_cloud_check_retry();
+        self.sync_ui(deferred);
+        true
     }
 
     fn sync_ui(&mut self, deferred: &mut DeferredSender<Message>) {
@@ -2306,6 +2400,48 @@ mod tests {
     }
 
     #[test]
+    fn connectivity_reconnect_while_cloud_check_is_in_flight_retries_after_offline_finish() {
+        let manager = preview_manager(
+            FlowState::Welcome { error_message: None },
+            CloudRestoreDiscovery::Checking,
+        );
+        manager.cloud_check_in_flight.store(true, Ordering::Release);
+
+        manager.handle_connectivity_change(true);
+
+        assert!(manager.pending_cloud_check_retry.load(Ordering::Acquire));
+        assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Checking);
+
+        assert!(manager.finish_cloud_check_and_prepare_retry(
+            CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline),
+            true,
+        ));
+        assert!(!manager.cloud_check_in_flight.load(Ordering::Acquire));
+        assert!(!manager.pending_cloud_check_retry.load(Ordering::Acquire));
+        assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Checking);
+        assert_eq!(manager.state().cloud_restore_message, None);
+    }
+
+    #[test]
+    fn connectivity_reconnect_while_cloud_check_is_in_flight_does_not_retry_non_offline_finish() {
+        let manager = preview_manager(
+            FlowState::Welcome { error_message: None },
+            CloudRestoreDiscovery::Checking,
+        );
+        manager.cloud_check_in_flight.store(true, Ordering::Release);
+
+        manager.handle_connectivity_change(true);
+
+        assert!(
+            !manager
+                .finish_cloud_check_and_prepare_retry(CloudCheckOutcome::NoBackupConfirmed, true,)
+        );
+        assert!(!manager.cloud_check_in_flight.load(Ordering::Acquire));
+        assert!(!manager.pending_cloud_check_retry.load(Ordering::Acquire));
+        assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::NoBackupFound);
+    }
+
+    #[test]
     fn cloud_check_timeout_is_treated_as_cloud_unavailable() {
         let error = CloudStorageError::NotAvailable("iCloud metadata query timed out".into());
 
@@ -2465,5 +2601,34 @@ mod tests {
             cloud_backup_enabled: false,
             secret_words_saved: false,
         }
+    }
+    fn preview_internal_state(
+        flow: FlowState,
+        cloud_restore_discovery: CloudRestoreDiscovery,
+    ) -> InternalState {
+        let ui = flow.ui_state(cloud_restore_discovery, false);
+
+        InternalState { flow, cloud_restore_discovery, restore_offer_allowed: true, ui }
+    }
+
+    fn preview_manager(
+        flow: FlowState,
+        cloud_restore_discovery: CloudRestoreDiscovery,
+    ) -> Arc<RustOnboardingManager> {
+        let (sender, receiver) = flume::bounded(16);
+
+        Arc::new(RustOnboardingManager {
+            state: Arc::new(RwLock::new(preview_internal_state(flow, cloud_restore_discovery))),
+            cloud_check_in_flight: Arc::new(AtomicBool::new(false)),
+            pending_cloud_check_retry: Arc::new(AtomicBool::new(false)),
+            reconciler: MessageSender::new(sender),
+            reconcile_receiver: Arc::new(receiver),
+        })
+    }
+
+    fn prepare_offline_cloud_check_retry(state: &mut InternalState) -> bool {
+        let (sender, _receiver) = flume::bounded(16);
+        let mut deferred = DeferredSender::new(MessageSender::new(sender));
+        state.prepare_offline_cloud_check_retry(&mut deferred)
     }
 }

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -441,11 +441,26 @@ impl RustOnboardingManager {
             return;
         }
 
-        if self.cloud_check_in_flight.load(Ordering::Acquire) {
-            self.pending_cloud_check_retry.store(true, Ordering::Release);
+        if self.cloud_check_in_flight.load(Ordering::Acquire)
+            && !self.mark_pending_cloud_check_retry()
+        {
             return;
         }
 
+        self.start_offline_cloud_check_retry();
+    }
+
+    fn mark_pending_cloud_check_retry(&self) -> bool {
+        self.pending_cloud_check_retry.store(true, Ordering::Release);
+
+        if self.cloud_check_in_flight.load(Ordering::Acquire) {
+            return false;
+        }
+
+        self.pending_cloud_check_retry.swap(false, Ordering::AcqRel)
+    }
+
+    fn start_offline_cloud_check_retry(self: &Arc<Self>) {
         if !self.prepare_offline_cloud_check_retry() {
             return;
         }
@@ -2427,6 +2442,27 @@ mod tests {
         assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Checking);
         assert_eq!(manager.state().cloud_restore_message, None);
         assert_no_reconcile_messages(&manager);
+    }
+
+    #[test]
+    fn late_pending_connectivity_retry_after_offline_finish_is_taken_over() {
+        let manager = preview_manager(
+            FlowState::Welcome { error_message: None },
+            CloudRestoreDiscovery::Checking,
+        );
+        manager.cloud_check_in_flight.store(true, Ordering::Release);
+
+        assert!(!manager.finish_cloud_check_and_prepare_retry(
+            CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline),
+            true,
+        ));
+        assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Inconclusive);
+
+        assert!(manager.mark_pending_cloud_check_retry());
+        assert!(!manager.pending_cloud_check_retry.load(Ordering::Acquire));
+        assert!(manager.prepare_offline_cloud_check_retry());
+        assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Checking);
+        assert_eq!(manager.state().cloud_restore_message, None);
     }
 
     #[test]

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use backon::{FibonacciBuilder, Retryable as _};
 use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
 use cove_util::ResultExt as _;
 use flume::Receiver;
@@ -464,10 +465,8 @@ impl RustOnboardingManager {
                 return;
             }
 
-            let retry_delays = [1u64, 2, 2, 3, 5, 10];
             let cloud = CloudStorage::global().clone();
             let outcome = determine_cloud_check_outcome_async(
-                &retry_delays,
                 || {
                     let cloud = cloud.clone();
                     async move { cloud.has_any_cloud_backup().await }
@@ -504,10 +503,12 @@ impl RustOnboardingManager {
             );
             self.cloud_check_in_flight.store(false, Ordering::Release);
 
-            let should_retry = self.pending_cloud_check_retry.swap(false, Ordering::AcqRel)
+            let retry_was_requested = self.pending_cloud_check_retry.swap(false, Ordering::AcqRel);
+            let should_retry_offline_cloud_check = retry_was_requested
                 && outcome == CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline)
                 && connected;
-            if should_retry && state.prepare_offline_cloud_check_retry(deferred) {
+            if should_retry_offline_cloud_check && state.prepare_offline_cloud_check_retry(deferred)
+            {
                 return true;
             }
 
@@ -1582,34 +1583,32 @@ fn cloud_check_inconclusive_message(issue: CloudCheckIssue) -> String {
     }
 }
 
-async fn determine_cloud_check_outcome_async<F, Fut, S, SleepFut>(
-    retry_delays: &[u64],
+async fn determine_cloud_check_outcome_async<F, Fut, S>(
     mut has_any_cloud_backup: F,
-    mut sleep: S,
+    sleep: S,
 ) -> CloudCheckOutcome
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<bool, CloudStorageError>>,
-    S: FnMut(Duration) -> SleepFut,
-    SleepFut: std::future::Future<Output = ()>,
+    S: backon::Sleeper,
 {
-    for (attempt, delay) in retry_delays.iter().enumerate() {
-        info!(
-            "Onboarding: checking cloud backup attempt={}/{}",
-            attempt + 1,
-            retry_delays.len() + 1
-        );
+    let max_retries = 6;
+    let mut attempt = 0;
+    let result = (|| {
+        attempt += 1;
+        info!("Onboarding: checking cloud backup attempt={attempt}");
+        has_any_cloud_backup()
+    })
+    .retry(
+        FibonacciBuilder::default()
+            .with_max_delay(Duration::from_secs(10))
+            .with_max_times(max_retries),
+    )
+    .sleep(sleep)
+    .notify(|error: &CloudStorageError, _| warn!("Onboarding: cloud backup check failed: {error}"))
+    .await;
 
-        match has_any_cloud_backup().await {
-            Ok(true) => return CloudCheckOutcome::BackupFound,
-            Ok(false) => return CloudCheckOutcome::NoBackupConfirmed,
-            Err(error) => warn!("Onboarding: cloud backup check failed: {error}"),
-        }
-
-        sleep(Duration::from_secs(*delay)).await;
-    }
-
-    match has_any_cloud_backup().await {
+    match result {
         Ok(true) => CloudCheckOutcome::BackupFound,
         Ok(false) => CloudCheckOutcome::NoBackupConfirmed,
         Err(error) => {
@@ -2490,7 +2489,6 @@ mod tests {
         let slept = Arc::new(Mutex::new(Vec::new()));
         let sleep_log = Arc::clone(&slept);
         let outcome = determine_cloud_check_outcome_async(
-            &[1, 2, 3],
             || async { Ok(false) },
             move |duration| {
                 let sleep_log = Arc::clone(&sleep_log);
@@ -2507,22 +2505,13 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn cloud_check_retries_errors_and_returns_inconclusive() {
-        let slept = Arc::new(Mutex::new(Vec::new()));
-        let sleep_log = Arc::clone(&slept);
         let outcome = determine_cloud_check_outcome_async(
-            &[1, 2],
             || async { Err(CloudStorageError::NotAvailable("network timed out".into())) },
-            move |duration| {
-                let sleep_log = Arc::clone(&sleep_log);
-                async move {
-                    sleep_log.lock().unwrap().push(duration);
-                }
-            },
+            |_| async {},
         )
         .await;
 
         assert_eq!(outcome, CloudCheckOutcome::Inconclusive(CloudCheckIssue::CloudUnavailable));
-        assert_eq!(*slept.lock().unwrap(), vec![Duration::from_secs(1), Duration::from_secs(2)]);
     }
 
     #[test]

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -496,17 +496,24 @@ impl RustOnboardingManager {
         outcome: CloudCheckOutcome,
         connected: bool,
     ) -> bool {
-        self.apply_event(InternalEvent::CloudCheckFinished(outcome));
-        self.cloud_check_in_flight.store(false, Ordering::Release);
+        self.mutate_state(|state, deferred| {
+            state.flow.apply_event(
+                InternalEvent::CloudCheckFinished(outcome),
+                &mut state.cloud_restore_discovery,
+                state.restore_offer_allowed,
+            );
+            self.cloud_check_in_flight.store(false, Ordering::Release);
 
-        if !self.pending_cloud_check_retry.swap(false, Ordering::AcqRel)
-            || outcome != CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline)
-            || !connected
-        {
-            return false;
-        }
+            let should_retry = self.pending_cloud_check_retry.swap(false, Ordering::AcqRel)
+                && outcome == CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline)
+                && connected;
+            if should_retry && state.prepare_offline_cloud_check_retry(deferred) {
+                return true;
+            }
 
-        self.prepare_offline_cloud_check_retry()
+            state.sync_ui(deferred);
+            false
+        })
     }
 
     fn apply_event(&self, event: InternalEvent) {
@@ -2420,6 +2427,29 @@ mod tests {
         assert!(!manager.pending_cloud_check_retry.load(Ordering::Acquire));
         assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Checking);
         assert_eq!(manager.state().cloud_restore_message, None);
+        assert_no_reconcile_messages(&manager);
+    }
+
+    #[test]
+    fn startup_restore_retry_after_offline_finish_skips_transient_offline_messages() {
+        let manager = preview_manager(
+            FlowState::CloudCheck { origin: RestoreOrigin::Startup },
+            CloudRestoreDiscovery::Checking,
+        );
+        manager.cloud_check_in_flight.store(true, Ordering::Release);
+
+        manager.handle_connectivity_change(true);
+
+        assert!(manager.finish_cloud_check_and_prepare_retry(
+            CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline),
+            true,
+        ));
+        assert!(!manager.cloud_check_in_flight.load(Ordering::Acquire));
+        assert!(!manager.pending_cloud_check_retry.load(Ordering::Acquire));
+        assert_eq!(manager.state().step, OnboardingStep::CloudCheck);
+        assert_eq!(manager.state().cloud_restore_state, OnboardingCloudRestoreState::Checking);
+        assert_eq!(manager.state().cloud_restore_message, None);
+        assert_no_reconcile_messages(&manager);
     }
 
     #[test]
@@ -2624,6 +2654,10 @@ mod tests {
             reconciler: MessageSender::new(sender),
             reconcile_receiver: Arc::new(receiver),
         })
+    }
+
+    fn assert_no_reconcile_messages(manager: &RustOnboardingManager) {
+        assert!(matches!(manager.reconcile_receiver.try_recv(), Err(flume::TryRecvError::Empty)));
     }
 
     fn prepare_offline_cloud_check_retry(state: &mut InternalState) -> bool {

--- a/rust/src/manager/onboarding_manager.rs
+++ b/rust/src/manager/onboarding_manager.rs
@@ -1,10 +1,4 @@
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use cove_device::cloud_storage::{CloudStorage, CloudStorageError};
 use cove_util::ResultExt as _;
@@ -16,10 +10,7 @@ use tracing::{info, warn};
 use crate::{
     app::{App, AppAction, FfiApp},
     database::{Database, global_config::GlobalConfigKey},
-    manager::{
-        cloud_backup_manager::{CLOUD_BACKUP_MANAGER, RustCloudBackupManager},
-        connectivity_manager::CONNECTIVITY_MANAGER,
-    },
+    manager::cloud_backup_manager::{CLOUD_BACKUP_MANAGER, RustCloudBackupManager},
     mnemonic::{Mnemonic as StoredMnemonic, MnemonicExt, NumberOfBip39Words},
     network::Network,
     pending_wallet::PendingWallet,
@@ -316,7 +307,6 @@ struct InternalState {
 #[derive(Clone, Debug, uniffi::Object)]
 pub struct RustOnboardingManager {
     state: Arc<RwLock<InternalState>>,
-    cloud_check_in_flight: Arc<AtomicBool>,
     reconciler: MessageSender<Message>,
     reconcile_receiver: Arc<Receiver<SingleOrMany<Message>>>,
 }
@@ -355,12 +345,10 @@ impl RustOnboardingManager {
 
         let manager = Arc::new(Self {
             state: Arc::new(RwLock::new(InternalState::new(resolution.flow))),
-            cloud_check_in_flight: Arc::new(AtomicBool::new(false)),
             reconciler: MessageSender::new(sender),
             reconcile_receiver: Arc::new(receiver),
         });
 
-        manager.start_connectivity_listener();
         manager.maybe_advance_accepted_terms();
 
         if should_start_cloud_check {
@@ -417,60 +405,27 @@ impl RustOnboardingManager {
 }
 
 impl RustOnboardingManager {
-    fn start_connectivity_listener(self: &Arc<Self>) {
-        let manager = Arc::downgrade(self);
-        let receiver = CONNECTIVITY_MANAGER.subscribe();
-
-        std::thread::spawn(move || {
-            while let Ok(connected) = receiver.recv() {
-                let Some(manager) = manager.upgrade() else {
-                    break;
-                };
-
-                manager.handle_connectivity_change(connected);
-            }
-        });
-    }
-
-    fn handle_connectivity_change(self: &Arc<Self>, connected: bool) {
-        if !connected || !self.prepare_offline_cloud_check_retry() {
-            return;
-        }
-
-        self.start_cloud_check();
-    }
-
     fn start_cloud_check(self: &Arc<Self>) {
-        if self.cloud_check_in_flight.swap(true, Ordering::AcqRel) {
-            return;
-        }
-
         let me = Arc::clone(self);
         cove_tokio::task::spawn(async move {
-            let outcome = if CLOUD_BACKUP_MANAGER.is_offline() {
-                CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline)
-            } else {
-                let retry_delays = [1u64, 2, 2, 3, 5, 10];
-                let cloud = CloudStorage::global().clone();
+            if CLOUD_BACKUP_MANAGER.is_offline() {
+                me.finish_cloud_check(CloudCheckOutcome::Inconclusive(CloudCheckIssue::Offline));
+                return;
+            }
 
-                determine_cloud_check_outcome_async(
-                    &retry_delays,
-                    || {
-                        let cloud = cloud.clone();
-                        async move { cloud.has_any_cloud_backup().await }
-                    },
-                    |duration| tokio::time::sleep(duration),
-                )
-                .await
-            };
-
-            me.cloud_check_in_flight.store(false, Ordering::Release);
+            let retry_delays = [1u64, 2, 2, 3, 5, 10];
+            let cloud = CloudStorage::global().clone();
+            let outcome = determine_cloud_check_outcome_async(
+                &retry_delays,
+                || {
+                    let cloud = cloud.clone();
+                    async move { cloud.has_any_cloud_backup().await }
+                },
+                |duration| tokio::time::sleep(duration),
+            )
+            .await;
             me.finish_cloud_check(outcome);
         });
-    }
-
-    fn prepare_offline_cloud_check_retry(&self) -> bool {
-        self.mutate_state(|state, deferred| state.prepare_offline_cloud_check_retry(deferred))
     }
 
     fn finish_cloud_check(&self, outcome: CloudCheckOutcome) {
@@ -667,23 +622,6 @@ impl InternalState {
         }
 
         self.flow.resolve_terms_acceptance(true)
-    }
-
-    fn prepare_offline_cloud_check_retry(
-        &mut self,
-        deferred: &mut DeferredSender<Message>,
-    ) -> bool {
-        if self.cloud_restore_discovery
-            != CloudRestoreDiscovery::Inconclusive(CloudCheckIssue::Offline)
-            || !self.flow.is_offline_cloud_check_retry_eligible()
-        {
-            return false;
-        }
-
-        self.cloud_restore_discovery = CloudRestoreDiscovery::Checking;
-        self.flow.prepare_for_cloud_check_retry();
-        self.sync_ui(deferred);
-        true
     }
 
     fn sync_ui(&mut self, deferred: &mut DeferredSender<Message>) {
@@ -2527,20 +2465,5 @@ mod tests {
             cloud_backup_enabled: false,
             secret_words_saved: false,
         }
-    }
-
-    fn preview_internal_state(
-        flow: FlowState,
-        cloud_restore_discovery: CloudRestoreDiscovery,
-    ) -> InternalState {
-        let ui = flow.ui_state(cloud_restore_discovery, false);
-
-        InternalState { flow, cloud_restore_discovery, restore_offer_allowed: true, ui }
-    }
-
-    fn prepare_offline_cloud_check_retry(state: &mut InternalState) -> bool {
-        let (sender, _receiver) = flume::bounded(16);
-        let mut deferred = DeferredSender::new(MessageSender::new(sender));
-        state.prepare_offline_cloud_check_retry(&mut deferred)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of connectivity changes during cloud backup; offline-triggered retries are now remembered and retried when appropriate.

* **Refactor**
  * Event notifications switched to lightweight events to reduce spurious payloads and ensure receivers observe the latest connectivity state.
  * Cloud-check retry strategy updated to a Fibonacci backoff with capped retries/delay.

* **Tests**
  * Expanded tests for reconnection during in-flight cloud checks and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->