### PR TITLE
feat: watch-only import for wsh(sortedmulti) descriptors

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1896,6 +1896,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_constructor_rustwalletmanager_preview_new_wallet_with_metadata(
     ): Short
+    external fun uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_multisig_descriptor(
+    ): Short
     external fun uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_tap_signer(
     ): Short
     external fun uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_xpub(
@@ -1945,6 +1947,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_constructor_urresult_new(
     ): Short
     external fun uniffi_cove_checksum_constructor_wallet_new_from_export(
+    ): Short
+    external fun uniffi_cove_checksum_constructor_wallet_new_from_multisig_descriptor(
     ): Short
     external fun uniffi_cove_checksum_constructor_wallet_new_from_xpub(
     ): Short
@@ -2602,6 +2606,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_constructor_rustwalletmanager_preview_new_wallet_with_metadata(`metadata`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
+    external fun uniffi_cove_fn_constructor_rustwalletmanager_try_new_from_multisig_descriptor(`descriptor`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
     external fun uniffi_cove_fn_constructor_rustwalletmanager_try_new_from_tap_signer(`tapSigner`: Long,`deriveInfo`: RustBuffer.ByValue,`backup`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_constructor_rustwalletmanager_try_new_from_xpub(`xpub`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -3031,6 +3037,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_free_wallet(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     external fun uniffi_cove_fn_constructor_wallet_new_from_export(`export`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Long
+    external fun uniffi_cove_fn_constructor_wallet_new_from_multisig_descriptor(`descriptor`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
     external fun uniffi_cove_fn_constructor_wallet_new_from_xpub(`xpub`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Long
@@ -4799,6 +4807,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_constructor_rustwalletmanager_preview_new_wallet_with_metadata() != 41631.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_multisig_descriptor() != 57425.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_tap_signer() != 14372.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4872,6 +4883,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_constructor_wallet_new_from_export() != 38500.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_constructor_wallet_new_from_multisig_descriptor() != 20465.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_constructor_wallet_new_from_xpub() != 12329.toShort()) {
@@ -21950,6 +21964,18 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
     
 
         
+    @Throws(WalletManagerException::class) fun `tryNewFromMultisigDescriptor`(`descriptor`: kotlin.String): RustWalletManager {
+            return FfiConverterTypeRustWalletManager.lift(
+    uniffiRustCallWithError(WalletManagerException) { _status ->
+    UniffiLib.uniffi_cove_fn_constructor_rustwalletmanager_try_new_from_multisig_descriptor(
+    
+        FfiConverterString.lower(`descriptor`),_status)
+}
+    )
+    }
+    
+
+        
     @Throws(WalletManagerException::class) fun `tryNewFromTapSigner`(`tapSigner`: TapSigner, `deriveInfo`: DeriveInfo, `backup`: kotlin.ByteArray? = null): RustWalletManager {
             return FfiConverterTypeRustWalletManager.lift(
     uniffiRustCallWithError(WalletManagerException) { _status ->
@@ -25662,6 +25688,18 @@ open class Wallet: Disposable, AutoCloseable, WalletInterface
     UniffiLib.uniffi_cove_fn_constructor_wallet_new_from_export(
     
         FfiConverterTypeHardwareExport.lower(`export`),_status)
+}
+    )
+    }
+    
+
+        
+    @Throws(WalletException::class) fun `newFromMultisigDescriptor`(`descriptor`: kotlin.String): Wallet {
+            return FfiConverterTypeWallet.lift(
+    uniffiRustCallWithError(WalletException) { _status ->
+    UniffiLib.uniffi_cove_fn_constructor_wallet_new_from_multisig_descriptor(
+    
+        FfiConverterString.lower(`descriptor`),_status)
 }
     )
     }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -8910,6 +8910,14 @@ public static func previewNewWalletWithMetadata(metadata: WalletMetadata) -> Rus
 })
 }
     
+public static func tryNewFromMultisigDescriptor(descriptor: String)throws  -> RustWalletManager  {
+    return try  FfiConverterTypeRustWalletManager_lift(try rustCallWithError(FfiConverterTypeWalletManagerError_lift) {
+    uniffi_cove_fn_constructor_rustwalletmanager_try_new_from_multisig_descriptor(
+        FfiConverterString.lower(descriptor),$0
+    )
+})
+}
+    
 public static func tryNewFromTapSigner(tapSigner: TapSigner, deriveInfo: DeriveInfo, backup: Data? = nil)throws  -> RustWalletManager  {
     return try  FfiConverterTypeRustWalletManager_lift(try rustCallWithError(FfiConverterTypeWalletManagerError_lift) {
     uniffi_cove_fn_constructor_rustwalletmanager_try_new_from_tap_signer(
@@ -11644,6 +11652,14 @@ public static func newFromExport(export: HardwareExport)throws  -> Wallet  {
     return try  FfiConverterTypeWallet_lift(try rustCallWithError(FfiConverterTypeWalletError_lift) {
     uniffi_cove_fn_constructor_wallet_new_from_export(
         FfiConverterTypeHardwareExport_lower(export),$0
+    )
+})
+}
+    
+public static func newFromMultisigDescriptor(descriptor: String)throws  -> Wallet  {
+    return try  FfiConverterTypeWallet_lift(try rustCallWithError(FfiConverterTypeWalletError_lift) {
+    uniffi_cove_fn_constructor_wallet_new_from_multisig_descriptor(
+        FfiConverterString.lower(descriptor),$0
     )
 })
 }
@@ -37260,6 +37276,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_constructor_rustwalletmanager_preview_new_wallet_with_metadata() != 41631) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_multisig_descriptor() != 57425) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_constructor_rustwalletmanager_try_new_from_tap_signer() != 14372) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -37333,6 +37352,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_constructor_wallet_new_from_export() != 38500) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_constructor_wallet_new_from_multisig_descriptor() != 20465) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_constructor_wallet_new_from_xpub() != 12329) {

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -388,6 +388,34 @@ impl RustWalletManager {
         })
     }
 
+    #[uniffi::constructor]
+    pub fn try_new_from_multisig_descriptor(descriptor: String) -> Result<Self, Error> {
+        let (sender, receiver) = flume::bounded(100);
+
+        let wallet = Wallet::try_new_persisted_multisig_watch_only(descriptor)?;
+        let id = wallet.id.clone();
+        let metadata = wallet.metadata.clone();
+
+        let scanner =
+            WalletScanner::try_new(metadata.clone(), sender.clone()).ok().map(spawn_actor);
+
+        let wallet_actor = WalletActor::new(wallet, sender.clone())
+            .map_err(|e| Error::DatabaseCorruption { id: id.clone(), error: e.to_string() })?;
+        let actor = task::spawn_actor(wallet_actor);
+        let label_manager = LabelManager::new(id.clone()).into();
+
+        Ok(Self {
+            id,
+            actor,
+            metadata: Arc::new(RwLock::new(metadata)),
+            reconciler: MessageSender::new(sender),
+            reconcile_receiver: Arc::new(receiver),
+            label_manager,
+            initial_load_state: WalletLoadState::Loading,
+            scanner,
+        })
+    }
+
     #[uniffi::constructor(default(backup = None))]
     pub fn try_new_from_tap_signer(
         tap_signer: Arc<cove_tap_card::TapSigner>,

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -396,12 +396,12 @@ impl RustWalletManager {
         let id = wallet.id.clone();
         let metadata = wallet.metadata.clone();
 
-        let scanner =
-            WalletScanner::try_new(metadata.clone(), sender.clone()).ok().map(spawn_actor);
-
         let wallet_actor = WalletActor::new(wallet, sender.clone())
             .map_err(|e| Error::DatabaseCorruption { id: id.clone(), error: e.to_string() })?;
         let actor = task::spawn_actor(wallet_actor);
+
+        let scanner =
+            WalletScanner::try_new(metadata.clone(), sender.clone()).ok().map(spawn_actor);
         let label_manager = LabelManager::new(id.clone()).into();
 
         Ok(Self {

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -374,10 +374,10 @@ impl Wallet {
         let external_str = external.to_string();
         let existing = database.wallets.get_all(network, mode).unwrap_or_default();
         for wm in existing {
-            if let Ok(Some((stored_ext, _))) = keychain.get_public_descriptor(&wm.id) {
-                if stored_ext.to_string() == external_str {
-                    return Err(WalletError::WalletAlreadyExists(wm.id));
-                }
+            if let Ok(Some((stored_ext, _))) = keychain.get_public_descriptor(&wm.id)
+                && stored_ext.to_string() == external_str
+            {
+                return Err(WalletError::WalletAlreadyExists(wm.id));
             }
         }
 

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -369,6 +369,17 @@ impl Wallet {
         let keychain = Keychain::global();
         let database = Database::global();
         let network = database.global_config.selected_network();
+        let mode = database.global_config.wallet_mode();
+
+        let external_str = external.to_string();
+        let existing = database.wallets.get_all(network, mode).unwrap_or_default();
+        for wm in existing {
+            if let Ok(Some((stored_ext, _))) = keychain.get_public_descriptor(&wm.id) {
+                if stored_ext.to_string() == external_str {
+                    return Err(WalletError::WalletAlreadyExists(wm.id));
+                }
+            }
+        }
 
         let id = WalletId::new();
         let mut metadata = WalletMetadata::new_for_hardware(id.clone(), name, None);
@@ -769,7 +780,7 @@ fn parse_multisig_descriptors(
     let parse = |s: &str| -> Result<ExtendedDescriptor, WalletError> {
         MiniscriptDescriptor::<DescriptorPublicKey>::parse_descriptor(&secp, s)
             .map(|(d, _)| d)
-            .map_err(|e| WalletError::DescriptorKeyParseError(e.to_string()))
+            .map_err_str(WalletError::DescriptorKeyParseError)
     };
 
     let lines: Vec<&str> = input.lines().map(str::trim).filter(|l| !l.is_empty()).collect();

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -361,6 +361,37 @@ impl Wallet {
         Ok(Self { id, metadata, network, bdk: wallet, db: Mutex::new(store.conn) })
     }
 
+    pub fn try_new_persisted_multisig_watch_only(descriptor: String) -> Result<Self, WalletError> {
+        use bdk_wallet::keys::KeyMap;
+
+        let (external, internal, name) = parse_multisig_descriptors(&descriptor)?;
+
+        let keychain = Keychain::global();
+        let database = Database::global();
+        let network = database.global_config.selected_network();
+
+        let id = WalletId::new();
+        let mut metadata = WalletMetadata::new_for_hardware(id.clone(), name, None);
+        metadata.wallet_type = WalletType::WatchOnly;
+
+        let mut store = BdkStore::try_new(&id, network).map_err_str(WalletError::LoadError)?;
+
+        let wallet = Descriptors {
+            external: Descriptor { extended_descriptor: external.clone(), key_map: KeyMap::new() },
+            internal: Descriptor { extended_descriptor: internal.clone(), key_map: KeyMap::new() },
+        }
+        .into_create_params()
+        .network(network.into())
+        .create_wallet(&mut store.conn)
+        .map_err_str(WalletError::BdkError)?;
+
+        keychain.save_public_descriptor(&id, external, internal)?;
+        database.wallets.save_new_wallet_metadata(metadata.clone())?;
+        CLOUD_BACKUP_MANAGER.handle_wallet_set_change();
+
+        Ok(Self { id, metadata, network, bdk: wallet, db: Mutex::new(store.conn) })
+    }
+
     pub fn try_new_persisted_from_tap_signer(
         tap_signer: Arc<cove_tap_card::TapSigner>,
         derive: DeriveInfo,
@@ -712,9 +743,118 @@ pub fn delete_wallet_specific_data(wallet_id: &WalletId) -> eyre::Result<()> {
     Ok(())
 }
 
+/// Parse a multisig descriptor string into (external, internal, wallet_name).
+///
+/// Accepts either two newline-separated descriptors (external then internal),
+/// or a single descriptor containing `<0;1>` multipath notation.
+/// Only `wsh(sortedmulti(...))` is supported.
+fn parse_multisig_descriptors(
+    input: &str,
+) -> Result<
+    (
+        bdk_wallet::descriptor::ExtendedDescriptor,
+        bdk_wallet::descriptor::ExtendedDescriptor,
+        String,
+    ),
+    WalletError,
+> {
+    use bdk_wallet::descriptor::ExtendedDescriptor;
+    use bdk_wallet::keys::DescriptorPublicKey;
+    use bdk_wallet::miniscript::Descriptor as MiniscriptDescriptor;
+    use bdk_wallet::miniscript::descriptor::WshInner;
+    use bitcoin::secp256k1::Secp256k1;
+
+    let secp = Secp256k1::signing_only();
+
+    let parse = |s: &str| -> Result<ExtendedDescriptor, WalletError> {
+        MiniscriptDescriptor::<DescriptorPublicKey>::parse_descriptor(&secp, s)
+            .map(|(d, _)| d)
+            .map_err(|e| WalletError::DescriptorKeyParseError(e.to_string()))
+    };
+
+    let lines: Vec<&str> = input.lines().map(str::trim).filter(|l| !l.is_empty()).collect();
+
+    let (external, internal) = match lines.as_slice() {
+        [ext, int] => (parse(ext)?, parse(int)?),
+        [single] if single.contains("<0;1>") => {
+            let ext_str = single.replace("<0;1>", "0");
+            let int_str = single.replace("<0;1>", "1");
+            (parse(&ext_str)?, parse(&int_str)?)
+        }
+        _ => return Err(WalletError::UnsupportedWallet(
+            "expected two descriptor lines (external, internal) or a single multipath descriptor"
+                .to_string(),
+        )),
+    };
+
+    let name = match &external {
+        MiniscriptDescriptor::Wsh(wsh) => match wsh.as_inner() {
+            WshInner::SortedMulti(sm) => {
+                format!("{}-of-{} Multisig Watch-Only", sm.k(), sm.pks().len())
+            }
+            _ => {
+                return Err(WalletError::UnsupportedWallet(
+                    "only wsh(sortedmulti) descriptors are supported".to_string(),
+                ));
+            }
+        },
+        _ => {
+            return Err(WalletError::UnsupportedWallet(
+                "only wsh(sortedmulti) descriptors are supported".to_string(),
+            ));
+        }
+    };
+
+    Ok((external, internal, name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const XPUB1: &str = "xpub6CiKnWv7PPyyeb4kCwK4fidKqVjPfD9TP6MiXnzBVGZYNanNdY3mMvywcrdDc6wK82jyBSd95vsk26QujnJWPrSaPfYeyW7NyX37HHGtfQM";
+    const XPUB2: &str = "xpub6DM7CYgaTMdMbhTcLTUWmNUE5WLXK5hx8ZMa4sRw8qYJPqtqKYiKnwsmT8A6AijDVAUZRivdBnXdR8QE7Y9vVnqvzPL3fXCmu1WtCRLdAoz";
+
+    fn multisig_two_line() -> String {
+        let ext = format!(
+            "wsh(sortedmulti(2,[817e7be0/48h/0h/0h/2h]{XPUB1}/0/*,[a262308d/48h/0h/0h/2h]{XPUB2}/0/*))"
+        );
+        let int = format!(
+            "wsh(sortedmulti(2,[817e7be0/48h/0h/0h/2h]{XPUB1}/1/*,[a262308d/48h/0h/0h/2h]{XPUB2}/1/*))"
+        );
+        format!("{ext}\n{int}")
+    }
+
+    fn multisig_multipath() -> String {
+        format!(
+            "wsh(sortedmulti(2,[817e7be0/48h/0h/0h/2h]{XPUB1}/<0;1>/*,[a262308d/48h/0h/0h/2h]{XPUB2}/<0;1>/*))"
+        )
+    }
+
+    #[test]
+    fn test_parse_multisig_two_line() {
+        let (_, _, name) = parse_multisig_descriptors(&multisig_two_line()).unwrap();
+        assert_eq!(name, "2-of-2 Multisig Watch-Only");
+    }
+
+    #[test]
+    fn test_parse_multisig_multipath() {
+        let (_, _, name) = parse_multisig_descriptors(&multisig_multipath()).unwrap();
+        assert_eq!(name, "2-of-2 Multisig Watch-Only");
+    }
+
+    #[test]
+    fn test_parse_multisig_rejects_singlesig() {
+        let singlesig = format!("wpkh([817e7be0/84h/0h/0h]{XPUB1}/0/*)");
+        let result = parse_multisig_descriptors(&singlesig);
+        assert!(matches!(result, Err(WalletError::UnsupportedWallet(_))));
+    }
+
+    #[test]
+    fn test_parse_multisig_rejects_empty() {
+        let result = parse_multisig_descriptors("");
+        assert!(matches!(result, Err(WalletError::UnsupportedWallet(_))));
+    }
 
     #[test]
     fn test_fingerprint() {
@@ -749,5 +889,10 @@ impl Wallet {
     ) -> Result<Self, WalletError> {
         let export = Arc::unwrap_or_clone(export);
         Self::try_new_persisted_from_pubport(export.into_format())
+    }
+
+    #[uniffi::constructor]
+    pub fn new_from_multisig_descriptor(descriptor: String) -> Result<Self, WalletError> {
+        Self::try_new_persisted_multisig_watch_only(descriptor)
     }
 }


### PR DESCRIPTION
## Summary

Implements watch-only multisig wallet import via wsh(sortedmulti) descriptors, as scoped in issue #491.

## Testing

- Wallet::new_from_multisig_descriptor : creates and persists the BDK wallet                
- RustWalletManager::try_new_from_multisig_descriptor : UniFFI-exported entry point, mirrors the existing try_new_from_xpub pattern

The parse_multisig_descriptors helper accepts two formats:
- Two newline-separated descriptors (external then internal), as exported by most hardware coordinators (Sparrow, Nunchuk, etc.)
- A single BIP-389 multipath descriptor using <0;1> notation

I have't tested it, as their is no UI wired up yet

### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [x] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating watch-only wallets directly from multisig descriptors
  * Implemented automatic duplicate wallet detection and prevention to avoid redundant configurations
  * Extended wallet initialization APIs with new descriptor-based constructor methods

* **Tests**
  * Added comprehensive unit tests validating multisig descriptor parsing and wallet creation flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->