### PR TITLE
fix(android): keep seed QR sheet screenshot-protected

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -48,6 +49,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.window.SecureFlagPolicy
 import android.view.WindowManager
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.Auth
@@ -281,6 +283,9 @@ fun SecretWordsScreen(
         ModalBottomSheet(
             onDismissRequest = { showSeedQrSheet = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            properties = ModalBottomSheetProperties(
+                securePolicy = SecureFlagPolicy.SecureOn,
+            ),
         ) {
             SeedQrSheetContent(seedQrString = words!!.toSeedQrString())
         }


### PR DESCRIPTION
## Summary

While checking the Android screenshot-protection follow-up from #684  I noticed the Seed QR is shown through a ModalBottomSheet.
On Android this sheet can be a separate window from the seed words screen, so I made the sheet explicitly request SecureFlagPolicy.SecureOn too. That keeps the QR path covered the same way the recovery-words screen is covered.



## Testing

## Testing

- `just build-android`
- Before: Seed QR sheet could be captured
- After: screenshot / Recents preview is blocked

### Platform Coverage

- [ ] Tested on iOS device
- [x] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [ ] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced screenshot protection for the seed phrase QR code display in the bottom sheet modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->