### PR TITLE
Remove `mempool.space` replace with other electrum nodes

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
@@ -103,6 +103,7 @@ fun NodeSettingsScreen(
             selectedNodeName == customElectrum ||
             selectedNodeName == customEsplora
 
+    // pull a fresh snapshot because NodeSelector mutates persisted node settings directly
     fun refreshNodeState() {
         NodeSelector().use { refreshedNodeSelector ->
             nodeList = refreshedNodeSelector.nodeList()

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
@@ -71,7 +71,7 @@ fun NodeSettingsScreen(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val nodeList = remember { nodeSelector.nodeList() }
+    var nodeList by remember { mutableStateOf(nodeSelector.nodeList()) }
     var selectedNodeSelection by remember { mutableStateOf(nodeSelector.selectedNode()) }
     var selectedNodeName by remember {
         mutableStateOf(selectedNodeSelection.toNode().name)
@@ -102,6 +102,14 @@ fun NodeSettingsScreen(
         selectedNodeSelection is NodeSelection.Custom ||
             selectedNodeName == customElectrum ||
             selectedNodeName == customEsplora
+
+    fun refreshNodeState() {
+        NodeSelector().use { refreshedNodeSelector ->
+            nodeList = refreshedNodeSelector.nodeList()
+            selectedNodeSelection = refreshedNodeSelector.selectedNode()
+        }
+        selectedNodeName = selectedNodeSelection.toNode().name
+    }
 
     // pre-fill custom fields if a custom node was previously saved
     LaunchedEffect(showCustomFields, selectedNodeSelection) {
@@ -139,7 +147,7 @@ fun NodeSettingsScreen(
                 withContext(Dispatchers.IO) {
                     nodeSelector.checkSelectedNode(node)
                 }
-                selectedNodeSelection = NodeSelection.Preset(node)
+                refreshNodeState()
 
                 // launch snackbar in separate coroutine so it doesn't block finally
                 scope.launch {
@@ -188,8 +196,7 @@ fun NodeSettingsScreen(
                 withContext(Dispatchers.IO) {
                     nodeSelector.checkAndSaveNode(node)
                 }
-                selectedNodeSelection = NodeSelection.Custom(node)
-                selectedNodeName = node.name
+                refreshNodeState()
 
                 // launch snackbar in separate coroutine so it doesn't block finally
                 scope.launch {

--- a/ios/Cove/Flows/SettingsFlow/SettingsScreen/NodeSelectionView.swift
+++ b/ios/Cove/Flows/SettingsFlow/SettingsScreen/NodeSelectionView.swift
@@ -13,7 +13,7 @@ struct NodeSelectionView: View {
     private let nodeSelector = NodeSelector()
 
     @State private var selectedNodeName: String
-    private var nodeList: [NodeSelection]
+    @State private var nodeList: [NodeSelection]
 
     @State private var nodeIsChecking = false
     @State private var customNodeName: String = ""
@@ -37,6 +37,13 @@ struct NodeSelectionView: View {
         if let checkUrlTask {
             checkUrlTask.cancel()
         }
+    }
+
+    @MainActor
+    private func refreshNodeState() {
+        let refreshedNodeSelector = NodeSelector()
+        nodeList = refreshedNodeSelector.nodeList()
+        selectedNodeName = refreshedNodeSelector.selectedNode().name
     }
 
     private func showLoadingPopup() {
@@ -121,7 +128,9 @@ struct NodeSelectionView: View {
                 let result = await Result { try await nodeSelector.checkAndSaveNode(node: node) }
 
                 switch result {
-                case .success: completeLoading(.success("Connected to node successfully"))
+                case .success:
+                    refreshNodeState()
+                    completeLoading(.success("Connected to node successfully"))
                 case let .failure(error):
                     let errorMessage = "Failed to connect to node\n \(error.localizedDescription)"
                     let formattedMessage = errorMessage.replacingOccurrences(of: "\\n", with: "\n")
@@ -190,6 +199,8 @@ struct NodeSelectionView: View {
         }
         .scrollContentBackground(.hidden)
         .onChange(of: selectedNodeName) { _, newSelectedNodeName in
+            guard nodeSelector.selectedNode().name != newSelectedNodeName else { return }
+
             if selectedNodeName.hasPrefix("Custom") {
                 if case let .custom(savedSelectedNode) = nodeSelector.selectedNode() {
                     if savedSelectedNode.apiType == .electrum, selectedNodeName.contains("Electrum") {
@@ -212,15 +223,13 @@ struct NodeSelectionView: View {
             let task = Task {
                 do {
                     try await nodeSelector.checkSelectedNode(node: node)
+                    refreshNodeState()
                     completeLoading(.success("Succesfully connected to \(node.url)"))
                 } catch {
                     completeLoading(.failure("Failed to connect to \(node.url), reason: \(error.localizedDescription)"))
                 }
             }
             checkUrlTask = task
-        }
-        .onChange(of: nodeList) { _, _ in
-            selectedNodeName = nodeSelector.selectedNode().name
         }
         .onDisappear {
             // custom esplora or electrum is selected

--- a/rust/src/node_connect.rs
+++ b/rust/src/node_connect.rs
@@ -295,25 +295,18 @@ fn default_node_selection() -> NodeSelection {
     match network {
         Network::Bitcoin => {
             let (name, url) = BITCOIN_ELECTRUM[0];
-
             NodeSelection::Preset(Node::new_electrum(name.to_string(), url.to_string(), network))
         }
-
         Network::Testnet => {
             let (name, url) = TESTNET_ESPLORA[0];
-
             NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
         }
-
         Network::Signet => {
             let (name, url) = SIGNET_ESPLORA[0];
-
             NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
         }
-
         Network::Testnet4 => {
             let (name, url) = TESTNET4_ESPLORA[0];
-
             NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
         }
     }

--- a/rust/src/node_connect.rs
+++ b/rust/src/node_connect.rs
@@ -9,13 +9,13 @@ pub const BITCOIN_ESPLORA: [(&str, &str); 1] =
     [("blockstream.info", "https://blockstream.info/api/")];
 
 pub const BITCOIN_ELECTRUM: [(&str, &str); 7] = [
+    ("fulcrum.bullbitcoin.com", "ssl://fulcrum.bullbitcoin.com:50002"),
     ("electrum.blockstream.info", "ssl://electrum.blockstream.info:50002"),
     ("electrum.diynodes.com", "ssl://electrum.diynodes.com:50022"),
     ("electrum.emzy.de", "ssl://electrum.emzy.de:50002"),
     ("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002"),
     ("fulcrum.sethforprivacy.com", "ssl://fulcrum.sethforprivacy.com:50002"),
     ("electrum1.bluewallet.io", "ssl://electrum1.bluewallet.io:443"),
-    ("fulcrum.bullbitcoin.com", "ssl://fulcrum.bullbitcoin.com:50002"),
 ];
 
 pub const TESTNET_ESPLORA: [(&str, &str); 2] = [
@@ -292,12 +292,29 @@ impl NodeSelection {
 fn default_node_selection() -> NodeSelection {
     let network = Database::global().global_config.selected_network();
 
-    let (name, url) = match network {
-        Network::Bitcoin => BITCOIN_ESPLORA[0],
-        Network::Testnet => TESTNET_ESPLORA[0],
-        Network::Signet => SIGNET_ESPLORA[0],
-        Network::Testnet4 => TESTNET4_ESPLORA[0],
-    };
+    match network {
+        Network::Bitcoin => {
+            let (name, url) = BITCOIN_ELECTRUM[0];
 
-    NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
+            NodeSelection::Preset(Node::new_electrum(name.to_string(), url.to_string(), network))
+        }
+
+        Network::Testnet => {
+            let (name, url) = TESTNET_ESPLORA[0];
+
+            NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
+        }
+
+        Network::Signet => {
+            let (name, url) = SIGNET_ESPLORA[0];
+
+            NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
+        }
+
+        Network::Testnet4 => {
+            let (name, url) = TESTNET4_ESPLORA[0];
+
+            NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
+        }
+    }
 }

--- a/rust/src/node_connect.rs
+++ b/rust/src/node_connect.rs
@@ -10,10 +10,16 @@ pub const BITCOIN_ESPLORA: [(&str, &str); 2] = [
     ("mempool.space", "https://mempool.space/api/"),
 ];
 
-pub const BITCOIN_ELECTRUM: [(&str, &str); 3] = [
+pub const BITCOIN_ELECTRUM: [(&str, &str); 9] = [
     ("electrum.blockstream.info", "ssl://electrum.blockstream.info:50002"),
     ("mempool.space electrum", "ssl://mempool.space:50002"),
     ("electrum.diynodes.com", "ssl://electrum.diynodes.com:50022"),
+    ("electrum.emzy.de", "ssl://electrum.emzy.de:50002"),
+    ("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002"),
+    ("fulcrum.sethforprivacy.com", "ssl://fulcrum.sethforprivacy.com:50002"),
+    ("electrum1.bluewallet.io", "ssl://electrum1.bluewallet.io:443"),
+    ("mainnet.nunchuk.io", "tcp://mainnet.nunchuk.io:51001"),
+    ("fulcrum.bullbitcoin.com", "ssl://fulcrum.bullbitcoin.com:50002"),
 ];
 
 pub const TESTNET_ESPLORA: [(&str, &str); 2] = [
@@ -298,4 +304,49 @@ fn default_node_selection() -> NodeSelection {
     };
 
     NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::ApiType;
+
+    #[test]
+    fn bitcoin_node_list_keeps_mempool_presets() {
+        let nodes = node_list(Network::Bitcoin);
+
+        assert!(
+            nodes
+                .iter()
+                .any(|node| { node.name == "mempool.space" && node.api_type == ApiType::Esplora })
+        );
+        assert!(nodes.iter().any(|node| {
+            node.name == "mempool.space electrum" && node.api_type == ApiType::Electrum
+        }));
+    }
+
+    #[test]
+    fn bitcoin_node_list_includes_added_electrum_presets() {
+        let nodes = node_list(Network::Bitcoin);
+
+        let expected_nodes = [
+            ("electrum.emzy.de", "ssl://electrum.emzy.de:50002"),
+            ("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002"),
+            ("fulcrum.sethforprivacy.com", "ssl://fulcrum.sethforprivacy.com:50002"),
+            ("electrum1.bluewallet.io", "ssl://electrum1.bluewallet.io:443"),
+            ("mainnet.nunchuk.io", "tcp://mainnet.nunchuk.io:51001"),
+            ("fulcrum.bullbitcoin.com", "ssl://fulcrum.bullbitcoin.com:50002"),
+        ];
+
+        for (name, url) in expected_nodes {
+            let matches = nodes
+                .iter()
+                .filter(|node| {
+                    node.name == name && node.url == url && node.api_type == ApiType::Electrum
+                })
+                .count();
+
+            assert_eq!(matches, 1, "{name}");
+        }
+    }
 }

--- a/rust/src/node_connect.rs
+++ b/rust/src/node_connect.rs
@@ -8,14 +8,13 @@ use eyre::{Context, eyre};
 pub const BITCOIN_ESPLORA: [(&str, &str); 1] =
     [("blockstream.info", "https://blockstream.info/api/")];
 
-pub const BITCOIN_ELECTRUM: [(&str, &str); 8] = [
+pub const BITCOIN_ELECTRUM: [(&str, &str); 7] = [
     ("electrum.blockstream.info", "ssl://electrum.blockstream.info:50002"),
     ("electrum.diynodes.com", "ssl://electrum.diynodes.com:50022"),
     ("electrum.emzy.de", "ssl://electrum.emzy.de:50002"),
     ("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002"),
     ("fulcrum.sethforprivacy.com", "ssl://fulcrum.sethforprivacy.com:50002"),
     ("electrum1.bluewallet.io", "ssl://electrum1.bluewallet.io:443"),
-    ("mainnet.nunchuk.io", "tcp://mainnet.nunchuk.io:51001"),
     ("fulcrum.bullbitcoin.com", "ssl://fulcrum.bullbitcoin.com:50002"),
 ];
 

--- a/rust/src/node_connect.rs
+++ b/rust/src/node_connect.rs
@@ -5,14 +5,11 @@ use crate::{database::Database, network::Network, node::Node};
 use cove_macros::impl_default_for;
 use eyre::{Context, eyre};
 
-pub const BITCOIN_ESPLORA: [(&str, &str); 2] = [
-    ("blockstream.info", "https://blockstream.info/api/"),
-    ("mempool.space", "https://mempool.space/api/"),
-];
+pub const BITCOIN_ESPLORA: [(&str, &str); 1] =
+    [("blockstream.info", "https://blockstream.info/api/")];
 
-pub const BITCOIN_ELECTRUM: [(&str, &str); 9] = [
+pub const BITCOIN_ELECTRUM: [(&str, &str); 8] = [
     ("electrum.blockstream.info", "ssl://electrum.blockstream.info:50002"),
-    ("mempool.space electrum", "ssl://mempool.space:50002"),
     ("electrum.diynodes.com", "ssl://electrum.diynodes.com:50022"),
     ("electrum.emzy.de", "ssl://electrum.emzy.de:50002"),
     ("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002"),
@@ -304,49 +301,4 @@ fn default_node_selection() -> NodeSelection {
     };
 
     NodeSelection::Preset(Node::new_esplora(name.to_string(), url.to_string(), network))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::node::ApiType;
-
-    #[test]
-    fn bitcoin_node_list_keeps_mempool_presets() {
-        let nodes = node_list(Network::Bitcoin);
-
-        assert!(
-            nodes
-                .iter()
-                .any(|node| { node.name == "mempool.space" && node.api_type == ApiType::Esplora })
-        );
-        assert!(nodes.iter().any(|node| {
-            node.name == "mempool.space electrum" && node.api_type == ApiType::Electrum
-        }));
-    }
-
-    #[test]
-    fn bitcoin_node_list_includes_added_electrum_presets() {
-        let nodes = node_list(Network::Bitcoin);
-
-        let expected_nodes = [
-            ("electrum.emzy.de", "ssl://electrum.emzy.de:50002"),
-            ("electrum.bitaroo.net", "ssl://electrum.bitaroo.net:50002"),
-            ("fulcrum.sethforprivacy.com", "ssl://fulcrum.sethforprivacy.com:50002"),
-            ("electrum1.bluewallet.io", "ssl://electrum1.bluewallet.io:443"),
-            ("mainnet.nunchuk.io", "tcp://mainnet.nunchuk.io:51001"),
-            ("fulcrum.bullbitcoin.com", "ssl://fulcrum.bullbitcoin.com:50002"),
-        ];
-
-        for (name, url) in expected_nodes {
-            let matches = nodes
-                .iter()
-                .filter(|node| {
-                    node.name == name && node.url == url && node.api_type == ApiType::Electrum
-                })
-                .count();
-
-            assert_eq!(matches, 1, "{name}");
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Remove mainnet mempool.space Esplora and Electrum presets
- Keep existing saved retired selections working through the custom-node fallback
- Refresh iOS and Android node settings lists after successful node changes

## Testing
- just ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved node configuration updates on iOS and Android—settings now refresh immediately when changes are made
  * Updated Bitcoin node provider options and default selection preferences

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitcoinppl/cove/pull/769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->