### PR TITLE
Add ability to send directly to other imported wallets

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAddressView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAddressView.kt
@@ -9,22 +9,34 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.background
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -36,9 +48,21 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove_core.types.addressStringSpacedOut
+import org.bitcoinppl.cove.WalletManager
+import org.bitcoinppl.cove.ui.theme.CoveColor
+import org.bitcoinppl.cove_core.Database
+import org.bitcoinppl.cove_core.WalletMetadata
+import org.bitcoinppl.cove_core.types.WalletId
+import kotlinx.coroutines.launch
+import org.bitcoinppl.cove.Log
+import kotlin.collections.emptyList
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EnterAddressView(
     onScanQr: () -> Unit,
@@ -47,9 +71,17 @@ fun EnterAddressView(
     focusRequester: FocusRequester,
     onFocusChanged: (Boolean) -> Unit = {},
     onDone: () -> Unit = {},
+    currentWalletId: WalletId? = null,
 ) {
+    val tag = "EnterAddressView"
+
     var address by remember { mutableStateOf(initialAddress) }
     var isFocused by remember { mutableStateOf(false) }
+
+    var showingWalletPicker by remember { mutableStateOf(false) }
+    var selectedWallet by remember { mutableStateOf<WalletMetadata?>(null) }
+    var showRawAddress by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
 
     // bidirectional sync: update local state when parent state changes
     LaunchedEffect(initialAddress) {
@@ -98,6 +130,12 @@ fun EnterAddressView(
                 }
             }
             IconButton(
+                onClick = { showingWalletPicker = true },
+                modifier = Modifier.offset(x = 8.dp),
+            ) {
+                Icon(Icons.Filled.AccountBalanceWallet, contentDescription = "Select Wallet", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            IconButton(
                 onClick = onScanQr,
                 modifier = Modifier.offset(x = 8.dp),
             ) {
@@ -105,57 +143,183 @@ fun EnterAddressView(
             }
         }
         Spacer(Modifier.height(10.dp))
-        Box(modifier = Modifier.fillMaxWidth()) {
-            BasicTextField(
-                value = if (isFocused) address else "",
-                onValueChange = { newValue ->
-                    address = newValue
-                    onAddressChanged(newValue)
-                },
-                textStyle =
-                    TextStyle(
+        if (selectedWallet != null) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f))
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Filled.AccountBalanceWallet,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        selectedWallet!!.name,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 16.sp
+                    )
+                    Spacer(Modifier.weight(1f))
+                    IconButton(
+                        onClick = {
+                            selectedWallet = null
+                            address = ""
+                            onAddressChanged("")
+                        },
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        Icon(
+                            Icons.Filled.Cancel,
+                            contentDescription = "Remove selected wallet",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                if (showRawAddress) {
+                    Text(
+                        text = address,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                    )
+                } else {
+                    Text(
+                        text = "Show address",
+                        color = CoveColor.LinkBlue,
+                        fontSize = 12.sp,
+                        modifier = Modifier.clickable { showRawAddress = true }
+                    )
+                }
+            }
+        } else {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                BasicTextField(
+                    value = if (isFocused) address else "",
+                    onValueChange = { newValue ->
+                        address = newValue
+                        onAddressChanged(newValue)
+                    },
+                    textStyle =
+                        TextStyle(
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontSize = 15.sp,
+                            lineHeight = 20.sp,
+                            fontWeight = FontWeight.Medium,
+                        ),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { onDone() }),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester)
+                            .onFocusChanged { focusState ->
+                                isFocused = focusState.isFocused
+                                onFocusChanged(focusState.isFocused)
+                            },
+                )
+                // show spaced-out address when not focused
+                if (!isFocused && address.isNotEmpty()) {
+                    Text(
+                        text = addressStringSpacedOut(address),
                         color = MaterialTheme.colorScheme.onSurface,
                         fontSize = 15.sp,
                         lineHeight = 20.sp,
                         fontWeight = FontWeight.Medium,
-                    ),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = { onDone() }),
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester)
-                        .onFocusChanged { focusState ->
-                            isFocused = focusState.isFocused
-                            onFocusChanged(focusState.isFocused)
-                        },
-            )
-            // show spaced-out address when not focused
-            if (!isFocused && address.isNotEmpty()) {
-                Text(
-                    text = addressStringSpacedOut(address),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 15.sp,
-                    lineHeight = 20.sp,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 3,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clickable { focusRequester.requestFocus() },
-                )
-            }
-            // placeholder when empty and not focused
-            if (address.isEmpty() && !isFocused) {
-                Text(
-                    text = "bc1p...",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                    fontSize = 15.sp,
-                    lineHeight = 20.sp,
-                    fontWeight = FontWeight.Medium,
-                )
+                        maxLines = 3,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { focusRequester.requestFocus() },
+                    )
+                }
+                // placeholder when empty and not focused
+                if (address.isEmpty() && !isFocused) {
+                    Text(
+                        text = "bc1p...",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        fontSize = 15.sp,
+                        lineHeight = 20.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
             }
         }
         Spacer(Modifier.height(24.dp))
+    }
+
+    if (showingWalletPicker) {
+        ModalBottomSheet(
+            onDismissRequest = { showingWalletPicker = false },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        "Select Wallet",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f)
+                    )
+                    TextButton(onClick = { showingWalletPicker = false }) {
+                        Text("Cancel", color = CoveColor.LinkBlue)
+                    }
+                }
+                Spacer(Modifier.height(16.dp))
+
+                val wallets = remember {
+                    try {
+                        Database().wallets().allSortedActive().filter { it.id != currentWalletId }
+                    } catch (e: Exception) {
+                        emptyList()
+                    }
+                }
+
+                LazyColumn {
+                    items(wallets, key = { it.id }) { wallet ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    coroutineScope.launch {
+                                        try {
+                                            val wm = WalletManager(wallet.id)
+                                            val addressInfo = wm.firstAddress()
+                                            address = addressInfo.address().unformatted()
+                                            onAddressChanged(address)
+                                            selectedWallet = wallet
+                                            showRawAddress = false
+                                            showingWalletPicker = false
+                                            wm.close()
+                                        } catch (e: Exception) {
+                                            Log.w(tag, "Error wallet items: ${e.message}")
+                                        }
+                                    }
+                                }
+                                .padding(vertical = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = wallet.name,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 16.sp
+                            )
+                        }
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    }
+                }
+                Spacer(Modifier.height(24.dp))
+            }
+        }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowSetAmountScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowSetAmountScreen.kt
@@ -318,6 +318,7 @@ fun SendFlowSetAmountScreen(
                                         null
                                     }
                             },
+                            currentWalletId = walletManager.id
                         )
                         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
                         SpendingWidget(

--- a/ios/Cove/Flows/SendFlow/SetAmountScreen/EnterAddressView.swift
+++ b/ios/Cove/Flows/SendFlow/SetAmountScreen/EnterAddressView.swift
@@ -18,6 +18,9 @@ struct EnterAddressView: View {
 
     /// private
     @FocusState private var focusField: SendFlowPresenter.FocusField?
+    @State private var showingWalletPicker: Bool = false
+    @State private var selectedWallet: WalletMetadata?
+    @State private var showRawAddress: Bool = false
 
     var body: some View {
         VStack(spacing: 8) {
@@ -27,6 +30,11 @@ struct EnterAddressView: View {
                     .fontWeight(.bold)
 
                 Spacer()
+
+                Button(action: { showingWalletPicker = true }) {
+                    Image(systemName: "wallet.bifold")
+                }
+                .foregroundStyle(.secondary)
 
                 Button(action: { presenter.sheetState = TaggedItem(.qr) }) {
                     Image(systemName: "qrcode")
@@ -43,15 +51,75 @@ struct EnterAddressView: View {
                 Spacer()
             }
 
-            HStack {
-                AddressTextEditor(text: $address)
-                    .focused($focusField, equals: .address)
-                    .foregroundStyle(.primary.opacity(0.9))
-                    .autocorrectionDisabled(true)
-                    .keyboardType(.asciiCapable)
+            if let dest = selectedWallet {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Image(systemName: "wallet.bifold")
+                        Text(dest.name).font(.headline).fontWeight(.semibold)
+                        Spacer()
+                        Button(action: {
+                            selectedWallet = nil
+                            address = ""
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding()
+                    .background(Color.secondary.opacity(0.2))
+                    .cornerRadius(8)
+
+                    if showRawAddress {
+                        Text(address)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
+                        Button("Show address") {
+                            showRawAddress = true
+                        }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                    }
+                }
+            } else {
+                HStack {
+                    AddressTextEditor(text: $address)
+                        .focused($focusField, equals: .address)
+                        .foregroundStyle(.primary.opacity(0.9))
+                        .autocorrectionDisabled(true)
+                        .keyboardType(.asciiCapable)
+                }
             }
         }
         .contentShape(Rectangle())
+        .sheet(isPresented: $showingWalletPicker) {
+            NavigationView {
+                List {
+                    let wallets = (try? Database().wallets().allSortedActive()) ?? []
+                    ForEach(wallets.filter { $0.id != presenter.manager.id }, id: \.id) { wallet in
+                        Button(action: {
+                            Task {
+                                if let wm = try? WalletManager(id: wallet.id),
+                                   let addrInfo = try? await wm.firstAddress()
+                                {
+                                    address = addrInfo.addressUnformatted()
+                                    selectedWallet = wallet
+                                    showRawAddress = false
+                                    showingWalletPicker = false
+                                }
+                            }
+                        }) {
+                            HStack {
+                                Text(wallet.name)
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+                .navigationTitle("Select Wallet")
+                .navigationBarItems(trailing: Button("Cancel") { showingWalletPicker = false })
+            }
+        }
         .onTapGesture {
             presenter.focusField = .address
         }


### PR DESCRIPTION
## Summary
- Allow `self-transfer` of funds between different imported wallet.
- Add a `Show address` toggle, allowing users to manually verify the underlying raw address.
- closes: #224 

## Images
|IOS|Android|
|-|-|
|<img width="371" height="762" alt="Screenshot 2026-04-20 at 18 27 41" src="https://github.com/user-attachments/assets/0f15a9fc-c1cc-4b42-8ef3-fa7d2474419a" />|<img width="371" height="762" alt="Screenshot 2026-04-20 at 18 25 12" src="https://github.com/user-attachments/assets/1e94be46-24b2-4c73-a003-dbeb51a78948" />|

## Testing
- Did manual testing on both platforms.

### Platform Coverage

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on iOS simulator
- [x] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet selection functionality to the address entry screen in the Send flow: users can now select a wallet to automatically populate the recipient address
  * Selected wallet information is displayed with an option to deselect and clear the address field
  * Added toggle to show or hide the raw address text for transparency
  * Feature available on both iOS and Android platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->