### PR TITLE
wire payjoin endpoint through to send flow state

### DIFF
--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -663,6 +663,7 @@ impl RustSendFlowManager {
                 let mut state = self.state.lock();
                 state.address = Some(address.clone());
                 state.entering_address = address.to_string();
+                state.payjoin_endpoint = None;
             }
 
             Action::NotifyAmountChanged(amount) => self.handle_amount_changed(*amount),
@@ -910,8 +911,16 @@ impl RustSendFlowManager {
             self.handle_amount_changed(amount);
         }
 
+        let payjoin_endpoint = parsed
+            .as_ref()
+            .and_then(|address_with_network| address_with_network.payjoin.as_ref())
+            .map(|payjoin| payjoin.endpoint.clone());
         let address = parsed.map(|address_with_network| Arc::new(address_with_network.address));
-        self.state.lock().address = address.clone();
+        {
+            let mut state = self.state.lock();
+            state.address = address.clone();
+            state.payjoin_endpoint = payjoin_endpoint;
+        }
         sender.queue(Message::UpdateAddress(address.clone()));
 
         // if both address and amount are valid, then clear the focus field, if amount is invalid, then focus on amount
@@ -963,7 +972,11 @@ impl RustSendFlowManager {
 
     fn clear_address(self: &Arc<Self>) {
         let mut sender = DeferredSender::new(self.reconciler.clone());
-        self.state.lock().address = None;
+        {
+            let mut state = self.state.lock();
+            state.address = None;
+            state.payjoin_endpoint = None;
+        }
         sender.queue(Message::UpdateAddress(None));
 
         self.state.lock().entering_address = String::new();
@@ -1546,9 +1559,15 @@ impl RustSendFlowManager {
         }
 
         // set address
+        let payjoin_endpoint =
+            address_with_network.payjoin.as_ref().map(|payjoin| payjoin.endpoint.clone());
         let address = Arc::new(address_with_network.address);
 
-        self.state.lock().address = Some(address.clone());
+        {
+            let mut state = self.state.lock();
+            state.address = Some(address.clone());
+            state.payjoin_endpoint = payjoin_endpoint;
+        }
         sender.queue(Message::UpdateAddress(Some(address.clone())));
 
         self.state.lock().entering_address = address.to_string();

--- a/rust/src/manager/send_flow_manager/state.rs
+++ b/rust/src/manager/send_flow_manager/state.rs
@@ -47,6 +47,8 @@ pub struct SendFlowManagerState {
     pub focus_field: Option<SetAmountFocusField>,
 
     pub fee_selection: Option<FeeSelection>,
+
+    pub payjoin_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Record)]
@@ -145,6 +147,7 @@ impl SendFlowManagerState {
             btc_price_in_fiat,
             selected_fiat_currency,
             has_base_fees: false,
+            payjoin_endpoint: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

PR #630 added parsing of `pj=` from BIP21 URIs into `AddressWithNetwork.payjoin`, but both the text input path and QR scan path in `send_flow_manager.rs` were discarding it and only storing the bare address in state. The PayJoin endpoint was being lost immediately after parsing.

This PR adds `payjoin_endpoint: Option<String>` to `SendFlowManagerState` and wires both paths to preserve it. When a user enters or scans a PayJoin-capable address, the endpoint is now retained in state for the rest of the send flow to consume.

## Testing

No platform testing needed for this change — this is purely state wiring with no behavior change.

* Addresses without `pj=` continue to work exactly as before
* `payjoin_endpoint` simply remains `None`
* Existing `cove-types` tests (21 passing) confirm the address parsing layer is unchanged

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting and storing Payjoin endpoints from Bitcoin addresses and URIs, making endpoint information available when entering addresses or scanning codes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitcoinppl/cove/pull/738)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->