### PR TITLE
Cache Rust CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install stable toolchain with rustfmt available
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
 
       - name: Run rustfmt
@@ -52,9 +51,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: rust -> target
 
       - name: Set up just
         uses: taiki-e/install-action@v2
@@ -97,9 +99,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: rust -> target
 
       - name: Set up just
         uses: taiki-e/install-action@v2
@@ -136,9 +141,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install stable toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: rust -> target
 
       - name: Run tests
         run: cd rust && cargo test --workspace
@@ -147,10 +155,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
-          override: true
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
 
       - run: cd rust && cargo clippy -- -D warnings

--- a/.github/workflows/regenerate-bindings.yml
+++ b/.github/workflows/regenerate-bindings.yml
@@ -19,9 +19,12 @@ jobs:
           fetch-depth: 1
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: rust -> target
 
       - name: Set up just
         uses: taiki-e/install-action@v2
@@ -77,9 +80,12 @@ jobs:
         run: git pull --rebase origin ${{ github.ref_name }}
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: rust -> target
 
       - name: Set up just
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- switch Rust setup to dtolnay/rust-toolchain@stable
- add Swatinem/rust-cache to Rust build, test, clippy, and binding regeneration jobs
- keep rustfmt and clippy as explicit toolchain components where needed

## Validation
- just fmt
- just clippy