### PR TITLE
chore(deps): replace cbor4ii with minicbor-serde in redb Cbor wrapper

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -779,15 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbor4ii"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,7 +1036,6 @@ dependencies = [
  "bitcoin",
  "bitflags",
  "bitvec",
- "cbor4ii",
  "cfg-if",
  "chacha20poly1305",
  "cove-bdk",
@@ -1076,6 +1066,7 @@ dependencies = [
  "libc",
  "memchr",
  "minicbor 2.2.1",
+ "minicbor-serde",
  "nid",
  "num-bigint",
  "numfmt",
@@ -2645,6 +2636,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80047f75e28e3b38f6ab2ec3c2c7669f6b411fa6f8424e1a90a3fd784b19a3f4"
+dependencies = [
+ "minicbor 2.2.1",
+ "serde",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -215,7 +215,6 @@ jiff = { workspace = true, features = [] }
 # ser/de
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-cbor4ii = { version = "1.0", features = ["serde1"] }
 minicbor = { workspace = true }
 serde_urlencoded = { workspace = true }
 
@@ -275,6 +274,7 @@ csv = "1.3"
 
 # string fuzzy search
 strsim = "0.11"
+minicbor-serde = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/rust/src/database/cbor.rs
+++ b/rust/src/database/cbor.rs
@@ -30,15 +30,14 @@ where
     where
         Self: 'a,
     {
-        cbor4ii::serde::from_slice(data).unwrap()
+        minicbor_serde::from_slice(data).unwrap()
     }
 
     fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
     where
         Self: 'a + 'b,
     {
-        let buf = Vec::new();
-        cbor4ii::serde::to_vec(buf, value).unwrap()
+        minicbor_serde::to_vec(value).unwrap()
     }
 
     fn type_name() -> TypeName {


### PR DESCRIPTION



Closes #724

## Summary

Replaces the direct `cbor4ii` dependency with `minicbor-serde` in the redb `Cbor<T>` wrapper (`rust/src/database/cbor.rs`), consolidating all Cove-owned CBOR serialization under the `minicbor` family.

Byte compatibility was verified with 8 cross-encoding tests covering all four stored record types (TransactionRecord, AddressRecord, InputRecord, OutputRecord) including Option::None, Option::Some and variants. cbor4ii and minicbor-serde produce identical bytes for all cases, so existing redb tables remain readable without any migration.


<!-- describe what changed and why -->

## Testing

<!-- list the commands you ran or explain why testing was not needed -->

### Platform Coverage
- `cargo tree -i cbor4ii` — no output (removed from dependency graph)
- `cargo fmt --all` — clean
- `cargo clippy` — clean  
- `cargo test` — 502 passed, 0 failed

> Note: `just fmt` exits non-zero in my environment due to `swiftformat`
> not being installed. No Swift files were modified.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal serialization library dependency for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->