### PR TITLE
Drop payjoin v1 feature and pjos parsing

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -9289,8 +9289,6 @@ public object FfiConverterTypeBlockSizeLast: FfiConverterRustBuffer<BlockSizeLas
 
 data class PayJoinParams (
     var `endpoint`: kotlin.String
-    ,
-    var `outputSubstitutionEnabled`: kotlin.Boolean
 
 ){
 
@@ -9308,18 +9306,15 @@ public object FfiConverterTypePayJoinParams: FfiConverterRustBuffer<PayJoinParam
     override fun read(buf: ByteBuffer): PayJoinParams {
         return PayJoinParams(
             FfiConverterString.read(buf),
-            FfiConverterBoolean.read(buf),
         )
     }
 
     override fun allocationSize(value: PayJoinParams) = (
-            FfiConverterString.allocationSize(value.`endpoint`) +
-            FfiConverterBoolean.allocationSize(value.`outputSubstitutionEnabled`)
+            FfiConverterString.allocationSize(value.`endpoint`)
     )
 
     override fun write(value: PayJoinParams, buf: ByteBuffer) {
             FfiConverterString.write(value.`endpoint`, buf)
-            FfiConverterBoolean.write(value.`outputSubstitutionEnabled`, buf)
     }
 }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -4522,13 +4522,11 @@ public func FfiConverterTypeBlockSizeLast_lower(_ value: BlockSizeLast) -> RustB
 
 public struct PayJoinParams: Equatable, Hashable {
     public var endpoint: String
-    public var outputSubstitutionEnabled: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(endpoint: String, outputSubstitutionEnabled: Bool) {
+    public init(endpoint: String) {
         self.endpoint = endpoint
-        self.outputSubstitutionEnabled = outputSubstitutionEnabled
     }
 
 
@@ -4547,14 +4545,12 @@ public struct FfiConverterTypePayJoinParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayJoinParams {
         return
             try PayJoinParams(
-                endpoint: FfiConverterString.read(from: &buf),
-                outputSubstitutionEnabled: FfiConverterBool.read(from: &buf)
+                endpoint: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: PayJoinParams, into buf: inout [UInt8]) {
         FfiConverterString.write(value.endpoint, into: &buf)
-        FfiConverterBool.write(value.outputSubstitutionEnabled, into: &buf)
     }
 }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -43,12 +43,48 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.7",
  "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher 0.3.0",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+dependencies = [
+ "aead 0.4.3",
+ "aes",
+ "cipher 0.3.0",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -554,6 +590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
+name = "bhttp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16fc24bc615b9fd63148f59b218ea58a444b55762f8845da910e23aca686398b"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +657,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-hpke"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37a54c486727c1d1ae9cc28dcf78b6e6ba20dcb88e8c892f1437d9ce215dc8c"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20poly1305 0.10.1",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
+ "rand_core 0.6.4",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +689,29 @@ name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin-ohttp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a803a4b54e44635206b53329c78c0029d0c70926288ac2f07f4bb1267546cb"
+dependencies = [
+ "aead 0.4.3",
+ "aes-gcm",
+ "bitcoin-hpke",
+ "byteorder",
+ "chacha20poly1305 0.8.0",
+ "hex",
+ "hkdf 0.11.0",
+ "lazy_static",
+ "log",
+ "rand 0.8.6",
+ "serde",
+ "serde_derive",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "toml 0.5.11",
+]
 
 [[package]]
 name = "bitcoin-units"
@@ -700,6 +787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -838,12 +934,24 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
+dependencies = [
+ "cfg-if",
+ "cipher 0.3.0",
+ "cpufeatures 0.1.5",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -860,14 +968,27 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
+dependencies = [
+ "aead 0.4.3",
+ "chacha20 0.7.1",
+ "cipher 0.3.0",
+ "poly1305 0.7.2",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
- "poly1305",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -896,6 +1017,15 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1076,7 +1206,7 @@ dependencies = [
  "bitflags",
  "bitvec",
  "cfg-if",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "cove-bdk",
  "cove-bdk-progressive-scan",
  "cove-bip39",
@@ -1100,7 +1230,7 @@ dependencies = [
  "foundation-ur",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "itertools 0.14.0",
  "jiff",
  "libc",
@@ -1125,7 +1255,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.11.0",
  "strsim",
  "strum",
  "tap",
@@ -1175,7 +1305,7 @@ dependencies = [
  "bip39",
  "num-bigint",
  "rand 0.10.1",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 
@@ -1202,14 +1332,14 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "cove-util",
  "hex",
- "hkdf",
+ "hkdf 0.13.0",
  "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "zeroize",
@@ -1260,7 +1390,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "uniffi 0.31.1",
@@ -1347,7 +1477,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "cove-macros",
  "hex",
  "memchr",
@@ -1357,6 +1487,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "uniffi 0.31.1",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1453,6 +1592,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1620,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+dependencies = [
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -1516,6 +1674,15 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "digest"
@@ -1954,6 +2121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,11 +2286,49 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3037,7 +3252,10 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "844f2404db4ae16c4062a53da2c73812c7a130abf612149c06650a36e34d0a35"
 dependencies = [
+ "bhttp",
  "bitcoin",
+ "bitcoin-hpke",
+ "bitcoin-ohttp",
  "bitcoin_uri",
  "http",
  "serde",
@@ -3144,13 +3362,36 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.4.0",
+]
+
+[[package]]
+name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.4.0",
 ]
 
 [[package]]
@@ -3998,6 +4239,30 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -4826,6 +5091,16 @@ dependencies = [
  "textwrap",
  "uniffi_meta 0.31.1",
  "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs?branch=main)",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,7 +57,7 @@ bitcoin = { version = "0.32.9" }
 bdk_wallet = { version = "3.0.0", features = ["keys-bip39", "file_store", "rusqlite"] }
 bip39 = { version = "2.2.2", features = ["zeroize"] }
 bip329 = { version = "0.4.0" }
-payjoin = { version = "0.25.0", default-features = false, features = ["v1"] }
+payjoin = { version = "0.25.0", default-features = false, features = ["v2"] }
 pubport = { version = "0.5.0" }
 
 # bitcoin nodes

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -58,7 +58,6 @@ pub struct AddressInfoWithDerivation {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Record)]
 pub struct PayJoinParams {
     pub endpoint: String,
-    pub output_substitution_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Object)]
@@ -235,17 +234,7 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         let payjoin = match checked.check_pj_supported() {
             Ok(pj_uri) => {
                 let endpoint = pj_uri.extras.endpoint();
-
-                // pjos=0 means output substitution is disabled; anything else (including
-                // absent) means enabled. Check the raw query string directly so we don't
-                // depend on the v1-only OutputSubstitution type.
-                let pjos_disabled = match normalized.split_once('?') {
-                    Some((_, query)) => query.split('&').any(|p| p == "pjos=0"),
-                    None => false,
-                };
-                let output_substitution_enabled = !pjos_disabled;
-
-                Some(PayJoinParams { endpoint, output_substitution_enabled })
+                Some(PayJoinParams { endpoint })
             }
             Err(_) => None,
         };
@@ -662,28 +651,6 @@ mod tests {
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
         let pj = parsed.payjoin.as_ref().unwrap();
         assert!(pj.endpoint.to_lowercase().contains("payjo.in"));
-        // pjos defaults to enabled when omitted
-        assert!(pj.output_substitution_enabled);
-    }
-
-    #[test]
-    fn test_parse_bitcoin_uri_with_pj_and_pjos_disabled() {
-        let a = format!(
-            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj={TEST_PJ_ENDPOINT}&pjos=0"
-        );
-        let parsed = parse_bitcoin_uri(&a).unwrap();
-        let pj = parsed.payjoin.as_ref().unwrap();
-        assert!(!pj.output_substitution_enabled);
-    }
-
-    #[test]
-    fn test_parse_bitcoin_uri_with_pjos_only() {
-        // pjos without pj is ignored per BIP 78 backward compatibility
-        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pjos=0";
-        let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
-        assert_eq!(parsed.amount, None);
-        assert_eq!(parsed.payjoin, None);
     }
 
     #[test]
@@ -691,36 +658,6 @@ mod tests {
         // malformed pj is ignored per BIP 78 backward compatibility;
         // address and amount are still extracted
         let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=not-a-url";
-        let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
-        assert_eq!(parsed.amount, None);
-        assert_eq!(parsed.payjoin, None);
-    }
-
-    #[test]
-    fn test_parse_bitcoin_uri_pjos_enabled() {
-        // pjos=1 means output substitution is enabled
-        let a = format!(
-            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj={TEST_PJ_ENDPOINT}&pjos=1"
-        );
-        let parsed = parse_bitcoin_uri(&a).unwrap();
-        assert!(parsed.payjoin.as_ref().unwrap().output_substitution_enabled);
-    }
-
-    #[test]
-    fn test_parse_bitcoin_uri_pjos_invalid_value() {
-        // invalid pjos value causes payjoin params to be ignored per BIP 78
-        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=garbage";
-        let parsed = parse_bitcoin_uri(a).unwrap();
-        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
-        assert_eq!(parsed.amount, None);
-        assert_eq!(parsed.payjoin, None);
-    }
-
-    #[test]
-    fn test_parse_bitcoin_uri_pjos_without_pj_is_ignored() {
-        // pjos without pj is ignored per BIP 78 backward compatibility
-        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pjos=1";
         let parsed = parse_bitcoin_uri(a).unwrap();
         assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, None);
@@ -737,12 +674,12 @@ mod tests {
     #[test]
     fn test_address_with_network_carries_pj() {
         let a = format!(
-            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj={TEST_PJ_ENDPOINT}&pjos=0"
+            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj={TEST_PJ_ENDPOINT}"
         );
         let address_with_network = AddressWithNetwork::try_new(&a).unwrap();
 
         let pj = address_with_network.payjoin.as_ref().unwrap();
-        assert!(!pj.output_substitution_enabled);
+        assert!(pj.endpoint.to_lowercase().contains("payjo.in"));
         assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -242,9 +242,9 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         return Ok(ParsedBitcoinUri { address, amount, payjoin });
     }
 
-    // Fallback: strip payjoin params (pj, pjos) and re-parse as regular bitcoin URI.
-    // Per BIP 78 backward compatibility, non-payjoin senders should ignore pj/pjos
-    // and proceed with a normal payment.
+    // Fallback: strip pj and pjos, re-parse as a regular bitcoin URI.
+    // Both params are stripped because pjos without pj= causes the v2 crate to reject the URI
+    // entirely; stripping both lets the address/amount still be extracted for a normal payment.
     let stripped = strip_payjoin_params(&normalized);
     let uri = payjoin::Uri::try_from(stripped.as_str()).map_err(|_| Error::InvalidAddress)?;
     let amount = uri.amount.map(|a| Amount::from_sat(a.to_sat()));
@@ -254,7 +254,11 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
     Ok(ParsedBitcoinUri { address, amount, payjoin: None })
 }
 
-/// Strips `pj` and `pjos` query parameters from a `bitcoin:` URI string.
+/// Strips `pj` and `pjos` from a `bitcoin:` URI string.
+///
+/// `pjos` is BIP78-specific but the v2-only payjoin crate rejects any URI containing it
+/// without a corresponding `pj=` endpoint. Both are stripped together so a legacy BIP78
+/// payment request still yields a usable address/amount as a regular payment.
 fn strip_payjoin_params(uri: &str) -> String {
     let (base, query) = match uri.split_once('?') {
         Some((b, q)) => (b, q),
@@ -668,6 +672,17 @@ mod tests {
     fn test_parse_bitcoin_uri_no_pj() {
         let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001";
         let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.payjoin, None);
+    }
+
+    #[test]
+    fn test_parse_bitcoin_uri_pjos_without_pj() {
+        // pjos without a pj= causes the v2 crate to reject the URI;
+        // both are stripped so address and amount are still extracted
+        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pjos=0";
+        let parsed = parse_bitcoin_uri(a).unwrap();
+        assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
+        assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
         assert_eq!(parsed.payjoin, None);
     }
 

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -235,10 +235,16 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         let payjoin = match checked.check_pj_supported() {
             Ok(pj_uri) => {
                 let endpoint = pj_uri.extras.endpoint();
-                let output_substitution_enabled = match pj_uri.extras.output_substitution() {
-                    payjoin::OutputSubstitution::Enabled => true,
-                    payjoin::OutputSubstitution::Disabled => false,
+
+                // pjos=0 means output substitution is disabled; anything else (including
+                // absent) means enabled. Check the raw query string directly so we don't
+                // depend on the v1-only OutputSubstitution type.
+                let pjos_disabled = match normalized.split_once('?') {
+                    Some((_, query)) => query.split('&').any(|p| p == "pjos=0"),
+                    None => false,
                 };
+                let output_substitution_enabled = !pjos_disabled;
+
                 Some(PayJoinParams { endpoint, output_substitution_enabled })
             }
             Err(_) => None,
@@ -503,6 +509,9 @@ impl Address {
 mod tests {
     use super::*;
 
+    // valid BIP77 v2 pj= endpoint, from the payjoin crate's own session test vectors
+    const TEST_PJ_ENDPOINT: &str = "HTTPS://PAYJO.IN/TXJCGKTKXLUUZ%23EX1C4UC6ES-OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV";
+
     #[test]
     fn test_parse_bitcoin_uri_no_amount() {
         let a = "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm";
@@ -645,22 +654,25 @@ mod tests {
 
     #[test]
     fn test_parse_bitcoin_uri_with_pj() {
-        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin";
-        let parsed = parse_bitcoin_uri(a).unwrap();
+        let a = format!(
+            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj={TEST_PJ_ENDPOINT}"
+        );
+        let parsed = parse_bitcoin_uri(&a).unwrap();
         assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
         let pj = parsed.payjoin.as_ref().unwrap();
-        assert_eq!(pj.endpoint, "https://example.com/payjoin");
+        assert!(pj.endpoint.to_lowercase().contains("payjo.in"));
         // pjos defaults to enabled when omitted
         assert!(pj.output_substitution_enabled);
     }
 
     #[test]
     fn test_parse_bitcoin_uri_with_pj_and_pjos_disabled() {
-        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin&pjos=0";
-        let parsed = parse_bitcoin_uri(a).unwrap();
+        let a = format!(
+            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj={TEST_PJ_ENDPOINT}&pjos=0"
+        );
+        let parsed = parse_bitcoin_uri(&a).unwrap();
         let pj = parsed.payjoin.as_ref().unwrap();
-        assert_eq!(pj.endpoint, "https://example.com/payjoin");
         assert!(!pj.output_substitution_enabled);
     }
 
@@ -688,8 +700,10 @@ mod tests {
     #[test]
     fn test_parse_bitcoin_uri_pjos_enabled() {
         // pjos=1 means output substitution is enabled
-        let a = "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj=https://example.com/payjoin&pjos=1";
-        let parsed = parse_bitcoin_uri(a).unwrap();
+        let a = format!(
+            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?pj={TEST_PJ_ENDPOINT}&pjos=1"
+        );
+        let parsed = parse_bitcoin_uri(&a).unwrap();
         assert!(parsed.payjoin.as_ref().unwrap().output_substitution_enabled);
     }
 
@@ -722,13 +736,12 @@ mod tests {
 
     #[test]
     fn test_address_with_network_carries_pj() {
-        let address_with_network = AddressWithNetwork::try_new(
-            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj=https://example.com/payjoin&pjos=0",
-        )
-        .unwrap();
+        let a = format!(
+            "bitcoin:bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm?amount=0.001&pj={TEST_PJ_ENDPOINT}&pjos=0"
+        );
+        let address_with_network = AddressWithNetwork::try_new(&a).unwrap();
 
         let pj = address_with_network.payjoin.as_ref().unwrap();
-        assert_eq!(pj.endpoint, "https://example.com/payjoin");
         assert!(!pj.output_substitution_enabled);
         assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
     }


### PR DESCRIPTION
## Summary

Removes the PayJoin `v1` feature from the workspace. The only remaining usage was `payjoin::OutputSubstitution` in `cove-types`.

Since `pjos` is a BIP78 concept and is not used by PayJoin v2, this PR removes the field and all associated `pjos` parsing from `PayJoinParams`.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PayJoin protocol dependency to support the latest version features.

* **Refactor**
  * Simplified PayJoin parameter handling for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->