### PR TITLE
Improve unsupported SLIP-132 xpub import error

### DIFF
--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -255,6 +255,10 @@ impl Wallet {
     /// Create a new watch-only wallet from the given xpub
     pub fn try_new_persisted_from_xpub(xpub: String) -> Result<Self, WalletError> {
         let xpub = xpub.trim();
+        if let Some(error) = xpub::XpubError::unsupported_slip132_prefix(xpub) {
+            return Err(WalletError::ParseXpubError(error));
+        }
+
         let hardware_export = pubport::Format::try_new_from_str(xpub)
             .map_err(Into::into)
             .map_err(WalletError::ParseXpubError);
@@ -739,6 +743,23 @@ mod tests {
 
         let _ = delete_wallet_specific_data(&metadata.id);
         assert_eq!("73c5da0a", fingerprint.as_str());
+    }
+
+    #[test]
+    fn importing_slip132_xpub_returns_actionable_error() {
+        let zpub = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs";
+
+        let message = match Wallet::try_new_persisted_from_xpub(zpub.to_string()).unwrap_err() {
+            WalletError::ParseXpubError(xpub::XpubError::InvalidXpub(message)) => message,
+            error => panic!("unexpected error: {error}"),
+        };
+
+        assert!(message.contains("zpub"));
+        assert!(message.contains("SLIP-132"));
+        assert!(message.contains("BIP32"));
+        assert!(message.contains("xpub"));
+        assert!(message.contains("public descriptors"));
+        assert!(!message.contains("magic bytes"));
     }
 }
 

--- a/rust/src/xpub.rs
+++ b/rust/src/xpub.rs
@@ -22,6 +22,21 @@ pub enum XpubError {
     InvalidXpub(String),
 }
 
+impl XpubError {
+    pub(crate) fn unsupported_slip132_prefix(input: &str) -> Option<Self> {
+        let prefix = input.get(..4)?;
+
+        match prefix {
+            "ypub" | "zpub" | "Ypub" | "Zpub" | "upub" | "vpub" | "Upub" | "Vpub" => {
+                Some(Self::InvalidXpub(format!(
+                    "{prefix} is a SLIP-132 extended public key. Cove currently accepts BIP32 xpub/tpub keys or public descriptors."
+                )))
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Error, thiserror::Error)]
 #[uniffi::export(Display)]
 pub enum DescriptorError {


### PR DESCRIPTION
## Summary
Fixes #723 

This improves the error returned when a bare SLIP-132 public key, like `zpub`, is pasted into the direct xpub import path.

Cove still accepts BIP32 `xpub`/`tpub` keys and public descriptors here. This does not add `zpub` import support or change accepted import formats; it only avoids leaking the low-level BIP32 “magic bytes” parser error and gives the user an actionable message instead.

## Changes
- Detect common SLIP-132 public key prefixes before direct xpub parsing
- Reuse the existing `XpubError::InvalidXpub` path to avoid UniFFI binding churn
- Add a regression test for direct `zpub` import


## Testing
- `cargo fmt --all`
- `just clippy`
- `just lint-rust`
- `just ctest importing_slip132_xpub_returns_actionable_error`
- `just test-gh`


### Platform Coverage

- [ ] Tested on iOS device
- [ ] Tested on Android device
- [ ] Tested on iOS simulator
- [ ] Tested on Android simulator
- [x] Not tested

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling when importing extended public keys with unsupported formats. The system now detects incompatible key types early and provides clearer, more actionable error messages guiding users toward compatible formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->