### PR TITLE
Make cloud backup enable idempotent

### DIFF
--- a/rust/src/manager/cloud_backup_manager.rs
+++ b/rust/src/manager/cloud_backup_manager.rs
@@ -327,9 +327,13 @@ pub(crate) enum BlockingCloudStep {
     DetailRefresh,
 }
 
+/// Tracks passkey material created during enable before the flow fully completes
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PendingEnableSessionKind {
+    /// A new passkey and master key are staged while the user confirms Create New Backup
     AwaitingForceNewConfirmation,
+
+    /// Upload already started and should retry with the same staged passkey material
     RetryUpload,
 }
 
@@ -427,6 +431,10 @@ impl PendingEnableSession {
 
     fn is_retry_upload(&self) -> bool {
         matches!(self.kind, PendingEnableSessionKind::RetryUpload)
+    }
+
+    fn is_awaiting_force_new_confirmation(&self) -> bool {
+        matches!(self.kind, PendingEnableSessionKind::AwaitingForceNewConfirmation)
     }
 }
 
@@ -1507,6 +1515,12 @@ impl RustCloudBackupManager {
         act_zero::call!(self.supervisor.take_retry_pending_enable_session())
             .await
             .expect("take retry pending enable session")
+    }
+
+    pub(crate) async fn has_awaiting_force_new_pending_enable_session(&self) -> bool {
+        act_zero::call!(self.supervisor.has_awaiting_force_new_pending_enable_session())
+            .await
+            .expect("check pending enable session")
     }
 
     pub(crate) async fn take_pending_enable_session(&self) -> Option<PendingEnableSession> {

--- a/rust/src/manager/cloud_backup_manager/ops.rs
+++ b/rust/src/manager/cloud_backup_manager/ops.rs
@@ -75,6 +75,16 @@ impl RustCloudBackupManager {
         self.set_status(status);
     }
 
+    async fn keep_awaiting_force_new_confirmation(&self) -> bool {
+        if !self.has_awaiting_force_new_pending_enable_session().await {
+            return false;
+        }
+
+        self.set_existing_backup_found_prompt();
+        self.clear_enable_progress(CloudBackupStatus::Disabled);
+        true
+    }
+
     fn rollback_new_local_master_key(
         &self,
         cspp: &cove_cspp::Cspp<Keychain>,
@@ -489,6 +499,10 @@ impl RustCloudBackupManager {
                 .await;
         }
 
+        if self.keep_awaiting_force_new_confirmation().await {
+            return Ok(());
+        }
+
         let passkey = PasskeyAccess::global();
         if !passkey.is_prf_supported() {
             return Err(CloudBackupError::NotSupported(
@@ -645,6 +659,9 @@ impl RustCloudBackupManager {
                 .enable_cloud_backup_with_passkey_material(Keychain::global(), master_key, passkey)
                 .await;
         }
+        if self.keep_awaiting_force_new_confirmation().await {
+            return Ok(());
+        }
 
         let passkey_access = PasskeyAccess::global();
         let keychain = Keychain::global();
@@ -716,6 +733,9 @@ impl RustCloudBackupManager {
             return self
                 .enable_cloud_backup_with_passkey_material(Keychain::global(), master_key, passkey)
                 .await;
+        }
+        if self.keep_awaiting_force_new_confirmation().await {
+            return Ok(());
         }
 
         let passkey_access = PasskeyAccess::global();
@@ -4323,7 +4343,16 @@ mod tests {
             ))
             .await;
 
+        let create_count = globals.passkey.create_count();
+
         manager.do_enable_cloud_backup_no_discovery().await.unwrap();
+
+        assert_eq!(globals.passkey.create_count(), create_count);
+        assert_eq!(manager.current_status(), CloudBackupStatus::Disabled);
+        assert!(matches!(
+            manager.state().prompt_intent,
+            CloudBackupPromptIntent::ExistingBackupFound
+        ));
 
         let pending = manager.take_pending_enable_session().await.unwrap();
         let (pending_master_key, pending_passkey) = pending.into_parts();

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -480,6 +480,10 @@ impl MockPasskeyProviderImpl {
         *self.authenticate_count.lock()
     }
 
+    pub(crate) fn create_count(&self) -> usize {
+        *self.create_count.lock()
+    }
+
     pub(crate) fn discover_count(&self) -> usize {
         *self.discover_count.lock()
     }

--- a/rust/src/manager/cloud_backup_manager/workers.rs
+++ b/rust/src/manager/cloud_backup_manager/workers.rs
@@ -343,6 +343,14 @@ impl CloudBackupSupervisor {
         Produces::ok(None)
     }
 
+    pub async fn has_awaiting_force_new_pending_enable_session(&self) -> ActorResult<bool> {
+        Produces::ok(
+            self.pending_enable_session
+                .as_ref()
+                .is_some_and(PendingEnableSession::is_awaiting_force_new_confirmation),
+        )
+    }
+
     pub async fn clear_pending_enable_session(&mut self) -> ActorResult<()> {
         self.pending_enable_session = None;
         Produces::ok(())


### PR DESCRIPTION
### Summary

- keep staged create-new-backup passkey material authoritative across repeated enable taps
- re-show the existing-backup prompt instead of creating another passkey
- add a regression assertion that no additional passkey creation occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cloud backup enable flow now properly detects and manages pending user confirmations, preventing unnecessary passkey creation attempts and displaying appropriate existing-backup prompts when applicable during the enable process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->