### PR TITLE
Fix android drive account persistence

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         applicationId = "org.bitcoinppl.cove"
         minSdk = 33
         targetSdk = 36
-        versionCode = 21
+        versionCode = 24
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoveApplication.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoveApplication.kt
@@ -16,6 +16,7 @@ import org.bitcoinppl.cove_core.device.CloudStorage
 import org.bitcoinppl.cove_core.device.Connectivity
 import org.bitcoinppl.cove_core.device.Keychain
 import org.bitcoinppl.cove_core.device.PasskeyAccess
+import org.bitcoinppl.cove_core.initializeApp
 import org.bitcoinppl.cove_core.setRootDataDir
 import java.time.Instant
 
@@ -72,6 +73,9 @@ class CoveApplication : Application() {
     /// Called from MainActivity after bootstrap completes on the main thread
     fun onBootstrapComplete() {
         if (bootstrapCompleted) return
+
+        // initialize app/updater before lifecycle callbacks can write auth state
+        initializeApp()
         bootstrapCompleted = true
 
         connectivityMonitor?.start()

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -197,6 +197,9 @@ private fun ApiException.cloudStorageMessage(prefix: String): String {
     return if (details == null) "$prefix: $status" else "$prefix: $status: $details"
 }
 
+private fun driveIdentityLookupFailedMessage(error: Throwable): String =
+    "google drive identity verification failed: ${error.message ?: "unknown error"}"
+
 private fun logDriveWarning(message: String, error: Throwable) {
     runCatching { Log.w("AndroidCloudStorage", message, error) }
 }
@@ -215,13 +218,13 @@ internal fun driveAccountIdentityFromAboutResponse(response: JSONObject): DriveA
     response
         .optJSONObject("user")
         ?.let { user ->
-            val id = user.optString("permissionId").takeIf(String::isNotBlank)
+            val drivePermissionId = user.optString("permissionId").takeIf(String::isNotBlank)
             val email = user.optString("emailAddress").takeIf(String::isNotBlank)
 
-            if (id == null && email == null) {
+            if (drivePermissionId == null && email == null) {
                 null
             } else {
-                DriveAccountIdentity(id = id, email = email)
+                DriveAccountIdentity(drivePermissionId = drivePermissionId, email = email)
             }
         }
 
@@ -265,6 +268,8 @@ internal fun mapDriveUploadError(error: Throwable, target: String): CloudStorage
     when (error) {
         is DriveAccountBindingException ->
             CloudStorageException.AuthorizationRequired(error.cloudStorageMessage())
+        is DriveAccountIdentityLookupException ->
+            mapDriveIdentityLookupError(error)
         is ForegroundAuthorizationTimeoutException ->
             CloudStorageException.AuthorizationRequired(error.cloudStorageMessage())
         is AuthorizationRequiredException ->
@@ -308,6 +313,8 @@ internal fun mapDriveListError(error: Throwable): CloudStorageException =
     when (error) {
         is DriveAccountBindingException ->
             CloudStorageException.AuthorizationRequired(error.cloudStorageMessage())
+        is DriveAccountIdentityLookupException ->
+            mapDriveIdentityLookupError(error)
         is ForegroundAuthorizationTimeoutException ->
             CloudStorageException.AuthorizationRequired(error.cloudStorageMessage())
         is AuthorizationRequiredException ->
@@ -342,13 +349,54 @@ internal class DriveHttpException(
     val body: String,
 ) : IOException("drive request failed with status=$statusCode")
 
+internal class DriveAccountIdentityLookupException(
+    cause: Throwable,
+) : IOException(driveIdentityLookupFailedMessage(cause), cause)
+
+private fun mapDriveIdentityLookupError(error: DriveAccountIdentityLookupException): CloudStorageException {
+    val cause = error.cause ?: return CloudStorageException.NotAvailable(
+        error.message ?: "google drive identity verification failed",
+    )
+
+    return when (cause) {
+        is DriveHttpException ->
+            when (cause.statusCode) {
+                HttpURLConnection.HTTP_UNAUTHORIZED ->
+                    CloudStorageException.AuthorizationRequired(
+                        "google drive identity verification requires authorization",
+                    )
+                HTTP_TOO_MANY_REQUESTS -> CloudStorageException.QuotaExceeded()
+                HttpURLConnection.HTTP_FORBIDDEN -> cause.identityLookupForbiddenError()
+                else -> CloudStorageException.NotAvailable(cause.identityLookupMessage())
+            }
+        is UnknownHostException, is SocketTimeoutException, is IOException ->
+            CloudStorageException.Offline(cause.message ?: "offline")
+        else -> CloudStorageException.NotAvailable(driveIdentityLookupFailedMessage(cause))
+    }
+}
+
+private fun DriveHttpException.identityLookupForbiddenError(): CloudStorageException =
+    when {
+        isQuotaExceeded() -> CloudStorageException.QuotaExceeded()
+        isGoogleDriveApiDisabled() ->
+            CloudStorageException.NotAvailable(
+                "google drive API is not enabled for this Google Cloud project",
+            )
+        isAuthorizationRejected() ->
+            CloudStorageException.AuthorizationRequired("google drive identity verification was rejected")
+        else -> CloudStorageException.NotAvailable(identityLookupMessage())
+    }
+
+private fun DriveHttpException.identityLookupMessage(): String =
+    "google drive identity verification failed: ${driveMessage("drive identity lookup failed")}"
+
 internal data class DriveApiEndpoints(
     val aboutEndpoint: String = DRIVE_ABOUT_ENDPOINT,
     val filesEndpoint: String = DRIVE_FILES_ENDPOINT,
     val uploadEndpoint: String = DRIVE_UPLOAD_ENDPOINT,
 )
 
-private fun driveApiUrl(
+internal fun driveApiUrl(
     endpoint: String,
     queryParameters: List<Pair<String, String>>,
 ): String {
@@ -1158,27 +1206,34 @@ class AndroidCloudStorageAccess internal constructor(
     }
 
     private suspend fun driveAccountIdentity(token: String): DriveAccountIdentity? {
-        return driveAccountIdentityFromAboutResponse(
-            driveRequest(
-                token = token,
-                method = "GET",
-                url = driveApiUrl(
-                    driveApiEndpoints.aboutEndpoint,
-                    listOf("fields" to "user(emailAddress,permissionId)"),
-                ),
-            ).asJsonObject(),
-        )
+        try {
+            return driveAccountIdentityFromAboutResponse(
+                driveRequest(
+                    token = token,
+                    method = "GET",
+                    url = driveApiUrl(
+                        driveApiEndpoints.aboutEndpoint,
+                        listOf("fields" to "user(emailAddress,permissionId)"),
+                    ),
+                ).asJsonObject(),
+            )
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+
+            throw DriveAccountIdentityLookupException(error)
+        }
     }
 
     private suspend fun clearFailedIdentityLookupToken(token: String, error: Throwable): Boolean {
+        val lookupError = (error as? DriveAccountIdentityLookupException)?.cause ?: error
         val logMessage =
             when {
-                error is DriveHttpException &&
-                    error.statusCode == HttpURLConnection.HTTP_UNAUTHORIZED ->
+                lookupError is DriveHttpException &&
+                    lookupError.statusCode == HttpURLConnection.HTTP_UNAUTHORIZED ->
                     "failed to clear expired drive token"
-                error is DriveHttpException &&
-                    error.statusCode == HttpURLConnection.HTTP_FORBIDDEN &&
-                    error.isAuthorizationRejected() ->
+                lookupError is DriveHttpException &&
+                    lookupError.statusCode == HttpURLConnection.HTTP_FORBIDDEN &&
+                    lookupError.isAuthorizationRejected() ->
                     "failed to clear rejected drive token"
                 else -> return false
             }
@@ -1271,7 +1326,7 @@ class AndroidCloudStorageAccess internal constructor(
 
             if (statusCode !in 200..299) {
                 val responseText = responseBody.toString(Charsets.UTF_8)
-                logDriveWarning("google drive request failed method=$method status=$statusCode")
+                logDriveWarning("google drive request failed method=$method status=$statusCode url=$url")
                 throw DriveHttpException(statusCode, responseText)
             }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -1300,37 +1300,43 @@ class AndroidCloudStorageAccess internal constructor(
     ): DriveResponse =
         withContext(Dispatchers.IO) {
             val connection = (URL(url).openConnection() as HttpURLConnection)
-            connection.requestMethod = method
-            connection.connectTimeout = NETWORK_TIMEOUT_MS
-            connection.readTimeout = NETWORK_TIMEOUT_MS
-            connection.setRequestProperty("Authorization", "Bearer $token")
-            connection.setRequestProperty("Accept", "application/json")
+            try {
+                connection.requestMethod = method
+                connection.connectTimeout = NETWORK_TIMEOUT_MS
+                connection.readTimeout = NETWORK_TIMEOUT_MS
+                connection.setRequestProperty("Authorization", "Bearer $token")
+                connection.setRequestProperty("Accept", "application/json")
 
-            if (body != null) {
-                connection.doOutput = true
-                connection.setRequestProperty("Content-Type", contentType)
-                connection.outputStream.use { output ->
-                    output.write(body)
-                }
-            }
-
-            val statusCode = connection.responseCode
-            val stream =
-                if (statusCode in 200..299) {
-                    connection.inputStream
-                } else {
-                    connection.errorStream ?: connection.inputStream
+                if (body != null) {
+                    connection.doOutput = true
+                    connection.setRequestProperty("Content-Type", contentType)
+                    connection.outputStream.use { output ->
+                        output.write(body)
+                    }
                 }
 
-            val responseBody = stream?.use { input -> input.readBytes() } ?: ByteArray(0)
+                val statusCode = connection.responseCode
+                val stream =
+                    if (statusCode in 200..299) {
+                        connection.inputStream
+                    } else {
+                        connection.errorStream ?: connection.inputStream
+                    }
 
-            if (statusCode !in 200..299) {
-                val responseText = responseBody.toString(Charsets.UTF_8)
-                logDriveWarning("google drive request failed method=$method status=$statusCode url=$url")
-                throw DriveHttpException(statusCode, responseText)
+                val responseBody = stream?.use { input -> input.readBytes() } ?: ByteArray(0)
+
+                if (statusCode !in 200..299) {
+                    val responseText = responseBody.toString(Charsets.UTF_8)
+                    logDriveWarning(
+                        "google drive request failed method=$method status=$statusCode url=$url",
+                    )
+                    throw DriveHttpException(statusCode, responseText)
+                }
+
+                DriveResponse(statusCode, responseBody)
+            } finally {
+                connection.disconnect()
             }
-
-            DriveResponse(statusCode, responseBody)
         }
 
     private fun DriveResponse.asJsonObject(): JSONObject =

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -1,15 +1,16 @@
 package org.bitcoinppl.cove.cloudbackup
 
 import android.content.Context
-import android.net.Uri
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
+import java.net.URLEncoder
 import java.net.URL
 import java.net.UnknownHostException
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -200,6 +201,14 @@ private fun logDriveWarning(message: String, error: Throwable) {
     runCatching { Log.w("AndroidCloudStorage", message, error) }
 }
 
+private fun logDriveWarning(message: String) {
+    runCatching { Log.w("AndroidCloudStorage", message) }
+}
+
+private fun logDriveDebug(message: String) {
+    runCatching { Log.d("AndroidCloudStorage", message) }
+}
+
 internal fun monotonicTimeMs(): Long = System.nanoTime() / 1_000_000L
 
 internal fun driveAccountIdentityFromAboutResponse(response: JSONObject): DriveAccountIdentity? =
@@ -332,10 +341,36 @@ internal data class DriveApiEndpoints(
     val uploadEndpoint: String = DRIVE_UPLOAD_ENDPOINT,
 )
 
+private fun driveApiUrl(
+    endpoint: String,
+    queryParameters: List<Pair<String, String>>,
+): String {
+    if (queryParameters.isEmpty()) {
+        return endpoint
+    }
+
+    val fragmentIndex = endpoint.indexOf('#')
+    val endpointWithoutFragment = if (fragmentIndex == -1) endpoint else endpoint.substring(0, fragmentIndex)
+    val fragment = if (fragmentIndex == -1) "" else endpoint.substring(fragmentIndex)
+    val separator = if (endpointWithoutFragment.contains("?")) "&" else "?"
+    val query =
+        queryParameters.joinToString("&") { (name, value) ->
+            "${driveQueryParameter(name)}=${driveQueryParameter(value)}"
+        }
+
+    return "$endpointWithoutFragment$separator$query$fragment"
+}
+
+private fun driveQueryParameter(value: String): String =
+    URLEncoder
+        .encode(value, StandardCharsets.UTF_8)
+        .replace("+", "%20")
+
 class AndroidCloudStorageAccess internal constructor(
     private val driveAuthorization: DriveAuthorization,
     private val accountBindingStore: DriveAccountBindingStore,
     private val driveApiEndpoints: DriveApiEndpoints = DriveApiEndpoints(),
+    drivePathNamesProvider: () -> DrivePathNames = { DrivePaths.defaultNames },
 ) : CloudStorageAccess {
     constructor(context: Context) : this(
         SharedPreferencesDriveAccountBindingStore(context.applicationContext),
@@ -354,6 +389,7 @@ class AndroidCloudStorageAccess internal constructor(
     private val namespacesRootFolderMutex = Mutex()
     private val namespaceFolderMutexes = ConcurrentHashMap<String, Mutex>()
     private val childFolderMutexes = ConcurrentHashMap<String, Mutex>()
+    private val drivePathNames: DrivePathNames by lazy(drivePathNamesProvider)
 
     private fun CloudAccessPolicy.allowsConsent(): Boolean =
         this == CloudAccessPolicy.CONSENT_ALLOWED
@@ -486,7 +522,7 @@ class AndroidCloudStorageAccess internal constructor(
                     )
                 } catch (error: Throwable) {
                     if (error is CancellationException) throw error
-                    Log.w("AndroidCloudStorage", "failed to delete drive backup file", error)
+                    logDriveWarning("failed to delete drive backup file", error)
                     failures.add(DriveDeleteFailure(fileId = file.id, error = error))
                 }
             }
@@ -568,7 +604,7 @@ class AndroidCloudStorageAccess internal constructor(
         findChildByName(
             token = token,
             parentId = APP_DATA_FOLDER,
-            fileName = DrivePaths.namespacesRootFolderName,
+            fileName = drivePathNames.namespacesRootFolderName,
             foldersOnly = true,
         )?.id
 
@@ -580,7 +616,7 @@ class AndroidCloudStorageAccess internal constructor(
                         createFolder(
                             token = token,
                             parentId = APP_DATA_FOLDER,
-                            folderName = DrivePaths.namespacesRootFolderName,
+                            folderName = drivePathNames.namespacesRootFolderName,
                         )
                     findNamespacesRootFolderId(token) ?: createdId
                 }
@@ -806,7 +842,7 @@ class AndroidCloudStorageAccess internal constructor(
             listBackupLocations(
                 token = token,
                 namespaceFolderId = namespaceFolderId,
-            ).filter(DrivePaths::isWalletFile)
+            ).filter(drivePathNames::isWalletFile)
         }
 
     private suspend fun listBackupLocations(
@@ -826,24 +862,24 @@ class AndroidCloudStorageAccess internal constructor(
                 .toMutableList()
 
         immediateChildren
-            .singleFolderChild(DrivePaths.masterKeyFolderName)
+            .singleFolderChild(drivePathNames.masterKeyFolderName)
             ?.let { masterKeyFolder ->
                 listChildren(
                     token = token,
                     parentId = masterKeyFolder.id,
                     foldersOnly = false,
-                ).backupFileLocations { "${DrivePaths.masterKeyFolderName}/$it" }
+                ).backupFileLocations { "${drivePathNames.masterKeyFolderName}/$it" }
                     .let(locations::addAll)
             }
 
         immediateChildren
-            .singleFolderChild(DrivePaths.walletsFolderName)
+            .singleFolderChild(drivePathNames.walletsFolderName)
             ?.let { walletsFolder ->
                 listChildren(
                     token = token,
                     parentId = walletsFolder.id,
                     foldersOnly = false,
-                ).backupFileLocations(DrivePaths::walletLocationForFileName)
+                ).backupFileLocations(drivePathNames::walletLocationForFileName)
                     .let(locations::addAll)
             }
 
@@ -940,22 +976,20 @@ class AndroidCloudStorageAccess internal constructor(
         var pageToken: String? = null
 
         do {
-            val builder =
-                Uri
-                    .parse(driveApiEndpoints.filesEndpoint)
-                    .buildUpon()
-                    .appendQueryParameter("spaces", APP_DATA_SPACE)
-                    .appendQueryParameter("fields", "nextPageToken,files(id,name,mimeType)")
-                    .appendQueryParameter("pageSize", "1000")
-                    .appendQueryParameter("q", query)
-
-            pageToken?.let { builder.appendQueryParameter("pageToken", it) }
+            val parameters =
+                buildList {
+                    add("spaces" to APP_DATA_SPACE)
+                    add("fields" to "nextPageToken,files(id,name,mimeType)")
+                    add("pageSize" to "1000")
+                    add("q" to query)
+                    pageToken?.let { add("pageToken" to it) }
+                }
 
             val response =
                 driveRequest(
                     token = token,
                     method = "GET",
-                    url = builder.build().toString(),
+                    url = driveApiUrl(driveApiEndpoints.filesEndpoint, parameters),
                 ).asJsonObject()
 
             val files = response.optJSONArray("files") ?: JSONArray()
@@ -1025,7 +1059,7 @@ class AndroidCloudStorageAccess internal constructor(
                 runCatching {
                     driveAuthorization.clearToken(firstAccess.token)
                 }.onFailure { tokenError ->
-                    Log.w("AndroidCloudStorage", "failed to clear expired drive token", tokenError)
+                    logDriveWarning("failed to clear expired drive token", tokenError)
                 }
 
                 val retryAccess =
@@ -1077,6 +1111,9 @@ class AndroidCloudStorageAccess internal constructor(
 
                 throw error
             }
+        if (access != unresolvedAccess) {
+            driveAuthorization.updateCachedToken(access)
+        }
 
         try {
             verifyDriveAccountBinding(accountBindingStore, access.account, bindIfMissing = false)
@@ -1084,7 +1121,7 @@ class AndroidCloudStorageAccess internal constructor(
             runCatching {
                 driveAuthorization.clearToken(access.token)
             }.onFailure { tokenError ->
-                Log.w("AndroidCloudStorage", "failed to clear mismatched drive token", tokenError)
+                logDriveWarning("failed to clear mismatched drive token", tokenError)
             }
 
             throw error
@@ -1101,19 +1138,14 @@ class AndroidCloudStorageAccess internal constructor(
         }
 
     private suspend fun driveAccountIdentity(token: String): DriveAccountIdentity? {
-        val url =
-            Uri
-                .parse(driveApiEndpoints.aboutEndpoint)
-                .buildUpon()
-                .appendQueryParameter("fields", "user(emailAddress)")
-                .build()
-                .toString()
-
         return driveAccountIdentityFromAboutResponse(
             driveRequest(
                 token = token,
                 method = "GET",
-                url = url,
+                url = driveApiUrl(
+                    driveApiEndpoints.aboutEndpoint,
+                    listOf("fields" to "user(emailAddress)"),
+                ),
             ).asJsonObject(),
         )
     }
@@ -1134,7 +1166,7 @@ class AndroidCloudStorageAccess internal constructor(
         runCatching {
             driveAuthorization.clearToken(token)
         }.onFailure { tokenError ->
-            Log.w("AndroidCloudStorage", logMessage, tokenError)
+            logDriveWarning(logMessage, tokenError)
         }
 
         return true
@@ -1152,10 +1184,7 @@ class AndroidCloudStorageAccess internal constructor(
         }
 
         val retryLabel = if (retry) " retry" else ""
-        Log.d(
-            "AndroidCloudStorage",
-            "drive operation$retryLabel elapsed_ms=${monotonicTimeMs() - started}",
-        )
+        logDriveDebug("drive operation$retryLabel elapsed_ms=${monotonicTimeMs() - started}")
         return result
     }
 
@@ -1166,7 +1195,7 @@ class AndroidCloudStorageAccess internal constructor(
             runCatching {
                 driveAuthorization.clearToken(access.token)
             }.onFailure { tokenError ->
-                Log.w("AndroidCloudStorage", "failed to clear mismatched drive token", tokenError)
+                logDriveWarning("failed to clear mismatched drive token", tokenError)
             }
 
             throw error
@@ -1182,7 +1211,7 @@ class AndroidCloudStorageAccess internal constructor(
             runCatching {
                 driveAuthorization.clearToken(token)
             }.onFailure { tokenError ->
-                Log.w("AndroidCloudStorage", "failed to clear rejected drive token", tokenError)
+                logDriveWarning("failed to clear rejected drive token", tokenError)
             }
         }
     }
@@ -1222,7 +1251,7 @@ class AndroidCloudStorageAccess internal constructor(
 
             if (statusCode !in 200..299) {
                 val responseText = responseBody.toString(Charsets.UTF_8)
-                Log.w("AndroidCloudStorage", "google drive request failed method=$method status=$statusCode")
+                logDriveWarning("google drive request failed method=$method status=$statusCode")
                 throw DriveHttpException(statusCode, responseText)
             }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -1191,7 +1191,8 @@ class AndroidCloudStorageAccess internal constructor(
     }
 
     private suspend fun DriveAccessToken.withResolvedAccountIdentity(): DriveAccessToken {
-        if (account?.isComplete == true) {
+        val selectedAccount = accountBindingStore.selectedIdentity()
+        if (account?.isComplete == true && !account.missingSelectedDrivePermissionId(selectedAccount)) {
             return this
         }
 
@@ -1204,6 +1205,11 @@ class AndroidCloudStorageAccess internal constructor(
             copy(account = mergedAccount)
         }
     }
+
+    private fun DriveAccountIdentity.missingSelectedDrivePermissionId(
+        selectedAccount: DriveAccountIdentity?,
+    ): Boolean =
+        drivePermissionId == null && selectedAccount?.drivePermissionId != null
 
     private suspend fun driveAccountIdentity(token: String): DriveAccountIdentity? {
         try {

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -326,9 +326,16 @@ internal class DriveHttpException(
     val body: String,
 ) : IOException("drive request failed with status=$statusCode")
 
+internal data class DriveApiEndpoints(
+    val aboutEndpoint: String = DRIVE_ABOUT_ENDPOINT,
+    val filesEndpoint: String = DRIVE_FILES_ENDPOINT,
+    val uploadEndpoint: String = DRIVE_UPLOAD_ENDPOINT,
+)
+
 class AndroidCloudStorageAccess internal constructor(
     private val driveAuthorization: DriveAuthorization,
     private val accountBindingStore: DriveAccountBindingStore,
+    private val driveApiEndpoints: DriveApiEndpoints = DriveApiEndpoints(),
 ) : CloudStorageAccess {
     constructor(context: Context) : this(
         SharedPreferencesDriveAccountBindingStore(context.applicationContext),
@@ -475,7 +482,7 @@ class AndroidCloudStorageAccess internal constructor(
                     driveRequest(
                         token = token,
                         method = "DELETE",
-                        url = "${DriveApi.FILES_ENDPOINT}/${file.id}",
+                        url = "${driveApiEndpoints.filesEndpoint}/${file.id}",
                     )
                 } catch (error: Throwable) {
                     if (error is CancellationException) throw error
@@ -507,7 +514,7 @@ class AndroidCloudStorageAccess internal constructor(
                 driveRequest(
                     token = token,
                     method = "DELETE",
-                    url = "${DriveApi.FILES_ENDPOINT}/$namespaceFolderId",
+                    url = "${driveApiEndpoints.filesEndpoint}/$namespaceFolderId",
                 )
             }
         }
@@ -740,7 +747,7 @@ class AndroidCloudStorageAccess internal constructor(
             driveRequest(
                 token = token,
                 method = "POST",
-                url = DriveApi.FILES_ENDPOINT,
+                url = driveApiEndpoints.filesEndpoint,
                 body = metadata.toString().toByteArray(),
                 contentType = "application/json; charset=utf-8",
             ).asJsonObject()
@@ -772,9 +779,9 @@ class AndroidCloudStorageAccess internal constructor(
         val body = buildMultipartBody(boundary, metadata, data)
         val url =
             if (existing == null) {
-                "${DriveApi.UPLOAD_ENDPOINT}?uploadType=multipart"
+                "${driveApiEndpoints.uploadEndpoint}?uploadType=multipart"
             } else {
-                "${DriveApi.UPLOAD_ENDPOINT}/${existing.id}?uploadType=multipart"
+                "${driveApiEndpoints.uploadEndpoint}/${existing.id}?uploadType=multipart"
             }
 
         driveRequest(
@@ -909,7 +916,7 @@ class AndroidCloudStorageAccess internal constructor(
         driveRequest(
             token = token,
             method = "GET",
-            url = "${DriveApi.FILES_ENDPOINT}/$fileId?alt=media",
+            url = "${driveApiEndpoints.filesEndpoint}/$fileId?alt=media",
         ).body
 
     private suspend fun listChildren(
@@ -935,7 +942,7 @@ class AndroidCloudStorageAccess internal constructor(
         do {
             val builder =
                 Uri
-                    .parse(DriveApi.FILES_ENDPOINT)
+                    .parse(driveApiEndpoints.filesEndpoint)
                     .buildUpon()
                     .appendQueryParameter("spaces", APP_DATA_SPACE)
                     .appendQueryParameter("fields", "nextPageToken,files(id,name,mimeType)")
@@ -1050,8 +1057,27 @@ class AndroidCloudStorageAccess internal constructor(
         }
     }
 
-    private suspend fun verifiedDriveAccessToken(interactive: Boolean): DriveAccessToken {
-        val access = driveAuthorization.accessToken(interactive).withResolvedAccountIdentity()
+    private suspend fun verifiedDriveAccessToken(interactive: Boolean): DriveAccessToken =
+        verifiedDriveAccessToken(interactive, retryIdentityLookup = true)
+
+    private suspend fun verifiedDriveAccessToken(
+        interactive: Boolean,
+        retryIdentityLookup: Boolean,
+    ): DriveAccessToken {
+        val unresolvedAccess = driveAuthorization.accessToken(interactive)
+        val access =
+            try {
+                unresolvedAccess.withResolvedAccountIdentity()
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                val tokenWasCleared = clearFailedIdentityLookupToken(unresolvedAccess.token, error)
+                if (tokenWasCleared && retryIdentityLookup) {
+                    return verifiedDriveAccessToken(interactive, retryIdentityLookup = false)
+                }
+
+                throw error
+            }
+
         try {
             verifyDriveAccountBinding(accountBindingStore, access.account, bindIfMissing = false)
         } catch (error: DriveAccountBindingException) {
@@ -1077,7 +1103,7 @@ class AndroidCloudStorageAccess internal constructor(
     private suspend fun driveAccountIdentity(token: String): DriveAccountIdentity? {
         val url =
             Uri
-                .parse(DriveApi.ABOUT_ENDPOINT)
+                .parse(driveApiEndpoints.aboutEndpoint)
                 .buildUpon()
                 .appendQueryParameter("fields", "user(emailAddress)")
                 .build()
@@ -1090,6 +1116,28 @@ class AndroidCloudStorageAccess internal constructor(
                 url = url,
             ).asJsonObject(),
         )
+    }
+
+    private suspend fun clearFailedIdentityLookupToken(token: String, error: Throwable): Boolean {
+        val logMessage =
+            when {
+                error is DriveHttpException &&
+                    error.statusCode == HttpURLConnection.HTTP_UNAUTHORIZED ->
+                    "failed to clear expired drive token"
+                error is DriveHttpException &&
+                    error.statusCode == HttpURLConnection.HTTP_FORBIDDEN &&
+                    error.isAuthorizationRejected() ->
+                    "failed to clear rejected drive token"
+                else -> return false
+            }
+
+        runCatching {
+            driveAuthorization.clearToken(token)
+        }.onFailure { tokenError ->
+            Log.w("AndroidCloudStorage", logMessage, tokenError)
+        }
+
+        return true
     }
 
     private suspend fun <T> finishDriveOperation(
@@ -1253,9 +1301,6 @@ class AndroidCloudStorageAccess internal constructor(
         }
 
     private object DriveApi {
-        const val ABOUT_ENDPOINT = "https://www.googleapis.com/drive/v3/about"
-        const val FILES_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
-        const val UPLOAD_ENDPOINT = "https://www.googleapis.com/upload/drive/v3/files"
         const val FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
     }
 
@@ -1266,4 +1311,7 @@ class AndroidCloudStorageAccess internal constructor(
     }
 }
 
+private const val DRIVE_ABOUT_ENDPOINT = "https://www.googleapis.com/drive/v3/about"
+private const val DRIVE_FILES_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
+private const val DRIVE_UPLOAD_ENDPOINT = "https://www.googleapis.com/upload/drive/v3/files"
 private const val HTTP_TOO_MANY_REQUESTS = 429

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -202,6 +202,13 @@ private fun logDriveWarning(message: String, error: Throwable) {
 
 internal fun monotonicTimeMs(): Long = System.nanoTime() / 1_000_000L
 
+internal fun driveAccountIdentityFromAboutResponse(response: JSONObject): DriveAccountIdentity? =
+    response
+        .optJSONObject("user")
+        ?.optString("emailAddress")
+        ?.takeIf(String::isNotBlank)
+        ?.let { email -> DriveAccountIdentity(id = null, email = email) }
+
 internal fun duplicateDriveFolderNames(folderNames: List<String>): Set<String> =
     folderNames
         .groupingBy { it }
@@ -1044,7 +1051,7 @@ class AndroidCloudStorageAccess internal constructor(
     }
 
     private suspend fun verifiedDriveAccessToken(interactive: Boolean): DriveAccessToken {
-        val access = driveAuthorization.accessToken(interactive)
+        val access = driveAuthorization.accessToken(interactive).withResolvedAccountIdentity()
         try {
             verifyDriveAccountBinding(accountBindingStore, access.account, bindIfMissing = false)
         } catch (error: DriveAccountBindingException) {
@@ -1058,6 +1065,31 @@ class AndroidCloudStorageAccess internal constructor(
         }
 
         return access
+    }
+
+    private suspend fun DriveAccessToken.withResolvedAccountIdentity(): DriveAccessToken =
+        if (account == null) {
+            copy(account = driveAccountIdentity(token))
+        } else {
+            this
+        }
+
+    private suspend fun driveAccountIdentity(token: String): DriveAccountIdentity? {
+        val url =
+            Uri
+                .parse(DriveApi.ABOUT_ENDPOINT)
+                .buildUpon()
+                .appendQueryParameter("fields", "user(emailAddress)")
+                .build()
+                .toString()
+
+        return driveAccountIdentityFromAboutResponse(
+            driveRequest(
+                token = token,
+                method = "GET",
+                url = url,
+            ).asJsonObject(),
+        )
     }
 
     private suspend fun <T> finishDriveOperation(
@@ -1221,6 +1253,7 @@ class AndroidCloudStorageAccess internal constructor(
         }
 
     private object DriveApi {
+        const val ABOUT_ENDPOINT = "https://www.googleapis.com/drive/v3/about"
         const val FILES_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
         const val UPLOAD_ENDPOINT = "https://www.googleapis.com/upload/drive/v3/files"
         const val FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -214,9 +214,16 @@ internal fun monotonicTimeMs(): Long = System.nanoTime() / 1_000_000L
 internal fun driveAccountIdentityFromAboutResponse(response: JSONObject): DriveAccountIdentity? =
     response
         .optJSONObject("user")
-        ?.optString("emailAddress")
-        ?.takeIf(String::isNotBlank)
-        ?.let { email -> DriveAccountIdentity(id = null, email = email) }
+        ?.let { user ->
+            val id = user.optString("permissionId").takeIf(String::isNotBlank)
+            val email = user.optString("emailAddress").takeIf(String::isNotBlank)
+
+            if (id == null && email == null) {
+                null
+            } else {
+                DriveAccountIdentity(id = id, email = email)
+            }
+        }
 
 internal fun duplicateDriveFolderNames(folderNames: List<String>): Set<String> =
     folderNames
@@ -366,6 +373,11 @@ private fun driveQueryParameter(value: String): String =
         .encode(value, StandardCharsets.UTF_8)
         .replace("+", "%20")
 
+private object UnboundDriveAccountTokenCacheKey
+
+internal fun driveAccountTokenCacheKey(store: DriveAccountBindingStore): Any =
+    store.selectedIdentity() ?: UnboundDriveAccountTokenCacheKey
+
 class AndroidCloudStorageAccess internal constructor(
     private val driveAuthorization: DriveAuthorization,
     private val accountBindingStore: DriveAccountBindingStore,
@@ -381,7 +393,7 @@ class AndroidCloudStorageAccess internal constructor(
             DriveAuthorizationHelper(accountBindingStore.appContext) {
                 accountBindingStore.selectedIdentity()
             },
-            cacheKey = { accountBindingStore.selectedIdentity() },
+            cacheKey = { driveAccountTokenCacheKey(accountBindingStore) },
         ),
         accountBindingStore,
     )
@@ -1131,7 +1143,7 @@ class AndroidCloudStorageAccess internal constructor(
     }
 
     private suspend fun DriveAccessToken.withResolvedAccountIdentity(): DriveAccessToken {
-        if (account?.normalizedEmail != null) {
+        if (account?.isComplete == true) {
             return this
         }
 
@@ -1152,7 +1164,7 @@ class AndroidCloudStorageAccess internal constructor(
                 method = "GET",
                 url = driveApiUrl(
                     driveApiEndpoints.aboutEndpoint,
-                    listOf("fields" to "user(emailAddress)"),
+                    listOf("fields" to "user(emailAddress,permissionId)"),
                 ),
             ).asJsonObject(),
         )

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccess.kt
@@ -1130,12 +1130,20 @@ class AndroidCloudStorageAccess internal constructor(
         return access
     }
 
-    private suspend fun DriveAccessToken.withResolvedAccountIdentity(): DriveAccessToken =
-        if (account == null) {
-            copy(account = driveAccountIdentity(token))
-        } else {
-            this
+    private suspend fun DriveAccessToken.withResolvedAccountIdentity(): DriveAccessToken {
+        if (account?.normalizedEmail != null) {
+            return this
         }
+
+        val resolvedAccount = driveAccountIdentity(token)
+        val mergedAccount = account?.withMissingFieldsFrom(resolvedAccount) ?: resolvedAccount
+
+        return if (mergedAccount == account) {
+            this
+        } else {
+            copy(account = mergedAccount)
+        }
+    }
 
     private suspend fun driveAccountIdentity(token: String): DriveAccountIdentity? {
         return driveAccountIdentityFromAboutResponse(

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
@@ -63,8 +63,14 @@ internal data class DriveAccountIdentity(
 
 internal data class DriveAccessToken(
     val token: String,
-    val account: DriveAccountIdentity,
+    val account: DriveAccountIdentity?,
 )
+
+internal fun resolveDriveAccountIdentity(
+    authorizationIdentity: DriveAccountIdentity?,
+    constrainedIdentity: DriveAccountIdentity?,
+): DriveAccountIdentity? =
+    authorizationIdentity ?: constrainedIdentity?.takeIf { it.androidAccount() != null }
 
 internal sealed class DriveAccountBindingException(
     message: String,
@@ -141,6 +147,15 @@ internal fun verifyDriveAccountBinding(
 
     if (!selected.matches(actual)) {
         throw DriveAccountBindingException.Mismatch()
+    }
+
+    val enriched =
+        DriveAccountIdentity(
+            id = selected.id ?: actual.id,
+            email = selected.normalizedEmail ?: actual.normalizedEmail,
+        )
+    if (bindIfMissing && enriched != selected) {
+        store.bindIdentity(enriched)
     }
 }
 
@@ -229,7 +244,8 @@ internal class DriveAuthorizationHelper(
                 .builder()
                 .setRequestedScopes(requestedScopes)
 
-        selectedAccount()?.androidAccount()?.let(requestBuilder::setAccount)
+        val selectedIdentity = selectedAccount()
+        selectedIdentity?.androidAccount()?.let(requestBuilder::setAccount)
 
         val authorizationResult = client
             .authorize(requestBuilder.build())
@@ -238,8 +254,10 @@ internal class DriveAuthorizationHelper(
         val resolved = resolveIfNeeded(authorizationResult, interactive)
         val token = resolved.accessToken?.takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("drive authorization succeeded but returned a blank access token")
-        val identity = DriveAccountIdentity.fromAuthorizationResult(resolved)
-            ?: throw AuthorizationRequiredException("google drive account identity is unavailable")
+        val identity = resolveDriveAccountIdentity(
+            authorizationIdentity = DriveAccountIdentity.fromAuthorizationResult(resolved),
+            constrainedIdentity = selectedIdentity,
+        )
 
         return DriveAccessToken(token = token, account = identity)
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
@@ -21,55 +21,68 @@ internal class AuthorizationRequiredException(
 ) : Exception(message, cause)
 
 internal class DriveAccountIdentity(
-    id: String?,
-    email: String?,
+    googleAccountId: String? = null,
+    drivePermissionId: String? = null,
+    email: String? = null,
 ) {
-    val id: String? = id?.trim()?.takeIf(String::isNotEmpty)
+    val googleAccountId: String? = googleAccountId?.trim()?.takeIf(String::isNotEmpty)
+    val drivePermissionId: String? = drivePermissionId?.trim()?.takeIf(String::isNotEmpty)
     val email: String? = email?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
 
     init {
-        require(this.id != null || this.email != null) {
-            "drive account identity requires id or email"
+        require(this.googleAccountId != null || this.drivePermissionId != null || this.email != null) {
+            "drive account identity requires google account id, drive permission id, or email"
         }
     }
 
-    val normalizedEmail: String?
-        get() = email
-
     val isComplete: Boolean
-        get() = id != null && normalizedEmail != null
+        get() = (googleAccountId != null || drivePermissionId != null) && email != null
 
+    /**
+     * Fills missing fields without replacing values from the original authorization result
+     */
     fun withMissingFieldsFrom(other: DriveAccountIdentity?): DriveAccountIdentity =
         if (other == null) {
             this
         } else {
             DriveAccountIdentity(
-                id = id?.takeIf(String::isNotBlank) ?: other.id,
-                email = normalizedEmail ?: other.normalizedEmail,
+                googleAccountId = googleAccountId ?: other.googleAccountId,
+                drivePermissionId = drivePermissionId ?: other.drivePermissionId,
+                email = email ?: other.email,
             )
         }
 
     fun matches(other: DriveAccountIdentity): Boolean {
-        if (id != null && other.id != null) {
-            return id == other.id
+        if (googleAccountId != null && other.googleAccountId != null) {
+            return googleAccountId == other.googleAccountId
         }
 
-        return normalizedEmail != null && normalizedEmail == other.normalizedEmail
+        if (drivePermissionId != null && other.drivePermissionId != null) {
+            return drivePermissionId == other.drivePermissionId
+        }
+
+        return email != null && email == other.email
     }
 
     fun androidAccount(): Account? =
-        normalizedEmail?.let { Account(it, GOOGLE_ACCOUNT_TYPE) }
+        email?.let { Account(it, GOOGLE_ACCOUNT_TYPE) }
 
+    /**
+     * Merges a matching identity, preferring refreshed email data from the verified identity
+     */
     fun verifiedMerge(other: DriveAccountIdentity): DriveAccountIdentity {
+        val googleAccountIdMatched = googleAccountId != null && googleAccountId == other.googleAccountId
+        val drivePermissionIdMatched = drivePermissionId != null && drivePermissionId == other.drivePermissionId
         val mergedEmail =
-            if (id != null && id == other.id) {
-                other.normalizedEmail ?: normalizedEmail
+            if (googleAccountIdMatched || drivePermissionIdMatched) {
+                other.email ?: email
             } else {
-                normalizedEmail ?: other.normalizedEmail
+                email ?: other.email
             }
 
         return DriveAccountIdentity(
-            id = id ?: other.id,
+            googleAccountId = googleAccountId ?: other.googleAccountId,
+            drivePermissionId = drivePermissionId ?: other.drivePermissionId,
             email = mergedEmail,
         )
     }
@@ -83,17 +96,20 @@ internal class DriveAccountIdentity(
             return false
         }
 
-        return id == other.id && normalizedEmail == other.normalizedEmail
+        return googleAccountId == other.googleAccountId &&
+            drivePermissionId == other.drivePermissionId &&
+            email == other.email
     }
 
     override fun hashCode(): Int {
-        var result = id?.hashCode() ?: 0
-        result = 31 * result + (normalizedEmail?.hashCode() ?: 0)
+        var result = googleAccountId?.hashCode() ?: 0
+        result = 31 * result + (drivePermissionId?.hashCode() ?: 0)
+        result = 31 * result + (email?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String =
-        "DriveAccountIdentity(id=$id, email=$email)"
+        "DriveAccountIdentity(googleAccountId=$googleAccountId, drivePermissionId=$drivePermissionId, email=$email)"
 
     companion object {
         private const val GOOGLE_ACCOUNT_TYPE = "com.google"
@@ -106,7 +122,7 @@ internal class DriveAccountIdentity(
             return if (id == null && email == null) {
                 null
             } else {
-                DriveAccountIdentity(id = id, email = email)
+                DriveAccountIdentity(googleAccountId = id, email = email)
             }
         }
     }
@@ -143,21 +159,27 @@ internal class SharedPreferencesDriveAccountBindingStore(
         appContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
 
     override fun selectedIdentity(): DriveAccountIdentity? {
-        val id = preferences.getString(KEY_ID, null)?.takeIf(String::isNotBlank)
+        val googleAccountId = preferences.getString(KEY_ID, null)?.takeIf(String::isNotBlank)
+        val drivePermissionId = preferences.getString(KEY_PERMISSION_ID, null)?.takeIf(String::isNotBlank)
         val email = preferences.getString(KEY_EMAIL, null)?.takeIf(String::isNotBlank)
 
-        return if (id == null && email == null) {
+        return if (googleAccountId == null && drivePermissionId == null && email == null) {
             null
         } else {
-            DriveAccountIdentity(id = id, email = email)
+            DriveAccountIdentity(
+                googleAccountId = googleAccountId,
+                drivePermissionId = drivePermissionId,
+                email = email,
+            )
         }
     }
 
     override fun bindIdentity(identity: DriveAccountIdentity) {
         preferences
             .edit()
-            .putString(KEY_ID, identity.id)
-            .putString(KEY_EMAIL, identity.normalizedEmail)
+            .putString(KEY_ID, identity.googleAccountId)
+            .putString(KEY_PERMISSION_ID, identity.drivePermissionId)
+            .putString(KEY_EMAIL, identity.email)
             .apply()
     }
 
@@ -165,6 +187,7 @@ internal class SharedPreferencesDriveAccountBindingStore(
         preferences
             .edit()
             .remove(KEY_ID)
+            .remove(KEY_PERMISSION_ID)
             .remove(KEY_EMAIL)
             .apply()
     }
@@ -172,6 +195,7 @@ internal class SharedPreferencesDriveAccountBindingStore(
     companion object {
         private const val PREFERENCES_NAME = "cove_cloud_backup_drive_account"
         private const val KEY_ID = "google_account_id"
+        private const val KEY_PERMISSION_ID = "google_drive_permission_id"
         private const val KEY_EMAIL = "google_account_email"
     }
 }
@@ -209,6 +233,9 @@ internal interface DriveAuthorization {
 
     suspend fun updateCachedToken(accessToken: DriveAccessToken) = Unit
 
+    /**
+     * Invalidates local token state before starting failable remote clear work
+     */
     suspend fun clearToken(token: String)
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
@@ -166,6 +166,8 @@ internal fun clearCloudBackupDriveAccountBinding(context: Context) {
 internal interface DriveAuthorization {
     suspend fun accessToken(interactive: Boolean): DriveAccessToken
 
+    suspend fun updateCachedToken(accessToken: DriveAccessToken) = Unit
+
     suspend fun clearToken(token: String)
 }
 
@@ -216,6 +218,24 @@ internal class CachingDriveAuthorization(
             }
 
             delegate.clearToken(token)
+        }
+    }
+
+    override suspend fun updateCachedToken(accessToken: DriveAccessToken) {
+        tokenMutex.withLock {
+            val cached = cachedAccessToken ?: return@withLock
+            val currentCacheKey = cacheKey()
+            if (
+                currentCacheKey == null ||
+                    cached.cacheKey != currentCacheKey ||
+                    cached.expiresAtMs <= elapsedRealtime() ||
+                    cached.token.token != accessToken.token
+            ) {
+                cachedAccessToken = null
+                return@withLock
+            }
+
+            cachedAccessToken = cached.copy(token = accessToken)
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
@@ -33,6 +33,16 @@ internal data class DriveAccountIdentity(
     val normalizedEmail: String?
         get() = email?.trim()?.lowercase()?.takeIf(String::isNotBlank)
 
+    fun withMissingFieldsFrom(other: DriveAccountIdentity?): DriveAccountIdentity =
+        if (other == null) {
+            this
+        } else {
+            DriveAccountIdentity(
+                id = id?.takeIf(String::isNotBlank) ?: other.id,
+                email = normalizedEmail ?: other.normalizedEmail,
+            )
+        }
+
     fun matches(other: DriveAccountIdentity): Boolean {
         if (!id.isNullOrBlank() && !other.id.isNullOrBlank()) {
             return id == other.id

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DriveAuthorizationHelper.kt
@@ -20,18 +20,24 @@ internal class AuthorizationRequiredException(
     cause: Throwable? = null,
 ) : Exception(message, cause)
 
-internal data class DriveAccountIdentity(
-    val id: String?,
-    val email: String?,
+internal class DriveAccountIdentity(
+    id: String?,
+    email: String?,
 ) {
+    val id: String? = id?.trim()?.takeIf(String::isNotEmpty)
+    val email: String? = email?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
+
     init {
-        require(!id.isNullOrBlank() || !email.isNullOrBlank()) {
+        require(this.id != null || this.email != null) {
             "drive account identity requires id or email"
         }
     }
 
     val normalizedEmail: String?
-        get() = email?.trim()?.lowercase()?.takeIf(String::isNotBlank)
+        get() = email
+
+    val isComplete: Boolean
+        get() = id != null && normalizedEmail != null
 
     fun withMissingFieldsFrom(other: DriveAccountIdentity?): DriveAccountIdentity =
         if (other == null) {
@@ -44,7 +50,7 @@ internal data class DriveAccountIdentity(
         }
 
     fun matches(other: DriveAccountIdentity): Boolean {
-        if (!id.isNullOrBlank() && !other.id.isNullOrBlank()) {
+        if (id != null && other.id != null) {
             return id == other.id
         }
 
@@ -53,6 +59,41 @@ internal data class DriveAccountIdentity(
 
     fun androidAccount(): Account? =
         normalizedEmail?.let { Account(it, GOOGLE_ACCOUNT_TYPE) }
+
+    fun verifiedMerge(other: DriveAccountIdentity): DriveAccountIdentity {
+        val mergedEmail =
+            if (id != null && id == other.id) {
+                other.normalizedEmail ?: normalizedEmail
+            } else {
+                normalizedEmail ?: other.normalizedEmail
+            }
+
+        return DriveAccountIdentity(
+            id = id ?: other.id,
+            email = mergedEmail,
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (other !is DriveAccountIdentity) {
+            return false
+        }
+
+        return id == other.id && normalizedEmail == other.normalizedEmail
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + (normalizedEmail?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "DriveAccountIdentity(id=$id, email=$email)"
 
     companion object {
         private const val GOOGLE_ACCOUNT_TYPE = "com.google"
@@ -75,12 +116,6 @@ internal data class DriveAccessToken(
     val token: String,
     val account: DriveAccountIdentity?,
 )
-
-internal fun resolveDriveAccountIdentity(
-    authorizationIdentity: DriveAccountIdentity?,
-    constrainedIdentity: DriveAccountIdentity?,
-): DriveAccountIdentity? =
-    authorizationIdentity ?: constrainedIdentity?.takeIf { it.androidAccount() != null }
 
 internal sealed class DriveAccountBindingException(
     message: String,
@@ -159,11 +194,7 @@ internal fun verifyDriveAccountBinding(
         throw DriveAccountBindingException.Mismatch()
     }
 
-    val enriched =
-        DriveAccountIdentity(
-            id = selected.id ?: actual.id,
-            email = selected.normalizedEmail ?: actual.normalizedEmail,
-        )
+    val enriched = selected.verifiedMerge(actual)
     if (bindIfMissing && enriched != selected) {
         store.bindIdentity(enriched)
     }
@@ -284,10 +315,7 @@ internal class DriveAuthorizationHelper(
         val resolved = resolveIfNeeded(authorizationResult, interactive)
         val token = resolved.accessToken?.takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("drive authorization succeeded but returned a blank access token")
-        val identity = resolveDriveAccountIdentity(
-            authorizationIdentity = DriveAccountIdentity.fromAuthorizationResult(resolved),
-            constrainedIdentity = selectedIdentity,
-        )
+        val identity = DriveAccountIdentity.fromAuthorizationResult(resolved)
 
         return DriveAccessToken(token = token, account = identity)
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DrivePaths.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/cloudbackup/DrivePaths.kt
@@ -6,16 +6,28 @@ import org.bitcoinppl.cove_core.csppWalletFilePrefix
 import org.bitcoinppl.cove_core.csppWalletsDirectory
 
 internal object DrivePaths {
-    val namespacesRootFolderName: String = csppNamespacesSubdirectory()
-    val masterKeyFolderName: String = csppMasterKeyDirectory()
-    val walletsFolderName: String = csppWalletsDirectory()
+    val defaultNames: DrivePathNames by lazy {
+        DrivePathNames(
+            namespacesRootFolderName = csppNamespacesSubdirectory(),
+            masterKeyFolderName = csppMasterKeyDirectory(),
+            walletsFolderName = csppWalletsDirectory(),
+            walletFilePrefix = csppWalletFilePrefix(),
+        )
+    }
+}
 
+internal data class DrivePathNames(
+    val namespacesRootFolderName: String,
+    val masterKeyFolderName: String,
+    val walletsFolderName: String,
+    val walletFilePrefix: String,
+) {
     fun walletLocationForFileName(fileName: String): String = "$walletsFolderName/$fileName"
 
     fun isWalletFile(name: String): Boolean =
         isWalletFileLocation(
             location = name,
-            walletFilePrefix = csppWalletFilePrefix(),
+            walletFilePrefix = walletFilePrefix,
             walletsFolderName = walletsFolderName,
         )
 }

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -56,22 +56,33 @@ class AndroidCloudStorageAccessTest {
     }
 
     @Test
-    fun driveAboutResponseProvidesAccountEmail() {
+    fun driveAboutResponseProvidesAccountIdentity() {
         val response =
             JSONObject(
                 """
                 {
                     "user": {
-                        "emailAddress": "Person@Example.com"
+                        "emailAddress": "Person@Example.com",
+                        "permissionId": "account-1"
                     }
                 }
                 """.trimIndent(),
             )
 
         assertEquals(
-            DriveAccountIdentity(id = null, email = "Person@Example.com"),
+            DriveAccountIdentity(id = "account-1", email = "person@example.com"),
             driveAccountIdentityFromAboutResponse(response),
         )
+    }
+
+    @Test
+    fun driveAccountIdentityNormalizesEmailForEqualityAndHashCode() {
+        val first = DriveAccountIdentity(id = "account-1", email = " Person@Example.com ")
+        val second = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+        assertEquals("person@example.com", first.email)
     }
 
     @Test
@@ -207,7 +218,8 @@ class AndroidCloudStorageAccessTest {
                     """
                     {
                         "user": {
-                            "emailAddress": "person@example.com"
+                            "emailAddress": "person@example.com",
+                            "permissionId": "account-1"
                         }
                     }
                     """.trimIndent(),
@@ -256,7 +268,8 @@ class AndroidCloudStorageAccessTest {
                     """
                     {
                         "user": {
-                            "emailAddress": "person@example.com"
+                            "emailAddress": "person@example.com",
+                            "permissionId": "account-1"
                         }
                     }
                     """.trimIndent(),
@@ -305,6 +318,107 @@ class AndroidCloudStorageAccessTest {
                 assertEquals(emptyList<String>(), secondResult.getOrNull())
                 assertEquals(listOf(false), delegate.accessRequests)
                 assertTrue(delegate.clearedTokens.isEmpty())
+
+                val requests = server.requests()
+                assertEquals(listOf("/about", "/files", "/files"), requests.map { it.path.substringBefore("?") })
+                assertEquals(
+                    listOf("Bearer token-1", "Bearer token-1", "Bearer token-1"),
+                    requests.map { it.authorization },
+                )
+            }
+        }
+
+    @Test
+    fun constrainedAuthorizationWithoutIdentityIsVerifiedThroughDriveAbout() =
+        runBlocking {
+            TestDriveServer().use { server ->
+                server.enqueue(
+                    HttpURLConnection.HTTP_OK,
+                    """
+                    {
+                        "user": {
+                            "emailAddress": "other@example.com",
+                            "permissionId": "account-2"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+
+                val selected = DriveAccountIdentity(id = null, email = "person@example.com")
+                val authorization = RecordingDriveAuthorization().apply {
+                    account = null
+                }
+                val storage = AndroidCloudStorageAccess(
+                    driveAuthorization = authorization,
+                    accountBindingStore = TestDriveAccountBindingStore(selected),
+                    driveApiEndpoints = DriveApiEndpoints(
+                        aboutEndpoint = "${server.baseUrl}/about",
+                        filesEndpoint = "${server.baseUrl}/files",
+                        uploadEndpoint = "${server.baseUrl}/upload",
+                    ),
+                    drivePathNamesProvider = { testDrivePathNames },
+                )
+
+                val error = captureError {
+                    storage.listNamespaces(CloudAccessPolicy.SILENT)
+                }
+
+                assertTrue(error is CloudStorageException.AuthorizationRequired)
+                assertEquals(
+                    "google drive account does not match the account selected for Cloud Backup",
+                    (error as CloudStorageException.AuthorizationRequired).v1,
+                )
+                assertEquals(listOf("token-1"), authorization.clearedTokens)
+
+                val requests = server.requests()
+                assertEquals(listOf("/about"), requests.map { it.path.substringBefore("?") })
+                assertTrue(requests.single().path.contains("permissionId"))
+            }
+        }
+
+    @Test
+    fun unboundReadOnlyOperationsReuseResolvedDriveAccountIdentity() =
+        runBlocking {
+            TestDriveServer().use { server ->
+                server.enqueue(
+                    HttpURLConnection.HTTP_OK,
+                    """
+                    {
+                        "user": {
+                            "emailAddress": "person@example.com",
+                            "permissionId": "account-1"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+
+                val store = TestDriveAccountBindingStore()
+                val delegate = RecordingDriveAuthorization().apply {
+                    account = null
+                }
+                val authorization = CachingDriveAuthorization(
+                    delegate = delegate,
+                    elapsedRealtime = { 0 },
+                    cacheWindowMs = 1_000,
+                    cacheKey = { driveAccountTokenCacheKey(store) },
+                )
+                val storage = AndroidCloudStorageAccess(
+                    driveAuthorization = authorization,
+                    accountBindingStore = store,
+                    driveApiEndpoints = DriveApiEndpoints(
+                        aboutEndpoint = "${server.baseUrl}/about",
+                        filesEndpoint = "${server.baseUrl}/files",
+                        uploadEndpoint = "${server.baseUrl}/upload",
+                    ),
+                    drivePathNamesProvider = { testDrivePathNames },
+                )
+
+                assertEquals(emptyList<String>(), storage.listNamespaces(CloudAccessPolicy.SILENT))
+                assertEquals(emptyList<String>(), storage.listNamespaces(CloudAccessPolicy.SILENT))
+                assertEquals(null, store.selectedIdentity())
+                assertEquals(listOf(false), delegate.accessRequests)
 
                 val requests = server.requests()
                 assertEquals(listOf("/about", "/files", "/files"), requests.map { it.path.substringBefore("?") })
@@ -512,46 +626,6 @@ class AndroidCloudStorageAccessTest {
         verifyDriveAccountBinding(store, verified)
 
         assertEquals(verified, store.selectedIdentity())
-    }
-
-    @Test
-    fun driveAccountIdentityUsesConstrainedAccountWhenAuthorizationOmitsIdentity() {
-        val selected = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-
-        assertEquals(
-            selected,
-            resolveDriveAccountIdentity(
-                authorizationIdentity = null,
-                constrainedIdentity = selected,
-            ),
-        )
-    }
-
-    @Test
-    fun driveAccountIdentityRejectsFallbackWhenTokenWasNotConstrained() {
-        val selected = DriveAccountIdentity(id = "account-1", email = null)
-
-        assertEquals(
-            null,
-            resolveDriveAccountIdentity(
-                authorizationIdentity = null,
-                constrainedIdentity = selected,
-            ),
-        )
-    }
-
-    @Test
-    fun driveAccountIdentityPrefersAuthorizationIdentity() {
-        val selected = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-        val actual = DriveAccountIdentity(id = "account-2", email = "other@example.com")
-
-        assertEquals(
-            actual,
-            resolveDriveAccountIdentity(
-                authorizationIdentity = actual,
-                constrainedIdentity = selected,
-            ),
-        )
     }
 
     @Test

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -3,8 +3,12 @@ package org.bitcoinppl.cove.cloudbackup
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Status
+import java.io.BufferedReader
 import java.io.IOException
+import java.io.InputStreamReader
 import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.SocketException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -142,6 +146,24 @@ class AndroidCloudStorageAccessTest {
             assertEquals(
                 "consent required",
                 (error as CloudStorageException.AuthorizationRequired).v1,
+            )
+        }
+
+    @Test
+    fun unauthorizedDriveAccountIdentityLookupClearsTokenAndRetries() =
+        runBlocking {
+            assertDriveAccountIdentityLookupClearsTokenAndRetries(
+                statusCode = HttpURLConnection.HTTP_UNAUTHORIZED,
+                body = "expired token",
+            )
+        }
+
+    @Test
+    fun rejectedDriveAccountIdentityLookupClearsTokenAndRetries() =
+        runBlocking {
+            assertDriveAccountIdentityLookupClearsTokenAndRetries(
+                statusCode = HttpURLConnection.HTTP_FORBIDDEN,
+                body = driveErrorBody("insufficientPermissions"),
             )
         }
 
@@ -725,6 +747,48 @@ class AndroidCloudStorageAccessTest {
         )
     }
 
+    private suspend fun assertDriveAccountIdentityLookupClearsTokenAndRetries(
+        statusCode: Int,
+        body: String,
+    ) {
+        TestDriveServer().use { server ->
+            server.enqueue(statusCode, body)
+            server.enqueue(
+                HttpURLConnection.HTTP_OK,
+                """
+                {
+                    "user": {
+                        "emailAddress": "person@example.com"
+                    }
+                }
+                """.trimIndent(),
+            )
+            server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+
+            val authorization = SequentialDriveAuthorization(listOf("token-1", "token-2"))
+            val storage = AndroidCloudStorageAccess(
+                driveAuthorization = authorization,
+                accountBindingStore = TestDriveAccountBindingStore(),
+                driveApiEndpoints = DriveApiEndpoints(
+                    aboutEndpoint = "${server.baseUrl}/about",
+                    filesEndpoint = "${server.baseUrl}/files",
+                    uploadEndpoint = "${server.baseUrl}/upload",
+                ),
+            )
+
+            assertEquals(emptyList<String>(), storage.listNamespaces(CloudAccessPolicy.SILENT))
+            assertEquals(listOf(false, false), authorization.accessRequests)
+            assertEquals(listOf("token-1"), authorization.clearedTokens)
+
+            val requests = server.requests()
+            assertEquals(listOf("/about", "/about", "/files"), requests.map { it.path.substringBefore("?") })
+            assertEquals(
+                listOf("Bearer token-1", "Bearer token-2", "Bearer token-2"),
+                requests.map { it.authorization },
+            )
+        }
+    }
+
     private fun driveErrorBody(reason: String): String =
         """
         {
@@ -774,6 +838,27 @@ class AndroidCloudStorageAccessTest {
         override suspend fun clearToken(token: String) = Unit
     }
 
+    private class SequentialDriveAuthorization(
+        tokens: List<String>,
+    ) : DriveAuthorization {
+        private val tokens = ArrayDeque(tokens)
+        val accessRequests = mutableListOf<Boolean>()
+        val clearedTokens = mutableListOf<String>()
+
+        override suspend fun accessToken(interactive: Boolean): DriveAccessToken {
+            accessRequests.add(interactive)
+            if (tokens.isEmpty()) {
+                throw AssertionError("unexpected drive access token request")
+            }
+
+            return DriveAccessToken(token = tokens.removeFirst(), account = null)
+        }
+
+        override suspend fun clearToken(token: String) {
+            clearedTokens.add(token)
+        }
+    }
+
     private class RecordingDriveAuthorization : DriveAuthorization {
         var token = "token-1"
         var account = DriveAccountIdentity(id = "account-1", email = "person@example.com")
@@ -809,6 +894,123 @@ class AndroidCloudStorageAccessTest {
             finishClear.await()
         }
     }
+
+    private class TestDriveServer : AutoCloseable {
+        private val serverSocket = ServerSocket(0)
+        private val responseLock = Any()
+        private val requestLock = Any()
+        private val responses = ArrayDeque<TestDriveResponse>()
+        private val requests = mutableListOf<TestDriveRequest>()
+
+        @Volatile
+        private var serverError: Throwable? = null
+
+        private val thread =
+            Thread({ serve() }, "test-drive-server")
+                .apply {
+                    isDaemon = true
+                    start()
+                }
+
+        val baseUrl = "http://127.0.0.1:${serverSocket.localPort}"
+
+        fun enqueue(statusCode: Int, body: String) {
+            synchronized(responseLock) {
+                responses.add(TestDriveResponse(statusCode, body))
+            }
+        }
+
+        fun requests(): List<TestDriveRequest> =
+            synchronized(requestLock) {
+                requests.toList()
+            }
+
+        override fun close() {
+            serverSocket.close()
+            thread.join(1_000)
+            serverError?.let { throw AssertionError("test drive server failed", it) }
+        }
+
+        private fun serve() {
+            try {
+                while (!serverSocket.isClosed) {
+                    val socket =
+                        try {
+                            serverSocket.accept()
+                        } catch (_: SocketException) {
+                            return
+                        }
+
+                    socket.use {
+                        val reader = BufferedReader(InputStreamReader(it.getInputStream(), Charsets.UTF_8))
+                        val requestLine = reader.readLine() ?: return@use
+                        val authorization = readAuthorizationHeader(reader)
+                        val requestTarget = requestLine.split(" ").getOrNull(1).orEmpty()
+
+                        synchronized(requestLock) {
+                            requests.add(TestDriveRequest(path = requestTarget, authorization = authorization))
+                        }
+
+                        val response =
+                            synchronized(responseLock) {
+                                if (responses.isEmpty()) {
+                                    TestDriveResponse(HttpURLConnection.HTTP_INTERNAL_ERROR, "unexpected request")
+                                } else {
+                                    responses.removeFirst()
+                                }
+                            }
+                        val responseBody = response.body.toByteArray(Charsets.UTF_8)
+                        val statusText = if (response.statusCode in 200..299) "OK" else "Error"
+                        val headers =
+                            "HTTP/1.1 ${response.statusCode} $statusText\r\n" +
+                                "Content-Type: application/json\r\n" +
+                                "Content-Length: ${responseBody.size}\r\n" +
+                                "Connection: close\r\n" +
+                                "\r\n"
+
+                        it.getOutputStream().use { output ->
+                            output.write(headers.toByteArray(Charsets.UTF_8))
+                            output.write(responseBody)
+                        }
+                    }
+                }
+            } catch (error: Throwable) {
+                if (!serverSocket.isClosed) {
+                    serverError = error
+                }
+            }
+        }
+
+        private fun readAuthorizationHeader(reader: BufferedReader): String? {
+            var authorization: String? = null
+            while (true) {
+                val line = reader.readLine() ?: return authorization
+                if (line.isEmpty()) {
+                    return authorization
+                }
+
+                val separator = line.indexOf(':')
+                if (separator < 0) {
+                    continue
+                }
+
+                val name = line.substring(0, separator)
+                if (name.equals("Authorization", ignoreCase = true)) {
+                    authorization = line.substring(separator + 1).trim()
+                }
+            }
+        }
+    }
+
+    private data class TestDriveResponse(
+        val statusCode: Int,
+        val body: String,
+    )
+
+    private data class TestDriveRequest(
+        val path: String,
+        val authorization: String?,
+    )
 
     private class TestDriveAccountBindingStore(
         private var identity: DriveAccountIdentity? = null,

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -602,6 +602,67 @@ class AndroidCloudStorageAccessTest {
         }
 
     @Test
+    fun storedDrivePermissionIdIsResolvedBeforeBindingVerification() =
+        runBlocking {
+            TestDriveServer().use { server ->
+                server.enqueue(
+                    HttpURLConnection.HTTP_OK,
+                    """
+                    {
+                        "user": {
+                            "permissionId": "permission-1"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+
+                val store = TestDriveAccountBindingStore(
+                    DriveAccountIdentity(drivePermissionId = "permission-1", email = null),
+                )
+                val delegate = RecordingDriveAuthorization().apply {
+                    account = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+                }
+                val authorization = CachingDriveAuthorization(
+                    delegate = delegate,
+                    elapsedRealtime = { 0 },
+                    cacheWindowMs = 1_000,
+                    cacheKey = { store.selectedIdentity() },
+                )
+                val storage = AndroidCloudStorageAccess(
+                    driveAuthorization = authorization,
+                    accountBindingStore = store,
+                    driveApiEndpoints = DriveApiEndpoints(
+                        aboutEndpoint = "${server.baseUrl}/about",
+                        filesEndpoint = "${server.baseUrl}/files",
+                        uploadEndpoint = "${server.baseUrl}/upload",
+                    ),
+                    drivePathNamesProvider = { testDrivePathNames },
+                )
+
+                val result = runCatching {
+                    storage.listNamespaces(CloudAccessPolicy.SILENT)
+                }
+
+                assertTrue(
+                    cloudStorageFailureMessage(result.exceptionOrNull()),
+                    result.isSuccess,
+                )
+                assertEquals(emptyList<String>(), result.getOrNull())
+                assertEquals(listOf(false), delegate.accessRequests)
+                assertTrue(delegate.clearedTokens.isEmpty())
+
+                val requests = server.requests()
+                assertEquals(listOf("/about", "/files"), requests.map { it.path.substringBefore("?") })
+                assertTrue(requests.first().path.contains("permissionId"))
+                assertEquals(
+                    listOf("Bearer token-1", "Bearer token-1"),
+                    requests.map { it.authorization },
+                )
+            }
+        }
+
+    @Test
     fun constrainedAuthorizationWithoutIdentityIsVerifiedThroughDriveAbout() =
         runBlocking {
             TestDriveServer().use { server ->

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -248,6 +248,74 @@ class AndroidCloudStorageAccessTest {
         }
 
     @Test
+    fun sparseDriveAccountIdentityIsResolvedBeforeVerification() =
+        runBlocking {
+            TestDriveServer().use { server ->
+                server.enqueue(
+                    HttpURLConnection.HTTP_OK,
+                    """
+                    {
+                        "user": {
+                            "emailAddress": "person@example.com"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+
+                val store = TestDriveAccountBindingStore(
+                    DriveAccountIdentity(id = null, email = "person@example.com"),
+                )
+                val delegate = RecordingDriveAuthorization().apply {
+                    account = DriveAccountIdentity(id = "account-1", email = null)
+                }
+                val authorization = CachingDriveAuthorization(
+                    delegate = delegate,
+                    elapsedRealtime = { 0 },
+                    cacheWindowMs = 1_000,
+                    cacheKey = { store.selectedIdentity() },
+                )
+                val storage = AndroidCloudStorageAccess(
+                    driveAuthorization = authorization,
+                    accountBindingStore = store,
+                    driveApiEndpoints = DriveApiEndpoints(
+                        aboutEndpoint = "${server.baseUrl}/about",
+                        filesEndpoint = "${server.baseUrl}/files",
+                        uploadEndpoint = "${server.baseUrl}/upload",
+                    ),
+                    drivePathNamesProvider = { testDrivePathNames },
+                )
+
+                val firstResult = runCatching {
+                    storage.listNamespaces(CloudAccessPolicy.SILENT)
+                }
+                val secondResult = runCatching {
+                    storage.listNamespaces(CloudAccessPolicy.SILENT)
+                }
+                assertTrue(
+                    cloudStorageFailureMessage(firstResult.exceptionOrNull()),
+                    firstResult.isSuccess,
+                )
+                assertTrue(
+                    cloudStorageFailureMessage(secondResult.exceptionOrNull()),
+                    secondResult.isSuccess,
+                )
+                assertEquals(emptyList<String>(), firstResult.getOrNull())
+                assertEquals(emptyList<String>(), secondResult.getOrNull())
+                assertEquals(listOf(false), delegate.accessRequests)
+                assertTrue(delegate.clearedTokens.isEmpty())
+
+                val requests = server.requests()
+                assertEquals(listOf("/about", "/files", "/files"), requests.map { it.path.substringBefore("?") })
+                assertEquals(
+                    listOf("Bearer token-1", "Bearer token-1", "Bearer token-1"),
+                    requests.map { it.authorization },
+                )
+            }
+        }
+
+    @Test
     fun cachingDriveAuthorizationReusesTokenUntilCleared() =
         runBlocking {
             var now = 0L

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -24,6 +24,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AndroidCloudStorageAccessTest {
+    private val testDrivePathNames = DrivePathNames(
+        namespacesRootFolderName = "cspp-namespaces",
+        masterKeyFolderName = "master-key",
+        walletsFolderName = "wallets",
+        walletFilePrefix = "wallet-",
+    )
+
     @Test
     fun createUploadMetadataIncludesParents() {
         val metadata = createUploadMetadata(fileName = "wallet-record.json", parentId = "folder-123")
@@ -165,6 +172,30 @@ class AndroidCloudStorageAccessTest {
                 statusCode = HttpURLConnection.HTTP_FORBIDDEN,
                 body = driveErrorBody("insufficientPermissions"),
             )
+        }
+
+    @Test
+    fun cachingDriveAuthorizationReusesUpdatedTokenIdentity() =
+        runBlocking {
+            var now = 0L
+            val delegate = RecordingDriveAuthorization().apply {
+                account = null
+            }
+            val authorization = CachingDriveAuthorization(
+                delegate = delegate,
+                elapsedRealtime = { now },
+                cacheWindowMs = 1_000,
+            )
+            val unresolved = authorization.accessToken(interactive = false)
+            val resolved = unresolved.copy(
+                account = DriveAccountIdentity(id = null, email = "person@example.com"),
+            )
+
+            authorization.updateCachedToken(resolved)
+
+            now = 500
+            assertEquals(resolved, authorization.accessToken(interactive = false))
+            assertEquals(listOf(false), delegate.accessRequests)
         }
 
     @Test
@@ -774,9 +805,17 @@ class AndroidCloudStorageAccessTest {
                     filesEndpoint = "${server.baseUrl}/files",
                     uploadEndpoint = "${server.baseUrl}/upload",
                 ),
+                drivePathNamesProvider = { testDrivePathNames },
             )
 
-            assertEquals(emptyList<String>(), storage.listNamespaces(CloudAccessPolicy.SILENT))
+            val namespacesResult = runCatching {
+                storage.listNamespaces(CloudAccessPolicy.SILENT)
+            }
+            assertTrue(
+                cloudStorageFailureMessage(namespacesResult.exceptionOrNull()),
+                namespacesResult.isSuccess,
+            )
+            assertEquals(emptyList<String>(), namespacesResult.getOrNull())
             assertEquals(listOf(false, false), authorization.accessRequests)
             assertEquals(listOf("token-1"), authorization.clearedTokens)
 
@@ -788,6 +827,26 @@ class AndroidCloudStorageAccessTest {
             )
         }
     }
+
+    private fun cloudStorageFailureMessage(error: Throwable?): String =
+        when (error) {
+            null -> "listNamespaces succeeded"
+            is CloudStorageException.AuthorizationRequired ->
+                "listNamespaces failed with AuthorizationRequired: ${error.v1}"
+            is CloudStorageException.NotAvailable ->
+                "listNamespaces failed with NotAvailable: ${error.v1}"
+            is CloudStorageException.NotFound ->
+                "listNamespaces failed with NotFound: ${error.v1}"
+            is CloudStorageException.Offline ->
+                "listNamespaces failed with Offline: ${error.v1}"
+            is CloudStorageException.QuotaExceeded ->
+                "listNamespaces failed with QuotaExceeded"
+            is CloudStorageException.UploadFailed ->
+                "listNamespaces failed with UploadFailed: ${error.v1}"
+            is CloudStorageException.DownloadFailed ->
+                "listNamespaces failed with DownloadFailed: ${error.v1}"
+            else -> "listNamespaces failed with ${error.javaClass.name}: ${error.message}"
+        }
 
     private fun driveErrorBody(reason: String): String =
         """
@@ -861,7 +920,7 @@ class AndroidCloudStorageAccessTest {
 
     private class RecordingDriveAuthorization : DriveAuthorization {
         var token = "token-1"
-        var account = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        var account: DriveAccountIdentity? = DriveAccountIdentity(id = "account-1", email = "person@example.com")
         val accessRequests = mutableListOf<Boolean>()
         val clearedTokens = mutableListOf<String>()
 

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -199,6 +199,55 @@ class AndroidCloudStorageAccessTest {
         }
 
     @Test
+    fun resolvedDriveAccountIdentityIsCachedAcrossOperations() =
+        runBlocking {
+            TestDriveServer().use { server ->
+                server.enqueue(
+                    HttpURLConnection.HTTP_OK,
+                    """
+                    {
+                        "user": {
+                            "emailAddress": "person@example.com"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+                server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
+
+                val delegate = RecordingDriveAuthorization().apply {
+                    account = null
+                }
+                val authorization = CachingDriveAuthorization(
+                    delegate = delegate,
+                    elapsedRealtime = { 0 },
+                    cacheWindowMs = 1_000,
+                )
+                val storage = AndroidCloudStorageAccess(
+                    driveAuthorization = authorization,
+                    accountBindingStore = TestDriveAccountBindingStore(),
+                    driveApiEndpoints = DriveApiEndpoints(
+                        aboutEndpoint = "${server.baseUrl}/about",
+                        filesEndpoint = "${server.baseUrl}/files",
+                        uploadEndpoint = "${server.baseUrl}/upload",
+                    ),
+                    drivePathNamesProvider = { testDrivePathNames },
+                )
+
+                assertEquals(emptyList<String>(), storage.listNamespaces(CloudAccessPolicy.SILENT))
+                assertEquals(emptyList<String>(), storage.listNamespaces(CloudAccessPolicy.SILENT))
+                assertEquals(listOf(false), delegate.accessRequests)
+
+                val requests = server.requests()
+                assertEquals(listOf("/about", "/files", "/files"), requests.map { it.path.substringBefore("?") })
+                assertEquals(
+                    listOf("Bearer token-1", "Bearer token-1", "Bearer token-1"),
+                    requests.map { it.authorization },
+                )
+            }
+        }
+
+    @Test
     fun cachingDriveAuthorizationReusesTokenUntilCleared() =
         runBlocking {
             var now = 0L

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -70,19 +70,151 @@ class AndroidCloudStorageAccessTest {
             )
 
         assertEquals(
-            DriveAccountIdentity(id = "account-1", email = "person@example.com"),
+            DriveAccountIdentity(drivePermissionId = "account-1", email = "person@example.com"),
             driveAccountIdentityFromAboutResponse(response),
         )
     }
 
     @Test
+    fun driveAboutResponseOmitsBlankIdentity() {
+        assertEquals(null, driveAccountIdentityFromAboutResponse(JSONObject("{}")))
+        assertEquals(
+            null,
+            driveAccountIdentityFromAboutResponse(
+                JSONObject(
+                    """
+                    {
+                        "user": {
+                            "emailAddress": " ",
+                            "permissionId": ""
+                        }
+                    }
+                    """.trimIndent(),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun driveAccountIdentityNormalizesEmailForEqualityAndHashCode() {
-        val first = DriveAccountIdentity(id = "account-1", email = " Person@Example.com ")
-        val second = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        val first = DriveAccountIdentity(googleAccountId = "account-1", email = " Person@Example.com ")
+        val second = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
 
         assertEquals(first, second)
         assertEquals(first.hashCode(), second.hashCode())
         assertEquals("person@example.com", first.email)
+    }
+
+    @Test
+    fun driveAccountIdentityKeepsIdSourcesSeparate() {
+        val googleIdentity = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+        val driveIdentity = DriveAccountIdentity(drivePermissionId = "permission-1", email = "PERSON@example.com")
+
+        assertTrue(googleIdentity.matches(driveIdentity))
+        assertEquals(
+            DriveAccountIdentity(
+                googleAccountId = "account-1",
+                drivePermissionId = "permission-1",
+                email = "person@example.com",
+            ),
+            googleIdentity.verifiedMerge(driveIdentity),
+        )
+    }
+
+    @Test
+    fun driveAccountIdentityMergePoliciesHandleEmailRefreshes() {
+        val original = DriveAccountIdentity(googleAccountId = "account-1", email = "old@example.com")
+        val refreshed = DriveAccountIdentity(
+            googleAccountId = "account-1",
+            drivePermissionId = "permission-1",
+            email = "new@example.com",
+        )
+
+        assertEquals(
+            DriveAccountIdentity(
+                googleAccountId = "account-1",
+                drivePermissionId = "permission-1",
+                email = "old@example.com",
+            ),
+            original.withMissingFieldsFrom(refreshed),
+        )
+        assertEquals(
+            DriveAccountIdentity(
+                googleAccountId = "account-1",
+                drivePermissionId = "permission-1",
+                email = "new@example.com",
+            ),
+            original.verifiedMerge(refreshed),
+        )
+    }
+
+    @Test
+    fun driveAccountIdentityMergePoliciesFallbackWithoutRefreshedEmail() {
+        val original = DriveAccountIdentity(googleAccountId = "account-1", email = "old@example.com")
+        val withoutEmail = DriveAccountIdentity(
+            googleAccountId = "account-1",
+            drivePermissionId = "permission-1",
+            email = null,
+        )
+
+        assertEquals(
+            DriveAccountIdentity(
+                googleAccountId = "account-1",
+                drivePermissionId = "permission-1",
+                email = "old@example.com",
+            ),
+            original.withMissingFieldsFrom(withoutEmail),
+        )
+        assertEquals(
+            DriveAccountIdentity(
+                googleAccountId = "account-1",
+                drivePermissionId = "permission-1",
+                email = "old@example.com",
+            ),
+            original.verifiedMerge(withoutEmail),
+        )
+    }
+
+    @Test
+    fun driveAccountIdentityWithMissingFieldsDoesNotOverwriteExistingIds() {
+        val original = DriveAccountIdentity(
+            googleAccountId = "account-1",
+            drivePermissionId = "permission-1",
+            email = "person@example.com",
+        )
+        val other = DriveAccountIdentity(
+            googleAccountId = "account-2",
+            drivePermissionId = "permission-2",
+            email = "other@example.com",
+        )
+
+        assertEquals(original, original.withMissingFieldsFrom(other))
+    }
+
+    @Test
+    fun driveApiUrlEncodesQueryParameters() {
+        assertEquals(
+            "https://example.test/files?q=name%20%3D%20%27a%20b%2Bc%27&email=a%2Bb%40example.com",
+            driveApiUrl(
+                "https://example.test/files",
+                listOf("q" to "name = 'a b+c'", "email" to "a+b@example.com"),
+            ),
+        )
+    }
+
+    @Test
+    fun driveApiUrlKeepsExistingQueryAndFragmentOrder() {
+        assertEquals(
+            "https://example.test/files?alt=json&fields=files%28id%2Cname%29#metadata",
+            driveApiUrl(
+                "https://example.test/files?alt=json#metadata",
+                listOf("fields" to "files(id,name)"),
+            ),
+        )
+        assertEquals(
+            "https://example.test/files#metadata",
+            driveApiUrl("https://example.test/files#metadata", emptyList()),
+        )
     }
 
     @Test
@@ -186,6 +318,42 @@ class AndroidCloudStorageAccessTest {
         }
 
     @Test
+    fun repeatedRejectedDriveAccountIdentityLookupIdentifiesVerificationFailure() =
+        runBlocking {
+            TestDriveServer().use { server ->
+                server.enqueue(HttpURLConnection.HTTP_FORBIDDEN, driveErrorBody("insufficientPermissions"))
+                server.enqueue(HttpURLConnection.HTTP_FORBIDDEN, driveErrorBody("insufficientPermissions"))
+
+                val authorization = SequentialDriveAuthorization(listOf("token-1", "token-2"))
+                val storage = AndroidCloudStorageAccess(
+                    driveAuthorization = authorization,
+                    accountBindingStore = TestDriveAccountBindingStore(),
+                    driveApiEndpoints = DriveApiEndpoints(
+                        aboutEndpoint = "${server.baseUrl}/about",
+                        filesEndpoint = "${server.baseUrl}/files",
+                        uploadEndpoint = "${server.baseUrl}/upload",
+                    ),
+                    drivePathNamesProvider = { testDrivePathNames },
+                )
+
+                val error = captureError {
+                    storage.listNamespaces(CloudAccessPolicy.SILENT)
+                }
+
+                assertTrue(error is CloudStorageException.AuthorizationRequired)
+                assertEquals(
+                    "google drive identity verification was rejected",
+                    (error as CloudStorageException.AuthorizationRequired).v1,
+                )
+                assertEquals(listOf(false, false), authorization.accessRequests)
+                assertEquals(listOf("token-1", "token-2"), authorization.clearedTokens)
+
+                val requests = server.requests()
+                assertEquals(listOf("/about", "/about"), requests.map { it.path.substringBefore("?") })
+            }
+        }
+
+    @Test
     fun cachingDriveAuthorizationReusesUpdatedTokenIdentity() =
         runBlocking {
             var now = 0L
@@ -199,7 +367,7 @@ class AndroidCloudStorageAccessTest {
             )
             val unresolved = authorization.accessToken(interactive = false)
             val resolved = unresolved.copy(
-                account = DriveAccountIdentity(id = null, email = "person@example.com"),
+                account = DriveAccountIdentity(googleAccountId = null, email = "person@example.com"),
             )
 
             authorization.updateCachedToken(resolved)
@@ -207,6 +375,111 @@ class AndroidCloudStorageAccessTest {
             now = 500
             assertEquals(resolved, authorization.accessToken(interactive = false))
             assertEquals(listOf(false), delegate.accessRequests)
+        }
+
+    @Test
+    fun cachingDriveAuthorizationDropsUpdatedTokenWhenCacheKeyChanges() =
+        runBlocking {
+            var cacheKey: Any? = "account-1"
+            val delegate = RecordingDriveAuthorization().apply {
+                account = null
+            }
+            val authorization = CachingDriveAuthorization(
+                delegate = delegate,
+                elapsedRealtime = { 0 },
+                cacheWindowMs = 1_000,
+                cacheKey = { cacheKey },
+            )
+            val unresolved = authorization.accessToken(interactive = false)
+            val resolved = unresolved.copy(
+                account = DriveAccountIdentity(googleAccountId = null, email = "person@example.com"),
+            )
+
+            cacheKey = "account-2"
+            authorization.updateCachedToken(resolved)
+
+            delegate.token = "token-2"
+
+            assertEquals("token-2", authorization.accessToken(interactive = false).token)
+            assertEquals(listOf(false, false), delegate.accessRequests)
+        }
+
+    @Test
+    fun cachingDriveAuthorizationDropsUpdatedTokenWhenTokenChanges() =
+        runBlocking {
+            val delegate = RecordingDriveAuthorization().apply {
+                account = null
+            }
+            val authorization = CachingDriveAuthorization(
+                delegate = delegate,
+                elapsedRealtime = { 0 },
+                cacheWindowMs = 1_000,
+            )
+            val unresolved = authorization.accessToken(interactive = false)
+            val resolved = unresolved.copy(
+                token = "token-2",
+                account = DriveAccountIdentity(googleAccountId = null, email = "person@example.com"),
+            )
+
+            authorization.updateCachedToken(resolved)
+
+            delegate.token = "token-3"
+
+            assertEquals("token-3", authorization.accessToken(interactive = false).token)
+            assertEquals(listOf(false, false), delegate.accessRequests)
+        }
+
+    @Test
+    fun cachingDriveAuthorizationDropsUpdatedTokenAfterExpiry() =
+        runBlocking {
+            var now = 0L
+            val delegate = RecordingDriveAuthorization().apply {
+                account = null
+            }
+            val authorization = CachingDriveAuthorization(
+                delegate = delegate,
+                elapsedRealtime = { now },
+                cacheWindowMs = 1_000,
+            )
+            val unresolved = authorization.accessToken(interactive = false)
+            val resolved = unresolved.copy(
+                account = DriveAccountIdentity(googleAccountId = null, email = "person@example.com"),
+            )
+
+            now = 1_000
+            authorization.updateCachedToken(resolved)
+
+            delegate.token = "token-2"
+
+            assertEquals("token-2", authorization.accessToken(interactive = false).token)
+            assertEquals(listOf(false, false), delegate.accessRequests)
+        }
+
+    @Test
+    fun cachingDriveAuthorizationDropsUpdatedTokenWhenCacheKeyIsUnavailable() =
+        runBlocking {
+            var cacheKey: Any? = "account-1"
+            val delegate = RecordingDriveAuthorization().apply {
+                account = null
+            }
+            val authorization = CachingDriveAuthorization(
+                delegate = delegate,
+                elapsedRealtime = { 0 },
+                cacheWindowMs = 1_000,
+                cacheKey = { cacheKey },
+            )
+            val unresolved = authorization.accessToken(interactive = false)
+            val resolved = unresolved.copy(
+                account = DriveAccountIdentity(googleAccountId = null, email = "person@example.com"),
+            )
+
+            cacheKey = null
+            authorization.updateCachedToken(resolved)
+
+            delegate.token = "token-2"
+
+            assertEquals("token-2", authorization.accessToken(interactive = false).token)
+            assertEquals(listOf(false, false), delegate.accessRequests)
         }
 
     @Test
@@ -278,10 +551,10 @@ class AndroidCloudStorageAccessTest {
                 server.enqueue(HttpURLConnection.HTTP_OK, """{"files":[]}""")
 
                 val store = TestDriveAccountBindingStore(
-                    DriveAccountIdentity(id = null, email = "person@example.com"),
+                    DriveAccountIdentity(googleAccountId = null, email = "person@example.com"),
                 )
                 val delegate = RecordingDriveAuthorization().apply {
-                    account = DriveAccountIdentity(id = "account-1", email = null)
+                    account = DriveAccountIdentity(googleAccountId = "account-1", email = null)
                 }
                 val authorization = CachingDriveAuthorization(
                     delegate = delegate,
@@ -344,7 +617,7 @@ class AndroidCloudStorageAccessTest {
                     """.trimIndent(),
                 )
 
-                val selected = DriveAccountIdentity(id = null, email = "person@example.com")
+                val selected = DriveAccountIdentity(googleAccountId = null, email = "person@example.com")
                 val authorization = RecordingDriveAuthorization().apply {
                     account = null
                 }
@@ -547,9 +820,9 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun driveAccountBindingPersistsFirstAccountAndRejectsMismatch() {
         val store = TestDriveAccountBindingStore()
-        val first = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-        val sameEmailFallback = DriveAccountIdentity(id = null, email = "PERSON@example.com")
-        val mismatch = DriveAccountIdentity(id = "account-2", email = "other@example.com")
+        val first = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+        val sameEmailFallback = DriveAccountIdentity(googleAccountId = null, email = "PERSON@example.com")
+        val mismatch = DriveAccountIdentity(googleAccountId = "account-2", email = "other@example.com")
 
         verifyDriveAccountBinding(store, first)
         verifyDriveAccountBinding(store, sameEmailFallback)
@@ -560,9 +833,28 @@ class AndroidCloudStorageAccessTest {
     }
 
     @Test
+    fun driveAccountBindingMatchesStoredGoogleIdToDrivePermissionIdByEmail() {
+        val store = TestDriveAccountBindingStore(
+            DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com"),
+        )
+        val fallback = DriveAccountIdentity(drivePermissionId = "permission-1", email = "PERSON@example.com")
+
+        verifyDriveAccountBinding(store, fallback)
+
+        assertEquals(
+            DriveAccountIdentity(
+                googleAccountId = "account-1",
+                drivePermissionId = "permission-1",
+                email = "person@example.com",
+            ),
+            store.selectedIdentity(),
+        )
+    }
+
+    @Test
     fun driveAccountBindingValidationDoesNotPersistUnverifiedAccount() {
         val store = TestDriveAccountBindingStore()
-        val probe = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        val probe = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
 
         verifyDriveAccountBinding(store, probe, bindIfMissing = false)
 
@@ -572,8 +864,8 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun driveAccountBindingCanBeClearedAndRebound() {
         val store = TestDriveAccountBindingStore()
-        val first = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-        val second = DriveAccountIdentity(id = "account-2", email = "other@example.com")
+        val first = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+        val second = DriveAccountIdentity(googleAccountId = "account-2", email = "other@example.com")
 
         verifyDriveAccountBinding(store, first)
         store.clearIdentity()
@@ -595,7 +887,7 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun driveAccountBindingRejectsMissingIdentityWhenAccountIsSelected() {
         val store = TestDriveAccountBindingStore(
-            DriveAccountIdentity(id = "account-1", email = "person@example.com"),
+            DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com"),
         )
 
         val error = runCatching { verifyDriveAccountBinding(store, identity = null) }
@@ -607,7 +899,7 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun driveAccountBindingRejectsMissingIdentityWhenSelectedAccountCannotConstrainAuthorization() {
         val store = TestDriveAccountBindingStore(
-            DriveAccountIdentity(id = "account-1", email = null),
+            DriveAccountIdentity(googleAccountId = "account-1", email = null),
         )
 
         val error = runCatching { verifyDriveAccountBinding(store, identity = null) }
@@ -619,9 +911,9 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun driveAccountBindingEnrichesSparseSelectedAccountAfterMatchingVerification() {
         val store = TestDriveAccountBindingStore(
-            DriveAccountIdentity(id = "account-1", email = null),
+            DriveAccountIdentity(googleAccountId = "account-1", email = null),
         )
-        val verified = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        val verified = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
 
         verifyDriveAccountBinding(store, verified)
 
@@ -631,8 +923,8 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun wrongDriveAccountBlocksOperationsBeforeRemoteMutation() =
         runBlocking {
-            val selected = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-            val actual = DriveAccountIdentity(id = "account-2", email = "other@example.com")
+            val selected = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+            val actual = DriveAccountIdentity(googleAccountId = "account-2", email = "other@example.com")
             val authorization = RecordingDriveAuthorization().apply {
                 account = actual
             }
@@ -685,8 +977,8 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun cachedWrongDriveAccountTokenIsClearedAfterMismatch() =
         runBlocking {
-            val selected = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-            val actual = DriveAccountIdentity(id = "account-2", email = "other@example.com")
+            val selected = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+            val actual = DriveAccountIdentity(googleAccountId = "account-2", email = "other@example.com")
             val store = TestDriveAccountBindingStore(selected)
             val delegate = RecordingDriveAuthorization().apply {
                 account = actual
@@ -714,8 +1006,8 @@ class AndroidCloudStorageAccessTest {
     @Test
     fun clearingDriveAccountBindingInvalidatesCachedToken() =
         runBlocking {
-            val first = DriveAccountIdentity(id = "account-1", email = "person@example.com")
-            val second = DriveAccountIdentity(id = "account-2", email = "other@example.com")
+            val first = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
+            val second = DriveAccountIdentity(googleAccountId = "account-2", email = "other@example.com")
             val store = TestDriveAccountBindingStore(first)
             val delegate = RecordingDriveAuthorization()
             val authorization = CachingDriveAuthorization(
@@ -1111,7 +1403,7 @@ class AndroidCloudStorageAccessTest {
 
     private class RecordingDriveAuthorization : DriveAuthorization {
         var token = "token-1"
-        var account: DriveAccountIdentity? = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        var account: DriveAccountIdentity? = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
         val accessRequests = mutableListOf<Boolean>()
         val clearedTokens = mutableListOf<String>()
 
@@ -1127,7 +1419,7 @@ class AndroidCloudStorageAccessTest {
 
     private class BlockingClearDriveAuthorization : DriveAuthorization {
         var token = "token-1"
-        var account = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        var account = DriveAccountIdentity(googleAccountId = "account-1", email = "person@example.com")
         val accessRequests = mutableListOf<Boolean>()
         val clearedTokens = mutableListOf<String>()
         val clearStarted = CompletableDeferred<Unit>()

--- a/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/cloudbackup/AndroidCloudStorageAccessTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.yield
 import org.bitcoinppl.cove_core.device.CloudAccessPolicy
 import org.bitcoinppl.cove_core.device.CloudStorageException
 import org.bitcoinppl.cove_core.device.RemoteBackupLocation
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -41,6 +42,25 @@ class AndroidCloudStorageAccessTest {
         val json = metadata.toJson()
         assertEquals("wallet-record.json", json.getString("name"))
         assertFalse(json.has("parents"))
+    }
+
+    @Test
+    fun driveAboutResponseProvidesAccountEmail() {
+        val response =
+            JSONObject(
+                """
+                {
+                    "user": {
+                        "emailAddress": "Person@Example.com"
+                    }
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(
+            DriveAccountIdentity(id = null, email = "Person@Example.com"),
+            driveAccountIdentityFromAboutResponse(response),
+        )
     }
 
     @Test
@@ -276,6 +296,92 @@ class AndroidCloudStorageAccessTest {
         verifyDriveAccountBinding(store, second)
 
         assertEquals(second, store.selectedIdentity())
+    }
+
+    @Test
+    fun driveAccountBindingRejectsMissingIdentityWhenNoAccountIsSelected() {
+        val store = TestDriveAccountBindingStore()
+
+        val error = runCatching { verifyDriveAccountBinding(store, identity = null) }
+            .exceptionOrNull()
+
+        assertTrue(error is DriveAccountBindingException.MissingIdentity)
+    }
+
+    @Test
+    fun driveAccountBindingRejectsMissingIdentityWhenAccountIsSelected() {
+        val store = TestDriveAccountBindingStore(
+            DriveAccountIdentity(id = "account-1", email = "person@example.com"),
+        )
+
+        val error = runCatching { verifyDriveAccountBinding(store, identity = null) }
+            .exceptionOrNull()
+
+        assertTrue(error is DriveAccountBindingException.MissingIdentity)
+    }
+
+    @Test
+    fun driveAccountBindingRejectsMissingIdentityWhenSelectedAccountCannotConstrainAuthorization() {
+        val store = TestDriveAccountBindingStore(
+            DriveAccountIdentity(id = "account-1", email = null),
+        )
+
+        val error = runCatching { verifyDriveAccountBinding(store, identity = null) }
+            .exceptionOrNull()
+
+        assertTrue(error is DriveAccountBindingException.MissingIdentity)
+    }
+
+    @Test
+    fun driveAccountBindingEnrichesSparseSelectedAccountAfterMatchingVerification() {
+        val store = TestDriveAccountBindingStore(
+            DriveAccountIdentity(id = "account-1", email = null),
+        )
+        val verified = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+
+        verifyDriveAccountBinding(store, verified)
+
+        assertEquals(verified, store.selectedIdentity())
+    }
+
+    @Test
+    fun driveAccountIdentityUsesConstrainedAccountWhenAuthorizationOmitsIdentity() {
+        val selected = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+
+        assertEquals(
+            selected,
+            resolveDriveAccountIdentity(
+                authorizationIdentity = null,
+                constrainedIdentity = selected,
+            ),
+        )
+    }
+
+    @Test
+    fun driveAccountIdentityRejectsFallbackWhenTokenWasNotConstrained() {
+        val selected = DriveAccountIdentity(id = "account-1", email = null)
+
+        assertEquals(
+            null,
+            resolveDriveAccountIdentity(
+                authorizationIdentity = null,
+                constrainedIdentity = selected,
+            ),
+        )
+    }
+
+    @Test
+    fun driveAccountIdentityPrefersAuthorizationIdentity() {
+        val selected = DriveAccountIdentity(id = "account-1", email = "person@example.com")
+        val actual = DriveAccountIdentity(id = "account-2", email = "other@example.com")
+
+        assertEquals(
+            actual,
+            resolveDriveAccountIdentity(
+                authorizationIdentity = actual,
+                constrainedIdentity = selected,
+            ),
+        )
     }
 
     @Test

--- a/rust/src/app/reconcile.rs
+++ b/rust/src/app/reconcile.rs
@@ -47,13 +47,16 @@ impl Updater {
         UPDATER.get_or_init(|| Self(sender));
     }
 
-    pub fn global() -> &'static Self {
-        UPDATER.get().expect("updater is not initialized")
-    }
-
     pub fn send_update(message: AppStateReconcileMessage) {
-        if let Err(e) = Self::global().0.send(message) {
-            tracing::error!("Failed to send update, frontend may be disconnected: {e}");
+        let Some(updater) = UPDATER.get() else {
+            tracing::warn!(
+                "Dropping app reconcile update before updater initialization: {message:?}"
+            );
+            return;
+        };
+
+        if let Err(error) = updater.0.send(message) {
+            tracing::error!("Failed to send update, frontend may be disconnected: {error}");
         }
     }
 }

--- a/rust/src/manager/cloud_backup_manager/ops/tests.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/tests.rs
@@ -7293,9 +7293,23 @@ async fn restore_activation_upload_failure_keeps_restore_successful_and_queues_u
 
     assert_eq!(report.wallets_restored, 1);
     wait_for_test_condition(
-        Duration::from_secs(1),
-        "background reupload should be attempted after restore",
-        || globals.cloud.wallet_backup_upload_attempt_count() > 0,
+        Duration::from_secs(5),
+        "background reupload should fail after restore and remain queued for retry",
+        || {
+            let upload_attempted = globals.cloud.wallet_backup_upload_attempt_count() > 0;
+            let retryable_failure = matches!(
+                Database::global().cloud_blob_sync_states.get(&record_id).unwrap(),
+                Some(PersistedCloudBlobSyncState {
+                    state: PersistedCloudBlobState::Failed(CloudBlobFailedState {
+                        retryable: true,
+                        ..
+                    }),
+                    ..
+                })
+            );
+
+            upload_attempted && retryable_failure
+        },
     )
     .await;
     assert_eq!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Google Drive cloud backup reliability with improved identity verification, matching, and token caching behavior
  * Improved recovery from Drive authorization failures by clearing cached tokens and retrying when appropriate
  * Fixed Drive API request construction, including safer endpoint/query handling and correct URL encoding
  * Improved startup flow by running initialization after bootstrap and made updater sending safer before it’s ready
* **Tests**
  * Added extensive unit and integration-style coverage for Drive identity parsing, URL encoding, and failure/retry behavior
* **Chores**
  * Updated the app’s internal version code for the release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->