### PR TITLE
Ci/regenerate bindings workflow

### DIFF
--- a/.github/workflows/regenerate-bindings.yml
+++ b/.github/workflows/regenerate-bindings.yml
@@ -3,6 +3,10 @@ name: Regenerate Bindings
 on:
   workflow_dispatch: {}
 
+concurrency:
+  group: regenerate-bindings-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   regenerate-android-bindings:
     runs-on: ubuntu-latest
@@ -12,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -65,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Pull latest (includes Android binding commit)
         run: git pull --rebase origin ${{ github.ref_name }}

--- a/.github/workflows/regenerate-bindings.yml
+++ b/.github/workflows/regenerate-bindings.yml
@@ -1,0 +1,104 @@
+name: Regenerate Bindings
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  regenerate-android-bindings:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Set up just
+        uses: extractions/setup-just@v1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install build dependencies
+        run: cd rust && cargo xtask install-deps
+
+      - name: Build Rust FFI and generate Kotlin bindings
+        run: just build-android
+
+      - name: Show git status before commit
+        run: |
+          echo "=== Files changed after build ==="
+          git status
+          echo "=== Diff stat ==="
+          git diff --stat
+
+      - name: Commit regenerated Android bindings
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add android/app/src/main/java/org/bitcoinppl/cove_core/
+
+          if git diff --cached --quiet; then
+            echo "No Android binding changes to commit"
+          else
+            echo "Committing changes..."
+            git commit -m "chore: regenerate Android (Kotlin) UniFFI bindings"
+            git push origin HEAD:${{ github.ref_name }}
+          fi
+
+  regenerate-ios-bindings:
+    runs-on: macos-26
+    needs: regenerate-android-bindings
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Pull latest (includes Android binding commit)
+        run: git pull --rebase origin ${{ github.ref_name }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Set up just
+        uses: extractions/setup-just@v1
+
+      - name: Build Rust FFI and generate Swift bindings
+        run: just build-ios
+
+      - name: Show git status before commit
+        run: |
+          echo "=== Files changed after build ==="
+          git status
+          echo "=== Diff stat ==="
+          git diff --stat
+
+      - name: Commit regenerated iOS bindings
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add ios/CoveCore/Sources/CoveCore/generated/
+
+          if git diff --cached --quiet; then
+            echo "No iOS binding changes to commit"
+          else
+            echo "Committing changes..."
+            git commit -m "chore: regenerate iOS (Swift) UniFFI bindings"
+            git push origin HEAD:${{ github.ref_name }}
+          fi


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` CI workflow that regenerates UniFFI bindings for both platforms when triggered manually. This helps contributors on Windows or Linux who don't have the full cross-platform toolchain (NDK + Xcode) locally.

**How it works:**
1. **Android job** (Ubuntu): Runs `just build-android`, commits regenerated Kotlin bindings
2. **iOS job** (macOS): Runs `just build-ios`, commits regenerated Swift bindings
3. Both jobs push the generated files back to the triggering branch automatically
**Usage:** Go to Actions → "Regenerate Bindings" → Run workflow → select your branch.



## Testing

Workflow syntax validated. Runtime testing requires merge and manual trigger.

## Platform Coverage
- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [x] Not tested (CI workflow — no device testing applicable)

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have read ARCHITECTURE.md
