### PR TITLE
feat: show incoming unconfirmed funds separately in wallet header

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
@@ -136,9 +136,7 @@ fun SelectedWalletScreen(
         remember(manager?.balance, manager?.walletMetadata?.selectedUnit) {
             manager?.let {
                 val pending = it.balance.untrustedPending()
-                if (pending.asSats() > 0UL) {
-                    "+ " + it.displayAmount(pending, showUnit = true) + " pending"
-                } else null
+                it.rust.displayAmountPendingFmt(pending)
             }
         }
 
@@ -155,11 +153,9 @@ fun SelectedWalletScreen(
         remember(manager?.balance, app?.prices) {
             manager?.let {
                 val pending = it.balance.untrustedPending()
-                if (pending.asSats() > 0UL) {
-                    it.rust.amountInFiat(pending)?.let { fiat ->
-                        "+ " + it.rust.displayFiatAmount(fiat) + " pending"
-                    }
-                } else null
+                it.rust.amountInFiat(pending)?.let { fiat ->
+                    it.rust.displayFiatAmountPendingFmt(fiat, withSuffix = true)
+                }
             }
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
@@ -132,6 +132,14 @@ fun SelectedWalletScreen(
             it.displayAmount(spendable, showUnit = true)
         } ?: satsAmount
 
+    val actualSatsPending =
+        manager?.let {
+            val pending = it.balance.untrustedPending()
+            if (pending.asSats() > 0UL) {
+                "+ " + it.displayAmount(pending, showUnit = true) + " pending"
+            } else null
+        }
+
     val fiatBalance =
         remember(manager?.balance, app?.prices) {
             manager?.let {
@@ -140,6 +148,19 @@ fun SelectedWalletScreen(
                 }
             }
         }
+
+    val fiatBalancePending =
+        remember(manager?.balance, app?.prices) {
+            manager?.let {
+                val pending = it.balance.untrustedPending()
+                if (pending.asSats() > 0UL) {
+                    it.rust.amountInFiat(pending)?.let { fiat ->
+                        "+ " + it.rust.displayFiatAmount(fiat) + " pending"
+                    }
+                } else null
+            }
+        }
+
     val unsignedTransactions = manager?.unsignedTransactions ?: emptyList()
 
     LaunchedEffect(manager) {
@@ -312,6 +333,12 @@ fun SelectedWalletScreen(
                         FiatOrBtc.BTC -> actualSatsAmount to fiatBalance
                     }
 
+                val pendingAmount =
+                    when (fiatOrBtc) {
+                        FiatOrBtc.FIAT -> fiatBalancePending
+                        FiatOrBtc.BTC -> actualSatsPending
+                    }
+
                 val hasTransactions =
                     when (val loadState = manager?.loadState) {
                         is WalletLoadState.SCANNING -> loadState.txns.isNotEmpty() || unsignedTransactions.isNotEmpty()
@@ -414,6 +441,7 @@ fun SelectedWalletScreen(
                                     sensitiveVisible = sensitiveVisible,
                                     primaryAmount = primaryAmount,
                                     secondaryAmount = secondaryAmount,
+                                    pendingAmount = pendingAmount,
                                     onToggleUnit = { manager?.dispatch(WalletManagerAction.ToggleFiatBtcPrimarySecondary) },
                                     onToggleSensitive = { manager?.dispatch(WalletManagerAction.ToggleSensitiveVisibility) },
                                     onSend = onSend,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
@@ -133,11 +133,13 @@ fun SelectedWalletScreen(
         } ?: satsAmount
 
     val actualSatsPending =
-        manager?.let {
-            val pending = it.balance.untrustedPending()
-            if (pending.asSats() > 0UL) {
-                "+ " + it.displayAmount(pending, showUnit = true) + " pending"
-            } else null
+        remember(manager?.balance) {
+            manager?.let {
+                val pending = it.balance.untrustedPending()
+                if (pending.asSats() > 0UL) {
+                    "+ " + it.displayAmount(pending, showUnit = true) + " pending"
+                } else null
+            }
         }
 
     val fiatBalance =

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletScreen.kt
@@ -133,7 +133,7 @@ fun SelectedWalletScreen(
         } ?: satsAmount
 
     val actualSatsPending =
-        remember(manager?.balance) {
+        remember(manager?.balance, manager?.walletMetadata?.selectedUnit) {
             manager?.let {
                 val pending = it.balance.untrustedPending()
                 if (pending.asSats() > 0UL) {
@@ -337,7 +337,7 @@ fun SelectedWalletScreen(
 
                 val pendingAmount =
                     when (fiatOrBtc) {
-                        FiatOrBtc.FIAT -> fiatBalancePending
+                        FiatOrBtc.FIAT -> fiatBalancePending ?: actualSatsPending
                         FiatOrBtc.BTC -> actualSatsPending
                     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/WalletBalanceHeaderView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/WalletBalanceHeaderView.kt
@@ -49,6 +49,7 @@ fun WalletBalanceHeaderView(
     sensitiveVisible: Boolean,
     primaryAmount: String?,
     secondaryAmount: String?,
+    pendingAmount: String? = null,
     onToggleUnit: () -> Unit,
     onToggleSensitive: () -> Unit,
     onSend: () -> Unit,
@@ -94,6 +95,7 @@ fun WalletBalanceHeaderView(
                 sensitiveVisible = sensitiveVisible,
                 primaryAmount = primaryAmount,
                 secondaryAmount = secondaryAmount,
+                pendingAmount = pendingAmount,
                 onToggleUnit = onToggleUnit,
                 onToggleSensitive = onToggleSensitive,
             )
@@ -112,6 +114,7 @@ internal fun BalanceWidget(
     sensitiveVisible: Boolean,
     primaryAmount: String?,
     secondaryAmount: String?,
+    pendingAmount: String? = null,
     onToggleUnit: () -> Unit,
     onToggleSensitive: () -> Unit,
 ) {
@@ -175,6 +178,28 @@ internal fun BalanceWidget(
                     Modifier
                         .size(24.dp)
                         .clickable { onToggleSensitive() },
+            )
+        }
+
+        if (pendingAmount != null) {
+            AmountDisplay(
+                amount = pendingAmount,
+                isHidden = isHidden,
+                textContent = { text ->
+                    Text(
+                        text = text,
+                        color = Color.White.copy(alpha = 0.6f),
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                },
+                loadingContent = {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        color = Color.White.copy(alpha = 0.6f),
+                        strokeWidth = 1.5.dp,
+                    )
+                },
             )
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/WalletBalanceHeaderView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/WalletBalanceHeaderView.kt
@@ -185,6 +185,7 @@ internal fun BalanceWidget(
             AmountDisplay(
                 amount = pendingAmount,
                 isHidden = isHidden,
+                hiddenText = "+ •••••• pending",
                 textContent = { text ->
                     Text(
                         text = text,

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1824,6 +1824,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_balance_spendable(
     ): Short
+    external fun uniffi_cove_checksum_method_balance_untrusted_pending(
+    ): Short
     external fun uniffi_cove_checksum_method_fingerprint_as_lowercase(
     ): Short
     external fun uniffi_cove_checksum_method_fingerprint_as_uppercase(
@@ -3045,6 +3047,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_constructor_balance_zero(uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_method_balance_spendable(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_fn_method_balance_untrusted_pending(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_method_balance_uniffi_trait_eq_eq(`ptr`: Long,`other`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
@@ -4689,6 +4693,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_balance_spendable() != 31487.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_balance_untrusted_pending() != 30274.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_fingerprint_as_lowercase() != 43161.toShort()) {
@@ -6916,6 +6923,8 @@ public interface BalanceInterface {
     
     fun `spendable`(): Amount
     
+    fun `untrustedPending`(): Amount
+    
     companion object
 }
 
@@ -7025,6 +7034,19 @@ open class Balance: Disposable, AutoCloseable, BalanceInterface
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_method_balance_spendable(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    override fun `untrustedPending`(): Amount {
+            return FfiConverterTypeAmount.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_balance_untrusted_pending(
         it,
         _status)
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1544,9 +1544,13 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_display_amount(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_display_amount_pending_fmt(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_display_amount_with_direction(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount_pending_fmt(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount_with_direction(
     ): Short
@@ -2636,9 +2640,13 @@ internal object UniffiLib {
     ): Unit
     external fun uniffi_cove_fn_method_rustwalletmanager_display_amount(`ptr`: Long,`amount`: Long,`showUnit`: Byte,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_rustwalletmanager_display_amount_pending_fmt(`ptr`: Long,`amount`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_display_amount_with_direction(`ptr`: Long,`amount`: Long,`direction`: RustBufferTransactionDirection.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount(`ptr`: Long,`amount`: Double,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount_pending_fmt(`ptr`: Long,`amount`: Double,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount_with_direction(`ptr`: Long,`amount`: Double,`direction`: RustBufferTransactionDirection.ByValue,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -4275,10 +4283,16 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_display_amount() != 41368.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_display_amount_pending_fmt() != 5678.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_display_amount_with_direction() != 60498.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount() != 60595.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount_pending_fmt() != 55764.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount_with_direction() != 5406.toShort()) {
@@ -20666,6 +20680,12 @@ public interface RustWalletManagerInterface {
     fun `displayAmount`(`amount`: Amount, `showUnit`: kotlin.Boolean = true): kotlin.String
     
     /**
+     * Formats a pending BTC amount (e.g. "+ 0.00050000 BTC pending")
+     * Returns None if the amount is zero.
+     */
+    fun `displayAmountPendingFmt`(`amount`: Amount): kotlin.String?
+    
+    /**
      * Formats a BTC amount with direction prefix (e.g., "-0.00050000 BTC")
      *
      * Includes "-" prefix for outgoing transactions, no prefix for incoming.
@@ -20674,6 +20694,12 @@ public interface RustWalletManagerInterface {
     fun `displayAmountWithDirection`(`amount`: Amount, `direction`: TransactionDirection): kotlin.String
     
     fun `displayFiatAmount`(`amount`: kotlin.Double, `withSuffix`: kotlin.Boolean = true): kotlin.String
+    
+    /**
+     * Formats a pending fiat amount (e.g. "+ $50.00 pending")
+     * Returns None if the amount is zero.
+     */
+    fun `displayFiatAmountPendingFmt`(`amount`: kotlin.Double, `withSuffix`: kotlin.Boolean = true): kotlin.String?
     
     /**
      * Formats a fiat amount with direction prefix (e.g., "-$50.00")
@@ -21152,6 +21178,23 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
 
     
     /**
+     * Formats a pending BTC amount (e.g. "+ 0.00050000 BTC pending")
+     * Returns None if the amount is zero.
+     */override fun `displayAmountPendingFmt`(`amount`: Amount): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustwalletmanager_display_amount_pending_fmt(
+        it,
+        FfiConverterTypeAmount.lower(`amount`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
      * Formats a BTC amount with direction prefix (e.g., "-0.00050000 BTC")
      *
      * Includes "-" prefix for outgoing transactions, no prefix for incoming.
@@ -21174,6 +21217,23 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount(
+        it,
+        FfiConverterDouble.lower(`amount`),FfiConverterBoolean.lower(`withSuffix`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Formats a pending fiat amount (e.g. "+ $50.00 pending")
+     * Returns None if the amount is zero.
+     */override fun `displayFiatAmountPendingFmt`(`amount`: kotlin.Double, `withSuffix`: kotlin.Boolean): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount_pending_fmt(
         it,
         FfiConverterDouble.lower(`amount`),FfiConverterBoolean.lower(`withSuffix`),_status)
 }

--- a/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
@@ -70,9 +70,10 @@ struct WalletBalanceHeaderView: View {
                         .font(.footnote)
                         .padding(.leading, 2)
                 } else {
-                    ProgressView()
-                        .tint(.white.opacity(0.6))
-                        .scaleEffect(0.7)
+                    Text("+ \(manager.amountFmtUnit(pending)) pending")
+                        .foregroundColor(.white.opacity(0.6))
+                        .font(.footnote)
+                        .padding(.leading, 2)
                 }
             } else {
                 Text("+ \(manager.amountFmtUnit(pending)) pending")

--- a/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
@@ -60,15 +60,21 @@ struct WalletBalanceHeaderView: View {
         
         if metadata.fiatOrBtc == .fiat, let fiatPendingBalance,
            let pendingStr = manager.rust.displayFiatAmountPendingFmt(amount: fiatPendingBalance, withSuffix: true) {
-            Text(pendingStr)
-                .foregroundColor(.white.opacity(0.6))
-                .font(.footnote)
-                .padding(.leading, 2)
+            HStack {
+                Text(pendingStr)
+                    .foregroundColor(.white.opacity(0.6))
+                    .font(.footnote)
+                    .padding(.leading, 2)
+                Spacer()
+            }
         } else if let pendingStr = manager.rust.displayAmountPendingFmt(amount: pending) {
-            Text(pendingStr)
-                .foregroundColor(.white.opacity(0.6))
-                .font(.footnote)
-                .padding(.leading, 2)
+            HStack {
+                Text(pendingStr)
+                    .foregroundColor(.white.opacity(0.6))
+                    .font(.footnote)
+                    .padding(.leading, 2)
+                Spacer()
+            }
         }
     }
 
@@ -118,10 +124,7 @@ struct WalletBalanceHeaderView: View {
                         .onTapGesture { updater(.toggleSensitiveVisibility) }
                 }
 
-                HStack {
-                    pendingBalanceView
-                    Spacer()
-                }
+                pendingBalanceView
             }
             .onTapGesture {
                 manager.dispatch(action: .toggleFiatBtcPrimarySecondary)

--- a/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
@@ -57,30 +57,18 @@ struct WalletBalanceHeaderView: View {
     @ViewBuilder
     private var pendingBalanceView: some View {
         let pending = manager.balance.untrustedPending()
-        if pending.asSats() > 0 {
-            if !metadata.sensitiveVisible {
-                Text("+ •••••• pending")
-                    .foregroundColor(.white.opacity(0.6))
-                    .font(.footnote)
-                    .padding(.leading, 2)
-            } else if metadata.fiatOrBtc == .fiat {
-                if let fiatPendingBalance {
-                    Text("+ \(manager.rust.displayFiatAmount(amount: fiatPendingBalance)) pending")
-                        .foregroundColor(.white.opacity(0.6))
-                        .font(.footnote)
-                        .padding(.leading, 2)
-                } else {
-                    Text("+ \(manager.amountFmtUnit(pending)) pending")
-                        .foregroundColor(.white.opacity(0.6))
-                        .font(.footnote)
-                        .padding(.leading, 2)
-                }
-            } else {
-                Text("+ \(manager.amountFmtUnit(pending)) pending")
-                    .foregroundColor(.white.opacity(0.6))
-                    .font(.footnote)
-                    .padding(.leading, 2)
-            }
+        
+        if metadata.fiatOrBtc == .fiat, let fiatPendingBalance,
+           let pendingStr = manager.rust.displayFiatAmountPendingFmt(amount: fiatPendingBalance, withSuffix: true) {
+            Text(pendingStr)
+                .foregroundColor(.white.opacity(0.6))
+                .font(.footnote)
+                .padding(.leading, 2)
+        } else if let pendingStr = manager.rust.displayAmountPendingFmt(amount: pending) {
+            Text(pendingStr)
+                .foregroundColor(.white.opacity(0.6))
+                .font(.footnote)
+                .padding(.leading, 2)
         }
     }
 

--- a/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
@@ -16,6 +16,7 @@ struct WalletBalanceHeaderView: View {
     // trusted spendable balance
     let balance: Amount
     @State var fiatBalance: Double? = nil
+    @State var fiatPendingBalance: Double? = nil
     let metadata: WalletMetadata
     let updater: (WalletManagerAction) -> Void
     let showReceiveSheet: () -> Void
@@ -50,6 +51,35 @@ struct WalletBalanceHeaderView: View {
             }
         } else {
             Text(manager.amountFmtUnit(balance))
+        }
+    }
+
+    @ViewBuilder
+    private var pendingBalanceView: some View {
+        let pending = manager.balance.untrustedPending()
+        if pending.asSats() > 0 {
+            if !metadata.sensitiveVisible {
+                Text("+ •••••• pending")
+                    .foregroundColor(.white.opacity(0.6))
+                    .font(.footnote)
+                    .padding(.leading, 2)
+            } else if metadata.fiatOrBtc == .fiat {
+                if let fiatPendingBalance {
+                    Text("+ \(manager.rust.displayFiatAmount(amount: fiatPendingBalance)) pending")
+                        .foregroundColor(.white.opacity(0.6))
+                        .font(.footnote)
+                        .padding(.leading, 2)
+                } else {
+                    ProgressView()
+                        .tint(.white.opacity(0.6))
+                        .scaleEffect(0.7)
+                }
+            } else {
+                Text("+ \(manager.amountFmtUnit(pending)) pending")
+                    .foregroundColor(.white.opacity(0.6))
+                    .font(.footnote)
+                    .padding(.leading, 2)
+            }
         }
     }
 
@@ -97,6 +127,11 @@ struct WalletBalanceHeaderView: View {
                     Image(systemName: eyeIcon)
                         .foregroundColor(.gray)
                         .onTapGesture { updater(.toggleSensitiveVisibility) }
+                }
+
+                HStack {
+                    pendingBalanceView
+                    Spacer()
                 }
             }
             .onTapGesture {
@@ -175,16 +210,18 @@ struct WalletBalanceHeaderView: View {
         )
         .background(.midnightBlue)
         .onAppear {
-            if fiatBalance != nil { return }
-            fiatBalance = manager.rust.amountInFiat(amount: balance)
+            if fiatBalance == nil { fiatBalance = manager.rust.amountInFiat(amount: balance) }
+            if fiatPendingBalance == nil { fiatPendingBalance = manager.rust.amountInFiat(amount: manager.balance.untrustedPending()) }
         }
         .onChange(of: manager.balance, initial: false) { _, newBalance in
             // recalculate fiat when balance changes
             fiatBalance = manager.rust.amountInFiat(amount: newBalance.spendable())
+            fiatPendingBalance = manager.rust.amountInFiat(amount: newBalance.untrustedPending())
         }
         .onChange(of: app.prices, initial: false) { _, _ in
             // recalculate fiat when prices are loaded/updated
             fiatBalance = manager.rust.amountInFiat(amount: balance)
+            fiatPendingBalance = manager.rust.amountInFiat(amount: manager.balance.untrustedPending())
         }
     }
 }

--- a/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/WalletBalanceHeaderView.swift
@@ -57,9 +57,10 @@ struct WalletBalanceHeaderView: View {
     @ViewBuilder
     private var pendingBalanceView: some View {
         let pending = manager.balance.untrustedPending()
-        
+
         if metadata.fiatOrBtc == .fiat, let fiatPendingBalance,
-           let pendingStr = manager.rust.displayFiatAmountPendingFmt(amount: fiatPendingBalance, withSuffix: true) {
+           let pendingStr = manager.rust.displayFiatAmountPendingFmt(amount: fiatPendingBalance, withSuffix: true)
+        {
             HStack {
                 Text(pendingStr)
                     .foregroundColor(.white.opacity(0.6))

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -8713,6 +8713,12 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
     func displayAmount(amount: Amount, showUnit: Bool)  -> String
     
     /**
+     * Formats a pending BTC amount (e.g. "+ 0.00050000 BTC pending")
+     * Returns None if the amount is zero.
+     */
+    func displayAmountPendingFmt(amount: Amount)  -> String?
+    
+    /**
      * Formats a BTC amount with direction prefix (e.g., "-0.00050000 BTC")
      *
      * Includes "-" prefix for outgoing transactions, no prefix for incoming.
@@ -8721,6 +8727,12 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
     func displayAmountWithDirection(amount: Amount, direction: TransactionDirection)  -> String
     
     func displayFiatAmount(amount: Double, withSuffix: Bool)  -> String
+    
+    /**
+     * Formats a pending fiat amount (e.g. "+ $50.00 pending")
+     * Returns None if the amount is zero.
+     */
+    func displayFiatAmountPendingFmt(amount: Double, withSuffix: Bool)  -> String?
     
     /**
      * Formats a fiat amount with direction prefix (e.g., "-$50.00")
@@ -9127,6 +9139,19 @@ open func displayAmount(amount: Amount, showUnit: Bool = true) -> String  {
 }
     
     /**
+     * Formats a pending BTC amount (e.g. "+ 0.00050000 BTC pending")
+     * Returns None if the amount is zero.
+     */
+open func displayAmountPendingFmt(amount: Amount) -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_cove_fn_method_rustwalletmanager_display_amount_pending_fmt(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeAmount_lower(amount),$0
+    )
+})
+}
+    
+    /**
      * Formats a BTC amount with direction prefix (e.g., "-0.00050000 BTC")
      *
      * Includes "-" prefix for outgoing transactions, no prefix for incoming.
@@ -9145,6 +9170,20 @@ open func displayAmountWithDirection(amount: Amount, direction: TransactionDirec
 open func displayFiatAmount(amount: Double, withSuffix: Bool = true) -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount(
+            self.uniffiCloneHandle(),
+        FfiConverterDouble.lower(amount),
+        FfiConverterBool.lower(withSuffix),$0
+    )
+})
+}
+    
+    /**
+     * Formats a pending fiat amount (e.g. "+ $50.00 pending")
+     * Returns None if the amount is zero.
+     */
+open func displayFiatAmountPendingFmt(amount: Double, withSuffix: Bool = true) -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_cove_fn_method_rustwalletmanager_display_fiat_amount_pending_fmt(
             self.uniffiCloneHandle(),
         FfiConverterDouble.lower(amount),
         FfiConverterBool.lower(withSuffix),$0
@@ -36742,10 +36781,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_display_amount() != 41368) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_rustwalletmanager_display_amount_pending_fmt() != 5678) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_rustwalletmanager_display_amount_with_direction() != 60498) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount() != 60595) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount_pending_fmt() != 55764) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_display_fiat_amount_with_direction() != 5406) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -1366,6 +1366,8 @@ public protocol BalanceProtocol: AnyObject, Sendable {
     
     func spendable()  -> Amount
     
+    func untrustedPending()  -> Amount
+    
 }
 open class Balance: BalanceProtocol, @unchecked Sendable, Equatable {
     fileprivate let handle: UInt64
@@ -1430,6 +1432,14 @@ public static func zero() -> Balance  {
 open func spendable() -> Amount  {
     return try!  FfiConverterTypeAmount_lift(try! rustCall() {
     uniffi_cove_fn_method_balance_spendable(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func untrustedPending() -> Amount  {
+    return try!  FfiConverterTypeAmount_lift(try! rustCall() {
+    uniffi_cove_fn_method_balance_untrusted_pending(
             self.uniffiCloneHandle(),$0
     )
 })
@@ -37150,6 +37160,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_balance_spendable() != 31487) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_balance_untrusted_pending() != 30274) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_fingerprint_as_lowercase() != 43161) {

--- a/rust/crates/cove-types/src/amount.rs
+++ b/rust/crates/cove-types/src/amount.rs
@@ -118,3 +118,22 @@ impl Amount {
         format!("{} SATS", self.sats_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_amount_fmt_strings() {
+        let amount = Amount::from_sat(12000);
+        
+        assert_eq!(amount.sats_string(), "12,000");
+        assert_eq!(amount.sats_string_with_unit(), "12,000 SATS");
+        
+        assert_eq!(amount.btc_string(), "0.00012");
+        assert_eq!(amount.btc_string_with_unit(), "0.00012 BTC");
+
+        assert_eq!(amount.fmt_string_with_unit(BitcoinUnit::Sat), "12,000 SATS");
+        assert_eq!(amount.fmt_string_with_unit(BitcoinUnit::Btc), "0.00012 BTC");
+    }
+}

--- a/rust/crates/cove-types/src/amount.rs
+++ b/rust/crates/cove-types/src/amount.rs
@@ -126,10 +126,10 @@ mod tests {
     #[test]
     fn test_amount_fmt_strings() {
         let amount = Amount::from_sat(12000);
-        
+
         assert_eq!(amount.sats_string(), "12,000");
         assert_eq!(amount.sats_string_with_unit(), "12,000 SATS");
-        
+
         assert_eq!(amount.btc_string(), "0.00012");
         assert_eq!(amount.btc_string_with_unit(), "0.00012 BTC");
 

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -790,7 +790,11 @@ impl RustWalletManager {
     /// Formats a pending fiat amount (e.g. "+ $50.00 pending")
     /// Returns None if the amount is zero.
     #[uniffi::method(default(with_suffix = true))]
-    pub fn display_fiat_amount_pending_fmt(&self, amount: f64, with_suffix: bool) -> Option<String> {
+    pub fn display_fiat_amount_pending_fmt(
+        &self,
+        amount: f64,
+        with_suffix: bool,
+    ) -> Option<String> {
         if amount <= 0.0 {
             return None;
         }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -716,6 +716,18 @@ impl RustWalletManager {
         if show_unit { amount.fmt_string_with_unit(unit) } else { amount.fmt_string(unit) }
     }
 
+    /// Formats a pending BTC amount (e.g. "+ 0.00050000 BTC pending")
+    /// Returns None if the amount is zero.
+    #[uniffi::method]
+    pub fn display_amount_pending_fmt(&self, amount: Arc<Amount>) -> Option<String> {
+        if amount.as_sats() == 0 {
+            return None;
+        }
+
+        let formatted = self.display_amount(amount, true);
+        Some(format!("+ {formatted} pending"))
+    }
+
     /// Formats a BTC amount with direction prefix (e.g., "-0.00050000 BTC")
     ///
     /// Includes "-" prefix for outgoing transactions, no prefix for incoming.
@@ -773,6 +785,18 @@ impl RustWalletManager {
         }
 
         format!("{symbol}{fiat}")
+    }
+
+    /// Formats a pending fiat amount (e.g. "+ $50.00 pending")
+    /// Returns None if the amount is zero.
+    #[uniffi::method(default(with_suffix = true))]
+    pub fn display_fiat_amount_pending_fmt(&self, amount: f64, with_suffix: bool) -> Option<String> {
+        if amount <= 0.0 {
+            return None;
+        }
+
+        let formatted = self.display_fiat_amount(amount, with_suffix);
+        Some(format!("+ {formatted} pending"))
     }
 
     /// Formats a fiat amount with direction prefix (e.g., "-$50.00")

--- a/rust/src/wallet/balance.rs
+++ b/rust/src/wallet/balance.rs
@@ -26,4 +26,8 @@ impl Balance {
     pub fn spendable(&self) -> Amount {
         self.0.trusted_spendable().into()
     }
+    #[uniffi::method]
+    pub fn untrusted_pending(&self) -> Amount {
+        self.0.untrusted_pending.into()
+    }
 }


### PR DESCRIPTION
Resolves #517.

Adds a subtle, secondary '+ X pending' label below the main wallet balance specifically for incoming unconfirmed funds.
- Rust Core: Exposed BDK's untrusted_pending rather than trusted_pending to avoid treating change outputs as pending funds.
- UI Parity: Implemented a matching lower-opacity, smaller label below the main balance on both Android and iOS.
- State handling: Fully respects the privacy eye-toggle and unit display toggle (Fiat / SATS / BTC).

## Summary

This PR addresses the feature request to clearly separate unconfirmed funds from the spendable balance on the main wallet header. 

Previously, unconfirmed incoming transactions would appear in the transaction list but the header only showed the strictly spendable balance, causing confusion for users expecting to see incoming funds.

By introducing a secondary "+ X pending" subtitle dynamically fetched via `untrusted_pending`, the user is explicitly informed about unconfirmed incoming funds without muddying the main spendable balance. The pending balance properly recalculates its fiat value on the fly and appropriately toggles between fiat/SATS/BTC depending on the user's unit settings, as well as hiding securely when the privacy eye icon is toggled.

## Testing

I built and compiled the application cross-platform to ensure there were no structural breaks and that binding parity was maintained.

Commands run during local verification:
- `just build-android` to compile and test UniFFI Kotlin bindings.
- `just build-ios` and `just compile-ios` to compile and test UniFFI Swift bindings & iOS UI.
- `just lint` to verify Rust code quality and formatting. 

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on iOS simulator
- [x] Tested on Android simulator
- [ ] Not tested

### Demo
- [Screenshot](https://drive.google.com/file/d/1iqB8HceSCsRnyEXgdCs-cVVsZqsvErHI/view?usp=sharing)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet header now shows a separate "pending" line for unconfirmed balances (BTC or fiat) when pending > 0; respects unit toggles and sensitive/masked display.
  * Pending amounts prefer fiat in FIAT mode when available; otherwise show BTC/SATS; displays a small loading indicator while resolving.

* **Bug Fixes / Quality**
  * Improved amount formatting for primary and pending displays (commas, BTC/SATS precision).

* **Tests**
  * Added unit tests validating amount formatting outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->