### PR TITLE
Deny Rust CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
 
   compile-android:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v6
 
@@ -95,6 +97,8 @@ jobs:
 
   compile-ios:
     runs-on: macos-26
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v6
 
@@ -137,6 +141,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v6
 
@@ -153,6 +159,8 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/regenerate-bindings.yml
+++ b/.github/workflows/regenerate-bindings.yml
@@ -10,6 +10,8 @@ concurrency:
 jobs:
   regenerate-android-bindings:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     permissions:
       contents: write
     steps:
@@ -67,6 +69,8 @@ jobs:
 
   regenerate-ios-bindings:
     runs-on: macos-26
+    env:
+      RUSTFLAGS: -D warnings
     needs: regenerate-android-bindings
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- add explicit RUSTFLAGS=-D warnings to Rust compile, test, clippy, and binding regeneration jobs
- preserve the warning-as-error behavior that actions-rust-lang/setup-rust-toolchain previously provided implicitly

## Validation
- just fmt
- just clippy