### PR TITLE
Add SATSCARD Rust core for tap-card integration

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
@@ -55,6 +55,16 @@ class ScanManager private constructor() {
                     }
                 }
 
+                is MultiFormat.SatsCard -> {
+                    Log.d(tag, "SATSCARD detected: slot ${multiFormat.v1.slotNumber} state ${multiFormat.v1.state}")
+                    app.alertState = TaggedItem(
+                        AppAlertState.General(
+                            title = "SATSCARD Detected",
+                            message = "SATSCARD support is coming soon. Slot ${multiFormat.v1.slotNumber} was scanned.",
+                        ),
+                    )
+                }
+
                 is MultiFormat.Bip329Labels -> {
                     val selectedWallet = Database().globalConfig().selectedWallet()
                     if (selectedWallet == null) {

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -44,8 +44,10 @@ import org.bitcoinppl.cove_core.device.FfiConverterTypeKeychainError
 import org.bitcoinppl.cove_core.device.KeychainException
 import org.bitcoinppl.cove_core.nfc.FfiConverterTypeNfcMessage
 import org.bitcoinppl.cove_core.nfc.NfcMessage
+import org.bitcoinppl.cove_core.tapcard.FfiConverterTypeSatsCard
 import org.bitcoinppl.cove_core.tapcard.FfiConverterTypeTapCardParseError
 import org.bitcoinppl.cove_core.tapcard.FfiConverterTypeTapSigner
+import org.bitcoinppl.cove_core.tapcard.SatsCard
 import org.bitcoinppl.cove_core.tapcard.TapCardParseException
 import org.bitcoinppl.cove_core.tapcard.TapSigner
 import org.bitcoinppl.cove_core.types.Address
@@ -115,6 +117,7 @@ import org.bitcoinppl.cove_core.ur.UrException
 import org.bitcoinppl.cove_core.device.RustBuffer as RustBufferCloudSyncHealth
 import org.bitcoinppl.cove_core.device.RustBuffer as RustBufferKeychainError
 import org.bitcoinppl.cove_core.nfc.RustBuffer as RustBufferNfcMessage
+import org.bitcoinppl.cove_core.tapcard.RustBuffer as RustBufferSatsCard
 import org.bitcoinppl.cove_core.tapcard.RustBuffer as RustBufferTapCardParseError
 import org.bitcoinppl.cove_core.tapcard.RustBuffer as RustBufferTapSigner
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferAddress
@@ -1094,6 +1097,14 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_func_is_valid_chain_code(
     ): Short
+    external fun uniffi_cove_checksum_func_create_sats_card_reader(
+    ): Short
+    external fun uniffi_cove_checksum_func_satscardresponsedumpdata(
+    ): Short
+    external fun uniffi_cove_checksum_func_satscardresponsestatusdata(
+    ): Short
+    external fun uniffi_cove_checksum_func_satscardresponseunsealsession(
+    ): Short
     external fun uniffi_cove_checksum_func_create_tap_signer_reader(
     ): Short
     external fun uniffi_cove_checksum_func_tapsignerresponsebackupresponse(
@@ -1707,6 +1718,20 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_headericonpresenter_icon_color(
     ): Short
     external fun uniffi_cove_checksum_method_headericonpresenter_ring_color(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardreader_run(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardreader_status(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardreader_verified_address(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardsweepsession_address(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardsweepsession_network(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardsweepsession_pubkey_bytes(
+    ): Short
+    external fun uniffi_cove_checksum_method_satscardsweepsession_slot(
     ): Short
     external fun uniffi_cove_checksum_method_tapsignerreader_continue_setup(
     ): Short
@@ -2862,6 +2887,28 @@ internal object UniffiLib {
     ): RustBufferFfiColor.ByValue
     external fun uniffi_cove_fn_method_headericonpresenter_ring_color(`ptr`: Long,`state`: RustBuffer.ByValue,`colorScheme`: RustBufferFfiColorScheme.ByValue,`direction`: RustBufferTransactionDirection.ByValue,`confirmations`: Long,`ringNumber`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBufferFfiColor.ByValue
+    external fun uniffi_cove_fn_clone_satscardreader(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_fn_free_satscardreader(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_fn_method_satscardreader_run(`ptr`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_satscardreader_status(`ptr`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_satscardreader_verified_address(`ptr`: Long,
+    ): Long
+    external fun uniffi_cove_fn_clone_satscardsweepsession(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_fn_free_satscardsweepsession(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_cove_fn_method_satscardsweepsession_address(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_satscardsweepsession_network(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBufferNetwork.ByValue
+    external fun uniffi_cove_fn_method_satscardsweepsession_pubkey_bytes(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_satscardsweepsession_slot(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
     external fun uniffi_cove_fn_clone_setupcmd(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_free_setupcmd(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -3254,6 +3301,12 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_transporterror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_satscardreadererror_isautherror(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
+    external fun uniffi_cove_fn_method_satscardreadererror_isratelimited(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
+    external fun uniffi_cove_fn_method_satscardreadererror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_tapsignerreadererror_isautherror(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_cove_fn_method_tapsignerreadererror_isnobackuperror(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -3362,6 +3415,14 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_is_valid_chain_code(`chainCode`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
+    external fun uniffi_cove_fn_func_create_sats_card_reader(`transport`: Long,`cmd`: RustBuffer.ByValue,`expectedUrlSuffix`: RustBuffer.ByValue,
+    ): Long
+    external fun uniffi_cove_fn_func_satscardresponsedumpdata(`response`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_satscardresponsestatusdata(`response`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_satscardresponseunsealsession(`response`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_create_tap_signer_reader(`transport`: Long,`cmd`: RustBuffer.ByValue,
     ): Long
     external fun uniffi_cove_fn_func_tapsignerresponsebackupresponse(`response`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -3606,6 +3667,18 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_is_valid_chain_code() != 38380.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_create_sats_card_reader() != 34660.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_satscardresponsedumpdata() != 240.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_satscardresponsestatusdata() != 17903.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_satscardresponseunsealsession() != 3295.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_create_tap_signer_reader() != 37635.toShort()) {
@@ -4527,6 +4600,27 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_headericonpresenter_ring_color() != 38756.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardreader_run() != 30335.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardreader_status() != 58264.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardreader_verified_address() != 26883.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardsweepsession_address() != 27077.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardsweepsession_network() != 50397.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardsweepsession_pubkey_bytes() != 34999.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_satscardsweepsession_slot() != 46812.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_tapsignerreader_continue_setup() != 49046.toShort()) {
@@ -22168,6 +22262,687 @@ public object FfiConverterTypeRustWalletManager: FfiConverter<RustWalletManager,
 //
 
 
+public interface SatsCardReaderInterface {
+    
+    suspend fun `run`(): SatsCardResponse
+    
+    /**
+     * Get the current status of the SatsCard.
+     *
+     * `address` on the returned status is the **card-reported, unverified**
+     * string. Call [`Self::verified_address`] before showing balance or
+     * allowing a sweep.
+     */
+    suspend fun `status`(): SatsCardStatus
+    
+    /**
+     * Verify that the active slot's address really belongs to the slot
+     * pubkey reported via the `read` APDU, and that the URL suffix scanned
+     * (when present) matches the card-reported address.
+     *
+     * `read()` performs an internal signature check against the card's
+     * master pubkey. We re-derive the P2WPKH address from the verified
+     * slot pubkey and require it to match `reader.addr`. The optional
+     * 8-character URL suffix is then a cheap second-source sanity check.
+     *
+     * The UI must call this and observe `Ok` before displaying balance
+     * or enabling the sweep CTA.
+     */
+    suspend fun `verifiedAddress`(): kotlin.String
+    
+    companion object
+}
+
+open class SatsCardReader: Disposable, AutoCloseable, SatsCardReaderInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    /**
+     * Whether the current object has been destroyed and its reference is gone in the Rust side.
+     */
+    val uniffiIsDestroyed: Boolean get() = wasDestroyed.get()
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_cove_fn_free_satscardreader(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_cove_fn_clone_satscardreader(handle, status)
+        }
+    }
+
+    
+    @Throws(SatsCardReaderException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `run`() : SatsCardResponse {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_satscardreader_run(
+                uniffiHandle,
+                
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_rust_buffer(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_rust_buffer(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_rust_buffer(future) },
+        // lift function
+        { FfiConverterTypeSatsCardResponse.lift(it) },
+        // Error FFI converter
+        SatsCardReaderException.ErrorHandler,
+    )
+    }
+
+    
+    /**
+     * Get the current status of the SatsCard.
+     *
+     * `address` on the returned status is the **card-reported, unverified**
+     * string. Call [`Self::verified_address`] before showing balance or
+     * allowing a sweep.
+     */
+    @Throws(SatsCardReaderException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `status`() : SatsCardStatus {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_satscardreader_status(
+                uniffiHandle,
+                
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_rust_buffer(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_rust_buffer(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_rust_buffer(future) },
+        // lift function
+        { FfiConverterTypeSatsCardStatus.lift(it) },
+        // Error FFI converter
+        SatsCardReaderException.ErrorHandler,
+    )
+    }
+
+    
+    /**
+     * Verify that the active slot's address really belongs to the slot
+     * pubkey reported via the `read` APDU, and that the URL suffix scanned
+     * (when present) matches the card-reported address.
+     *
+     * `read()` performs an internal signature check against the card's
+     * master pubkey. We re-derive the P2WPKH address from the verified
+     * slot pubkey and require it to match `reader.addr`. The optional
+     * 8-character URL suffix is then a cheap second-source sanity check.
+     *
+     * The UI must call this and observe `Ok` before displaying balance
+     * or enabling the sweep CTA.
+     */
+    @Throws(SatsCardReaderException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `verifiedAddress`() : kotlin.String {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_satscardreader_verified_address(
+                uniffiHandle,
+                
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_rust_buffer(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_rust_buffer(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_rust_buffer(future) },
+        // lift function
+        { FfiConverterString.lift(it) },
+        // Error FFI converter
+        SatsCardReaderException.ErrorHandler,
+    )
+    }
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardReader: FfiConverter<SatsCardReader, Long> {
+    override fun lower(value: SatsCardReader): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): SatsCardReader {
+        return SatsCardReader(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): SatsCardReader {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: SatsCardReader) = 8UL
+
+    override fun write(value: SatsCardReader, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+/**
+ * Owns the unsealed slot's key material for the duration of one sweep.
+ *
+ * `privkey`, `master_pk`, and `chain_code` are wrapped in
+ * [`Zeroizing`], so the underlying buffers are scrubbed when the
+ * session drops. The FFI surface only exposes non-sensitive accessors
+ * (`slot`, `address`). Phase 3 will add `balance()` and
+ * `build_and_broadcast()` on this type — both consuming the session so
+ * it can never be reused.
+ */
+public interface SatsCardSweepSessionInterface {
+    
+    /**
+     * The verified P2WPKH address for the unsealed slot.
+     */
+    fun `address`(): kotlin.String
+    
+    fun `network`(): Network
+    
+    /**
+     * 33-byte compressed slot pubkey (safe to expose).
+     */
+    fun `pubkeyBytes`(): kotlin.ByteArray
+    
+    fun `slot`(): kotlin.UByte
+    
+    companion object
+}
+
+/**
+ * Owns the unsealed slot's key material for the duration of one sweep.
+ *
+ * `privkey`, `master_pk`, and `chain_code` are wrapped in
+ * [`Zeroizing`], so the underlying buffers are scrubbed when the
+ * session drops. The FFI surface only exposes non-sensitive accessors
+ * (`slot`, `address`). Phase 3 will add `balance()` and
+ * `build_and_broadcast()` on this type — both consuming the session so
+ * it can never be reused.
+ */
+open class SatsCardSweepSession: Disposable, AutoCloseable, SatsCardSweepSessionInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    /**
+     * Whether the current object has been destroyed and its reference is gone in the Rust side.
+     */
+    val uniffiIsDestroyed: Boolean get() = wasDestroyed.get()
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_cove_fn_free_satscardsweepsession(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_cove_fn_clone_satscardsweepsession(handle, status)
+        }
+    }
+
+    
+    /**
+     * The verified P2WPKH address for the unsealed slot.
+     */override fun `address`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardsweepsession_address(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `network`(): Network {
+            return FfiConverterTypeNetwork.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardsweepsession_network(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * 33-byte compressed slot pubkey (safe to expose).
+     */override fun `pubkeyBytes`(): kotlin.ByteArray {
+            return FfiConverterByteArray.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardsweepsession_pubkey_bytes(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `slot`(): kotlin.UByte {
+            return FfiConverterUByte.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardsweepsession_slot(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardSweepSession: FfiConverter<SatsCardSweepSession, Long> {
+    override fun lower(value: SatsCardSweepSession): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): SatsCardSweepSession {
+        return SatsCardSweepSession(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): SatsCardSweepSession {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: SatsCardSweepSession) = 8UL
+
+    override fun write(value: SatsCardSweepSession, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
 public interface SeedQrInterface {
     
     fun `getWords`(): List<kotlin.String>
@@ -29215,6 +29990,150 @@ public object FfiConverterTypeRouter: FfiConverterRustBuffer<Router> {
             FfiConverterTypeFfiApp.write(value.`app`, buf)
             FfiConverterTypeRoute.write(value.`default`, buf)
             FfiConverterSequenceTypeRoute.write(value.`routes`, buf)
+    }
+}
+
+
+
+data class SatsCardSlotDump (
+    var `slot`: kotlin.UByte
+    , 
+    /**
+     * 33-byte compressed slot pubkey (safe to expose).
+     */
+    var `pubkey`: kotlin.ByteArray
+    , 
+    var `used`: kotlin.Boolean?
+    , 
+    var `sealed`: kotlin.Boolean?
+    , 
+    var `address`: kotlin.String?
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardSlotDump: FfiConverterRustBuffer<SatsCardSlotDump> {
+    override fun read(buf: ByteBuffer): SatsCardSlotDump {
+        return SatsCardSlotDump(
+            FfiConverterUByte.read(buf),
+            FfiConverterByteArray.read(buf),
+            FfiConverterOptionalBoolean.read(buf),
+            FfiConverterOptionalBoolean.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: SatsCardSlotDump) = (
+            FfiConverterUByte.allocationSize(value.`slot`) +
+            FfiConverterByteArray.allocationSize(value.`pubkey`) +
+            FfiConverterOptionalBoolean.allocationSize(value.`used`) +
+            FfiConverterOptionalBoolean.allocationSize(value.`sealed`) +
+            FfiConverterOptionalString.allocationSize(value.`address`)
+    )
+
+    override fun write(value: SatsCardSlotDump, buf: ByteBuffer) {
+            FfiConverterUByte.write(value.`slot`, buf)
+            FfiConverterByteArray.write(value.`pubkey`, buf)
+            FfiConverterOptionalBoolean.write(value.`used`, buf)
+            FfiConverterOptionalBoolean.write(value.`sealed`, buf)
+            FfiConverterOptionalString.write(value.`address`, buf)
+    }
+}
+
+
+
+data class SatsCardStatus (
+    /**
+     * Active slot number (0-indexed)
+     */
+    var `activeSlot`: kotlin.UByte
+    , 
+    /**
+     * Total number of slots on the card
+     */
+    var `numSlots`: kotlin.UByte
+    , 
+    /**
+     * Card-reported address for the active slot — UNVERIFIED.
+     *
+     * Treat this as a display hint only. Call
+     * [`SatsCardReader::verified_address`] before showing balance or
+     * allowing a sweep.
+     */
+    var `address`: kotlin.String?
+    , 
+    /**
+     * Protocol version
+     */
+    var `proto`: kotlin.UInt
+    , 
+    /**
+     * Firmware version
+     */
+    var `ver`: kotlin.String
+    , 
+    /**
+     * Auth delay remaining (rate limit after bad CVC)
+     */
+    var `authDelay`: kotlin.UInt?
+    , 
+    /**
+     * The network the card is on
+     */
+    var `network`: Network
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardStatus: FfiConverterRustBuffer<SatsCardStatus> {
+    override fun read(buf: ByteBuffer): SatsCardStatus {
+        return SatsCardStatus(
+            FfiConverterUByte.read(buf),
+            FfiConverterUByte.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterUInt.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterOptionalUInt.read(buf),
+            FfiConverterTypeNetwork.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: SatsCardStatus) = (
+            FfiConverterUByte.allocationSize(value.`activeSlot`) +
+            FfiConverterUByte.allocationSize(value.`numSlots`) +
+            FfiConverterOptionalString.allocationSize(value.`address`) +
+            FfiConverterUInt.allocationSize(value.`proto`) +
+            FfiConverterString.allocationSize(value.`ver`) +
+            FfiConverterOptionalUInt.allocationSize(value.`authDelay`) +
+            FfiConverterTypeNetwork.allocationSize(value.`network`)
+    )
+
+    override fun write(value: SatsCardStatus, buf: ByteBuffer) {
+            FfiConverterUByte.write(value.`activeSlot`, buf)
+            FfiConverterUByte.write(value.`numSlots`, buf)
+            FfiConverterOptionalString.write(value.`address`, buf)
+            FfiConverterUInt.write(value.`proto`, buf)
+            FfiConverterString.write(value.`ver`, buf)
+            FfiConverterOptionalUInt.write(value.`authDelay`, buf)
+            FfiConverterTypeNetwork.write(value.`network`, buf)
     }
 }
 
@@ -39928,6 +40847,28 @@ sealed class MultiFormat: Disposable  {
     }
     
     /**
+     * SATSCARD detected via NFC/QR
+     */
+    data class SatsCard(
+        val v1: org.bitcoinppl.cove_core.tapcard.SatsCard) : MultiFormat()
+        
+    {
+        
+
+    // The local Rust `Eq` implementation - only `eq` is used.
+    override fun equals(other: Any?): Boolean {
+        if (other !is MultiFormat) return false
+        return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_multiformat_uniffi_trait_eq_eq(FfiConverterTypeMultiFormat.lower(this),
+        FfiConverterTypeMultiFormat.lower(`other`),_status)
+}
+    )
+    }
+        companion object
+    }
+    
+    /**
      * A signed but un-finalized PSBT
      */
     data class SignedPsbt(
@@ -40003,6 +40944,13 @@ sealed class MultiFormat: Disposable  {
     )
                 
             }
+            is MultiFormat.SatsCard -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
             is MultiFormat.SignedPsbt -> {
                 
     Disposable.destroy(
@@ -40058,7 +41006,10 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
             7 -> MultiFormat.TapSignerUnused(
                 FfiConverterTypeTapSigner.read(buf),
                 )
-            8 -> MultiFormat.SignedPsbt(
+            8 -> MultiFormat.SatsCard(
+                FfiConverterTypeSatsCard.read(buf),
+                )
+            9 -> MultiFormat.SignedPsbt(
                 FfiConverterTypePsbt.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -40115,6 +41066,13 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
                 + FfiConverterTypeTapSigner.allocationSize(value.v1)
             )
         }
+        is MultiFormat.SatsCard -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCard.allocationSize(value.v1)
+            )
+        }
         is MultiFormat.SignedPsbt -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
@@ -40161,8 +41119,13 @@ public object FfiConverterTypeMultiFormat : FfiConverterRustBuffer<MultiFormat>{
                 FfiConverterTypeTapSigner.write(value.v1, buf)
                 Unit
             }
-            is MultiFormat.SignedPsbt -> {
+            is MultiFormat.SatsCard -> {
                 buf.putInt(8)
+                FfiConverterTypeSatsCard.write(value.v1, buf)
+                Unit
+            }
+            is MultiFormat.SignedPsbt -> {
+                buf.putInt(9)
                 FfiConverterTypePsbt.write(value.v1, buf)
                 Unit
             }
@@ -40199,6 +41162,14 @@ sealed class MultiFormatException: kotlin.Exception() {
     }
     
     class InvalidTapSigner(
+        
+        val v1: TapCardParseException
+        ) : MultiFormatException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+    
+    class InvalidSatsCard(
         
         val v1: TapCardParseException
         ) : MultiFormatException() {
@@ -40254,8 +41225,11 @@ public object FfiConverterTypeMultiFormatError : FfiConverterRustBuffer<MultiFor
             4 -> MultiFormatException.InvalidTapSigner(
                 FfiConverterTypeTapCardParseError.read(buf),
                 )
-            5 -> MultiFormatException.TaprootNotSupported()
-            6 -> MultiFormatException.PsbtNotSigned()
+            5 -> MultiFormatException.InvalidSatsCard(
+                FfiConverterTypeTapCardParseError.read(buf),
+                )
+            6 -> MultiFormatException.TaprootNotSupported()
+            7 -> MultiFormatException.PsbtNotSigned()
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
     }
@@ -40276,6 +41250,11 @@ public object FfiConverterTypeMultiFormatError : FfiConverterRustBuffer<MultiFor
                 4UL
             )
             is MultiFormatException.InvalidTapSigner -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterTypeTapCardParseError.allocationSize(value.v1)
+            )
+            is MultiFormatException.InvalidSatsCard -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterTypeTapCardParseError.allocationSize(value.v1)
@@ -40311,12 +41290,17 @@ public object FfiConverterTypeMultiFormatError : FfiConverterRustBuffer<MultiFor
                 FfiConverterTypeTapCardParseError.write(value.v1, buf)
                 Unit
             }
-            is MultiFormatException.TaprootNotSupported -> {
+            is MultiFormatException.InvalidSatsCard -> {
                 buf.putInt(5)
+                FfiConverterTypeTapCardParseError.write(value.v1, buf)
+                Unit
+            }
+            is MultiFormatException.TaprootNotSupported -> {
+                buf.putInt(6)
                 Unit
             }
             is MultiFormatException.PsbtNotSigned -> {
-                buf.putInt(6)
+                buf.putInt(7)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -42489,6 +43473,728 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
             is Route.CoinControl -> {
                 buf.putInt(8)
                 FfiConverterTypeCoinControlRoute.write(value.v1, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
+sealed class SatsCardCmd {
+    
+    /**
+     * Get the current status of the card (no CVC needed)
+     */
+    object Status : SatsCardCmd()
+    
+    
+    /**
+     * Unseal the active slot to reveal the private key.
+     *
+     * On success the FFI caller receives only an opaque
+     * [`SatsCardSweepSession`] handle — raw key bytes never cross the
+     * boundary.
+     */
+    data class Unseal(
+        val `cvc`: kotlin.String) : SatsCardCmd()
+        
+    {
+        
+
+        companion object
+    }
+    
+    /**
+     * Get info about a specific slot (status only — never returns key material
+     * across FFI even when a CVC is supplied internally).
+     */
+    data class Dump(
+        val `slot`: kotlin.UByte) : SatsCardCmd()
+        
+    {
+        
+
+        companion object
+    }
+    
+
+    
+
+    
+    
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardCmd : FfiConverterRustBuffer<SatsCardCmd>{
+    override fun read(buf: ByteBuffer): SatsCardCmd {
+        return when(buf.getInt()) {
+            1 -> SatsCardCmd.Status
+            2 -> SatsCardCmd.Unseal(
+                FfiConverterString.read(buf),
+                )
+            3 -> SatsCardCmd.Dump(
+                FfiConverterUByte.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: SatsCardCmd): ULong = when(value) {
+        is SatsCardCmd.Status -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is SatsCardCmd.Unseal -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`cvc`)
+            )
+        }
+        is SatsCardCmd.Dump -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterUByte.allocationSize(value.`slot`)
+            )
+        }
+    }
+
+    override fun write(value: SatsCardCmd, buf: ByteBuffer) {
+        when(value) {
+            is SatsCardCmd.Status -> {
+                buf.putInt(1)
+                Unit
+            }
+            is SatsCardCmd.Unseal -> {
+                buf.putInt(2)
+                FfiConverterString.write(value.`cvc`, buf)
+                Unit
+            }
+            is SatsCardCmd.Dump -> {
+                buf.putInt(3)
+                FfiConverterUByte.write(value.`slot`, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
+
+
+sealed class SatsCardReaderException: kotlin.Exception() {
+    
+    class SatsCardException(
+        
+        val v1: TransportException
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+    
+    class UnknownCardType(
+        
+        val v1: kotlin.String
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+    
+    class NoCommand(
+        ) : SatsCardReaderException() {
+        override val message
+            get() = ""
+    }
+    
+    class InvalidCvcLength(
+        
+        val v1: kotlin.UByte
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+    
+    class NonNumericCvc(
+        ) : SatsCardReaderException() {
+        override val message
+            get() = ""
+    }
+    
+    class SlotOutOfRange(
+        
+        val `slot`: kotlin.UByte, 
+        
+        val `numSlots`: kotlin.UByte
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "slot=${ `slot` }, numSlots=${ `numSlots` }"
+    }
+    
+    class NoAddress(
+        ) : SatsCardReaderException() {
+        override val message
+            get() = ""
+    }
+    
+    class InvalidPubkey(
+        ) : SatsCardReaderException() {
+        override val message
+            get() = ""
+    }
+    
+    class AddressMismatch(
+        
+        val `cardReported`: kotlin.String, 
+        
+        val `derived`: kotlin.String
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "cardReported=${ `cardReported` }, derived=${ `derived` }"
+    }
+    
+    class SuffixMismatch(
+        
+        val `cardReported`: kotlin.String, 
+        
+        val `expectedSuffix`: kotlin.String
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "cardReported=${ `cardReported` }, expectedSuffix=${ `expectedSuffix` }"
+    }
+    
+    class Unknown(
+        
+        val v1: kotlin.String
+        ) : SatsCardReaderException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+    
+
+     fun `isAuthError`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardreadererror_isautherror(FfiConverterTypeSatsCardReaderError.lower(this),
+        _status)
+}
+    )
+    }
+    
+
+     fun `isRateLimited`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardreadererror_isratelimited(FfiConverterTypeSatsCardReaderError.lower(this),
+        _status)
+}
+    )
+    }
+    
+
+    
+
+    // The local Rust `Display`/`Debug` implementation.
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_satscardreadererror_uniffi_trait_display(FfiConverterTypeSatsCardReaderError.lower(this),
+        _status)
+}
+    )
+    }
+
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<SatsCardReaderException> {
+        override fun lift(error_buf: RustBuffer.ByValue): SatsCardReaderException = FfiConverterTypeSatsCardReaderError.lift(error_buf)
+    }
+
+    
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardReaderError : FfiConverterRustBuffer<SatsCardReaderException> {
+    override fun read(buf: ByteBuffer): SatsCardReaderException {
+        
+
+        return when(buf.getInt()) {
+            1 -> SatsCardReaderException.SatsCardException(
+                FfiConverterTypeTransportError.read(buf),
+                )
+            2 -> SatsCardReaderException.UnknownCardType(
+                FfiConverterString.read(buf),
+                )
+            3 -> SatsCardReaderException.NoCommand()
+            4 -> SatsCardReaderException.InvalidCvcLength(
+                FfiConverterUByte.read(buf),
+                )
+            5 -> SatsCardReaderException.NonNumericCvc()
+            6 -> SatsCardReaderException.SlotOutOfRange(
+                FfiConverterUByte.read(buf),
+                FfiConverterUByte.read(buf),
+                )
+            7 -> SatsCardReaderException.NoAddress()
+            8 -> SatsCardReaderException.InvalidPubkey()
+            9 -> SatsCardReaderException.AddressMismatch(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            10 -> SatsCardReaderException.SuffixMismatch(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            11 -> SatsCardReaderException.Unknown(
+                FfiConverterString.read(buf),
+                )
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: SatsCardReaderException): ULong {
+        return when(value) {
+            is SatsCardReaderException.SatsCardException -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterTypeTransportError.allocationSize(value.v1)
+            )
+            is SatsCardReaderException.UnknownCardType -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+            is SatsCardReaderException.NoCommand -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
+            is SatsCardReaderException.InvalidCvcLength -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterUByte.allocationSize(value.v1)
+            )
+            is SatsCardReaderException.NonNumericCvc -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
+            is SatsCardReaderException.SlotOutOfRange -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterUByte.allocationSize(value.`slot`)
+                + FfiConverterUByte.allocationSize(value.`numSlots`)
+            )
+            is SatsCardReaderException.NoAddress -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
+            is SatsCardReaderException.InvalidPubkey -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
+            is SatsCardReaderException.AddressMismatch -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.`cardReported`)
+                + FfiConverterString.allocationSize(value.`derived`)
+            )
+            is SatsCardReaderException.SuffixMismatch -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.`cardReported`)
+                + FfiConverterString.allocationSize(value.`expectedSuffix`)
+            )
+            is SatsCardReaderException.Unknown -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+        }
+    }
+
+    override fun write(value: SatsCardReaderException, buf: ByteBuffer) {
+        when(value) {
+            is SatsCardReaderException.SatsCardException -> {
+                buf.putInt(1)
+                FfiConverterTypeTransportError.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardReaderException.UnknownCardType -> {
+                buf.putInt(2)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardReaderException.NoCommand -> {
+                buf.putInt(3)
+                Unit
+            }
+            is SatsCardReaderException.InvalidCvcLength -> {
+                buf.putInt(4)
+                FfiConverterUByte.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardReaderException.NonNumericCvc -> {
+                buf.putInt(5)
+                Unit
+            }
+            is SatsCardReaderException.SlotOutOfRange -> {
+                buf.putInt(6)
+                FfiConverterUByte.write(value.`slot`, buf)
+                FfiConverterUByte.write(value.`numSlots`, buf)
+                Unit
+            }
+            is SatsCardReaderException.NoAddress -> {
+                buf.putInt(7)
+                Unit
+            }
+            is SatsCardReaderException.InvalidPubkey -> {
+                buf.putInt(8)
+                Unit
+            }
+            is SatsCardReaderException.AddressMismatch -> {
+                buf.putInt(9)
+                FfiConverterString.write(value.`cardReported`, buf)
+                FfiConverterString.write(value.`derived`, buf)
+                Unit
+            }
+            is SatsCardReaderException.SuffixMismatch -> {
+                buf.putInt(10)
+                FfiConverterString.write(value.`cardReported`, buf)
+                FfiConverterString.write(value.`expectedSuffix`, buf)
+                Unit
+            }
+            is SatsCardReaderException.Unknown -> {
+                buf.putInt(11)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+
+}
+
+
+
+sealed class SatsCardResponse: Disposable  {
+    
+    data class Status(
+        val v1: org.bitcoinppl.cove_core.SatsCardStatus) : SatsCardResponse()
+        
+    {
+        
+
+        companion object
+    }
+    
+    /**
+     * Opaque handle. The unsealed key material is owned Rust-side and
+     * zeroised on drop (see [`SatsCardSweepSession`]).
+     */
+    data class Unseal(
+        val v1: org.bitcoinppl.cove_core.SatsCardSweepSession) : SatsCardResponse()
+        
+    {
+        
+
+        companion object
+    }
+    
+    data class Dump(
+        val v1: org.bitcoinppl.cove_core.SatsCardSlotDump) : SatsCardResponse()
+        
+    {
+        
+
+        companion object
+    }
+    
+
+    
+    @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
+    override fun destroy() {
+        when(this) {
+            is SatsCardResponse.Status -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
+            is SatsCardResponse.Unseal -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
+            is SatsCardResponse.Dump -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+    
+
+    
+    
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardResponse : FfiConverterRustBuffer<SatsCardResponse>{
+    override fun read(buf: ByteBuffer): SatsCardResponse {
+        return when(buf.getInt()) {
+            1 -> SatsCardResponse.Status(
+                FfiConverterTypeSatsCardStatus.read(buf),
+                )
+            2 -> SatsCardResponse.Unseal(
+                FfiConverterTypeSatsCardSweepSession.read(buf),
+                )
+            3 -> SatsCardResponse.Dump(
+                FfiConverterTypeSatsCardSlotDump.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: SatsCardResponse): ULong = when(value) {
+        is SatsCardResponse.Status -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCardStatus.allocationSize(value.v1)
+            )
+        }
+        is SatsCardResponse.Unseal -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCardSweepSession.allocationSize(value.v1)
+            )
+        }
+        is SatsCardResponse.Dump -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCardSlotDump.allocationSize(value.v1)
+            )
+        }
+    }
+
+    override fun write(value: SatsCardResponse, buf: ByteBuffer) {
+        when(value) {
+            is SatsCardResponse.Status -> {
+                buf.putInt(1)
+                FfiConverterTypeSatsCardStatus.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardResponse.Unseal -> {
+                buf.putInt(2)
+                FfiConverterTypeSatsCardSweepSession.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardResponse.Dump -> {
+                buf.putInt(3)
+                FfiConverterTypeSatsCardSlotDump.write(value.v1, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
+sealed class SatsCardRoute {
+    
+    /**
+     * Initial scan screen — prompt user to tap the card
+     */
+    data class Scan(
+        val v1: org.bitcoinppl.cove_core.tapcard.SatsCard) : SatsCardRoute()
+        
+    {
+        
+
+        companion object
+    }
+    
+    /**
+     * Show current slot status (slot N of M, sealed/unsealed, address, balance)
+     */
+    data class SlotStatus(
+        val v1: org.bitcoinppl.cove_core.SatsCardStatus) : SatsCardRoute()
+        
+    {
+        
+
+        companion object
+    }
+    
+    /**
+     * Confirm unseal — warn user this reveals the private key
+     */
+    data class UnsealConfirm(
+        val v1: org.bitcoinppl.cove_core.SatsCardStatus) : SatsCardRoute()
+        
+    {
+        
+
+        companion object
+    }
+    
+    /**
+     * Display-safe payload only.
+     *
+     * The unsealed key material lives inside a short-lived Rust-side
+     * `SatsCardSweepSession` (held by the manager) — never the route.
+     */
+    data class UnsealSuccess(
+        val `slot`: kotlin.UByte, 
+        val `address`: kotlin.String) : SatsCardRoute()
+        
+    {
+        
+
+        companion object
+    }
+    
+    /**
+     * Something went wrong — let user retry
+     */
+    data class Error(
+        val `message`: kotlin.String, 
+        val `status`: org.bitcoinppl.cove_core.SatsCardStatus?) : SatsCardRoute()
+        
+    {
+        
+
+        companion object
+    }
+    
+
+    
+
+    
+    
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSatsCardRoute : FfiConverterRustBuffer<SatsCardRoute>{
+    override fun read(buf: ByteBuffer): SatsCardRoute {
+        return when(buf.getInt()) {
+            1 -> SatsCardRoute.Scan(
+                FfiConverterTypeSatsCard.read(buf),
+                )
+            2 -> SatsCardRoute.SlotStatus(
+                FfiConverterTypeSatsCardStatus.read(buf),
+                )
+            3 -> SatsCardRoute.UnsealConfirm(
+                FfiConverterTypeSatsCardStatus.read(buf),
+                )
+            4 -> SatsCardRoute.UnsealSuccess(
+                FfiConverterUByte.read(buf),
+                FfiConverterString.read(buf),
+                )
+            5 -> SatsCardRoute.Error(
+                FfiConverterString.read(buf),
+                FfiConverterOptionalTypeSatsCardStatus.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: SatsCardRoute): ULong = when(value) {
+        is SatsCardRoute.Scan -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCard.allocationSize(value.v1)
+            )
+        }
+        is SatsCardRoute.SlotStatus -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCardStatus.allocationSize(value.v1)
+            )
+        }
+        is SatsCardRoute.UnsealConfirm -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSatsCardStatus.allocationSize(value.v1)
+            )
+        }
+        is SatsCardRoute.UnsealSuccess -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterUByte.allocationSize(value.`slot`)
+                + FfiConverterString.allocationSize(value.`address`)
+            )
+        }
+        is SatsCardRoute.Error -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`message`)
+                + FfiConverterOptionalTypeSatsCardStatus.allocationSize(value.`status`)
+            )
+        }
+    }
+
+    override fun write(value: SatsCardRoute, buf: ByteBuffer) {
+        when(value) {
+            is SatsCardRoute.Scan -> {
+                buf.putInt(1)
+                FfiConverterTypeSatsCard.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardRoute.SlotStatus -> {
+                buf.putInt(2)
+                FfiConverterTypeSatsCardStatus.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardRoute.UnsealConfirm -> {
+                buf.putInt(3)
+                FfiConverterTypeSatsCardStatus.write(value.v1, buf)
+                Unit
+            }
+            is SatsCardRoute.UnsealSuccess -> {
+                buf.putInt(4)
+                FfiConverterUByte.write(value.`slot`, buf)
+                FfiConverterString.write(value.`address`, buf)
+                Unit
+            }
+            is SatsCardRoute.Error -> {
+                buf.putInt(5)
+                FfiConverterString.write(value.`message`, buf)
+                FfiConverterOptionalTypeSatsCardStatus.write(value.`status`, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -53147,6 +54853,38 @@ public object FfiConverterOptionalDouble: FfiConverterRustBuffer<kotlin.Double?>
 /**
  * @suppress
  */
+public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
+    override fun read(buf: ByteBuffer): kotlin.Boolean? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterBoolean.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.Boolean?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterBoolean.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.Boolean?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterBoolean.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?> {
     override fun read(buf: ByteBuffer): kotlin.String? {
         if (buf.get().toInt() == 0) {
@@ -53329,6 +55067,38 @@ public object FfiConverterOptionalTypeMigration: FfiConverterRustBuffer<Migratio
         } else {
             buf.put(1)
             FfiConverterTypeMigration.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeSatsCardSweepSession: FfiConverterRustBuffer<SatsCardSweepSession?> {
+    override fun read(buf: ByteBuffer): SatsCardSweepSession? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSatsCardSweepSession.read(buf)
+    }
+
+    override fun allocationSize(value: SatsCardSweepSession?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSatsCardSweepSession.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SatsCardSweepSession?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSatsCardSweepSession.write(value, buf)
         }
     }
 }
@@ -53723,6 +55493,70 @@ public object FfiConverterOptionalTypeFiatAmount: FfiConverterRustBuffer<FiatAmo
 /**
  * @suppress
  */
+public object FfiConverterOptionalTypeSatsCardSlotDump: FfiConverterRustBuffer<SatsCardSlotDump?> {
+    override fun read(buf: ByteBuffer): SatsCardSlotDump? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSatsCardSlotDump.read(buf)
+    }
+
+    override fun allocationSize(value: SatsCardSlotDump?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSatsCardSlotDump.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SatsCardSlotDump?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSatsCardSlotDump.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeSatsCardStatus: FfiConverterRustBuffer<SatsCardStatus?> {
+    override fun read(buf: ByteBuffer): SatsCardStatus? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSatsCardStatus.read(buf)
+    }
+
+    override fun allocationSize(value: SatsCardStatus?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSatsCardStatus.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SatsCardStatus?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSatsCardStatus.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalTypeWalletMetadata: FfiConverterRustBuffer<WalletMetadata?> {
     override fun read(buf: ByteBuffer): WalletMetadata? {
         if (buf.get().toInt() == 0) {
@@ -53905,6 +55739,38 @@ public object FfiConverterOptionalTypeOnboardingBranch: FfiConverterRustBuffer<O
         } else {
             buf.put(1)
             FfiConverterTypeOnboardingBranch.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeSatsCardCmd: FfiConverterRustBuffer<SatsCardCmd?> {
+    override fun read(buf: ByteBuffer): SatsCardCmd? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSatsCardCmd.read(buf)
+    }
+
+    override fun allocationSize(value: SatsCardCmd?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSatsCardCmd.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SatsCardCmd?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSatsCardCmd.write(value, buf)
         }
     }
 }
@@ -54933,6 +56799,8 @@ public typealias FfiConverterTypeTimestamp = FfiConverterULong
 
 
 
+
+
 object KeychainExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<KeychainException> {
     override fun lift(error_buf: RustBuffer.ByValue): KeychainException =
         org.bitcoinppl.cove_core.device.KeychainException.ErrorHandler.lift(
@@ -55382,6 +57250,61 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
     UniffiLib.uniffi_cove_fn_func_is_valid_chain_code(
     
         FfiConverterString.lower(`chainCode`),_status)
+}
+    )
+    }
+    
+
+        /**
+         * Create a SatsCardReader instance for FFI callers.
+         *
+         * `expected_url_suffix` should be the 8-character `r=…` value parsed
+         * from the scanned `getsatscard.com/start#…` URL when available.
+         * [`SatsCardReader::verified_address`] cross-checks against it.
+         *
+         * UniFFI's Kotlin bindings do not support async primary constructors,
+         * hence the free function.
+         */
+    @Throws(SatsCardReaderException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+     suspend fun `createSatsCardReader`(`transport`: TapcardTransportProtocol, `cmd`: SatsCardCmd?, `expectedUrlSuffix`: kotlin.String?) : SatsCardReader {
+        return uniffiRustCallAsync(
+        UniffiLib.uniffi_cove_fn_func_create_sats_card_reader(FfiConverterTypeTapcardTransportProtocol.lower(`transport`),FfiConverterOptionalTypeSatsCardCmd.lower(`cmd`),FfiConverterOptionalString.lower(`expectedUrlSuffix`),),
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_u64(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_u64(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_u64(future) },
+        // lift function
+        { FfiConverterTypeSatsCardReader.lift(it) },
+        // Error FFI converter
+        SatsCardReaderException.ErrorHandler,
+    )
+    }
+ fun `satsCardResponseDumpData`(`response`: SatsCardResponse): SatsCardSlotDump? {
+            return FfiConverterOptionalTypeSatsCardSlotDump.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_satscardresponsedumpdata(
+    
+        FfiConverterTypeSatsCardResponse.lower(`response`),_status)
+}
+    )
+    }
+    
+ fun `satsCardResponseStatusData`(`response`: SatsCardResponse): SatsCardStatus? {
+            return FfiConverterOptionalTypeSatsCardStatus.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_satscardresponsestatusdata(
+    
+        FfiConverterTypeSatsCardResponse.lower(`response`),_status)
+}
+    )
+    }
+    
+ fun `satsCardResponseUnsealSession`(`response`: SatsCardResponse): SatsCardSweepSession? {
+            return FfiConverterOptionalTypeSatsCardSweepSession.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_satscardresponseunsealsession(
+    
+        FfiConverterTypeSatsCardResponse.lower(`response`),_status)
 }
     )
     }

--- a/ios/Cove/ScanManager.swift
+++ b/ios/Cove/ScanManager.swift
@@ -29,6 +29,12 @@ import SwiftUI
                 } else {
                     app.alertState = .init(.initializedTapSigner(tapSigner: tapSigner))
                 }
+            case let .satsCard(satsCard):
+                Log.debug("SATSCARD detected: slot \(satsCard.slotNumber) state \(satsCard.state)")
+                app.alertState = .init(.general(
+                    title: "SATSCARD Detected",
+                    message: "SATSCARD support is coming soon. Slot \(satsCard.slotNumber) was scanned."
+                ))
             case let .bip329Labels(labels):
                 guard let manager = app.walletManager else { return setInvalidLabels() }
                 guard let selectedWallet = Database().globalConfig().selectedWallet() else {
@@ -108,6 +114,12 @@ import SwiftUI
                 )
             case let .signedPsbt(psbt):
                 handleSignedPsbt(psbt)
+            case let .satsCard(satsCard):
+                Log.debug("SATSCARD detected via file: slot \(satsCard.slotNumber) state \(satsCard.state)")
+                app.alertState = .init(.general(
+                    title: "SATSCARD Detected",
+                    message: "SATSCARD support is coming soon. Slot \(satsCard.slotNumber) was scanned."
+                ))
             }
         } catch {
             switch error {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -9814,6 +9814,387 @@ public func FfiConverterTypeRustWalletManager_lower(_ value: RustWalletManager) 
 
 
 
+public protocol SatsCardReaderProtocol: AnyObject, Sendable {
+    
+    func run() async throws  -> SatsCardResponse
+    
+    /**
+     * Get the current status of the SatsCard.
+     *
+     * `address` on the returned status is the **card-reported, unverified**
+     * string. Call [`Self::verified_address`] before showing balance or
+     * allowing a sweep.
+     */
+    func status() async throws  -> SatsCardStatus
+    
+    /**
+     * Verify that the active slot's address really belongs to the slot
+     * pubkey reported via the `read` APDU, and that the URL suffix scanned
+     * (when present) matches the card-reported address.
+     *
+     * `read()` performs an internal signature check against the card's
+     * master pubkey. We re-derive the P2WPKH address from the verified
+     * slot pubkey and require it to match `reader.addr`. The optional
+     * 8-character URL suffix is then a cheap second-source sanity check.
+     *
+     * The UI must call this and observe `Ok` before displaying balance
+     * or enabling the sweep CTA.
+     */
+    func verifiedAddress() async throws  -> String
+    
+}
+open class SatsCardReader: SatsCardReaderProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_cove_fn_clone_satscardreader(self.handle, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_cove_fn_free_satscardreader(handle, $0) }
+    }
+
+    
+
+    
+open func run()async throws  -> SatsCardResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_satscardreader_run(
+                    self.uniffiCloneHandle()
+                    
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_rust_buffer,
+            completeFunc: ffi_cove_rust_future_complete_rust_buffer,
+            freeFunc: ffi_cove_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeSatsCardResponse_lift,
+            errorHandler: FfiConverterTypeSatsCardReaderError_lift
+        )
+}
+    
+    /**
+     * Get the current status of the SatsCard.
+     *
+     * `address` on the returned status is the **card-reported, unverified**
+     * string. Call [`Self::verified_address`] before showing balance or
+     * allowing a sweep.
+     */
+open func status()async throws  -> SatsCardStatus  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_satscardreader_status(
+                    self.uniffiCloneHandle()
+                    
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_rust_buffer,
+            completeFunc: ffi_cove_rust_future_complete_rust_buffer,
+            freeFunc: ffi_cove_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeSatsCardStatus_lift,
+            errorHandler: FfiConverterTypeSatsCardReaderError_lift
+        )
+}
+    
+    /**
+     * Verify that the active slot's address really belongs to the slot
+     * pubkey reported via the `read` APDU, and that the URL suffix scanned
+     * (when present) matches the card-reported address.
+     *
+     * `read()` performs an internal signature check against the card's
+     * master pubkey. We re-derive the P2WPKH address from the verified
+     * slot pubkey and require it to match `reader.addr`. The optional
+     * 8-character URL suffix is then a cheap second-source sanity check.
+     *
+     * The UI must call this and observe `Ok` before displaying balance
+     * or enabling the sweep CTA.
+     */
+open func verifiedAddress()async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_satscardreader_verified_address(
+                    self.uniffiCloneHandle()
+                    
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_rust_buffer,
+            completeFunc: ffi_cove_rust_future_complete_rust_buffer,
+            freeFunc: ffi_cove_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeSatsCardReaderError_lift
+        )
+}
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardReader: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = SatsCardReader
+
+    public static func lift(_ handle: UInt64) throws -> SatsCardReader {
+        return SatsCardReader(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: SatsCardReader) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardReader {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: SatsCardReader, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardReader_lift(_ handle: UInt64) throws -> SatsCardReader {
+    return try FfiConverterTypeSatsCardReader.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardReader_lower(_ value: SatsCardReader) -> UInt64 {
+    return FfiConverterTypeSatsCardReader.lower(value)
+}
+
+
+
+
+
+
+/**
+ * Owns the unsealed slot's key material for the duration of one sweep.
+ *
+ * `privkey`, `master_pk`, and `chain_code` are wrapped in
+ * [`Zeroizing`], so the underlying buffers are scrubbed when the
+ * session drops. The FFI surface only exposes non-sensitive accessors
+ * (`slot`, `address`). Phase 3 will add `balance()` and
+ * `build_and_broadcast()` on this type — both consuming the session so
+ * it can never be reused.
+ */
+public protocol SatsCardSweepSessionProtocol: AnyObject, Sendable {
+    
+    /**
+     * The verified P2WPKH address for the unsealed slot.
+     */
+    func address()  -> String
+    
+    func network()  -> Network
+    
+    /**
+     * 33-byte compressed slot pubkey (safe to expose).
+     */
+    func pubkeyBytes()  -> Data
+    
+    func slot()  -> UInt8
+    
+}
+/**
+ * Owns the unsealed slot's key material for the duration of one sweep.
+ *
+ * `privkey`, `master_pk`, and `chain_code` are wrapped in
+ * [`Zeroizing`], so the underlying buffers are scrubbed when the
+ * session drops. The FFI surface only exposes non-sensitive accessors
+ * (`slot`, `address`). Phase 3 will add `balance()` and
+ * `build_and_broadcast()` on this type — both consuming the session so
+ * it can never be reused.
+ */
+open class SatsCardSweepSession: SatsCardSweepSessionProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_cove_fn_clone_satscardsweepsession(self.handle, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_cove_fn_free_satscardsweepsession(handle, $0) }
+    }
+
+    
+
+    
+    /**
+     * The verified P2WPKH address for the unsealed slot.
+     */
+open func address() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_cove_fn_method_satscardsweepsession_address(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func network() -> Network  {
+    return try!  FfiConverterTypeNetwork_lift(try! rustCall() {
+    uniffi_cove_fn_method_satscardsweepsession_network(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * 33-byte compressed slot pubkey (safe to expose).
+     */
+open func pubkeyBytes() -> Data  {
+    return try!  FfiConverterData.lift(try! rustCall() {
+    uniffi_cove_fn_method_satscardsweepsession_pubkey_bytes(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func slot() -> UInt8  {
+    return try!  FfiConverterUInt8.lift(try! rustCall() {
+    uniffi_cove_fn_method_satscardsweepsession_slot(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardSweepSession: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = SatsCardSweepSession
+
+    public static func lift(_ handle: UInt64) throws -> SatsCardSweepSession {
+        return SatsCardSweepSession(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: SatsCardSweepSession) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardSweepSession {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: SatsCardSweepSession, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardSweepSession_lift(_ handle: UInt64) throws -> SatsCardSweepSession {
+    return try FfiConverterTypeSatsCardSweepSession.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardSweepSession_lower(_ value: SatsCardSweepSession) -> UInt64 {
+    return FfiConverterTypeSatsCardSweepSession.lower(value)
+}
+
+
+
+
+
+
 public protocol SeedQrProtocol: AnyObject, Sendable {
     
     func getWords()  -> [String]
@@ -14876,6 +15257,202 @@ public func FfiConverterTypeRouter_lift(_ buf: RustBuffer) throws -> Router {
 #endif
 public func FfiConverterTypeRouter_lower(_ value: Router) -> RustBuffer {
     return FfiConverterTypeRouter.lower(value)
+}
+
+
+public struct SatsCardSlotDump: Equatable, Hashable {
+    public var slot: UInt8
+    /**
+     * 33-byte compressed slot pubkey (safe to expose).
+     */
+    public var pubkey: Data
+    public var used: Bool?
+    public var sealed: Bool?
+    public var address: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(slot: UInt8, 
+        /**
+         * 33-byte compressed slot pubkey (safe to expose).
+         */pubkey: Data, used: Bool?, sealed: Bool?, address: String?) {
+        self.slot = slot
+        self.pubkey = pubkey
+        self.used = used
+        self.sealed = sealed
+        self.address = address
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension SatsCardSlotDump: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardSlotDump: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardSlotDump {
+        return
+            try SatsCardSlotDump(
+                slot: FfiConverterUInt8.read(from: &buf), 
+                pubkey: FfiConverterData.read(from: &buf), 
+                used: FfiConverterOptionBool.read(from: &buf), 
+                sealed: FfiConverterOptionBool.read(from: &buf), 
+                address: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: SatsCardSlotDump, into buf: inout [UInt8]) {
+        FfiConverterUInt8.write(value.slot, into: &buf)
+        FfiConverterData.write(value.pubkey, into: &buf)
+        FfiConverterOptionBool.write(value.used, into: &buf)
+        FfiConverterOptionBool.write(value.sealed, into: &buf)
+        FfiConverterOptionString.write(value.address, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardSlotDump_lift(_ buf: RustBuffer) throws -> SatsCardSlotDump {
+    return try FfiConverterTypeSatsCardSlotDump.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardSlotDump_lower(_ value: SatsCardSlotDump) -> RustBuffer {
+    return FfiConverterTypeSatsCardSlotDump.lower(value)
+}
+
+
+public struct SatsCardStatus: Equatable, Hashable {
+    /**
+     * Active slot number (0-indexed)
+     */
+    public var activeSlot: UInt8
+    /**
+     * Total number of slots on the card
+     */
+    public var numSlots: UInt8
+    /**
+     * Card-reported address for the active slot — UNVERIFIED.
+     *
+     * Treat this as a display hint only. Call
+     * [`SatsCardReader::verified_address`] before showing balance or
+     * allowing a sweep.
+     */
+    public var address: String?
+    /**
+     * Protocol version
+     */
+    public var proto: UInt32
+    /**
+     * Firmware version
+     */
+    public var ver: String
+    /**
+     * Auth delay remaining (rate limit after bad CVC)
+     */
+    public var authDelay: UInt32?
+    /**
+     * The network the card is on
+     */
+    public var network: Network
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Active slot number (0-indexed)
+         */activeSlot: UInt8, 
+        /**
+         * Total number of slots on the card
+         */numSlots: UInt8, 
+        /**
+         * Card-reported address for the active slot — UNVERIFIED.
+         *
+         * Treat this as a display hint only. Call
+         * [`SatsCardReader::verified_address`] before showing balance or
+         * allowing a sweep.
+         */address: String?, 
+        /**
+         * Protocol version
+         */proto: UInt32, 
+        /**
+         * Firmware version
+         */ver: String, 
+        /**
+         * Auth delay remaining (rate limit after bad CVC)
+         */authDelay: UInt32?, 
+        /**
+         * The network the card is on
+         */network: Network) {
+        self.activeSlot = activeSlot
+        self.numSlots = numSlots
+        self.address = address
+        self.proto = proto
+        self.ver = ver
+        self.authDelay = authDelay
+        self.network = network
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension SatsCardStatus: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardStatus: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardStatus {
+        return
+            try SatsCardStatus(
+                activeSlot: FfiConverterUInt8.read(from: &buf), 
+                numSlots: FfiConverterUInt8.read(from: &buf), 
+                address: FfiConverterOptionString.read(from: &buf), 
+                proto: FfiConverterUInt32.read(from: &buf), 
+                ver: FfiConverterString.read(from: &buf), 
+                authDelay: FfiConverterOptionUInt32.read(from: &buf), 
+                network: FfiConverterTypeNetwork.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: SatsCardStatus, into buf: inout [UInt8]) {
+        FfiConverterUInt8.write(value.activeSlot, into: &buf)
+        FfiConverterUInt8.write(value.numSlots, into: &buf)
+        FfiConverterOptionString.write(value.address, into: &buf)
+        FfiConverterUInt32.write(value.proto, into: &buf)
+        FfiConverterString.write(value.ver, into: &buf)
+        FfiConverterOptionUInt32.write(value.authDelay, into: &buf)
+        FfiConverterTypeNetwork.write(value.network, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardStatus_lift(_ buf: RustBuffer) throws -> SatsCardStatus {
+    return try FfiConverterTypeSatsCardStatus.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardStatus_lower(_ value: SatsCardStatus) -> RustBuffer {
+    return FfiConverterTypeSatsCardStatus.lower(value)
 }
 
 
@@ -23504,6 +24081,11 @@ public enum MultiFormat: Equatable {
     case tapSignerUnused(TapSigner
     )
     /**
+     * SATSCARD detected via NFC/QR
+     */
+    case satsCard(SatsCard
+    )
+    /**
      * A signed but un-finalized PSBT
      */
     case signedPsbt(Psbt
@@ -23561,7 +24143,10 @@ public struct FfiConverterTypeMultiFormat: FfiConverterRustBuffer {
         case 7: return .tapSignerUnused(try FfiConverterTypeTapSigner.read(from: &buf)
         )
         
-        case 8: return .signedPsbt(try FfiConverterTypePsbt.read(from: &buf)
+        case 8: return .satsCard(try FfiConverterTypeSatsCard.read(from: &buf)
+        )
+        
+        case 9: return .signedPsbt(try FfiConverterTypePsbt.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -23607,8 +24192,13 @@ public struct FfiConverterTypeMultiFormat: FfiConverterRustBuffer {
             FfiConverterTypeTapSigner.write(v1, into: &buf)
             
         
-        case let .signedPsbt(v1):
+        case let .satsCard(v1):
             writeInt(&buf, Int32(8))
+            FfiConverterTypeSatsCard.write(v1, into: &buf)
+            
+        
+        case let .signedPsbt(v1):
+            writeInt(&buf, Int32(9))
             FfiConverterTypePsbt.write(v1, into: &buf)
             
         }
@@ -23642,6 +24232,8 @@ enum MultiFormatError: Swift.Error, Equatable, Hashable, Foundation.LocalizedErr
     case UnsupportedNetworkAddress
     case UnrecognizedFormat
     case InvalidTapSigner(TapCardParseError
+    )
+    case InvalidSatsCard(TapCardParseError
     )
     case TaprootNotSupported
     case PsbtNotSigned
@@ -23692,8 +24284,11 @@ public struct FfiConverterTypeMultiFormatError: FfiConverterRustBuffer {
         case 4: return .InvalidTapSigner(
             try FfiConverterTypeTapCardParseError.read(from: &buf)
             )
-        case 5: return .TaprootNotSupported
-        case 6: return .PsbtNotSigned
+        case 5: return .InvalidSatsCard(
+            try FfiConverterTypeTapCardParseError.read(from: &buf)
+            )
+        case 6: return .TaprootNotSupported
+        case 7: return .PsbtNotSigned
 
          default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -23724,12 +24319,17 @@ public struct FfiConverterTypeMultiFormatError: FfiConverterRustBuffer {
             FfiConverterTypeTapCardParseError.write(v1, into: &buf)
             
         
-        case .TaprootNotSupported:
+        case let .InvalidSatsCard(v1):
             writeInt(&buf, Int32(5))
+            FfiConverterTypeTapCardParseError.write(v1, into: &buf)
+            
+        
+        case .TaprootNotSupported:
+            writeInt(&buf, Int32(6))
         
         
         case .PsbtNotSigned:
-            writeInt(&buf, Int32(6))
+            writeInt(&buf, Int32(7))
         
         }
     }
@@ -25728,6 +26328,498 @@ public func FfiConverterTypeRoute_lift(_ buf: RustBuffer) throws -> Route {
 #endif
 public func FfiConverterTypeRoute_lower(_ value: Route) -> RustBuffer {
     return FfiConverterTypeRoute.lower(value)
+}
+
+
+
+
+public enum SatsCardCmd: Equatable, Hashable {
+    
+    /**
+     * Get the current status of the card (no CVC needed)
+     */
+    case status
+    /**
+     * Unseal the active slot to reveal the private key.
+     *
+     * On success the FFI caller receives only an opaque
+     * [`SatsCardSweepSession`] handle — raw key bytes never cross the
+     * boundary.
+     */
+    case unseal(cvc: String
+    )
+    /**
+     * Get info about a specific slot (status only — never returns key material
+     * across FFI even when a CVC is supplied internally).
+     */
+    case dump(slot: UInt8
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension SatsCardCmd: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardCmd: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardCmd
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardCmd {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .status
+        
+        case 2: return .unseal(cvc: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 3: return .dump(slot: try FfiConverterUInt8.read(from: &buf)
+        )
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SatsCardCmd, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .status:
+            writeInt(&buf, Int32(1))
+        
+        
+        case let .unseal(cvc):
+            writeInt(&buf, Int32(2))
+            FfiConverterString.write(cvc, into: &buf)
+            
+        
+        case let .dump(slot):
+            writeInt(&buf, Int32(3))
+            FfiConverterUInt8.write(slot, into: &buf)
+            
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardCmd_lift(_ buf: RustBuffer) throws -> SatsCardCmd {
+    return try FfiConverterTypeSatsCardCmd.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardCmd_lower(_ value: SatsCardCmd) -> RustBuffer {
+    return FfiConverterTypeSatsCardCmd.lower(value)
+}
+
+
+
+public 
+enum SatsCardReaderError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
+
+    
+    
+    case SatsCardError(TransportError
+    )
+    case UnknownCardType(String
+    )
+    case NoCommand
+    case InvalidCvcLength(UInt8
+    )
+    case NonNumericCvc
+    case SlotOutOfRange(slot: UInt8, numSlots: UInt8
+    )
+    case NoAddress
+    case InvalidPubkey
+    case AddressMismatch(cardReported: String, derived: String
+    )
+    case SuffixMismatch(cardReported: String, expectedSuffix: String
+    )
+    case Unknown(String
+    )
+
+    
+public func isAuthError() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_cove_fn_method_satscardreadererror_isautherror(
+            FfiConverterTypeSatsCardReaderError_lower(self),$0
+    )
+})
+}
+    
+public func isRateLimited() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_cove_fn_method_satscardreadererror_isratelimited(
+            FfiConverterTypeSatsCardReaderError_lower(self),$0
+    )
+})
+}
+    
+
+    
+// The local Rust `Display` implementation.
+public var description: String {
+    return try!  FfiConverterString.lift(
+        try! rustCall() {
+    uniffi_cove_fn_method_satscardreadererror_uniffi_trait_display(
+            FfiConverterTypeSatsCardReaderError_lower(self),$0
+    )
+}
+    )
+}
+
+    
+    public var errorDescription: String? {
+        String(reflecting: self)
+    }
+    
+}
+
+#if compiler(>=6)
+extension SatsCardReaderError: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardReaderError: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardReaderError
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardReaderError {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        
+
+        
+        case 1: return .SatsCardError(
+            try FfiConverterTypeTransportError.read(from: &buf)
+            )
+        case 2: return .UnknownCardType(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 3: return .NoCommand
+        case 4: return .InvalidCvcLength(
+            try FfiConverterUInt8.read(from: &buf)
+            )
+        case 5: return .NonNumericCvc
+        case 6: return .SlotOutOfRange(
+            slot: try FfiConverterUInt8.read(from: &buf), 
+            numSlots: try FfiConverterUInt8.read(from: &buf)
+            )
+        case 7: return .NoAddress
+        case 8: return .InvalidPubkey
+        case 9: return .AddressMismatch(
+            cardReported: try FfiConverterString.read(from: &buf), 
+            derived: try FfiConverterString.read(from: &buf)
+            )
+        case 10: return .SuffixMismatch(
+            cardReported: try FfiConverterString.read(from: &buf), 
+            expectedSuffix: try FfiConverterString.read(from: &buf)
+            )
+        case 11: return .Unknown(
+            try FfiConverterString.read(from: &buf)
+            )
+
+         default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SatsCardReaderError, into buf: inout [UInt8]) {
+        switch value {
+
+        
+
+        
+        
+        case let .SatsCardError(v1):
+            writeInt(&buf, Int32(1))
+            FfiConverterTypeTransportError.write(v1, into: &buf)
+            
+        
+        case let .UnknownCardType(v1):
+            writeInt(&buf, Int32(2))
+            FfiConverterString.write(v1, into: &buf)
+            
+        
+        case .NoCommand:
+            writeInt(&buf, Int32(3))
+        
+        
+        case let .InvalidCvcLength(v1):
+            writeInt(&buf, Int32(4))
+            FfiConverterUInt8.write(v1, into: &buf)
+            
+        
+        case .NonNumericCvc:
+            writeInt(&buf, Int32(5))
+        
+        
+        case let .SlotOutOfRange(slot,numSlots):
+            writeInt(&buf, Int32(6))
+            FfiConverterUInt8.write(slot, into: &buf)
+            FfiConverterUInt8.write(numSlots, into: &buf)
+            
+        
+        case .NoAddress:
+            writeInt(&buf, Int32(7))
+        
+        
+        case .InvalidPubkey:
+            writeInt(&buf, Int32(8))
+        
+        
+        case let .AddressMismatch(cardReported,derived):
+            writeInt(&buf, Int32(9))
+            FfiConverterString.write(cardReported, into: &buf)
+            FfiConverterString.write(derived, into: &buf)
+            
+        
+        case let .SuffixMismatch(cardReported,expectedSuffix):
+            writeInt(&buf, Int32(10))
+            FfiConverterString.write(cardReported, into: &buf)
+            FfiConverterString.write(expectedSuffix, into: &buf)
+            
+        
+        case let .Unknown(v1):
+            writeInt(&buf, Int32(11))
+            FfiConverterString.write(v1, into: &buf)
+            
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardReaderError_lift(_ buf: RustBuffer) throws -> SatsCardReaderError {
+    return try FfiConverterTypeSatsCardReaderError.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardReaderError_lower(_ value: SatsCardReaderError) -> RustBuffer {
+    return FfiConverterTypeSatsCardReaderError.lower(value)
+}
+
+
+
+public enum SatsCardResponse {
+    
+    case status(SatsCardStatus
+    )
+    /**
+     * Opaque handle. The unsealed key material is owned Rust-side and
+     * zeroised on drop (see [`SatsCardSweepSession`]).
+     */
+    case unseal(SatsCardSweepSession
+    )
+    case dump(SatsCardSlotDump
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension SatsCardResponse: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardResponse: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardResponse
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardResponse {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .status(try FfiConverterTypeSatsCardStatus.read(from: &buf)
+        )
+        
+        case 2: return .unseal(try FfiConverterTypeSatsCardSweepSession.read(from: &buf)
+        )
+        
+        case 3: return .dump(try FfiConverterTypeSatsCardSlotDump.read(from: &buf)
+        )
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SatsCardResponse, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case let .status(v1):
+            writeInt(&buf, Int32(1))
+            FfiConverterTypeSatsCardStatus.write(v1, into: &buf)
+            
+        
+        case let .unseal(v1):
+            writeInt(&buf, Int32(2))
+            FfiConverterTypeSatsCardSweepSession.write(v1, into: &buf)
+            
+        
+        case let .dump(v1):
+            writeInt(&buf, Int32(3))
+            FfiConverterTypeSatsCardSlotDump.write(v1, into: &buf)
+            
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardResponse_lift(_ buf: RustBuffer) throws -> SatsCardResponse {
+    return try FfiConverterTypeSatsCardResponse.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardResponse_lower(_ value: SatsCardResponse) -> RustBuffer {
+    return FfiConverterTypeSatsCardResponse.lower(value)
+}
+
+
+
+
+public enum SatsCardRoute: Equatable, Hashable {
+    
+    /**
+     * Initial scan screen — prompt user to tap the card
+     */
+    case scan(SatsCard
+    )
+    /**
+     * Show current slot status (slot N of M, sealed/unsealed, address, balance)
+     */
+    case slotStatus(SatsCardStatus
+    )
+    /**
+     * Confirm unseal — warn user this reveals the private key
+     */
+    case unsealConfirm(SatsCardStatus
+    )
+    /**
+     * Display-safe payload only.
+     *
+     * The unsealed key material lives inside a short-lived Rust-side
+     * `SatsCardSweepSession` (held by the manager) — never the route.
+     */
+    case unsealSuccess(slot: UInt8, address: String
+    )
+    /**
+     * Something went wrong — let user retry
+     */
+    case error(message: String, status: SatsCardStatus?
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension SatsCardRoute: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSatsCardRoute: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardRoute
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SatsCardRoute {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .scan(try FfiConverterTypeSatsCard.read(from: &buf)
+        )
+        
+        case 2: return .slotStatus(try FfiConverterTypeSatsCardStatus.read(from: &buf)
+        )
+        
+        case 3: return .unsealConfirm(try FfiConverterTypeSatsCardStatus.read(from: &buf)
+        )
+        
+        case 4: return .unsealSuccess(slot: try FfiConverterUInt8.read(from: &buf), address: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 5: return .error(message: try FfiConverterString.read(from: &buf), status: try FfiConverterOptionTypeSatsCardStatus.read(from: &buf)
+        )
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SatsCardRoute, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case let .scan(v1):
+            writeInt(&buf, Int32(1))
+            FfiConverterTypeSatsCard.write(v1, into: &buf)
+            
+        
+        case let .slotStatus(v1):
+            writeInt(&buf, Int32(2))
+            FfiConverterTypeSatsCardStatus.write(v1, into: &buf)
+            
+        
+        case let .unsealConfirm(v1):
+            writeInt(&buf, Int32(3))
+            FfiConverterTypeSatsCardStatus.write(v1, into: &buf)
+            
+        
+        case let .unsealSuccess(slot,address):
+            writeInt(&buf, Int32(4))
+            FfiConverterUInt8.write(slot, into: &buf)
+            FfiConverterString.write(address, into: &buf)
+            
+        
+        case let .error(message,status):
+            writeInt(&buf, Int32(5))
+            FfiConverterString.write(message, into: &buf)
+            FfiConverterOptionTypeSatsCardStatus.write(status, into: &buf)
+            
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardRoute_lift(_ buf: RustBuffer) throws -> SatsCardRoute {
+    return try FfiConverterTypeSatsCardRoute.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSatsCardRoute_lower(_ value: SatsCardRoute) -> RustBuffer {
+    return FfiConverterTypeSatsCardRoute.lower(value)
 }
 
 
@@ -34260,6 +35352,30 @@ fileprivate struct FfiConverterOptionDouble: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionBool: FfiConverterRustBuffer {
+    typealias SwiftType = Bool?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterBool.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterBool.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
     typealias SwiftType = String?
 
@@ -34396,6 +35512,30 @@ fileprivate struct FfiConverterOptionTypeMigration: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeMigration.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeSatsCardSweepSession: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardSweepSession?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSatsCardSweepSession.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSatsCardSweepSession.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -34692,6 +35832,54 @@ fileprivate struct FfiConverterOptionTypeFiatAmount: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeSatsCardSlotDump: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardSlotDump?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSatsCardSlotDump.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSatsCardSlotDump.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeSatsCardStatus: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardStatus?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSatsCardStatus.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSatsCardStatus.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeWalletMetadata: FfiConverterRustBuffer {
     typealias SwiftType = WalletMetadata?
 
@@ -34828,6 +36016,30 @@ fileprivate struct FfiConverterOptionTypeOnboardingBranch: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeOnboardingBranch.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeSatsCardCmd: FfiConverterRustBuffer {
+    typealias SwiftType = SatsCardCmd?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSatsCardCmd.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSatsCardCmd.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -36106,6 +37318,51 @@ public func isValidChainCode(chainCode: String) -> Bool  {
 })
 }
 /**
+ * Create a SatsCardReader instance for FFI callers.
+ *
+ * `expected_url_suffix` should be the 8-character `r=…` value parsed
+ * from the scanned `getsatscard.com/start#…` URL when available.
+ * [`SatsCardReader::verified_address`] cross-checks against it.
+ *
+ * UniFFI's Kotlin bindings do not support async primary constructors,
+ * hence the free function.
+ */
+public func createSatsCardReader(transport: TapcardTransportProtocol, cmd: SatsCardCmd?, expectedUrlSuffix: String?)async throws  -> SatsCardReader  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_func_create_sats_card_reader(FfiConverterCallbackInterfaceTapcardTransportProtocol_lower(transport),FfiConverterOptionTypeSatsCardCmd.lower(cmd),FfiConverterOptionString.lower(expectedUrlSuffix)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_u64,
+            completeFunc: ffi_cove_rust_future_complete_u64,
+            freeFunc: ffi_cove_rust_future_free_u64,
+            liftFunc: FfiConverterTypeSatsCardReader_lift,
+            errorHandler: FfiConverterTypeSatsCardReaderError_lift
+        )
+}
+public func satsCardResponseDumpData(response: SatsCardResponse) -> SatsCardSlotDump?  {
+    return try!  FfiConverterOptionTypeSatsCardSlotDump.lift(try! rustCall() {
+    uniffi_cove_fn_func_satscardresponsedumpdata(
+        FfiConverterTypeSatsCardResponse_lower(response),$0
+    )
+})
+}
+public func satsCardResponseStatusData(response: SatsCardResponse) -> SatsCardStatus?  {
+    return try!  FfiConverterOptionTypeSatsCardStatus.lift(try! rustCall() {
+    uniffi_cove_fn_func_satscardresponsestatusdata(
+        FfiConverterTypeSatsCardResponse_lower(response),$0
+    )
+})
+}
+public func satsCardResponseUnsealSession(response: SatsCardResponse) -> SatsCardSweepSession?  {
+    return try!  FfiConverterOptionTypeSatsCardSweepSession.lift(try! rustCall() {
+    uniffi_cove_fn_func_satscardresponseunsealsession(
+        FfiConverterTypeSatsCardResponse_lower(response),$0
+    )
+})
+}
+/**
  * Create a TapSignerReader instance for FFI callers
  * UniFFI's Kotlin bindings do not support async primary constructors
  */
@@ -36335,6 +37592,18 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_is_valid_chain_code() != 38380) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_create_sats_card_reader() != 34660) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_satscardresponsedumpdata() != 240) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_satscardresponsestatusdata() != 17903) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_satscardresponseunsealsession() != 3295) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_create_tap_signer_reader() != 37635) {
@@ -37256,6 +38525,27 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_headericonpresenter_ring_color() != 38756) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardreader_run() != 30335) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardreader_status() != 58264) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardreader_verified_address() != 26883) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardsweepsession_address() != 27077) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardsweepsession_network() != 50397) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardsweepsession_pubkey_bytes() != 34999) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_satscardsweepsession_slot() != 46812) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_tapsignerreader_continue_setup() != 49046) {

--- a/rust/crates/cove-tap-card/src/parse.rs
+++ b/rust/crates/cove-tap-card/src/parse.rs
@@ -308,6 +308,45 @@ mod tests {
     }
 
     #[test]
+    fn test_parses_sats_card_unsealed() {
+        let card = "https://getsatscard.com/start#u=U&o=3&r=95kesdwq&n=ab78fd50637f8f5a&s=26d1a0684f99fe43b223dca75081bb05bd0233b901139cdd33a4d0a2e61666ed1470d7c53d90f6ae4c60a6cbc7a0f4ded5f13461092b24604ad476bbcf1dd913";
+        let TapCard::SatsCard(sats_card) = TapCard::parse(card).unwrap() else {
+            panic!("not a sats card")
+        };
+
+        assert_eq!(sats_card.state, SatsCardState::Unsealed);
+        assert_eq!(sats_card.slot_number, 3);
+        assert_eq!(sats_card.address_suffix, "95kesdwq");
+    }
+
+    #[test]
+    fn test_parses_sats_card_error_state() {
+        let card = "https://getsatscard.com/start#u=E&o=0&r=95kesdwq&n=ab78fd50637f8f5a&s=26d1a0684f99fe43b223dca75081bb05bd0233b901139cdd33a4d0a2e61666ed1470d7c53d90f6ae4c60a6cbc7a0f4ded5f13461092b24604ad476bbcf1dd913";
+        let TapCard::SatsCard(sats_card) = TapCard::parse(card).unwrap() else {
+            panic!("not a sats card")
+        };
+
+        assert_eq!(sats_card.state, SatsCardState::Error);
+    }
+
+    #[test]
+    fn test_sats_card_not_misidentified_as_tap_signer() {
+        let card = "https://getsatscard.com/start#u=S&o=0&r=95kesdwq&n=ab78fd50637f8f5a&s=26d1a0684f99fe43b223dca75081bb05bd0233b901139cdd33a4d0a2e61666ed1470d7c53d90f6ae4c60a6cbc7a0f4ded5f13461092b24604ad476bbcf1dd913";
+        let tap_card = TapCard::parse(card).unwrap();
+        assert!(
+            matches!(tap_card, TapCard::SatsCard(_)),
+            "getsatscard.com URL should never parse as TapSigner"
+        );
+    }
+
+    #[test]
+    fn test_invalid_url_domain_errors() {
+        let url = "https://example.com/start#u=S&o=0&r=95kesdwq&n=abc&s=def";
+        let err = TapCard::parse(url).unwrap_err();
+        assert!(matches!(err, Error::InvalidUrl(_)));
+    }
+
+    #[test]
     fn test_tap_signer_readable_ident_string() {
         let url = "https://tapsigner.com/start#t=1&u=S&c=04d74fb1dfee7a4d&n=8940dc9808088820&s=6bda376546b7074b5a52f3264fe118d38889f49501b591b0b9e90a2ff2e07d26572898aaeb0f963a52cf707e7483203520ce40bdf5071e8f80262d587b41b99f";
         let tap_card = TapCard::parse(url);

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -40,6 +40,8 @@ pub enum MultiFormat {
     TapSignerReady(Arc<cove_tap_card::TapSigner>),
     /// TAPSIGNER has not been initialized yet
     TapSignerUnused(Arc<cove_tap_card::TapSigner>),
+    /// SATSCARD detected via NFC/QR
+    SatsCard(cove_tap_card::SatsCard),
     /// A signed but un-finalized PSBT
     SignedPsbt(Arc<Psbt>),
 }
@@ -60,6 +62,9 @@ pub enum MultiFormatError {
 
     #[error("Invalid TapSigner {0}")]
     InvalidTapSigner(cove_tap_card::TapCardParseError),
+
+    #[error("Invalid SatsCard {0}")]
+    InvalidSatsCard(cove_tap_card::TapCardParseError),
 
     #[error("Taproot wallets are not supported yet")]
     TaprootNotSupported,
@@ -156,8 +161,27 @@ impl MultiFormat {
                     return Ok(Self::from(card));
                 }
 
-                cove_tap_card::TapCard::SatsCard(_) => {
-                    return Err(MultiFormatError::UnrecognizedFormat);
+                cove_tap_card::TapCard::SatsCard(_card) => {
+                    return Err(MultiFormatError::InvalidTapSigner(
+                        cove_tap_card::TapCardParseError::InvalidUrl(string.to_string()),
+                    ));
+                }
+            }
+        }
+
+        if string.contains("getsatscard.com/start") {
+            let tap_card = cove_tap_card::TapCard::parse(string)
+                .map_err(|e| MultiFormatError::InvalidSatsCard(e.into()))?;
+
+            match tap_card {
+                cove_tap_card::TapCard::SatsCard(card) => {
+                    return Ok(Self::SatsCard(card));
+                }
+
+                cove_tap_card::TapCard::TapSigner(_card) => {
+                    return Err(MultiFormatError::InvalidSatsCard(
+                        cove_tap_card::TapCardParseError::InvalidUrl(string.to_string()),
+                    ));
                 }
             }
         }

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -8,7 +8,10 @@ use crate::{
     database::Database,
     mnemonic::NumberOfBip39Words,
     psbt::Psbt,
-    tap_card::tap_signer_reader::{DeriveInfo, SetupCmdResponse, TapSignerSetupComplete},
+    tap_card::{
+        sats_card_reader::SatsCardStatus,
+        tap_signer_reader::{DeriveInfo, SetupCmdResponse, TapSignerSetupComplete},
+    },
     transaction::{Amount, TransactionDetails, ffi::BitcoinTransaction},
     wallet::Address,
 };
@@ -147,6 +150,27 @@ pub enum TapSignerRoute {
 
     // shared routes
     EnterPin { tap_signer: Arc<cove_tap_card::TapSigner>, action: AfterPinAction },
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum SatsCardRoute {
+    /// Initial scan screen — prompt user to tap the card
+    Scan(cove_tap_card::SatsCard),
+
+    /// Show current slot status (slot N of M, sealed/unsealed, address, balance)
+    SlotStatus(SatsCardStatus),
+
+    /// Confirm unseal — warn user this reveals the private key
+    UnsealConfirm(SatsCardStatus),
+
+    /// Display-safe payload only.
+    ///
+    /// The unsealed key material lives inside a short-lived Rust-side
+    /// `SatsCardSweepSession` (held by the manager) — never the route.
+    UnsealSuccess { slot: u8, address: String },
+
+    /// Something went wrong — let user retry
+    Error { message: String, status: Option<SatsCardStatus> },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Record)]

--- a/rust/src/tap_card.rs
+++ b/rust/src/tap_card.rs
@@ -1,3 +1,4 @@
+pub mod sats_card_reader;
 pub mod tap_signer_reader;
 
 use rust_cktap::{apdu::Error as ApduError, commands::CkTransport};

--- a/rust/src/tap_card/sats_card_reader.rs
+++ b/rust/src/tap_card/sats_card_reader.rs
@@ -1,0 +1,574 @@
+use std::hash::Hasher;
+use std::sync::Arc;
+
+use bitcoin::{Address, CompressedPublicKey, KnownHrp, secp256k1::PublicKey};
+use nid::Nanoid;
+use parking_lot::RwLock;
+use rust_cktap::{
+    CkTapCard,
+    commands::{Authentication as _, CkTransport as _, Read as _, Wait as _},
+};
+use tokio::sync::Mutex;
+use tracing::debug;
+use zeroize::Zeroizing;
+
+use crate::database::Database;
+use crate::network::Network;
+
+use super::{CkTapError, TapcardTransport, TapcardTransportProtocol, TransportError};
+
+// MARK: - Errors
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, thiserror::Error, uniffi::Error)]
+#[uniffi::export(Display)]
+pub enum SatsCardReaderError {
+    #[error(transparent)]
+    SatsCardError(#[from] TransportError),
+
+    #[error("UnknownCardType: {0}, expected SatsCard")]
+    UnknownCardType(String),
+
+    #[error("No command")]
+    NoCommand,
+
+    #[error("Invalid CVC length, must be 6 digits, found {0}")]
+    InvalidCvcLength(u8),
+
+    #[error("CVC must be numeric only")]
+    NonNumericCvc,
+
+    #[error("Slot {slot} is out of range, card has {num_slots} slots")]
+    SlotOutOfRange { slot: u8, num_slots: u8 },
+
+    #[error("Card did not report an address for the active slot")]
+    NoAddress,
+
+    #[error("Slot pubkey could not be parsed")]
+    InvalidPubkey,
+
+    #[error("Card-reported address does not match the slot pubkey")]
+    AddressMismatch { card_reported: String, derived: String },
+
+    #[error("Card-reported address does not match the URL suffix scanned")]
+    SuffixMismatch { card_reported: String, expected_suffix: String },
+
+    #[error("Unknown error: {0}")]
+    Unknown(String),
+}
+
+type Error = SatsCardReaderError;
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+// MARK: - Commands and Responses
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum SatsCardCmd {
+    /// Get the current status of the card (no CVC needed)
+    Status,
+
+    /// Unseal the active slot to reveal the private key.
+    ///
+    /// On success the FFI caller receives only an opaque
+    /// [`SatsCardSweepSession`] handle — raw key bytes never cross the
+    /// boundary.
+    Unseal { cvc: String },
+
+    /// Get info about a specific slot (status only — never returns key material
+    /// across FFI even when a CVC is supplied internally).
+    Dump { slot: u8 },
+}
+
+#[derive(Debug, uniffi::Enum)]
+pub enum SatsCardResponse {
+    Status(SatsCardStatus),
+    /// Opaque handle. The unsealed key material is owned Rust-side and
+    /// zeroised on drop (see [`SatsCardSweepSession`]).
+    Unseal(Arc<SatsCardSweepSession>),
+    Dump(SatsCardSlotDump),
+}
+
+// MARK: - Slot and Status types
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, uniffi::Record)]
+pub struct SatsCardStatus {
+    /// Active slot number (0-indexed)
+    pub active_slot: u8,
+    /// Total number of slots on the card
+    pub num_slots: u8,
+    /// Card-reported address for the active slot — UNVERIFIED.
+    ///
+    /// Treat this as a display hint only. Call
+    /// [`SatsCardReader::verified_address`] before showing balance or
+    /// allowing a sweep.
+    pub address: Option<String>,
+    /// Protocol version
+    pub proto: u32,
+    /// Firmware version
+    pub ver: String,
+    /// Auth delay remaining (rate limit after bad CVC)
+    pub auth_delay: Option<u32>,
+    /// The network the card is on
+    pub network: Network,
+}
+
+/// Internal-only payload of an `unseal` APDU.
+///
+/// **Not** a `uniffi::Record`. Crate-private. Constructed once inside
+/// [`SatsCardReader::unseal`] and immediately consumed by
+/// [`SatsCardSweepSession::from_unseal`]; raw key bytes never escape Rust.
+pub(crate) struct SatsCardUnsealData {
+    pub slot: u8,
+    pub privkey: Zeroizing<[u8; 32]>,
+    pub pubkey: PublicKey,
+    pub master_pk: Zeroizing<[u8; 32]>,
+    pub chain_code: Zeroizing<[u8; 32]>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct SatsCardSlotDump {
+    pub slot: u8,
+    /// 33-byte compressed slot pubkey (safe to expose).
+    pub pubkey: Vec<u8>,
+    pub used: Option<bool>,
+    pub sealed: Option<bool>,
+    pub address: Option<String>,
+}
+
+// MARK: - SatsCardSweepSession (opaque, key material lives Rust-side only)
+
+/// Owns the unsealed slot's key material for the duration of one sweep.
+///
+/// `privkey`, `master_pk`, and `chain_code` are wrapped in
+/// [`Zeroizing`], so the underlying buffers are scrubbed when the
+/// session drops. The FFI surface only exposes non-sensitive accessors
+/// (`slot`, `address`). Phase 3 will add `balance()` and
+/// `build_and_broadcast()` on this type — both consuming the session so
+/// it can never be reused.
+#[derive(uniffi::Object)]
+pub struct SatsCardSweepSession {
+    id: String,
+    slot: u8,
+    privkey: Zeroizing<[u8; 32]>,
+    pubkey: PublicKey,
+    #[allow(dead_code)] // consumed in Phase 3 sweep flow
+    master_pk: Zeroizing<[u8; 32]>,
+    #[allow(dead_code)] // consumed in Phase 3 sweep flow
+    chain_code: Zeroizing<[u8; 32]>,
+    address: String,
+    network: Network,
+}
+
+impl std::fmt::Debug for SatsCardSweepSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately omit any field that could lead a debug log to
+        // print key material.
+        f.debug_struct("SatsCardSweepSession")
+            .field("id", &self.id)
+            .field("slot", &self.slot)
+            .field("address", &self.address)
+            .field("network", &self.network)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SatsCardSweepSession {
+    fn from_unseal(data: SatsCardUnsealData, address: String, network: Network) -> Self {
+        Self {
+            id: Nanoid::<8>::new().to_string(),
+            slot: data.slot,
+            privkey: data.privkey,
+            pubkey: data.pubkey,
+            master_pk: data.master_pk,
+            chain_code: data.chain_code,
+            address,
+            network,
+        }
+    }
+
+    /// Crate-internal accessor for Phase 3 sweep code. Never `pub`.
+    #[allow(dead_code)]
+    pub(crate) fn privkey_bytes(&self) -> &[u8; 32] {
+        &self.privkey
+    }
+}
+
+#[uniffi::export]
+impl SatsCardSweepSession {
+    pub fn slot(&self) -> u8 {
+        self.slot
+    }
+
+    /// The verified P2WPKH address for the unsealed slot.
+    pub fn address(&self) -> String {
+        self.address.clone()
+    }
+
+    /// 33-byte compressed slot pubkey (safe to expose).
+    pub fn pubkey_bytes(&self) -> Vec<u8> {
+        self.pubkey.serialize().to_vec()
+    }
+
+    pub fn network(&self) -> Network {
+        self.network
+    }
+}
+
+// MARK: - SatsCardReader
+
+#[derive(Debug, uniffi::Object)]
+pub struct SatsCardReader {
+    id: String,
+    reader: Mutex<rust_cktap::SatsCard<TapcardTransport>>,
+    cmd: RwLock<Option<SatsCardCmd>>,
+    transport: TapcardTransport,
+    network: Network,
+    /// 8-character suffix from the scanned `getsatscard.com/start#…r=…` URL,
+    /// used by [`Self::verified_address`] as a sanity check.
+    expected_url_suffix: Option<String>,
+}
+
+impl SatsCardReader {
+    async fn new(
+        transport: Box<dyn TapcardTransportProtocol>,
+        cmd: Option<SatsCardCmd>,
+        expected_url_suffix: Option<String>,
+    ) -> Result<Self> {
+        let transport = TapcardTransport(Arc::new(transport));
+        let card = transport.clone().to_cktap().await.map_err(TransportError::from)?;
+
+        let card_type = match &card {
+            CkTapCard::SatsCard(_) => "SatsCard",
+            CkTapCard::TapSigner(_) => "TapSigner",
+            CkTapCard::SatsChip(_) => "SatsChip",
+        };
+        debug!("sats_card_reader: detected card type {card_type}");
+
+        let card = match card {
+            CkTapCard::SatsCard(card) => Ok(card),
+            CkTapCard::TapSigner(_) => {
+                Err(SatsCardReaderError::UnknownCardType("TapSigner".to_string()))
+            }
+            CkTapCard::SatsChip(_) => {
+                Err(SatsCardReaderError::UnknownCardType("SatsChip".to_string()))
+            }
+        }?;
+
+        let id: Nanoid = Nanoid::new();
+        let network = Database::global().global_config.selected_network();
+
+        let me = Self {
+            id: id.to_string(),
+            reader: Mutex::new(card),
+            transport,
+            cmd: RwLock::new(cmd),
+            network,
+            expected_url_suffix,
+        };
+
+        me.wait_if_needed().await?;
+
+        Ok(me)
+    }
+}
+
+#[uniffi::export]
+impl SatsCardReader {
+    #[uniffi::method]
+    pub async fn run(&self) -> Result<SatsCardResponse> {
+        let cmd = self.cmd.write().take().ok_or(SatsCardReaderError::NoCommand)?;
+
+        match cmd {
+            SatsCardCmd::Status => {
+                let status = self.status().await?;
+                Ok(SatsCardResponse::Status(status))
+            }
+
+            SatsCardCmd::Unseal { cvc } => {
+                let session = self.unseal(&cvc).await?;
+                Ok(SatsCardResponse::Unseal(session))
+            }
+
+            SatsCardCmd::Dump { slot } => {
+                let data = self.dump(slot).await?;
+                Ok(SatsCardResponse::Dump(data))
+            }
+        }
+    }
+
+    /// Get the current status of the SatsCard.
+    ///
+    /// `address` on the returned status is the **card-reported, unverified**
+    /// string. Call [`Self::verified_address`] before showing balance or
+    /// allowing a sweep.
+    pub async fn status(&self) -> Result<SatsCardStatus> {
+        let reader = self.reader.lock().await;
+
+        Ok(SatsCardStatus {
+            active_slot: reader.slots.0,
+            num_slots: reader.slots.1,
+            address: reader.addr.clone(),
+            proto: reader.proto as u32,
+            ver: reader.ver.clone(),
+            auth_delay: reader.auth_delay.map(|d| d as u32),
+            network: self.network,
+        })
+    }
+
+    /// Verify that the active slot's address really belongs to the slot
+    /// pubkey reported via the `read` APDU, and that the URL suffix scanned
+    /// (when present) matches the card-reported address.
+    ///
+    /// `read()` performs an internal signature check against the card's
+    /// master pubkey. We re-derive the P2WPKH address from the verified
+    /// slot pubkey and require it to match `reader.addr`. The optional
+    /// 8-character URL suffix is then a cheap second-source sanity check.
+    ///
+    /// The UI must call this and observe `Ok` before displaying balance
+    /// or enabling the sweep CTA.
+    pub async fn verified_address(&self) -> Result<String> {
+        let mut reader = self.reader.lock().await;
+
+        let claimed = reader.addr.clone().ok_or(SatsCardReaderError::NoAddress)?;
+
+        let read_resp = reader.read(None).await.map_err(TransportError::from)?;
+
+        let slot_pk = CompressedPublicKey::from_slice(&read_resp.pubkey)
+            .map_err(|_| SatsCardReaderError::InvalidPubkey)?;
+
+        let bnetwork: bitcoin::Network = self.network.into();
+        let derived = Address::p2wpkh(&slot_pk, KnownHrp::from(bnetwork)).to_string();
+
+        if derived != claimed {
+            return Err(SatsCardReaderError::AddressMismatch { card_reported: claimed, derived });
+        }
+
+        if let Some(suffix) = self.expected_url_suffix.as_deref()
+            && !claimed.ends_with(suffix)
+        {
+            return Err(SatsCardReaderError::SuffixMismatch {
+                card_reported: claimed,
+                expected_suffix: suffix.to_string(),
+            });
+        }
+
+        Ok(claimed)
+    }
+}
+
+impl SatsCardReader {
+    async fn wait_if_needed(&self) -> Result<(), Error> {
+        loop {
+            let delay = {
+                let reader = self.reader.lock().await;
+                reader.auth_delay
+            };
+
+            let Some(delay) = delay else { break };
+
+            self.transport
+                .set_message(format!("Too many CVC attempts, waiting for {delay} seconds..."));
+
+            {
+                let mut reader = self.reader.lock().await;
+                reader.wait(None).await.map_err(TransportError::from)?;
+            }
+        }
+
+        {
+            let mut reader = self.reader.lock().await;
+            reader.set_auth_delay(None);
+        }
+
+        Ok(())
+    }
+
+    async fn unseal(&self, cvc: &str) -> Result<Arc<SatsCardSweepSession>> {
+        validate_cvc(cvc)?;
+
+        // Verify the slot address before consuming the unseal — if the card
+        // is lying about its address, the sweep would broadcast funds the
+        // user can't recover.
+        let address = self.verified_address().await?;
+
+        let mut reader = self.reader.lock().await;
+        let active_slot = reader.slots.0;
+
+        let response = reader.unseal(active_slot, cvc).await.map_err(TransportError::from)?;
+
+        let pubkey = PublicKey::from_slice(&response.pubkey)
+            .map_err(|_| SatsCardReaderError::InvalidPubkey)?;
+
+        let unseal_data = SatsCardUnsealData {
+            slot: response.slot,
+            privkey: clone_into_zeroizing_32(&response.privkey)?,
+            pubkey,
+            master_pk: clone_into_zeroizing_32(&response.master_pk)?,
+            chain_code: clone_into_zeroizing_32(&response.chain_code)?,
+        };
+
+        let session = SatsCardSweepSession::from_unseal(unseal_data, address, self.network);
+        Ok(Arc::new(session))
+    }
+
+    async fn dump(&self, slot: u8) -> Result<SatsCardSlotDump> {
+        let reader = self.reader.lock().await;
+
+        let num_slots = reader.slots.1;
+        if slot >= num_slots {
+            return Err(SatsCardReaderError::SlotOutOfRange { slot, num_slots });
+        }
+
+        // Phase 1: dump-without-CVC only. Returns slot status (sealed/unsealed,
+        // address for unsealed slots) but never key material across FFI. A
+        // CVC-authenticated dump would return `privkey` for an already-unsealed
+        // slot — that's a future addition that, like `unseal`, must hand back
+        // an opaque `SatsCardSweepSession` rather than raw bytes.
+        let response = reader.dump(slot as usize, None).await.map_err(TransportError::from)?;
+
+        Ok(SatsCardSlotDump {
+            slot: response.slot as u8,
+            pubkey: response.pubkey,
+            used: response.used,
+            sealed: response.sealed,
+            address: response.addr,
+        })
+    }
+}
+
+fn validate_cvc(cvc: &str) -> Result<()> {
+    if cvc.len() != 6 {
+        return Err(SatsCardReaderError::InvalidCvcLength(cvc.len() as u8));
+    }
+
+    if !cvc.chars().all(|c| c.is_ascii_digit()) {
+        return Err(SatsCardReaderError::NonNumericCvc);
+    }
+
+    Ok(())
+}
+
+fn clone_into_zeroizing_32(bytes: &[u8]) -> Result<Zeroizing<[u8; 32]>> {
+    if bytes.len() != 32 {
+        return Err(SatsCardReaderError::Unknown(format!(
+            "expected 32-byte field, got {}",
+            bytes.len()
+        )));
+    }
+    let mut out = Zeroizing::new([0u8; 32]);
+    out.copy_from_slice(bytes);
+    Ok(out)
+}
+
+// MARK: - FFI
+
+/// Create a SatsCardReader instance for FFI callers.
+///
+/// `expected_url_suffix` should be the 8-character `r=…` value parsed
+/// from the scanned `getsatscard.com/start#…` URL when available.
+/// [`SatsCardReader::verified_address`] cross-checks against it.
+///
+/// UniFFI's Kotlin bindings do not support async primary constructors,
+/// hence the free function.
+#[uniffi::export]
+pub async fn create_sats_card_reader(
+    transport: Box<dyn TapcardTransportProtocol>,
+    cmd: Option<SatsCardCmd>,
+    expected_url_suffix: Option<String>,
+) -> Result<Arc<SatsCardReader>, SatsCardReaderError> {
+    let reader = SatsCardReader::new(transport, cmd, expected_url_suffix).await?;
+    Ok(Arc::new(reader))
+}
+
+#[uniffi::export(name = "satsCardResponseStatusData")]
+fn _ffi_sats_card_response_status(response: SatsCardResponse) -> Option<SatsCardStatus> {
+    match response {
+        SatsCardResponse::Status(status) => Some(status),
+        _ => None,
+    }
+}
+
+#[uniffi::export(name = "satsCardResponseUnsealSession")]
+fn _ffi_sats_card_response_unseal(response: SatsCardResponse) -> Option<Arc<SatsCardSweepSession>> {
+    match response {
+        SatsCardResponse::Unseal(session) => Some(session),
+        _ => None,
+    }
+}
+
+#[uniffi::export(name = "satsCardResponseDumpData")]
+fn _ffi_sats_card_response_dump(response: SatsCardResponse) -> Option<SatsCardSlotDump> {
+    match response {
+        SatsCardResponse::Dump(data) => Some(data),
+        _ => None,
+    }
+}
+
+// MARK: - Trait impls
+
+impl std::hash::Hash for SatsCardReader {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl Eq for SatsCardReader {}
+impl PartialEq for SatsCardReader {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+#[uniffi::export]
+impl SatsCardReaderError {
+    #[uniffi::method(name = "isAuthError")]
+    pub fn is_auth_error(&self) -> bool {
+        matches!(self, Self::SatsCardError(TransportError::CkTap(CkTapError::BadAuth)))
+    }
+
+    #[uniffi::method(name = "isRateLimited")]
+    pub fn is_rate_limited(&self) -> bool {
+        matches!(self, Self::SatsCardError(TransportError::CkTap(CkTapError::RateLimited)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_cvc_accepts_six_digits() {
+        assert!(validate_cvc("123456").is_ok());
+    }
+
+    #[test]
+    fn validate_cvc_rejects_wrong_length() {
+        assert!(matches!(validate_cvc("12345"), Err(SatsCardReaderError::InvalidCvcLength(5))));
+        assert!(matches!(validate_cvc("1234567"), Err(SatsCardReaderError::InvalidCvcLength(7))));
+    }
+
+    #[test]
+    fn validate_cvc_rejects_non_digit() {
+        // and importantly, the malformed value is NOT echoed back through
+        // Display — the variant has no payload.
+        let err = validate_cvc("12345a").unwrap_err();
+        assert!(matches!(err, SatsCardReaderError::NonNumericCvc));
+        assert!(!err.to_string().contains("12345a"));
+    }
+
+    #[test]
+    fn clone_into_zeroizing_32_rejects_wrong_length() {
+        assert!(clone_into_zeroizing_32(&[0u8; 31]).is_err());
+        assert!(clone_into_zeroizing_32(&[0u8; 32]).is_ok());
+        assert!(clone_into_zeroizing_32(&[0u8; 33]).is_err());
+    }
+
+    #[test]
+    fn unseal_data_is_not_uniffi_record() {
+        // Compile-time guard: SatsCardUnsealData must remain crate-private
+        // and must not implement uniffi::Record. If anyone re-derives
+        // uniffi::Record on it, the `pub(crate)` access here will still
+        // compile but the FFI surface will grow — review the security
+        // model before changing this.
+        fn _assert_crate_private(_: SatsCardUnsealData) {}
+    }
+}


### PR DESCRIPTION
Add SatsCardReader with status, unseal, and dump commands, SatsCardRoute enum for mobile navigation, MultiFormat detection for getsatscard.com URLs, and seven new parse tests. Replace unreachable! panics with proper error returns for crafted card-type mismatch payloads.

## Summary

<!-- describe what changed and why -->

## Testing

<!-- list the commands you ran or explain why testing was not needed -->

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform APIs and mobile bindings add SatsCard reader support and recognize SatsCard links.
  * Scanned SatsCards trigger a “SATSCARD Detected” alert (includes slot number) indicating support is coming soon.

* **Tests**
  * Added unit tests for SatsCard parsing, URL handling (including getsatscard links), and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->