### PR TITLE
Feature add new badge for first-time addresses

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAddressView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/EnterAddressView.kt
@@ -8,10 +8,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import org.bitcoinppl.cove.ui.theme.CoveColor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.QrCode2
@@ -43,6 +48,7 @@ import org.bitcoinppl.cove_core.types.addressStringSpacedOut
 fun EnterAddressView(
     onScanQr: () -> Unit,
     initialAddress: String,
+    isNewAddress: Boolean = false,
     onAddressChanged: (String) -> Unit,
     focusRequester: FocusRequester,
     onFocusChanged: (Boolean) -> Unit = {},
@@ -67,12 +73,26 @@ fun EnterAddressView(
         Spacer(Modifier.height(20.dp))
         Row(verticalAlignment = Alignment.CenterVertically) {
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    stringResource(R.string.label_enter_address),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        stringResource(R.string.label_enter_address),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    if (isNewAddress) {
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = "New Address",
+                            color = CoveColor.WarningOrange,
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier
+                                .background(CoveColor.WarningOrange.copy(alpha = 0.2f), RoundedCornerShape(4.dp))
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
                 Spacer(Modifier.height(4.dp))
                 Text(
                     stringResource(R.string.label_where_send_to),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowConfirmScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowConfirmScreen.kt
@@ -168,6 +168,7 @@ fun SendFlowConfirmScreen(
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
                     SummaryWidget(
                         address = address,
+                        isNewAddress = sendFlowManager.isNewAddress,
                         networkFee = networkFee,
                         willReceive = willReceive,
                         willPay = willPay,
@@ -374,6 +375,7 @@ private fun AmountWidget(
 @Composable
 private fun SummaryWidget(
     address: String,
+    isNewAddress: Boolean = false,
     networkFee: String,
     willReceive: String,
     willPay: String,
@@ -389,6 +391,7 @@ private fun SummaryWidget(
             valueColor = MaterialTheme.colorScheme.onSurface,
             keyColor = MaterialTheme.colorScheme.onSurfaceVariant,
             boldValue = true,
+            showNewAddressBadge = isNewAddress,
             onClick = onAddressClick,
         )
         Spacer(Modifier.height(20.dp))
@@ -428,6 +431,7 @@ private fun KeyValueRow(
     valueColor: Color,
     boldValue: Boolean = false,
     boldKey: Boolean = false,
+    showNewAddressBadge: Boolean = false,
     onClick: (() -> Unit)? = null,
 ) {
     val rowModifier =
@@ -442,13 +446,26 @@ private fun KeyValueRow(
         modifier = rowModifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            key,
-            color = keyColor,
-            fontSize = 14.sp,
-            fontWeight = if (boldKey) FontWeight.SemiBold else FontWeight.Normal,
-            modifier = Modifier.weight(1f),
-        )
+        Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                key,
+                color = keyColor,
+                fontSize = 14.sp,
+                fontWeight = if (boldKey) FontWeight.SemiBold else FontWeight.Normal,
+            )
+            if (showNewAddressBadge) {
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "New Address",
+                    color = CoveColor.WarningOrange,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier
+                        .background(CoveColor.WarningOrange.copy(alpha = 0.2f), RoundedCornerShape(4.dp))
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                )
+            }
+        }
         Text(
             value,
             color = valueColor,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -46,6 +46,9 @@ class SendFlowManager(
     private var _enteringAddress by mutableStateOf("")
 
     // validated state
+    var isNewAddress by mutableStateOf(false)
+        private set
+
     var address by mutableStateOf<Address?>(null)
 
     var amount by mutableStateOf<Amount?>(null)
@@ -205,6 +208,10 @@ class SendFlowManager(
 
             is SendFlowManagerReconcileMessage.UpdateEnteringFiatAmount -> {
                 enteringFiatAmount = message.v1
+            }
+
+            is SendFlowManagerReconcileMessage.UpdateIsNewAddress -> {
+                isNewAddress = message.v1
             }
 
             is SendFlowManagerReconcileMessage.UpdateSelectedFeeRate -> {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowSetAmountScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowSetAmountScreen.kt
@@ -302,6 +302,7 @@ fun SendFlowSetAmountScreen(
                         EnterAddressView(
                             onScanQr = onScanQr,
                             initialAddress = initialAddress,
+                            isNewAddress = sendFlowManager.isNewAddress,
                             onAddressChanged = { newAddress ->
                                 sendFlowManager.enteringAddress = newAddress
                             },

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -44447,6 +44447,15 @@ sealed class SendFlowManagerReconcileMessage: Disposable  {
         companion object
     }
     
+    data class UpdateIsNewAddress(
+        val v1: kotlin.Boolean) : SendFlowManagerReconcileMessage()
+        
+    {
+        
+
+        companion object
+    }
+    
     object RefreshPresenters : SendFlowManagerReconcileMessage()
     
     
@@ -44539,6 +44548,13 @@ sealed class SendFlowManagerReconcileMessage: Disposable  {
     )
                 
             }
+            is SendFlowManagerReconcileMessage.UpdateIsNewAddress -> {
+                
+    Disposable.destroy(
+        this.v1
+    )
+                
+            }
             is SendFlowManagerReconcileMessage.RefreshPresenters -> {// Nothing to destroy
             }
             is SendFlowManagerReconcileMessage.SetAlert -> {
@@ -44598,11 +44614,14 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
             11 -> SendFlowManagerReconcileMessage.UpdateFeeRateOptions(
                 FfiConverterTypeFeeRateOptionsWithTotalFee.read(buf),
                 )
-            12 -> SendFlowManagerReconcileMessage.RefreshPresenters
-            13 -> SendFlowManagerReconcileMessage.SetAlert(
+            12 -> SendFlowManagerReconcileMessage.UpdateIsNewAddress(
+                FfiConverterBoolean.read(buf),
+                )
+            13 -> SendFlowManagerReconcileMessage.RefreshPresenters
+            14 -> SendFlowManagerReconcileMessage.SetAlert(
                 FfiConverterTypeSendFlowAlertState.read(buf),
                 )
-            14 -> SendFlowManagerReconcileMessage.ClearAlert
+            15 -> SendFlowManagerReconcileMessage.ClearAlert
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -44684,6 +44703,13 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
                 + FfiConverterTypeFeeRateOptionsWithTotalFee.allocationSize(value.v1)
             )
         }
+        is SendFlowManagerReconcileMessage.UpdateIsNewAddress -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterBoolean.allocationSize(value.v1)
+            )
+        }
         is SendFlowManagerReconcileMessage.RefreshPresenters -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
@@ -44761,17 +44787,22 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
                 FfiConverterTypeFeeRateOptionsWithTotalFee.write(value.v1, buf)
                 Unit
             }
-            is SendFlowManagerReconcileMessage.RefreshPresenters -> {
+            is SendFlowManagerReconcileMessage.UpdateIsNewAddress -> {
                 buf.putInt(12)
+                FfiConverterBoolean.write(value.v1, buf)
+                Unit
+            }
+            is SendFlowManagerReconcileMessage.RefreshPresenters -> {
+                buf.putInt(13)
                 Unit
             }
             is SendFlowManagerReconcileMessage.SetAlert -> {
-                buf.putInt(13)
+                buf.putInt(14)
                 FfiConverterTypeSendFlowAlertState.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerReconcileMessage.ClearAlert -> {
-                buf.putInt(14)
+                buf.putInt(15)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/ios/Cove/Flows/SendFlow/Common/SendFlowDetailsView.swift
+++ b/ios/Cove/Flows/SendFlow/Common/SendFlowDetailsView.swift
@@ -14,6 +14,7 @@ struct SendFlowDetailsView: View {
     // args
     let manager: WalletManager
     let details: ConfirmDetails
+    var isNewAddress: Bool = false
     @State var prices: PriceResponse?
 
     // private
@@ -52,6 +53,17 @@ struct SendFlowDetailsView: View {
                     .fontWeight(.medium)
                     .foregroundStyle(.secondary)
                     .foregroundColor(.primary)
+
+                if isNewAddress {
+                    Text("New Address")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.2))
+                        .foregroundColor(.orange)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
 
                 Spacer()
                 Spacer()

--- a/ios/Cove/Flows/SendFlow/SendFlowCoinControlSetAmountScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowCoinControlSetAmountScreen.swift
@@ -184,7 +184,7 @@ struct SendFlowCoinControlSetAmountScreen: View {
                         // Address Section
                         VStack {
                             Divider()
-                            EnterAddressView(address: sendFlowManager.enteringAddress)
+                            EnterAddressView(address: sendFlowManager.enteringAddress, isNewAddress: sendFlowManager.isNewAddress)
                             Divider()
                         }
 

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SendFlowConfirmScreen: View {
     @Environment(AppManager.self) private var app
     @Environment(AuthManager.self) private var auth
+    @Environment(SendFlowManager.self) private var sendFlowManager: SendFlowManager?
 
     let id: WalletId
     @State var manager: WalletManager
@@ -154,7 +155,7 @@ struct SendFlowConfirmScreen: View {
 
                         Divider()
 
-                        SendFlowDetailsView(manager: manager, details: details, prices: prices)
+                        SendFlowDetailsView(manager: manager, details: details, isNewAddress: sendFlowManager?.isNewAddress ?? false, prices: prices)
                     }
                 }
                 .scrollIndicators(.hidden)

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -24,6 +24,7 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
     var enteringBtcAmount: String = ""
     var enteringFiatAmount: String = ""
     private var _enteringAddress: String = ""
+    var isNewAddress: Bool = false
 
     var address: Address? = nil
     var amount: Amount? = nil
@@ -136,6 +137,9 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
 
         case let .updateEnteringAddress(address):
             self._enteringAddress = address
+
+        case let .updateIsNewAddress(isNewAddress):
+            self.isNewAddress = isNewAddress
 
         case let .updateEnteringFiatAmount(amount):
             self.enteringFiatAmount = amount

--- a/ios/Cove/Flows/SendFlow/SendFlowSetAmountScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowSetAmountScreen.swift
@@ -143,7 +143,7 @@ struct SendFlowSetAmountScreen: View {
                         // Address Section
                         VStack {
                             Divider()
-                            EnterAddressView(address: sendFlowManager.enteringAddress)
+                            EnterAddressView(address: sendFlowManager.enteringAddress, isNewAddress: sendFlowManager.isNewAddress)
                             Divider()
                         }
 

--- a/ios/Cove/Flows/SendFlow/SetAmountScreen/EnterAddressView.swift
+++ b/ios/Cove/Flows/SendFlow/SetAmountScreen/EnterAddressView.swift
@@ -15,6 +15,7 @@ struct EnterAddressView: View {
 
     /// args
     @Binding var address: String
+    var isNewAddress: Bool = false
 
     /// private
     @FocusState private var focusField: SendFlowPresenter.FocusField?
@@ -25,6 +26,17 @@ struct EnterAddressView: View {
                 Text("Enter address")
                     .font(.headline)
                     .fontWeight(.bold)
+
+                if isNewAddress {
+                    Text("New Address")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.2))
+                        .foregroundColor(.orange)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
 
                 Spacer()
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -27124,6 +27124,8 @@ public enum SendFlowManagerReconcileMessage {
     )
     case updateFeeRateOptions(FeeRateOptionsWithTotalFee
     )
+    case updateIsNewAddress(Bool
+    )
     case refreshPresenters
     case setAlert(SendFlowAlertState
     )
@@ -27181,12 +27183,15 @@ public struct FfiConverterTypeSendFlowManagerReconcileMessage: FfiConverterRustB
         case 11: return .updateFeeRateOptions(try FfiConverterTypeFeeRateOptionsWithTotalFee.read(from: &buf)
         )
         
-        case 12: return .refreshPresenters
-        
-        case 13: return .setAlert(try FfiConverterTypeSendFlowAlertState.read(from: &buf)
+        case 12: return .updateIsNewAddress(try FfiConverterBool.read(from: &buf)
         )
         
-        case 14: return .clearAlert
+        case 13: return .refreshPresenters
+        
+        case 14: return .setAlert(try FfiConverterTypeSendFlowAlertState.read(from: &buf)
+        )
+        
+        case 15: return .clearAlert
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -27250,17 +27255,22 @@ public struct FfiConverterTypeSendFlowManagerReconcileMessage: FfiConverterRustB
             FfiConverterTypeFeeRateOptionsWithTotalFee.write(v1, into: &buf)
             
         
-        case .refreshPresenters:
+        case let .updateIsNewAddress(v1):
             writeInt(&buf, Int32(12))
+            FfiConverterBool.write(v1, into: &buf)
+            
+        
+        case .refreshPresenters:
+            writeInt(&buf, Int32(13))
         
         
         case let .setAlert(v1):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(14))
             FfiConverterTypeSendFlowAlertState.write(v1, into: &buf)
             
         
         case .clearAlert:
-            writeInt(&buf, Int32(14))
+            writeInt(&buf, Int32(15))
         
         }
     }

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -106,6 +106,8 @@ pub enum SendFlowManagerReconcileMessage {
     UpdateSelectedFeeRate(Arc<FeeRateOptionWithTotalFee>),
     UpdateFeeRateOptions(Arc<FeeRateOptionsWithTotalFee>),
 
+    UpdateIsNewAddress(bool),
+
     RefreshPresenters,
 
     // side effects
@@ -891,7 +893,21 @@ impl RustSendFlowManager {
         // when we have a valid address, use that to get the fee rate options
         let me = self.clone();
         let is_max_selected = self.state.lock().max_selected.is_some();
+        let valid_address = address.clone();
         cove_tokio::task::spawn(async move {
+            if let Some(address) = valid_address {
+                let actor = me.wallet_actor();
+                let cloned_address = (*address).clone();
+
+                let has_sent =
+                    call!(actor.has_sent_to_address(cloned_address)).await.unwrap_or(true);
+
+                me.reconciler.send(Message::UpdateIsNewAddress(!has_sent));
+            } else {
+                // Clear the stale badge state if the input is invalid
+                me.reconciler.send(Message::UpdateIsNewAddress(false));
+            }
+
             me.get_or_update_fee_rate_options().await;
 
             if is_max_selected {
@@ -930,6 +946,7 @@ impl RustSendFlowManager {
         let mut sender = DeferredSender::new(self.reconciler.clone());
         self.state.lock().address = None;
         sender.queue(Message::UpdateAddress(None));
+        sender.queue(Message::UpdateIsNewAddress(false));
 
         self.state.lock().entering_address = String::new();
         sender.queue(Message::UpdateEnteringAddress(String::new()));

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -331,6 +331,23 @@ impl WalletActor {
         Produces::ok(SplitOutput { external, internal })
     }
 
+    // Check whether this wallet has ever sent to the given address.
+    pub async fn has_sent_to_address(&mut self, address: Address) -> ActorResult<bool> {
+        let script_pubkey = address.script_pubkey();
+
+        let has_sent = self.wallet.bdk.transactions().any(|tx| {
+            let (sent, _received) = self.wallet.bdk.sent_and_received(&tx.tx_node.tx);
+            if sent.to_sat() == 0 {
+                return false; // incoming-only tx, skip
+            }
+
+            // Check if any output of the transaction has a matching script_pubkey
+            tx.tx_node.tx.output.iter().any(|output| output.script_pubkey == script_pubkey)
+        });
+
+        Produces::ok(has_sent)
+    }
+
     #[into_actor_result]
     pub async fn fee_rate_options_with_total_fee(
         &mut self,


### PR DESCRIPTION
## Summary
- Show `New Address` badge when sending to an address you've never sent to before.
- Close: #227 

## Testing
|IOS|Android|
|-|-|
|<img height="755" alt="Screenshot 2026-04-26 at 16 02 41" src="https://github.com/user-attachments/assets/6cf79a3f-cc4c-424a-9e43-5aeae7c50cbf" />|<img height="755" alt="Screenshot 2026-04-26 at 17 51 30" src="https://github.com/user-attachments/assets/8e201c5c-3c35-4b9e-9afc-17e0108c7329" />|

### Platform Coverage

- [x] Tested on iOS device
- [ ] Tested on Android device
- [x] Tested on iOS simulator
- [x] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "New Address" badge shown in address entry and confirmation when the recipient address appears unused.
  * Badge state is determined automatically from wallet history and updates as you type or scan an address.
  * The badge is cleared when the address field is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->