### PR TITLE
Update GitHub Actions Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain with rustfmt available
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -28,7 +28,7 @@ jobs:
   swiftformat:
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install SwiftFormat
         run: brew install swiftformat
       - name: SwiftFormat
@@ -37,9 +37,9 @@ jobs:
   ktlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -49,7 +49,7 @@ jobs:
   compile-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -57,10 +57,10 @@ jobs:
           toolchain: stable
 
       - name: Set up just
-        uses: extractions/setup-just@v1
+        uses: extractions/setup-just@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -92,7 +92,7 @@ jobs:
   compile-ios:
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -100,7 +100,7 @@ jobs:
           toolchain: stable
 
       - name: Set up just
-        uses: extractions/setup-just@v1
+        uses: extractions/setup-just@v4
 
       - name: Build Rust FFI bindings
         run: just build-ios
@@ -129,7 +129,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -142,7 +142,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/regenerate-bindings.yml
+++ b/.github/workflows/regenerate-bindings.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 1
@@ -24,10 +24,10 @@ jobs:
           toolchain: stable
 
       - name: Set up just
-        uses: extractions/setup-just@v1
+        uses: extractions/setup-just@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 1
@@ -80,7 +80,7 @@ jobs:
           toolchain: stable
 
       - name: Set up just
-        uses: extractions/setup-just@v1
+        uses: extractions/setup-just@v4
 
       - name: Build Rust FFI and generate Swift bindings
         run: just build-ios


### PR DESCRIPTION
## Summary
- Bump workflow actions to current major versions
- Update checkout, setup-java, and setup-just across CI and binding regeneration workflows
- Keep the Rust toolchain action on `v1`, which is still the latest major

## Testing
- `git diff --check`
- `just clippy`
- `just fmt` completed for Rust and Swift; Android formatting was blocked by a missing local Java runtime