### PR TITLE
Add UTXO locking

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -190,7 +190,12 @@ class AppManager private constructor() : FfiReconcile {
 
     fun reconcileAfterLabelImport(walletId: WalletId) {
         mainScope.launch {
-            reconcileAfterLabelImportAndWait(walletId)
+            val refreshed = reconcileAfterLabelImportAndWait(walletId)
+            if (!refreshed) {
+                walletManager
+                    ?.takeIf { it.id == walletId }
+                    ?.notifyLabelRefreshFailed()
+            }
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -260,6 +260,7 @@ class AppManager private constructor() : FfiReconcile {
         // close managers before clearing them
         walletManager?.close()
         sendFlowManager?.close()
+        coinControlManager?.close()
 
         database = Database()
         walletManager = null

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -190,7 +191,15 @@ class AppManager private constructor() : FfiReconcile {
 
     fun reconcileAfterLabelImport(walletId: WalletId) {
         mainScope.launch {
-            val refreshed = reconcileAfterLabelImportAndWait(walletId)
+            val refreshed =
+                try {
+                    reconcileAfterLabelImportAndWait(walletId)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.e(tag, "failed to reconcile after label import", e)
+                    false
+                }
             if (!refreshed) {
                 walletManager
                     ?.takeIf { it.id == walletId }

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -99,6 +99,9 @@ class AppManager private constructor() : FfiReconcile {
     internal var sendFlowManager: SendFlowManager? = null
         private set
 
+    internal var coinControlManager: CoinControlManager? = null
+        private set
+
     val cloudBackupManager: CloudBackupManager = CloudBackupManager.getInstance()
 
     init {
@@ -175,6 +178,34 @@ class AppManager private constructor() : FfiReconcile {
         return manager
     }
 
+    fun setCoinControlManager(manager: CoinControlManager) {
+        coinControlManager = manager
+    }
+
+    fun clearCoinControlManager(manager: CoinControlManager) {
+        if (coinControlManager === manager) {
+            coinControlManager = null
+        }
+    }
+
+    fun reconcileAfterLabelImport(walletId: WalletId) {
+        walletManager
+            ?.takeIf { it.id == walletId }
+            ?.reconcileAfterLabelImport()
+
+        coinControlManager
+            ?.takeIf { it.id == walletId }
+            ?.let { manager ->
+                mainScope.launch {
+                    manager.reloadLabels()
+                }
+            }
+
+        sendFlowManager
+            ?.takeIf { it.id == walletId }
+            ?.reconcileAfterLabelImport()
+    }
+
     fun clearWalletManager() {
         try {
             walletManager?.close()
@@ -233,6 +264,7 @@ class AppManager private constructor() : FfiReconcile {
         database = Database()
         walletManager = null
         sendFlowManager = null
+        coinControlManager = null
 
         val state = rust.state()
         router = RouterManager(state.router)

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -189,21 +189,27 @@ class AppManager private constructor() : FfiReconcile {
     }
 
     fun reconcileAfterLabelImport(walletId: WalletId) {
-        walletManager
-            ?.takeIf { it.id == walletId }
-            ?.reconcileAfterLabelImport()
+        mainScope.launch {
+            reconcileAfterLabelImportAndWait(walletId)
+        }
+    }
+
+    suspend fun reconcileAfterLabelImportAndWait(walletId: WalletId): Boolean {
+        val refreshed =
+            walletManager
+                ?.takeIf { it.id == walletId }
+                ?.reconcileAfterLabelImportAndWait()
+                ?: false
 
         coinControlManager
             ?.takeIf { it.id == walletId }
-            ?.let { manager ->
-                mainScope.launch {
-                    manager.reloadLabels()
-                }
-            }
+            ?.reloadLabels()
 
         sendFlowManager
             ?.takeIf { it.id == walletId }
             ?.reconcileAfterLabelImport()
+
+        return refreshed
     }
 
     fun clearWalletManager() {

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 @Stable
 class CoinControlManager(
-    val rust: RustCoinControlManager,
+    private val rust: RustCoinControlManager,
 ) : CoinControlManagerReconciler,
     Closeable {
     private val tag = "CoinControlManager"
@@ -89,8 +89,13 @@ class CoinControlManager(
     /**
      * get button arrow icon based on sort state
      */
+    fun buttonPresentation(key: CoinControlListSortKey): ButtonPresentation? {
+        if (isClosed.get()) return null
+        return rust.buttonPresentation(key)
+    }
+
     fun buttonArrow(key: CoinControlListSortKey): String? =
-        when (val presentation = rust.buttonPresentation(key)) {
+        when (val presentation = buttonPresentation(key)) {
             is ButtonPresentation.Selected -> {
                 when (presentation.v1) {
                     ListSortDirection.ASCENDING -> "arrow_upward"
@@ -98,6 +103,7 @@ class CoinControlManager(
                 }
             }
             is ButtonPresentation.NotSelected -> null
+            null -> null
         }
 
     val totalSelectedAmount: String
@@ -111,7 +117,7 @@ class CoinControlManager(
      * navigates forward to CoinControlSetAmount screen with selected UTXOs
      */
     fun continuePressed(app: AppManager) {
-        val walletId = rust.id()
+        val walletId = id
         val selectedUtxos = utxos.filter { it.spendable && selected.contains(it.outpoint.hashToUint()) }
 
         // navigate forward to coin control set amount screen
@@ -176,6 +182,7 @@ class CoinControlManager(
         }
 
     suspend fun reloadLabels() {
+        if (isClosed.get()) return
         rust.reloadLabels()
     }
 
@@ -183,24 +190,35 @@ class CoinControlManager(
         outpoint: OutPoint,
         spendable: Boolean,
     ) {
+        if (isClosed.get()) return
+
         withContext(Dispatchers.IO) {
             rust.setUtxoSpendability(outpoint, spendable)
         }
     }
 
     override fun reconcile(message: CoinControlManagerReconcileMessage) {
+        if (isClosed.get()) return
+
         logDebug("reconcile: $message")
         mainScope.launch { apply(message) }
     }
 
     override fun reconcileMany(messages: List<CoinControlManagerReconcileMessage>) {
+        if (isClosed.get()) return
+
         logDebug("reconcile_messages: ${messages.size} messages")
         mainScope.launch { messages.forEach { apply(it) } }
     }
 
     fun dispatch(action: CoinControlManagerAction) {
+        if (isClosed.get()) return
+
         logDebug("dispatch: $action")
-        mainScope.launch(Dispatchers.IO) { rust.dispatch(action) }
+        mainScope.launch(Dispatchers.IO) {
+            if (isClosed.get()) return@launch
+            rust.dispatch(action)
+        }
     }
 
     override fun close() {

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.types.*
 import java.io.Closeable
@@ -30,6 +31,8 @@ class CoinControlManager(
 
     private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val isClosed = AtomicBoolean(false)
+
+    val id: WalletId = rust.id()
 
     var sort by mutableStateOf<CoinControlListSort?>(
         CoinControlListSort.Date(ListSortDirection.DESCENDING),
@@ -76,8 +79,10 @@ class CoinControlManager(
      * update selected utxos and dispatch notification
      */
     fun updateSelected(value: Set<ULong>) {
-        selected = value
-        val outpoints = utxos.filter { value.contains(it.outpoint.hashToUint()) }.map { it.outpoint }
+        val spendableIds = utxos.filter { it.spendable }.map { it.outpoint.hashToUint() }.toSet()
+        val spendableSelection = value.intersect(spendableIds)
+        selected = spendableSelection
+        val outpoints = utxos.filter { spendableSelection.contains(it.outpoint.hashToUint()) }.map { it.outpoint }
         dispatch(CoinControlManagerAction.NotifySelectedUtxosChanged(outpoints))
     }
 
@@ -98,8 +103,8 @@ class CoinControlManager(
     val totalSelectedAmount: String
         get() = displayAmount(totalSelected)
 
-    val totalSelectedSats: Int
-        get() = totalSelected.asSats().toInt()
+    val totalSelectedSats: Long
+        get() = totalSelected.asSats().toLong()
 
     /**
      * called when user presses continue button
@@ -107,7 +112,7 @@ class CoinControlManager(
      */
     fun continuePressed(app: AppManager) {
         val walletId = rust.id()
-        val selectedUtxos = utxos.filter { selected.contains(it.outpoint.hashToUint()) }
+        val selectedUtxos = utxos.filter { it.spendable && selected.contains(it.outpoint.hashToUint()) }
 
         // navigate forward to coin control set amount screen
         val sendRoute = SendRoute.CoinControlSetAmount(walletId, selectedUtxos)
@@ -121,7 +126,7 @@ class CoinControlManager(
             mainScope.launch {
                 delay(SEND_FLOW_UPDATE_DELAY_MS)
                 if (!isActive) return@launch
-                val selectedUtxos = utxos.filter { selected.contains(it.outpoint.hashToUint()) }
+                val selectedUtxos = utxos.filter { it.spendable && selected.contains(it.outpoint.hashToUint()) }
                 sfm.dispatch(SendFlowManagerAction.SetCoinControlMode(selectedUtxos))
             }
     }
@@ -169,6 +174,19 @@ class CoinControlManager(
             BitcoinUnit.SAT to false -> amount.satsString()
             else -> amount.satsStringWithUnit()
         }
+
+    suspend fun reloadLabels() {
+        rust.reloadLabels()
+    }
+
+    suspend fun setSpendability(
+        outpoint: OutPoint,
+        spendable: Boolean,
+    ) {
+        withContext(Dispatchers.IO) {
+            rust.setUtxoSpendability(outpoint, spendable)
+        }
+    }
 
     override fun reconcile(message: CoinControlManagerReconcileMessage) {
         logDebug("reconcile: $message")

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -48,6 +48,9 @@ class CoinControlManager(
     var utxos by mutableStateOf<List<Utxo>>(emptyList())
         private set
 
+    var lockStateLoadFailed by mutableStateOf(false)
+        private set
+
     var unit by mutableStateOf(BitcoinUnit.SAT)
         private set
 
@@ -56,6 +59,7 @@ class CoinControlManager(
     init {
         logDebug("Initializing CoinControlManager")
         utxos = rust.utxos()
+        lockStateLoadFailed = rust.lockStateLoadFailed()
         unit = rust.unit()
         rust.listenForUpdates(this)
     }
@@ -86,13 +90,16 @@ class CoinControlManager(
     }
 
     /**
-     * get button arrow icon based on sort state
+     * get current button presentation based on sort state
      */
     fun buttonPresentation(key: CoinControlListSortKey): ButtonPresentation? {
         if (isClosed.get()) return null
         return rust.buttonPresentation(key)
     }
 
+    /**
+     * get button arrow icon based on sort state
+     */
     fun buttonArrow(key: CoinControlListSortKey): String? =
         when (val presentation = buttonPresentation(key)) {
             is ButtonPresentation.Selected -> {
@@ -162,6 +169,10 @@ class CoinControlManager(
 
             is CoinControlManagerReconcileMessage.UpdateUnit -> {
                 unit = message.v1
+            }
+
+            is CoinControlManagerReconcileMessage.UpdateLockStateLoadFailed -> {
+                lockStateLoadFailed = message.v1
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.types.*
 import java.io.Closeable
@@ -187,9 +186,7 @@ class CoinControlManager(
     ) {
         if (isClosed.get()) return
 
-        withContext(Dispatchers.IO) {
-            rust.setUtxoSpendability(outpoint, spendable)
-        }
+        rust.setUtxoSpendability(outpoint, spendable)
     }
 
     override fun reconcile(message: CoinControlManagerReconcileMessage) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -82,10 +82,24 @@ class CoinControlManager(
      * update selected utxos and dispatch notification
      */
     fun updateSelected(value: Set<ULong>) {
-        val spendableIds = utxos.filter { it.spendable }.map { it.outpoint.hashToUint() }.toSet()
-        val spendableSelection = value.intersect(spendableIds)
+        if (isClosed.get()) return
+
+        val visibleIds = utxos.map { it.outpoint.hashToUint() }.toSet()
+        val visibleSpendableIds = utxos.filter { it.spendable }.map { it.outpoint.hashToUint() }.toSet()
+        val selectedOutsideVisibleSearch = selected.subtract(visibleIds)
+        val spendableSelection = selectedOutsideVisibleSearch.union(value.intersect(visibleSpendableIds))
         selected = spendableSelection
-        val outpoints = utxos.filter { spendableSelection.contains(it.outpoint.hashToUint()) }.map { it.outpoint }
+
+        val hiddenSelectedOutpoints =
+            rust
+                .selectedUtxos()
+                .filter { selectedOutsideVisibleSearch.contains(it.outpoint.hashToUint()) }
+                .map { it.outpoint }
+        val visibleSelectedOutpoints =
+            utxos
+                .filter { it.spendable && spendableSelection.contains(it.outpoint.hashToUint()) }
+                .map { it.outpoint }
+        val outpoints = hiddenSelectedOutpoints + visibleSelectedOutpoints
         dispatch(CoinControlManagerAction.NotifySelectedUtxosChanged(outpoints))
     }
 
@@ -123,8 +137,10 @@ class CoinControlManager(
      * navigates forward to CoinControlSetAmount screen with selected UTXOs
      */
     fun continuePressed(app: AppManager) {
+        if (isClosed.get()) return
+
         val walletId = id
-        val selectedUtxos = utxos.filter { it.spendable && selected.contains(it.outpoint.hashToUint()) }
+        val selectedUtxos = rust.selectedUtxos()
 
         // navigate forward to coin control set amount screen
         val sendRoute = SendRoute.CoinControlSetAmount(walletId, selectedUtxos)
@@ -137,8 +153,9 @@ class CoinControlManager(
         updateSendFlowManagerTask =
             mainScope.launch {
                 delay(SEND_FLOW_UPDATE_DELAY_MS)
-                if (!isActive) return@launch
-                val selectedUtxos = utxos.filter { it.spendable && selected.contains(it.outpoint.hashToUint()) }
+                if (!isActive || isClosed.get()) return@launch
+
+                val selectedUtxos = rust.selectedUtxos()
                 sfm.dispatch(SendFlowManagerAction.SetCoinControlMode(selectedUtxos))
             }
     }
@@ -195,7 +212,7 @@ class CoinControlManager(
         outpoint: OutPoint,
         spendable: Boolean,
     ) {
-        if (isClosed.get()) return
+        check(!isClosed.get()) { "CoinControlManager is closed" }
 
         rust.setUtxoSpendability(outpoint, spendable)
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/CoinControlManager.kt
@@ -164,11 +164,6 @@ class CoinControlManager(
             is CoinControlManagerReconcileMessage.UpdateUnit -> {
                 unit = message.v1
             }
-
-            is CoinControlManagerReconcileMessage.UpdateTotalSelectedAmount -> {
-                updateSendFlowManager()
-                totalSelected = message.v1
-            }
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
@@ -64,8 +64,9 @@ class ScanManager private constructor() {
     }
 
     private fun importLabels(labels: Bip329Labels) {
+        val manager = app.walletManager
         val selectedWallet = Database().globalConfig().selectedWallet()
-        if (selectedWallet == null) {
+        if (manager == null || selectedWallet != manager.id) {
             app.alertState =
                 TaggedItem(
                     AppAlertState.InvalidFileFormat(
@@ -76,8 +77,7 @@ class ScanManager private constructor() {
         }
 
         try {
-            LabelManager(id = selectedWallet).use { it.importLabels(labels) }
-            app.reconcileAfterLabelImport(selectedWallet)
+            manager.importLabels(labels)
             app.alertState = TaggedItem(AppAlertState.ImportedLabelsSuccessfully)
         } catch (e: Exception) {
             Log.e(tag, "Failed to import labels", e)

--- a/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
@@ -1,10 +1,6 @@
 package org.bitcoinppl.cove
 
 import androidx.compose.runtime.Stable
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.AppAlertState
 import org.bitcoinppl.cove_core.tapcard.*
@@ -13,7 +9,6 @@ import org.bitcoinppl.cove_core.types.*
 @Stable
 class ScanManager private constructor() {
     private val tag = "ScanManager"
-    private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private val app: AppManager get() = AppManager.getInstance()
 
@@ -56,8 +51,8 @@ class ScanManager private constructor() {
                 }
 
                 is MultiFormat.Bip329Labels -> {
-                    val selectedWallet = Database().globalConfig().selectedWallet()
-                    if (selectedWallet == null) {
+                    val manager = app.walletManager
+                    if (manager == null || Database().globalConfig().selectedWallet() == null) {
                         app.alertState =
                             TaggedItem(
                                 AppAlertState.InvalidFileFormat(
@@ -68,14 +63,8 @@ class ScanManager private constructor() {
                     }
 
                     try {
-                        LabelManager(id = selectedWallet).use { it.importLabels(multiFormat.v1) }
+                        manager.importLabels(multiFormat.v1)
                         app.alertState = TaggedItem(AppAlertState.ImportedLabelsSuccessfully)
-
-                        app.walletManager?.let { wm ->
-                            mainScope.launch {
-                                wm.rust.getTransactions()
-                            }
-                        }
                     } catch (e: Exception) {
                         Log.e(tag, "Failed to import labels", e)
                         app.alertState =

--- a/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/ScanManager.kt
@@ -51,29 +51,7 @@ class ScanManager private constructor() {
                 }
 
                 is MultiFormat.Bip329Labels -> {
-                    val manager = app.walletManager
-                    if (manager == null || Database().globalConfig().selectedWallet() == null) {
-                        app.alertState =
-                            TaggedItem(
-                                AppAlertState.InvalidFileFormat(
-                                    "Currently BIP329 labels must be imported through the wallet actions",
-                                ),
-                            )
-                        return
-                    }
-
-                    try {
-                        manager.importLabels(multiFormat.v1)
-                        app.alertState = TaggedItem(AppAlertState.ImportedLabelsSuccessfully)
-                    } catch (e: Exception) {
-                        Log.e(tag, "Failed to import labels", e)
-                        app.alertState =
-                            TaggedItem(
-                                AppAlertState.InvalidFileFormat(
-                                    e.message ?: "Failed to import labels",
-                                ),
-                            )
-                    }
+                    importLabels(multiFormat.v1)
                 }
             }
         } catch (e: Exception) {
@@ -81,6 +59,33 @@ class ScanManager private constructor() {
             app.alertState =
                 TaggedItem(
                     AppAlertState.InvalidFileFormat(e.message ?: "Unknown error"),
+                )
+        }
+    }
+
+    private fun importLabels(labels: Bip329Labels) {
+        val selectedWallet = Database().globalConfig().selectedWallet()
+        if (selectedWallet == null) {
+            app.alertState =
+                TaggedItem(
+                    AppAlertState.InvalidFileFormat(
+                        "Currently BIP329 labels must be imported through the wallet actions",
+                    ),
+                )
+            return
+        }
+
+        try {
+            LabelManager(id = selectedWallet).use { it.importLabels(labels) }
+            app.reconcileAfterLabelImport(selectedWallet)
+            app.alertState = TaggedItem(AppAlertState.ImportedLabelsSuccessfully)
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to import labels", e)
+            app.alertState =
+                TaggedItem(
+                    AppAlertState.InvalidFileFormat(
+                        e.message ?: "Failed to import labels",
+                    ),
                 )
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -316,9 +316,20 @@ class WalletManager :
     }
 
     fun reconcileAfterLabelImport() {
-        transactionDetailsCache.clear()
         mainScope.launch {
+            reconcileAfterLabelImportAndWait()
+        }
+    }
+
+    suspend fun reconcileAfterLabelImportAndWait(): Boolean {
+        transactionDetailsCache.clear()
+
+        return try {
             rust.getTransactions()
+            true
+        } catch (e: Exception) {
+            Log.e(tag, "failed to refresh transactions after label import", e)
+            false
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -306,6 +306,22 @@ class WalletManager :
         return details
     }
 
+    suspend fun transactionLockState(txId: TxId): TransactionLockState = rust.transactionLockState(txId)
+
+    suspend fun toggleTransactionLockState(txId: TxId): TransactionLockState = rust.toggleTransactionLockState(txId)
+
+    fun importLabels(labels: Bip329Labels) {
+        LabelManager(id = id).use { it.importLabels(labels) }
+        AppManager.getInstance().reconcileAfterLabelImport(id)
+    }
+
+    fun reconcileAfterLabelImport() {
+        transactionDetailsCache.clear()
+        mainScope.launch {
+            rust.getTransactions()
+        }
+    }
+
     fun updateTransactionDetailsCache(txId: TxId, details: TransactionDetails) {
         transactionDetailsCache[txId] = details
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -90,6 +90,8 @@ class WalletManager :
     // errors
     var errorAlert by mutableStateOf<WalletErrorAlert?>(null)
     var sendFlowErrorAlert by mutableStateOf<TaggedItem<SendFlowErrorAlert>?>(null)
+    var labelRefreshFailed by mutableStateOf<TaggedItem<Unit>?>(null)
+        private set
 
     // cached transaction details (observable for Compose)
     val transactionDetailsCache: SnapshotStateMap<TxId, TransactionDetails> = mutableStateMapOf()
@@ -308,7 +310,12 @@ class WalletManager :
 
     suspend fun transactionLockState(txId: TxId): TransactionLockState = rust.transactionLockState(txId)
 
-    suspend fun toggleTransactionLockState(txId: TxId): TransactionLockState = rust.toggleTransactionLockState(txId)
+    suspend fun toggleTransactionLockState(txId: TxId): TransactionLockState {
+        val state = rust.toggleTransactionLockState(txId)
+        AppManager.getInstance().reconcileAfterLabelImport(id)
+
+        return state
+    }
 
     fun importLabels(labels: Bip329Labels) {
         LabelManager(id = id).use { it.importLabels(labels) }
@@ -317,7 +324,10 @@ class WalletManager :
 
     fun reconcileAfterLabelImport() {
         mainScope.launch {
-            reconcileAfterLabelImportAndWait()
+            val refreshed = reconcileAfterLabelImportAndWait()
+            if (!refreshed) {
+                notifyLabelRefreshFailed()
+            }
         }
     }
 
@@ -327,10 +337,18 @@ class WalletManager :
         return try {
             rust.getTransactions()
             true
-        } catch (e: Exception) {
+        } catch (e: IllegalStateException) {
             Log.e(tag, "failed to refresh transactions after label import", e)
             false
         }
+    }
+
+    fun notifyLabelRefreshFailed() {
+        labelRefreshFailed = TaggedItem(Unit)
+    }
+
+    fun clearLabelRefreshFailed() {
+        labelRefreshFailed = null
     }
 
     fun updateTransactionDetailsCache(txId: TxId, details: TransactionDetails) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -322,22 +323,15 @@ class WalletManager :
         AppManager.getInstance().reconcileAfterLabelImport(id)
     }
 
-    fun reconcileAfterLabelImport() {
-        mainScope.launch {
-            val refreshed = reconcileAfterLabelImportAndWait()
-            if (!refreshed) {
-                notifyLabelRefreshFailed()
-            }
-        }
-    }
-
     suspend fun reconcileAfterLabelImportAndWait(): Boolean {
         transactionDetailsCache.clear()
 
         return try {
             rust.getTransactions()
             true
-        } catch (e: IllegalStateException) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             Log.e(tag, "failed to refresh transactions after label import", e)
             false
         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/CoinControlContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/CoinControlContainer.kt
@@ -51,6 +51,7 @@ fun CoinControlContainer(
 
             walletManager = wm
             manager = ccm
+            app.setCoinControlManager(ccm)
         } catch (e: WalletManagerException.InitialScanIncomplete) {
             android.util.Log.e(tag, "initial scan incomplete", e)
             app.showInitialScanIncompleteAlert()
@@ -98,7 +99,10 @@ fun CoinControlContainer(
     // cleanup on disappear or wallet change
     DisposableEffect(walletId) {
         onDispose {
-            manager?.close()
+            manager?.let {
+                app.clearCoinControlManager(it)
+                it.close()
+            }
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ButtonDefaults
@@ -46,6 +48,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,6 +67,7 @@ import org.bitcoinppl.cove.ui.theme.CoveColor
 import org.bitcoinppl.cove.ui.theme.coveColors
 import org.bitcoinppl.cove.views.AutoSizeText
 import org.bitcoinppl.cove.views.ImageButton
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -95,9 +99,11 @@ fun UtxoListScreen(
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
+    val scope = rememberCoroutineScope()
+
     // reload labels on appear to match iOS behavior
     LaunchedEffect(manager) {
-        manager.rust.reloadLabels()
+        manager.reloadLabels()
     }
 
     UtxoListScreenContent(
@@ -110,14 +116,31 @@ fun UtxoListScreen(
         onToggleUnit = {
             manager.dispatch(org.bitcoinppl.cove_core.CoinControlManagerAction.ToggleUnit)
         },
-        onToggle = { hash ->
-            val newSelected =
-                if (manager.selected.contains(hash)) {
-                    manager.selected - hash
-                } else {
-                    manager.selected + hash
+        onToggle = { utxo ->
+            if (!utxo.spendable) {
+                scope.launch {
+                    snackbarHostState.showSnackbar("Unlock this UTXO before selecting it.")
                 }
-            manager.updateSelected(newSelected)
+            } else {
+                val id = utxo.id
+                val newSelected =
+                    if (manager.selected.contains(id)) {
+                        manager.selected - id
+                    } else {
+                        manager.selected + id
+                    }
+                manager.updateSelected(newSelected)
+            }
+        },
+        onSetSpendability = { utxo, spendable ->
+            scope.launch {
+                try {
+                    manager.setSpendability(utxo.outpoint, spendable)
+                } catch (e: Exception) {
+                    android.util.Log.e("UtxoListScreen", "Unable to update UTXO spendability", e)
+                    snackbarHostState.showSnackbar("Unable to update UTXO lock.")
+                }
+            }
         },
         onToggleSelectAll = {
             manager.dispatch(org.bitcoinppl.cove_core.CoinControlManagerAction.ToggleSelectAll)
@@ -155,7 +178,8 @@ private fun UtxoListScreenContent(
     searchQuery: String,
     onBack: () -> Unit,
     onToggleUnit: () -> Unit,
-    onToggle: (ULong) -> Unit,
+    onToggle: (org.bitcoinppl.cove_core.types.Utxo) -> Unit,
+    onSetSpendability: (org.bitcoinppl.cove_core.types.Utxo, Boolean) -> Unit,
     onToggleSelectAll: () -> Unit,
     onSortChange: (UtxoSort) -> Unit,
     onContinue: () -> Unit,
@@ -323,8 +347,11 @@ private fun UtxoListScreenContent(
                                 UtxoItemRow(
                                     manager = manager,
                                     utxo = utxo,
-                                    selected = selected.contains(utxo.id),
-                                    onToggle = { onToggle(utxo.id) },
+                                    selected = utxo.spendable && selected.contains(utxo.id),
+                                    onToggle = { onToggle(utxo) },
+                                    onSetSpendability = {
+                                        onSetSpendability(utxo, !utxo.spendable)
+                                    },
                                 )
                                 if (index != utxos.lastIndex) {
                                     HorizontalDivider(
@@ -417,16 +444,18 @@ private fun UtxoItemRow(
     utxo: org.bitcoinppl.cove_core.types.Utxo,
     selected: Boolean,
     onToggle: () -> Unit,
+    onSetSpendability: () -> Unit,
 ) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 16.dp)
+                .graphicsLayer(alpha = if (utxo.spendable) 1f else 0.58f)
                 .clickable { onToggle() },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        SelectionCircle(selected = selected)
+        SelectionCircle(selected = selected, spendable = utxo.spendable)
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -439,6 +468,15 @@ private fun UtxoItemRow(
                 if (utxo.type == org.bitcoinppl.cove_core.types.UtxoType.CHANGE) {
                     Spacer(Modifier.width(4.dp))
                     ChangeBadge()
+                }
+                if (!utxo.spendable) {
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        imageVector = Icons.Filled.Lock,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(14.dp),
+                    )
                 }
             }
             Spacer(Modifier.height(4.dp))
@@ -464,11 +502,22 @@ private fun UtxoItemRow(
                 fontSize = 12.sp,
             )
         }
+        Spacer(Modifier.width(8.dp))
+        IconButton(onClick = onSetSpendability) {
+            Icon(
+                imageVector = if (utxo.spendable) Icons.Filled.LockOpen else Icons.Filled.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 
 @Composable
-private fun SelectionCircle(selected: Boolean) {
+private fun SelectionCircle(
+    selected: Boolean,
+    spendable: Boolean,
+) {
     val selectedColor = CoveColor.LinkBlue
     val unselectedColor = MaterialTheme.colorScheme.outlineVariant
     Box(
@@ -483,7 +532,14 @@ private fun SelectionCircle(selected: Boolean) {
                 ).background(if (selected) selectedColor else Color.Transparent),
         contentAlignment = Alignment.Center,
     ) {
-        if (selected) {
+        if (!spendable) {
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                tint = unselectedColor,
+                modifier = Modifier.size(14.dp),
+            )
+        } else if (selected) {
             Icon(
                 imageVector = Icons.Default.Check,
                 contentDescription = null,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
@@ -574,10 +574,10 @@ private fun SortRow(
     @Suppress("UNUSED_VARIABLE")
     val sort = manager.sort
 
-    val datePresentation = manager.rust.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.DATE)
-    val namePresentation = manager.rust.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.NAME)
-    val amountPresentation = manager.rust.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.AMOUNT)
-    val changePresentation = manager.rust.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.CHANGE)
+    val datePresentation = manager.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.DATE)
+    val namePresentation = manager.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.NAME)
+    val amountPresentation = manager.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.AMOUNT)
+    val changePresentation = manager.buttonPresentation(org.bitcoinppl.cove_core.CoinControlListSortKey.CHANGE)
 
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
@@ -112,6 +112,7 @@ fun UtxoListScreen(
         manager = manager,
         utxos = manager.utxos,
         selected = manager.selected,
+        lockStateLoadFailed = manager.lockStateLoadFailed,
         totalSelectedAmount = manager.totalSelectedAmount,
         searchQuery = manager.search,
         onBack = { app.popRoute() },
@@ -176,6 +177,7 @@ private fun UtxoListScreenContent(
     manager: org.bitcoinppl.cove.CoinControlManager,
     utxos: List<org.bitcoinppl.cove_core.types.Utxo>,
     selected: Set<ULong>,
+    lockStateLoadFailed: Boolean,
     totalSelectedAmount: String,
     searchQuery: String,
     onBack: () -> Unit,
@@ -376,6 +378,19 @@ private fun UtxoListScreenContent(
                             color = secondaryText,
                             fontSize = 11.sp,
                             fontWeight = FontWeight.Medium,
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                        )
+                    }
+
+                    if (lockStateLoadFailed) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(R.string.warning_utxo_lock_state_load_failed),
+                            modifier = Modifier.fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.error,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 16.sp,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                         )
                     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/CoinControlFlow/UtxoListScreen.kt
@@ -100,6 +100,8 @@ fun UtxoListScreen(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val scope = rememberCoroutineScope()
+    val lockedSelectionMessage = stringResource(R.string.snackbar_utxo_locked_selection)
+    val updateUtxoLockErrorMessage = stringResource(R.string.snackbar_utxo_lock_update_error)
 
     // reload labels on appear to match iOS behavior
     LaunchedEffect(manager) {
@@ -119,7 +121,7 @@ fun UtxoListScreen(
         onToggle = { utxo ->
             if (!utxo.spendable) {
                 scope.launch {
-                    snackbarHostState.showSnackbar("Unlock this UTXO before selecting it.")
+                    snackbarHostState.showSnackbar(lockedSelectionMessage)
                 }
             } else {
                 val id = utxo.id
@@ -138,7 +140,7 @@ fun UtxoListScreen(
                     manager.setSpendability(utxo.outpoint, spendable)
                 } catch (e: Exception) {
                     android.util.Log.e("UtxoListScreen", "Unable to update UTXO spendability", e)
-                    snackbarHostState.showSnackbar("Unable to update UTXO lock.")
+                    snackbarHostState.showSnackbar(updateUtxoLockErrorMessage)
                 }
             }
         },

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletContainer.kt
@@ -10,11 +10,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.bitcoinppl.cove.AppManager
+import org.bitcoinppl.cove.R
+import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.WalletLoadState
 import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove.initialScanIncomplete
@@ -22,7 +25,6 @@ import org.bitcoinppl.cove.components.FullPageLoadingView
 import org.bitcoinppl.cove.wallet.WalletExportState
 import org.bitcoinppl.cove.wallet.WalletSheetsHost
 import org.bitcoinppl.cove.wallet.rememberWalletExportLaunchers
-import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove_core.AppAlertState
 import org.bitcoinppl.cove_core.Database
 import org.bitcoinppl.cove_core.DiscoveryState
@@ -134,6 +136,16 @@ fun SelectedWalletContainer(
 
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+    val labelRefreshFailed = manager?.labelRefreshFailed
+    val labelRefreshFailedMessage = stringResource(R.string.snackbar_label_refresh_failed)
+
+    LaunchedEffect(labelRefreshFailed?.id) {
+        val currentManager = manager ?: return@LaunchedEffect
+        if (labelRefreshFailed == null) return@LaunchedEffect
+
+        snackbarHostState.showSnackbar(labelRefreshFailedMessage)
+        currentManager.clearLabelRefreshFailed()
+    }
 
     // cleanup on dispose - clear alert state if export is in progress
     // keyed on exportState so effect restarts when wallet changes (exportState is remember(id))

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
@@ -78,6 +78,7 @@ import org.bitcoinppl.cove.views.BalanceAutoSizeText
 import org.bitcoinppl.cove.views.ImageButton
 import org.bitcoinppl.cove_core.HeaderIconPresenter
 import org.bitcoinppl.cove_core.TransactionDetails
+import org.bitcoinppl.cove_core.TransactionLockState
 import org.bitcoinppl.cove_core.TransactionState
 import org.bitcoinppl.cove_core.WalletManagerAction
 import org.bitcoinppl.cove_core.types.FfiColorScheme
@@ -117,6 +118,8 @@ fun TransactionDetailsScreen(
     // state for confirmation polling and pull-to-refresh
     var numberOfConfirmations by remember { mutableStateOf<Int?>(null) }
     var isRefreshing by remember { mutableStateOf(false) }
+    var lockState by remember { mutableStateOf<TransactionLockState?>(null) }
+    var isUpdatingLockState by remember { mutableStateOf(false) }
 
     // use cached fiat values for immediate display, null shows spinner
     var feeFiatFmt by remember { mutableStateOf(transactionDetails.feeFiatFmtCached()) }
@@ -136,6 +139,12 @@ fun TransactionDetailsScreen(
             manager.updateTransactionDetailsCache(txId, freshDetails)
         } catch (e: Exception) {
             android.util.Log.e("TransactionDetails", "error fetching fresh details", e)
+        }
+
+        try {
+            lockState = manager.transactionLockState(txId)
+        } catch (e: Exception) {
+            android.util.Log.e("TransactionDetails", "error fetching transaction lock state", e)
         }
     }
 
@@ -366,6 +375,7 @@ fun TransactionDetailsScreen(
                             val confirmations = manager.rust.numberOfConfirmations(blockHeight = blockNumber)
                             numberOfConfirmations = confirmations.toInt()
                         }
+                        lockState = manager.transactionLockState(txId)
                     } catch (e: Exception) {
                         android.util.Log.e("TransactionDetails", "error refreshing details", e)
                     }
@@ -513,6 +523,27 @@ fun TransactionDetailsScreen(
                         showStroke = capsuleConfig.third,
                     )
 
+                    if (lockState != null && lockState != TransactionLockState.NONE) {
+                        Spacer(Modifier.height(12.dp))
+                        TransactionLockAction(
+                            state = lockState!!,
+                            updating = isUpdatingLockState,
+                            color = sub,
+                            onToggle = {
+                                scope.launch {
+                                    isUpdatingLockState = true
+                                    try {
+                                        lockState = manager.toggleTransactionLockState(txId)
+                                    } catch (e: Exception) {
+                                        android.util.Log.e("TransactionDetails", "error toggling transaction lock state", e)
+                                        snackbarHostState.showSnackbar("Unable to update transaction lock.")
+                                    }
+                                    isUpdatingLockState = false
+                                }
+                            },
+                        )
+                    }
+
                     Spacer(Modifier.height(32.dp))
 
                     // show confirmation indicator if < 3 confirmations
@@ -604,6 +635,47 @@ fun TransactionDetailsScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TransactionLockAction(
+    state: TransactionLockState,
+    updating: Boolean,
+    color: Color,
+    onToggle: () -> Unit,
+) {
+    val stateText =
+        when (state) {
+            TransactionLockState.LOCKED -> "Locked"
+            TransactionLockState.MIXED -> "Mixed"
+            TransactionLockState.UNLOCKED -> "Unlocked"
+            TransactionLockState.NONE -> ""
+        }
+    val buttonText =
+        when (state) {
+            TransactionLockState.LOCKED -> "Unlock Transaction"
+            TransactionLockState.MIXED, TransactionLockState.UNLOCKED -> "Lock Transaction"
+            TransactionLockState.NONE -> ""
+        }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = stateText,
+            color = color,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        TextButton(
+            onClick = onToggle,
+            enabled = !updating,
+        ) {
+            Text(
+                text = if (updating) "Updating..." else buttonText,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
@@ -235,6 +235,8 @@ fun TransactionDetailsScreen(
     }
 
     val snackbarHostState = remember { SnackbarHostState() }
+    val transactionLockUpdateErrorMessage =
+        stringResource(R.string.snackbar_transaction_lock_update_error)
 
     // theme colors
     val bg = MaterialTheme.colorScheme.background
@@ -530,15 +532,18 @@ fun TransactionDetailsScreen(
                             updating = isUpdatingLockState,
                             color = sub,
                             onToggle = {
-                                scope.launch {
+                                if (!isUpdatingLockState) {
                                     isUpdatingLockState = true
-                                    try {
-                                        lockState = manager.toggleTransactionLockState(txId)
-                                    } catch (e: Exception) {
-                                        android.util.Log.e("TransactionDetails", "error toggling transaction lock state", e)
-                                        snackbarHostState.showSnackbar("Unable to update transaction lock.")
+                                    scope.launch {
+                                        try {
+                                            lockState = manager.toggleTransactionLockState(txId)
+                                        } catch (e: Exception) {
+                                            android.util.Log.e("TransactionDetails", "error toggling transaction lock state", e)
+                                            snackbarHostState.showSnackbar(transactionLockUpdateErrorMessage)
+                                        } finally {
+                                            isUpdatingLockState = false
+                                        }
                                     }
-                                    isUpdatingLockState = false
                                 }
                             },
                         )
@@ -648,17 +653,18 @@ private fun TransactionLockAction(
 ) {
     val stateText =
         when (state) {
-            TransactionLockState.LOCKED -> "Locked"
-            TransactionLockState.MIXED -> "Mixed"
-            TransactionLockState.UNLOCKED -> "Unlocked"
+            TransactionLockState.LOCKED -> stringResource(R.string.label_transaction_lock_state_locked)
+            TransactionLockState.MIXED -> stringResource(R.string.label_transaction_lock_state_mixed)
+            TransactionLockState.UNLOCKED -> stringResource(R.string.label_transaction_lock_state_unlocked)
             TransactionLockState.NONE -> ""
         }
     val buttonText =
         when (state) {
-            TransactionLockState.LOCKED -> "Unlock Transaction"
-            TransactionLockState.MIXED, TransactionLockState.UNLOCKED -> "Lock Transaction"
+            TransactionLockState.LOCKED -> stringResource(R.string.btn_unlock_transaction)
+            TransactionLockState.MIXED, TransactionLockState.UNLOCKED -> stringResource(R.string.btn_lock_transaction)
             TransactionLockState.NONE -> ""
         }
+    val updatingText = stringResource(R.string.label_transaction_lock_updating)
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
@@ -672,7 +678,7 @@ private fun TransactionLockAction(
             enabled = !updating,
         ) {
             Text(
-                text = if (updating) "Updating..." else buttonText,
+                text = if (updating) updatingText else buttonText,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
             )

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
@@ -150,6 +150,30 @@ fun TransactionDetailsScreen(
         }
     }
 
+    fun retryTransactionLockState() {
+        scope.launch {
+            refreshTransactionLockState(showSnackbar = true)
+        }
+    }
+
+    fun toggleTransactionLockState() {
+        if (isUpdatingLockState) {
+            return
+        }
+
+        isUpdatingLockState = true
+        scope.launch {
+            try {
+                lockState = manager.toggleTransactionLockState(txId)
+            } catch (e: Exception) {
+                android.util.Log.e("TransactionDetails", "error toggling transaction lock state", e)
+                snackbarHostState.showSnackbar(transactionLockUpdateErrorMessage)
+            } finally {
+                isUpdatingLockState = false
+            }
+        }
+    }
+
     // immediately fetch fresh transaction details on screen load
     LaunchedEffect(manager, txId, refreshOnAppear) {
         if (!refreshOnAppear) return@LaunchedEffect
@@ -538,39 +562,14 @@ fun TransactionDetailsScreen(
                         showStroke = capsuleConfig.third,
                     )
 
-                    if (lockStateLoadFailed) {
-                        Spacer(Modifier.height(12.dp))
-                        TransactionLockLoadError(
-                            color = sub,
-                            onRetry = {
-                                scope.launch {
-                                    refreshTransactionLockState(showSnackbar = true)
-                                }
-                            },
-                        )
-                    } else if (lockState != null && lockState != TransactionLockState.NONE) {
-                        Spacer(Modifier.height(12.dp))
-                        TransactionLockAction(
-                            state = lockState!!,
-                            updating = isUpdatingLockState,
-                            color = sub,
-                            onToggle = {
-                                if (!isUpdatingLockState) {
-                                    isUpdatingLockState = true
-                                    scope.launch {
-                                        try {
-                                            lockState = manager.toggleTransactionLockState(txId)
-                                        } catch (e: Exception) {
-                                            android.util.Log.e("TransactionDetails", "error toggling transaction lock state", e)
-                                            snackbarHostState.showSnackbar(transactionLockUpdateErrorMessage)
-                                        } finally {
-                                            isUpdatingLockState = false
-                                        }
-                                    }
-                                }
-                            },
-                        )
-                    }
+                    TransactionLockControls(
+                        state = lockState,
+                        loadFailed = lockStateLoadFailed,
+                        updating = isUpdatingLockState,
+                        color = sub,
+                        onRetry = ::retryTransactionLockState,
+                        onToggle = ::toggleTransactionLockState,
+                    )
 
                     Spacer(Modifier.height(32.dp))
 
@@ -663,6 +662,38 @@ fun TransactionDetailsScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TransactionLockControls(
+    state: TransactionLockState?,
+    loadFailed: Boolean,
+    updating: Boolean,
+    color: Color,
+    onRetry: () -> Unit,
+    onToggle: () -> Unit,
+) {
+    val actionState = state?.takeUnless { it == TransactionLockState.NONE }
+
+    when {
+        loadFailed -> {
+            Spacer(Modifier.height(12.dp))
+            TransactionLockLoadError(
+                color = color,
+                onRetry = onRetry,
+            )
+        }
+
+        actionState != null -> {
+            Spacer(Modifier.height(12.dp))
+            TransactionLockAction(
+                state = actionState,
+                updating = updating,
+                color = color,
+                onToggle = onToggle,
+            )
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
@@ -120,6 +120,7 @@ fun TransactionDetailsScreen(
     var isRefreshing by remember { mutableStateOf(false) }
     var lockState by remember { mutableStateOf<TransactionLockState?>(null) }
     var isUpdatingLockState by remember { mutableStateOf(false) }
+    var lockStateLoadFailed by remember { mutableStateOf(false) }
 
     // use cached fiat values for immediate display, null shows spinner
     var feeFiatFmt by remember { mutableStateOf(transactionDetails.feeFiatFmtCached()) }
@@ -129,6 +130,25 @@ fun TransactionDetailsScreen(
 
     // get current color scheme (respects in-app theme toggle)
     val isDark = !MaterialTheme.colorScheme.isLight
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val transactionLockUpdateErrorMessage =
+        stringResource(R.string.snackbar_transaction_lock_update_error)
+    val transactionLockLoadErrorMessage =
+        stringResource(R.string.snackbar_transaction_lock_load_error)
+
+    suspend fun refreshTransactionLockState(showSnackbar: Boolean) {
+        try {
+            lockState = manager.transactionLockState(txId)
+            lockStateLoadFailed = false
+        } catch (e: Exception) {
+            android.util.Log.e("TransactionDetails", "error fetching transaction lock state", e)
+            lockStateLoadFailed = true
+            if (showSnackbar) {
+                snackbarHostState.showSnackbar(transactionLockLoadErrorMessage)
+            }
+        }
+    }
 
     // immediately fetch fresh transaction details on screen load
     LaunchedEffect(manager, txId, refreshOnAppear) {
@@ -141,11 +161,7 @@ fun TransactionDetailsScreen(
             android.util.Log.e("TransactionDetails", "error fetching fresh details", e)
         }
 
-        try {
-            lockState = manager.transactionLockState(txId)
-        } catch (e: Exception) {
-            android.util.Log.e("TransactionDetails", "error fetching transaction lock state", e)
-        }
+        refreshTransactionLockState(showSnackbar = false)
     }
 
     // load fiat amounts (update cached values with fresh async values)
@@ -233,10 +249,6 @@ fun TransactionDetailsScreen(
             }
         }
     }
-
-    val snackbarHostState = remember { SnackbarHostState() }
-    val transactionLockUpdateErrorMessage =
-        stringResource(R.string.snackbar_transaction_lock_update_error)
 
     // theme colors
     val bg = MaterialTheme.colorScheme.background
@@ -377,10 +389,11 @@ fun TransactionDetailsScreen(
                             val confirmations = manager.rust.numberOfConfirmations(blockHeight = blockNumber)
                             numberOfConfirmations = confirmations.toInt()
                         }
-                        lockState = manager.transactionLockState(txId)
                     } catch (e: Exception) {
                         android.util.Log.e("TransactionDetails", "error refreshing details", e)
                     }
+
+                    refreshTransactionLockState(showSnackbar = true)
                     isRefreshing = false
                 }
             },
@@ -525,7 +538,17 @@ fun TransactionDetailsScreen(
                         showStroke = capsuleConfig.third,
                     )
 
-                    if (lockState != null && lockState != TransactionLockState.NONE) {
+                    if (lockStateLoadFailed) {
+                        Spacer(Modifier.height(12.dp))
+                        TransactionLockLoadError(
+                            color = sub,
+                            onRetry = {
+                                scope.launch {
+                                    refreshTransactionLockState(showSnackbar = true)
+                                }
+                            },
+                        )
+                    } else if (lockState != null && lockState != TransactionLockState.NONE) {
                         Spacer(Modifier.height(12.dp))
                         TransactionLockAction(
                             state = lockState!!,
@@ -679,6 +702,28 @@ private fun TransactionLockAction(
         ) {
             Text(
                 text = if (updating) updatingText else buttonText,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TransactionLockLoadError(
+    color: Color,
+    onRetry: () -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = stringResource(R.string.label_transaction_lock_load_failed),
+            color = color,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        TextButton(onClick = onRetry) {
+            Text(
+                text = stringResource(R.string.btn_retry),
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
             )

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -280,6 +280,10 @@ class SendFlowManager(
             }
     }
 
+    fun reconcileAfterLabelImport() {
+        dispatch(SendFlowManagerAction.RefreshWalletBalance)
+    }
+
     suspend fun getNewCustomFeeRateWithTotal(
         feeRate: FeeRate,
         feeSpeed: FeeSpeed,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowPresenter.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowPresenter.kt
@@ -95,7 +95,11 @@ class SendFlowPresenter(
             is SendFlowException.UnableToBuildTxn -> "Unable to build transaction"
             is SendFlowException.UnableToGetMaxSend -> "Unable to get max send"
             is SendFlowException.UnableToSaveUnsignedTransaction -> "Unable to Save Unsigned Transaction"
-            is SendFlowException.WalletManager -> "Error"
+            is SendFlowException.WalletManager ->
+                when (error.v1) {
+                    is WalletManagerException.LockedOutputsSelected -> "Insufficient Funds"
+                    else -> "Error"
+                }
             is SendFlowException.UnableToGetFeeDetails -> "Fee Details Error"
         }
 
@@ -139,7 +143,11 @@ class SendFlowPresenter(
                 "Are you connected to the internet?"
 
             is SendFlowException.WalletManager ->
-                error.v1.message ?: "Wallet Manager Error"
+                when (error.v1) {
+                    is WalletManagerException.LockedOutputsSelected ->
+                        "Selected coins include locked coins. Unlock them or choose different coins."
+                    else -> error.v1.message ?: "Wallet Manager Error"
+                }
 
             is SendFlowException.UnableToGetFeeDetails ->
                 error.v1

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/MoreInfoPopover.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/MoreInfoPopover.kt
@@ -65,11 +65,10 @@ fun rememberWalletExportLaunchers(
                             labelManager.import(fileContents.trim())
                         }
 
-                        // refresh transactions with updated labels
-                        try {
-                            currentManager.rust.getTransactions()
-                        } catch (refreshError: Exception) {
-                            android.util.Log.e(tag, "failed to refresh transactions after label import", refreshError)
+                        val refreshed =
+                            AppManager.getInstance()
+                                .reconcileAfterLabelImportAndWait(currentManager.id)
+                        if (!refreshed) {
                             snackbarHostState.showSnackbar("Labels imported successfully, but transaction list may need manual refresh")
                             return@launch
                         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
@@ -284,15 +284,9 @@ internal fun WalletSheetsHost(
                 onDismiss = onDismissNfcScanner,
                 onSuccess = {
                     onDismissNfcScanner()
+                    AppManager.getInstance().reconcileAfterLabelImport(manager.id)
                     scope.launch {
-                        // refresh transactions with updated labels
-                        try {
-                            manager.rust.getTransactions()
-                            snackbarHostState.showSnackbar("Labels imported successfully")
-                        } catch (e: Exception) {
-                            android.util.Log.e(tag, "Failed to refresh transactions after NFC label import")
-                            snackbarHostState.showSnackbar("Labels imported, but failed to refresh transactions")
-                        }
+                        snackbarHostState.showSnackbar("Labels imported successfully")
                     }
                 },
                 onError = { errorMsg ->

--- a/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/wallet/WalletSheets.kt
@@ -284,9 +284,17 @@ internal fun WalletSheetsHost(
                 onDismiss = onDismissNfcScanner,
                 onSuccess = {
                     onDismissNfcScanner()
-                    AppManager.getInstance().reconcileAfterLabelImport(manager.id)
                     scope.launch {
-                        snackbarHostState.showSnackbar("Labels imported successfully")
+                        val refreshed =
+                            AppManager.getInstance().reconcileAfterLabelImportAndWait(manager.id)
+                        val message =
+                            if (refreshed) {
+                                "Labels imported successfully"
+                            } else {
+                                "Labels imported successfully, but transaction list may need manual refresh"
+                            }
+
+                        snackbarHostState.showSnackbar(message)
                     }
                 },
                 onError = { errorMsg ->

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1377,8 +1377,6 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn(
     ): Short
-    external fun uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(
-    ): Short
     external fun uniffi_cove_checksum_method_labelmanager_export(
     ): Short
     external fun uniffi_cove_checksum_method_labelmanager_export_default_file_name(
@@ -2422,8 +2420,6 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_constructor_labelmanager_new(`id`: RustBufferWalletId.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): Long
     external fun uniffi_cove_fn_method_labelmanager_delete_labels_for_txn(`ptr`: Long,`txId`: Long,uniffi_out_err: UniffiRustCallStatus,
-    ): Unit
-    external fun uniffi_cove_fn_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(`ptr`: Long,`txId`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
     external fun uniffi_cove_fn_method_labelmanager_export(`ptr`: Long,
     ): Long
@@ -4080,9 +4076,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn() != 18479.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty() != 47716.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_labelmanager_export() != 24203.toShort()) {
@@ -14204,8 +14197,6 @@ public interface LabelManagerInterface {
 
     fun `deleteLabelsForTxn`(`txId`: TxId)
 
-    fun `deleteLabelsForTxnWithoutCloudBackupDirty`(`txId`: TxId)
-
     suspend fun `export`(): kotlin.String
 
     fun `exportDefaultFileName`(`name`: kotlin.String): kotlin.String
@@ -14344,20 +14335,6 @@ open class LabelManager: Disposable, AutoCloseable, LabelManagerInterface
     callWithHandle {
     uniffiRustCallWithError(LabelManagerException) { _status ->
     UniffiLib.uniffi_cove_fn_method_labelmanager_delete_labels_for_txn(
-        it,
-
-        FfiConverterTypeTxId.lower(`txId`),_status)
-}
-    }
-
-
-
-
-    @Throws(LabelManagerException::class)override fun `deleteLabelsForTxnWithoutCloudBackupDirty`(`txId`: TxId)
-        =
-    callWithHandle {
-    uniffiRustCallWithError(LabelManagerException) { _status ->
-    UniffiLib.uniffi_cove_fn_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(
         it,
 
         FfiConverterTypeTxId.lower(`txId`),_status)
@@ -38730,15 +38707,6 @@ sealed class CoinControlManagerReconcileMessage: Disposable  {
         companion object
     }
 
-    data class UpdateTotalSelectedAmount(
-        val v1: org.bitcoinppl.cove_core.types.Amount) : CoinControlManagerReconcileMessage()
-
-    {
-
-
-        companion object
-    }
-
     data class UpdateUnit(
         val v1: org.bitcoinppl.cove_core.types.BitcoinUnit) : CoinControlManagerReconcileMessage()
 
@@ -38784,13 +38752,6 @@ sealed class CoinControlManagerReconcileMessage: Disposable  {
     )
 
             }
-            is CoinControlManagerReconcileMessage.UpdateTotalSelectedAmount -> {
-
-    Disposable.destroy(
-        this.v1
-    )
-
-            }
             is CoinControlManagerReconcileMessage.UpdateUnit -> {
 
     Disposable.destroy(
@@ -38829,10 +38790,7 @@ public object FfiConverterTypeCoinControlManagerReconcileMessage : FfiConverterR
                 FfiConverterSequenceTypeOutPoint.read(buf),
                 FfiConverterTypeAmount.read(buf),
                 )
-            6 -> CoinControlManagerReconcileMessage.UpdateTotalSelectedAmount(
-                FfiConverterTypeAmount.read(buf),
-                )
-            7 -> CoinControlManagerReconcileMessage.UpdateUnit(
+            6 -> CoinControlManagerReconcileMessage.UpdateUnit(
                 FfiConverterTypeBitcoinUnit.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -38875,13 +38833,6 @@ public object FfiConverterTypeCoinControlManagerReconcileMessage : FfiConverterR
                 + FfiConverterTypeAmount.allocationSize(value.`totalValue`)
             )
         }
-        is CoinControlManagerReconcileMessage.UpdateTotalSelectedAmount -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-                + FfiConverterTypeAmount.allocationSize(value.v1)
-            )
-        }
         is CoinControlManagerReconcileMessage.UpdateUnit -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
@@ -38918,13 +38869,8 @@ public object FfiConverterTypeCoinControlManagerReconcileMessage : FfiConverterR
                 FfiConverterTypeAmount.write(value.`totalValue`, buf)
                 Unit
             }
-            is CoinControlManagerReconcileMessage.UpdateTotalSelectedAmount -> {
-                buf.putInt(6)
-                FfiConverterTypeAmount.write(value.v1, buf)
-                Unit
-            }
             is CoinControlManagerReconcileMessage.UpdateUnit -> {
-                buf.putInt(7)
+                buf.putInt(6)
                 FfiConverterTypeBitcoinUnit.write(value.v1, buf)
                 Unit
             }
@@ -53926,6 +53872,12 @@ sealed class WalletManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
 
+    class LockedOutputsSelected(
+        ) : WalletManagerException() {
+        override val message
+            get() = ""
+    }
+
     class GetConfirmDetailsException(
 
         val v1: kotlin.String
@@ -54096,38 +54048,39 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
             19 -> WalletManagerException.InsufficientFunds(
                 FfiConverterString.read(buf),
                 )
-            20 -> WalletManagerException.GetConfirmDetailsException(
+            20 -> WalletManagerException.LockedOutputsSelected()
+            21 -> WalletManagerException.GetConfirmDetailsException(
                 FfiConverterString.read(buf),
                 )
-            21 -> WalletManagerException.SignAndBroadcastException(
+            22 -> WalletManagerException.SignAndBroadcastException(
                 FfiConverterString.read(buf),
                 )
-            22 -> WalletManagerException.Converter(
+            23 -> WalletManagerException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            23 -> WalletManagerException.UnknownException(
+            24 -> WalletManagerException.UnknownException(
                 FfiConverterString.read(buf),
                 )
-            24 -> WalletManagerException.PsbtFinalizeException(
+            25 -> WalletManagerException.PsbtFinalizeException(
                 FfiConverterString.read(buf),
                 )
-            25 -> WalletManagerException.GetHistoricalPricesException(
+            26 -> WalletManagerException.GetHistoricalPricesException(
                 FfiConverterString.read(buf),
                 )
-            26 -> WalletManagerException.CsvCreationException(
+            27 -> WalletManagerException.CsvCreationException(
                 FfiConverterString.read(buf),
                 )
-            27 -> WalletManagerException.AddUtxosException(
+            28 -> WalletManagerException.AddUtxosException(
                 FfiConverterString.read(buf),
                 )
-            28 -> WalletManagerException.OutputLabelsException(
+            29 -> WalletManagerException.OutputLabelsException(
                 FfiConverterString.read(buf),
                 )
-            29 -> WalletManagerException.DatabaseCorruption(
+            30 -> WalletManagerException.DatabaseCorruption(
                 FfiConverterTypeWalletId.read(buf),
                 FfiConverterString.read(buf),
                 )
-            30 -> WalletManagerException.ReceiveAddressException(
+            31 -> WalletManagerException.ReceiveAddressException(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
@@ -54228,6 +54181,10 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.LockedOutputsSelected -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
             )
             is WalletManagerException.GetConfirmDetailsException -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
@@ -54383,59 +54340,63 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.GetConfirmDetailsException -> {
+            is WalletManagerException.LockedOutputsSelected -> {
                 buf.putInt(20)
-                FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.SignAndBroadcastException -> {
+            is WalletManagerException.GetConfirmDetailsException -> {
                 buf.putInt(21)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.Converter -> {
+            is WalletManagerException.SignAndBroadcastException -> {
                 buf.putInt(22)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.Converter -> {
+                buf.putInt(23)
                 FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.UnknownException -> {
-                buf.putInt(23)
-                FfiConverterString.write(value.v1, buf)
-                Unit
-            }
-            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(24)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.GetHistoricalPricesException -> {
+            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(25)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.CsvCreationException -> {
+            is WalletManagerException.GetHistoricalPricesException -> {
                 buf.putInt(26)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.AddUtxosException -> {
+            is WalletManagerException.CsvCreationException -> {
                 buf.putInt(27)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.OutputLabelsException -> {
+            is WalletManagerException.AddUtxosException -> {
                 buf.putInt(28)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.DatabaseCorruption -> {
+            is WalletManagerException.OutputLabelsException -> {
                 buf.putInt(29)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.DatabaseCorruption -> {
+                buf.putInt(30)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
                 FfiConverterString.write(value.`error`, buf)
                 Unit
             }
             is WalletManagerException.ReceiveAddressException -> {
-                buf.putInt(30)
+                buf.putInt(31)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1471,6 +1471,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_listen_for_updates(
     ): Short
+    external fun uniffi_cove_checksum_method_rustcoincontrolmanager_lock_state_load_failed(
+    ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_reload_labels(
     ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_selected_utxos(
@@ -2533,6 +2535,8 @@ internal object UniffiLib {
     ): RustBufferWalletId.ByValue
     external fun uniffi_cove_fn_method_rustcoincontrolmanager_listen_for_updates(`ptr`: Long,`reconciler`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
+    external fun uniffi_cove_fn_method_rustcoincontrolmanager_lock_state_load_failed(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): Byte
     external fun uniffi_cove_fn_method_rustcoincontrolmanager_reload_labels(`ptr`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustcoincontrolmanager_selected_utxos(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -4217,6 +4221,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_listen_for_updates() != 53354.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_lock_state_load_failed() != 30996.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_reload_labels() != 44692.toShort()) {
@@ -18690,6 +18697,8 @@ public interface RustCoinControlManagerInterface {
 
     fun `listenForUpdates`(`reconciler`: CoinControlManagerReconciler)
 
+    fun `lockStateLoadFailed`(): kotlin.Boolean
+
     suspend fun `reloadLabels`()
 
     fun `selectedUtxos`(): List<Utxo>
@@ -18858,6 +18867,19 @@ open class RustCoinControlManager: Disposable, AutoCloseable, RustCoinControlMan
 }
     }
 
+
+
+    override fun `lockStateLoadFailed`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustcoincontrolmanager_lock_state_load_failed(
+        it,
+        _status)
+}
+    }
+    )
+    }
 
 
 
@@ -38716,6 +38738,15 @@ sealed class CoinControlManagerReconcileMessage: Disposable  {
         companion object
     }
 
+    data class UpdateLockStateLoadFailed(
+        val v1: kotlin.Boolean) : CoinControlManagerReconcileMessage()
+
+    {
+
+
+        companion object
+    }
+
 
 
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -38759,6 +38790,13 @@ sealed class CoinControlManagerReconcileMessage: Disposable  {
     )
 
             }
+            is CoinControlManagerReconcileMessage.UpdateLockStateLoadFailed -> {
+
+    Disposable.destroy(
+        this.v1
+    )
+
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
@@ -38792,6 +38830,9 @@ public object FfiConverterTypeCoinControlManagerReconcileMessage : FfiConverterR
                 )
             6 -> CoinControlManagerReconcileMessage.UpdateUnit(
                 FfiConverterTypeBitcoinUnit.read(buf),
+                )
+            7 -> CoinControlManagerReconcileMessage.UpdateLockStateLoadFailed(
+                FfiConverterBoolean.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
@@ -38840,6 +38881,13 @@ public object FfiConverterTypeCoinControlManagerReconcileMessage : FfiConverterR
                 + FfiConverterTypeBitcoinUnit.allocationSize(value.v1)
             )
         }
+        is CoinControlManagerReconcileMessage.UpdateLockStateLoadFailed -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterBoolean.allocationSize(value.v1)
+            )
+        }
     }
 
     override fun write(value: CoinControlManagerReconcileMessage, buf: ByteBuffer) {
@@ -38872,6 +38920,11 @@ public object FfiConverterTypeCoinControlManagerReconcileMessage : FfiConverterR
             is CoinControlManagerReconcileMessage.UpdateUnit -> {
                 buf.putInt(6)
                 FfiConverterTypeBitcoinUnit.write(value.v1, buf)
+                Unit
+            }
+            is CoinControlManagerReconcileMessage.UpdateLockStateLoadFailed -> {
+                buf.putInt(7)
+                FfiConverterBoolean.write(value.v1, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -42496,6 +42549,12 @@ sealed class LabelManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
 
+    class WalletNotSelected(
+        ) : LabelManagerException() {
+        override val message
+            get() = ""
+    }
+
 
 
 
@@ -42554,6 +42613,7 @@ public object FfiConverterTypeLabelManagerError : FfiConverterRustBuffer<LabelMa
             10 -> LabelManagerException.SaveAddressLabels(
                 FfiConverterString.read(buf),
                 )
+            11 -> LabelManagerException.WalletNotSelected()
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
     }
@@ -42610,6 +42670,10 @@ public object FfiConverterTypeLabelManagerError : FfiConverterRustBuffer<LabelMa
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
             )
+            is LabelManagerException.WalletNotSelected -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+            )
         }
     }
 
@@ -42663,6 +42727,10 @@ public object FfiConverterTypeLabelManagerError : FfiConverterRustBuffer<LabelMa
             is LabelManagerException.SaveAddressLabels -> {
                 buf.putInt(10)
                 FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is LabelManagerException.WalletNotSelected -> {
+                buf.putInt(11)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1161,22 +1161,6 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_func_transactions_preview_new(
     ): Short
-    external fun uniffi_cove_checksum_func_wallet_amount_in_fiat_cached(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_amount(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_amount_pending_fmt(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_amount_with_direction(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_fiat_amount(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_fiat_amount_pending_fmt(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_fiat_amount_with_direction(
-    ): Short
-    external fun uniffi_cove_checksum_func_wallet_display_sent_and_received_amount(
-    ): Short
     external fun uniffi_cove_checksum_func_ffi_min_send_amount(
     ): Short
     external fun uniffi_cove_checksum_func_ffi_min_send_sats(
@@ -1393,6 +1377,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn(
     ): Short
+    external fun uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(
+    ): Short
     external fun uniffi_cove_checksum_method_labelmanager_export(
     ): Short
     external fun uniffi_cove_checksum_method_labelmanager_export_default_file_name(
@@ -1490,6 +1476,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_reload_labels(
     ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_selected_utxos(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustcoincontrolmanager_set_utxo_spendability(
     ): Short
     external fun uniffi_cove_checksum_method_rustcoincontrolmanager_unit(
     ): Short
@@ -1589,8 +1577,6 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_balance_presentation(
     ): Short
-    external fun uniffi_cove_checksum_method_rustwalletmanager_balance_presentation_for_state(
-    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_convert_and_display_fiat(
@@ -1659,8 +1645,6 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_label_manager(
     ): Short
-    external fun uniffi_cove_checksum_method_rustwalletmanager_ledger_state(
-    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_listen_for_updates(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_mark_wallet_as_verified(
@@ -1701,7 +1685,13 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_switch_to_different_wallet_address_type(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_toggle_transaction_lock_state(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_transaction_details(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_transaction_lock_state(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_unlocked_spendable_balance(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_validate_metadata(
     ): Short
@@ -1852,8 +1842,6 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_transactiondetails_block_number_fmt(
     ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_confirmation_date_time(
-    ): Short
-    external fun uniffi_cove_checksum_method_transactiondetails_display_amount(
     ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt(
     ): Short
@@ -2435,6 +2423,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_labelmanager_delete_labels_for_txn(`ptr`: Long,`txId`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
+    external fun uniffi_cove_fn_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(`ptr`: Long,`txId`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
     external fun uniffi_cove_fn_method_labelmanager_export(`ptr`: Long,
     ): Long
     external fun uniffi_cove_fn_method_labelmanager_export_default_file_name(`ptr`: Long,`name`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
@@ -2551,6 +2541,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustcoincontrolmanager_selected_utxos(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_rustcoincontrolmanager_set_utxo_spendability(`ptr`: Long,`outpoint`: Long,`spendable`: Byte,
+    ): Long
     external fun uniffi_cove_fn_method_rustcoincontrolmanager_unit(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBufferBitcoinUnit.ByValue
     external fun uniffi_cove_fn_method_rustcoincontrolmanager_utxos(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -2705,8 +2697,6 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_balance_presentation(`ptr`: Long,`scanStatus`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(`ptr`: Long,`ledgerState`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(`ptr`: Long,`signedTransaction`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_convert_and_display_fiat(`ptr`: Long,`amount`: Long,`prices`: Long,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
@@ -2775,8 +2765,6 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_label_manager(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
-    external fun uniffi_cove_fn_method_rustwalletmanager_ledger_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_listen_for_updates(`ptr`: Long,`reconciler`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
     external fun uniffi_cove_fn_method_rustwalletmanager_mark_wallet_as_verified(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -2817,7 +2805,13 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_switch_to_different_wallet_address_type(`ptr`: Long,`walletAddressType`: RustBuffer.ByValue,
     ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_toggle_transaction_lock_state(`ptr`: Long,`txId`: Long,
+    ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_transaction_details(`ptr`: Long,`txId`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_transaction_lock_state(`ptr`: Long,`txId`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_unlocked_spendable_balance(`ptr`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_validate_metadata(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
@@ -3072,8 +3066,6 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_transactiondetails_block_number_fmt(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_transactiondetails_confirmation_date_time(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_method_transactiondetails_display_amount(`ptr`: Long,`metadata`: RustBuffer.ByValue,`showUnit`: Byte,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt(`ptr`: Long,
     ): Long
@@ -3497,22 +3489,6 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_transactions_preview_new(`confirmed`: Byte,`unconfirmed`: Byte,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_amount_in_fiat_cached(`amount`: Long,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_amount(`metadata`: RustBuffer.ByValue,`amount`: Long,`showUnit`: Byte,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_amount_pending_fmt(`metadata`: RustBuffer.ByValue,`amount`: Long,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_amount_with_direction(`metadata`: RustBuffer.ByValue,`amount`: Long,`direction`: RustBufferTransactionDirection.ByValue,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_fiat_amount(`metadata`: RustBuffer.ByValue,`amount`: Double,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_fiat_amount_pending_fmt(`metadata`: RustBuffer.ByValue,`amount`: Double,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_fiat_amount_with_direction(`metadata`: RustBuffer.ByValue,`amount`: Double,`direction`: RustBufferTransactionDirection.ByValue,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_wallet_display_sent_and_received_amount(`metadata`: RustBuffer.ByValue,`sentAndReceived`: Long,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_ffi_min_send_amount(uniffi_out_err: UniffiRustCallStatus,
     ): Long
     external fun uniffi_cove_fn_func_ffi_min_send_sats(uniffi_out_err: UniffiRustCallStatus,
@@ -3780,30 +3756,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_transactions_preview_new() != 39646.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_amount_in_fiat_cached() != 26689.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_amount() != 61536.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_amount_pending_fmt() != 28974.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_amount_with_direction() != 31040.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_fiat_amount() != 19771.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_fiat_amount_pending_fmt() != 9763.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_fiat_amount_with_direction() != 59603.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_func_wallet_display_sent_and_received_amount() != 2923.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_ffi_min_send_amount() != 61138.toShort()) {
@@ -4130,6 +4082,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn() != 18479.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty() != 47716.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_labelmanager_export() != 24203.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4275,6 +4230,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_selected_utxos() != 30072.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_set_utxo_spendability() != 52265.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustcoincontrolmanager_unit() != 17965.toShort()) {
@@ -4424,9 +4382,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_balance_presentation() != 27753.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_balance_presentation_for_state() != 65105.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4529,9 +4484,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_label_manager() != 23571.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_ledger_state() != 45737.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_listen_for_updates() != 34012.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4541,10 +4493,10 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_master_fingerprint() != 64370.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 1459.toShort()) {
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 11951.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 10979.toShort()) {
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 55235.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_non_default_account_number() != 54959.toShort()) {
@@ -4592,7 +4544,16 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_switch_to_different_wallet_address_type() != 37401.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_toggle_transaction_lock_state() != 4815.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_transaction_details() != 34155.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_transaction_lock_state() != 22037.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_unlocked_spendable_balance() != 11834.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_validate_metadata() != 36684.toShort()) {
@@ -4818,9 +4779,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_method_transactiondetails_display_amount() != 46360.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt() != 57101.toShort()) {
@@ -14246,6 +14204,8 @@ public interface LabelManagerInterface {
 
     fun `deleteLabelsForTxn`(`txId`: TxId)
 
+    fun `deleteLabelsForTxnWithoutCloudBackupDirty`(`txId`: TxId)
+
     suspend fun `export`(): kotlin.String
 
     fun `exportDefaultFileName`(`name`: kotlin.String): kotlin.String
@@ -14384,6 +14344,20 @@ open class LabelManager: Disposable, AutoCloseable, LabelManagerInterface
     callWithHandle {
     uniffiRustCallWithError(LabelManagerException) { _status ->
     UniffiLib.uniffi_cove_fn_method_labelmanager_delete_labels_for_txn(
+        it,
+
+        FfiConverterTypeTxId.lower(`txId`),_status)
+}
+    }
+
+
+
+
+    @Throws(LabelManagerException::class)override fun `deleteLabelsForTxnWithoutCloudBackupDirty`(`txId`: TxId)
+        =
+    callWithHandle {
+    uniffiRustCallWithError(LabelManagerException) { _status ->
+    UniffiLib.uniffi_cove_fn_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(
         it,
 
         FfiConverterTypeTxId.lower(`txId`),_status)
@@ -18743,6 +18717,8 @@ public interface RustCoinControlManagerInterface {
 
     fun `selectedUtxos`(): List<Utxo>
 
+    suspend fun `setUtxoSpendability`(`outpoint`: OutPoint, `spendable`: kotlin.Boolean)
+
     fun `unit`(): BitcoinUnit
 
     fun `utxos`(): List<Utxo>
@@ -18940,6 +18916,30 @@ open class RustCoinControlManager: Disposable, AutoCloseable, RustCoinControlMan
     )
     }
 
+
+
+    @Throws(LabelManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `setUtxoSpendability`(`outpoint`: OutPoint, `spendable`: kotlin.Boolean) {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustcoincontrolmanager_set_utxo_spendability(
+                uniffiHandle,
+
+        FfiConverterTypeOutPoint.lower(`outpoint`),
+        FfiConverterBoolean.lower(`spendable`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+
+        // Error FFI converter
+        LabelManagerException.ErrorHandler,
+    )
+    }
 
     override fun `unit`(): BitcoinUnit {
             return FfiConverterTypeBitcoinUnit.lift(
@@ -21077,8 +21077,6 @@ public interface RustWalletManagerInterface {
 
     fun `balancePresentation`(`scanStatus`: WalletScanStatus): BalancePresentation
 
-    fun `balancePresentationForState`(`ledgerState`: WalletLedgerState): BalancePresentation
-
     suspend fun `broadcastTransaction`(`signedTransaction`: BitcoinTransaction)
 
     fun `convertAndDisplayFiat`(`amount`: Amount, `prices`: PriceResponse, `withSuffix`: kotlin.Boolean = true): kotlin.String
@@ -21213,11 +21211,6 @@ public interface RustWalletManagerInterface {
 
     fun `labelManager`(): LabelManager
 
-    /**
-     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
-     */
-    fun `ledgerState`(): WalletLedgerState
-
     fun `listenForUpdates`(`reconciler`: WalletManagerReconciler)
 
     fun `markWalletAsVerified`()
@@ -21263,7 +21256,13 @@ public interface RustWalletManagerInterface {
 
     suspend fun `switchToDifferentWalletAddressType`(`walletAddressType`: WalletAddressType)
 
+    suspend fun `toggleTransactionLockState`(`txId`: TxId): TransactionLockState
+
     suspend fun `transactionDetails`(`txId`: TxId): TransactionDetails
+
+    suspend fun `transactionLockState`(`txId`: TxId): TransactionLockState
+
+    suspend fun `unlockedSpendableBalance`(): Amount
 
     fun `validateMetadata`()
 
@@ -21454,20 +21453,6 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
         it,
 
         FfiConverterTypeWalletScanStatus.lower(`scanStatus`),_status)
-}
-    }
-    )
-    }
-
-
-    override fun `balancePresentationForState`(`ledgerState`: WalletLedgerState): BalancePresentation {
-            return FfiConverterTypeBalancePresentation.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(
-        it,
-
-        FfiConverterTypeWalletLedgerState.lower(`ledgerState`),_status)
 }
     }
     )
@@ -22140,22 +22125,6 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
     }
 
 
-
-    /**
-     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
-     */override fun `ledgerState`(): WalletLedgerState {
-            return FfiConverterTypeWalletLedgerState.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_method_rustwalletmanager_ledger_state(
-        it,
-        _status)
-}
-    }
-    )
-    }
-
-
     override fun `listenForUpdates`(`reconciler`: WalletManagerReconciler)
         =
     callWithHandle {
@@ -22196,7 +22165,6 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
 
 
 
-    @Throws(WalletManagerException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
     override suspend fun `newCoinControlManager`() : RustCoinControlManager {
         return uniffiRustCallAsync(
@@ -22212,15 +22180,14 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
         // lift function
         { FfiConverterTypeRustCoinControlManager.lift(it) },
         // Error FFI converter
-        WalletManagerException.ErrorHandler,
+        UniffiNullRustCallStatusErrorHandler,
     )
     }
 
-
-    @Throws(WalletManagerException::class)override fun `newSendFlowManager`(`balance`: Balance): RustSendFlowManager {
+    override fun `newSendFlowManager`(`balance`: Balance): RustSendFlowManager {
             return FfiConverterTypeRustSendFlowManager.lift(
     callWithHandle {
-    uniffiRustCallWithError(WalletManagerException) { _status ->
+    uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_method_rustwalletmanager_new_send_flow_manager(
         it,
 
@@ -22499,6 +22466,28 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
 
     @Throws(WalletManagerException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `toggleTransactionLockState`(`txId`: TxId) : TransactionLockState {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_toggle_transaction_lock_state(
+                uniffiHandle,
+
+        FfiConverterTypeTxId.lower(`txId`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_rust_buffer(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_rust_buffer(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_rust_buffer(future) },
+        // lift function
+        { FfiConverterTypeTransactionLockState.lift(it) },
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
+
+
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
     override suspend fun `transactionDetails`(`txId`: TxId) : TransactionDetails {
         return uniffiRustCallAsync(
         callWithHandle { uniffiHandle ->
@@ -22513,6 +22502,49 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
         { future -> UniffiLib.ffi_cove_rust_future_free_u64(future) },
         // lift function
         { FfiConverterTypeTransactionDetails.lift(it) },
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
+
+
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `transactionLockState`(`txId`: TxId) : TransactionLockState {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_transaction_lock_state(
+                uniffiHandle,
+
+        FfiConverterTypeTxId.lower(`txId`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_rust_buffer(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_rust_buffer(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_rust_buffer(future) },
+        // lift function
+        { FfiConverterTypeTransactionLockState.lift(it) },
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
+
+
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `unlockedSpendableBalance`() : Amount {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_unlocked_spendable_balance(
+                uniffiHandle,
+
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_u64(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_u64(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_u64(future) },
+        // lift function
+        { FfiConverterTypeAmount.lift(it) },
         // Error FFI converter
         WalletManagerException.ErrorHandler,
     )
@@ -23920,8 +23952,6 @@ public interface TransactionDetailsInterface {
 
     fun `confirmationDateTime`(): kotlin.String?
 
-    fun `displayAmount`(`metadata`: WalletMetadata, `showUnit`: kotlin.Boolean = true): kotlin.String
-
     suspend fun `feeFiatFmt`(): kotlin.String
 
     fun `feeFiatFmtCached`(): kotlin.String?
@@ -24209,21 +24239,6 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     UniffiLib.uniffi_cove_fn_method_transactiondetails_confirmation_date_time(
         it,
         _status)
-}
-    }
-    )
-    }
-
-
-    override fun `displayAmount`(`metadata`: WalletMetadata, `showUnit`: kotlin.Boolean): kotlin.String {
-            return FfiConverterString.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_method_transactiondetails_display_amount(
-        it,
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterBoolean.lower(`showUnit`),_status)
 }
     }
     )
@@ -42276,40 +42291,6 @@ public object FfiConverterTypeInitError : FfiConverterRustBuffer<InitException> 
 
 
 
-
-enum class InitialScanActivity {
-
-    ACTIVE,
-    IDLE;
-
-
-
-
-    companion object
-}
-
-
-/**
- * @suppress
- */
-public object FfiConverterTypeInitialScanActivity: FfiConverterRustBuffer<InitialScanActivity> {
-    override fun read(buf: ByteBuffer) = try {
-        InitialScanActivity.values()[buf.getInt() - 1]
-    } catch (e: IndexOutOfBoundsException) {
-        throw RuntimeException("invalid enum value, something is very wrong!!", e)
-    }
-
-    override fun allocationSize(value: InitialScanActivity) = 4UL
-
-    override fun write(value: InitialScanActivity, buf: ByteBuffer) {
-        buf.putInt(value.ordinal + 1)
-    }
-}
-
-
-
-
-
 sealed class InsertOrUpdate {
 
     data class Insert(
@@ -47849,6 +47830,9 @@ sealed class SendFlowManagerAction: Disposable  {
     object ClearAddress : SendFlowManagerAction()
 
 
+    object RefreshWalletBalance : SendFlowManagerAction()
+
+
     data class SetCoinControlMode(
         val v1: List<org.bitcoinppl.cove_core.types.Utxo>) : SendFlowManagerAction()
 
@@ -48020,6 +48004,8 @@ sealed class SendFlowManagerAction: Disposable  {
             }
             is SendFlowManagerAction.ClearAddress -> {// Nothing to destroy
             }
+            is SendFlowManagerAction.RefreshWalletBalance -> {// Nothing to destroy
+            }
             is SendFlowManagerAction.SetCoinControlMode -> {
 
     Disposable.destroy(
@@ -48160,58 +48146,59 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
             3 -> SendFlowManagerAction.SelectMaxSend
             4 -> SendFlowManagerAction.ClearSendAmount
             5 -> SendFlowManagerAction.ClearAddress
-            6 -> SendFlowManagerAction.SetCoinControlMode(
+            6 -> SendFlowManagerAction.RefreshWalletBalance
+            7 -> SendFlowManagerAction.SetCoinControlMode(
                 FfiConverterSequenceTypeUtxo.read(buf),
                 )
-            7 -> SendFlowManagerAction.DisableCoinControlMode
-            8 -> SendFlowManagerAction.SelectFeeRate(
+            8 -> SendFlowManagerAction.DisableCoinControlMode
+            9 -> SendFlowManagerAction.SelectFeeRate(
                 FfiConverterTypeFeeRateOptionWithTotalFee.read(buf),
                 )
-            9 -> SendFlowManagerAction.NotifyEnteringBtcAmountChanged(
+            10 -> SendFlowManagerAction.NotifyEnteringBtcAmountChanged(
                 FfiConverterString.read(buf),
                 )
-            10 -> SendFlowManagerAction.NotifyEnteringFiatAmountChanged(
+            11 -> SendFlowManagerAction.NotifyEnteringFiatAmountChanged(
                 FfiConverterString.read(buf),
                 )
-            11 -> SendFlowManagerAction.NotifyEnteringAddressChanged(
+            12 -> SendFlowManagerAction.NotifyEnteringAddressChanged(
                 FfiConverterString.read(buf),
                 )
-            12 -> SendFlowManagerAction.NotifySelectedUnitedChanged(
+            13 -> SendFlowManagerAction.NotifySelectedUnitedChanged(
                 FfiConverterTypeBitcoinUnit.read(buf),
                 FfiConverterTypeBitcoinUnit.read(buf),
                 )
-            13 -> SendFlowManagerAction.NotifyBtcOrFiatChanged(
+            14 -> SendFlowManagerAction.NotifyBtcOrFiatChanged(
                 FfiConverterTypeFiatOrBtc.read(buf),
                 FfiConverterTypeFiatOrBtc.read(buf),
                 )
-            14 -> SendFlowManagerAction.NotifyScanCodeChanged(
+            15 -> SendFlowManagerAction.NotifyScanCodeChanged(
                 FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
-            15 -> SendFlowManagerAction.NotifyPricesChanged(
+            16 -> SendFlowManagerAction.NotifyPricesChanged(
                 FfiConverterTypePriceResponse.read(buf),
                 )
-            16 -> SendFlowManagerAction.NotifyFocusFieldChanged(
+            17 -> SendFlowManagerAction.NotifyFocusFieldChanged(
                 FfiConverterOptionalTypeSetAmountFocusField.read(buf),
                 FfiConverterOptionalTypeSetAmountFocusField.read(buf),
                 )
-            17 -> SendFlowManagerAction.NotifyAddressChanged(
+            18 -> SendFlowManagerAction.NotifyAddressChanged(
                 FfiConverterTypeAddress.read(buf),
                 )
-            18 -> SendFlowManagerAction.NotifyAmountChanged(
+            19 -> SendFlowManagerAction.NotifyAmountChanged(
                 FfiConverterTypeAmount.read(buf),
                 )
-            19 -> SendFlowManagerAction.NotifyCoinControlAmountChanged(
+            20 -> SendFlowManagerAction.NotifyCoinControlAmountChanged(
                 FfiConverterDouble.read(buf),
                 )
-            20 -> SendFlowManagerAction.NotifyCoinControlEnteredAmountChanged(
+            21 -> SendFlowManagerAction.NotifyCoinControlEnteredAmountChanged(
                 FfiConverterString.read(buf),
                 FfiConverterBoolean.read(buf),
                 )
-            21 -> SendFlowManagerAction.ChangeFeeRateOptions(
+            22 -> SendFlowManagerAction.ChangeFeeRateOptions(
                 FfiConverterTypeFeeRateOptionsWithTotalFee.read(buf),
                 )
-            22 -> SendFlowManagerAction.FinalizeAndGoToNextScreen
+            23 -> SendFlowManagerAction.FinalizeAndGoToNextScreen
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -48244,6 +48231,12 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
             )
         }
         is SendFlowManagerAction.ClearAddress -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is SendFlowManagerAction.RefreshWalletBalance -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -48397,92 +48390,96 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
                 buf.putInt(5)
                 Unit
             }
-            is SendFlowManagerAction.SetCoinControlMode -> {
+            is SendFlowManagerAction.RefreshWalletBalance -> {
                 buf.putInt(6)
+                Unit
+            }
+            is SendFlowManagerAction.SetCoinControlMode -> {
+                buf.putInt(7)
                 FfiConverterSequenceTypeUtxo.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.DisableCoinControlMode -> {
-                buf.putInt(7)
+                buf.putInt(8)
                 Unit
             }
             is SendFlowManagerAction.SelectFeeRate -> {
-                buf.putInt(8)
+                buf.putInt(9)
                 FfiConverterTypeFeeRateOptionWithTotalFee.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyEnteringBtcAmountChanged -> {
-                buf.putInt(9)
-                FfiConverterString.write(value.v1, buf)
-                Unit
-            }
-            is SendFlowManagerAction.NotifyEnteringFiatAmountChanged -> {
                 buf.putInt(10)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is SendFlowManagerAction.NotifyEnteringAddressChanged -> {
+            is SendFlowManagerAction.NotifyEnteringFiatAmountChanged -> {
                 buf.putInt(11)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is SendFlowManagerAction.NotifySelectedUnitedChanged -> {
+            is SendFlowManagerAction.NotifyEnteringAddressChanged -> {
                 buf.putInt(12)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is SendFlowManagerAction.NotifySelectedUnitedChanged -> {
+                buf.putInt(13)
                 FfiConverterTypeBitcoinUnit.write(value.`old`, buf)
                 FfiConverterTypeBitcoinUnit.write(value.`new`, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyBtcOrFiatChanged -> {
-                buf.putInt(13)
+                buf.putInt(14)
                 FfiConverterTypeFiatOrBtc.write(value.`old`, buf)
                 FfiConverterTypeFiatOrBtc.write(value.`new`, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyScanCodeChanged -> {
-                buf.putInt(14)
+                buf.putInt(15)
                 FfiConverterString.write(value.`old`, buf)
                 FfiConverterString.write(value.`new`, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyPricesChanged -> {
-                buf.putInt(15)
+                buf.putInt(16)
                 FfiConverterTypePriceResponse.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyFocusFieldChanged -> {
-                buf.putInt(16)
+                buf.putInt(17)
                 FfiConverterOptionalTypeSetAmountFocusField.write(value.`old`, buf)
                 FfiConverterOptionalTypeSetAmountFocusField.write(value.`new`, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyAddressChanged -> {
-                buf.putInt(17)
+                buf.putInt(18)
                 FfiConverterTypeAddress.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyAmountChanged -> {
-                buf.putInt(18)
+                buf.putInt(19)
                 FfiConverterTypeAmount.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyCoinControlAmountChanged -> {
-                buf.putInt(19)
+                buf.putInt(20)
                 FfiConverterDouble.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.NotifyCoinControlEnteredAmountChanged -> {
-                buf.putInt(20)
+                buf.putInt(21)
                 FfiConverterString.write(value.v1, buf)
                 FfiConverterBoolean.write(value.v2, buf)
                 Unit
             }
             is SendFlowManagerAction.ChangeFeeRateOptions -> {
-                buf.putInt(21)
+                buf.putInt(22)
                 FfiConverterTypeFeeRateOptionsWithTotalFee.write(value.v1, buf)
                 Unit
             }
             is SendFlowManagerAction.FinalizeAndGoToNextScreen -> {
-                buf.putInt(22)
+                buf.putInt(23)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -51333,6 +51330,42 @@ public object FfiConverterTypeTransactionDetailError : FfiConverterRustBuffer<Tr
 
 
 
+enum class TransactionLockState {
+
+    NONE,
+    UNLOCKED,
+    LOCKED,
+    MIXED;
+
+
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTransactionLockState: FfiConverterRustBuffer<TransactionLockState> {
+    override fun read(buf: ByteBuffer) = try {
+        TransactionLockState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: TransactionLockState) = 4UL
+
+    override fun write(value: TransactionLockState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+
 enum class TransactionState {
 
     PENDING,
@@ -53209,79 +53242,6 @@ public object FfiConverterTypeWalletErrorAlert : FfiConverterRustBuffer<WalletEr
 
 
 
-sealed class WalletLedgerState {
-
-    object Complete : WalletLedgerState()
-
-
-    data class InitialScanIncomplete(
-        val v1: org.bitcoinppl.cove_core.InitialScanActivity) : WalletLedgerState()
-
-    {
-
-
-        companion object
-    }
-
-
-
-
-
-
-
-
-    companion object
-}
-
-/**
- * @suppress
- */
-public object FfiConverterTypeWalletLedgerState : FfiConverterRustBuffer<WalletLedgerState>{
-    override fun read(buf: ByteBuffer): WalletLedgerState {
-        return when(buf.getInt()) {
-            1 -> WalletLedgerState.Complete
-            2 -> WalletLedgerState.InitialScanIncomplete(
-                FfiConverterTypeInitialScanActivity.read(buf),
-                )
-            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
-        }
-    }
-
-    override fun allocationSize(value: WalletLedgerState): ULong = when(value) {
-        is WalletLedgerState.Complete -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-            )
-        }
-        is WalletLedgerState.InitialScanIncomplete -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-                + FfiConverterTypeInitialScanActivity.allocationSize(value.v1)
-            )
-        }
-    }
-
-    override fun write(value: WalletLedgerState, buf: ByteBuffer) {
-        when(value) {
-            is WalletLedgerState.Complete -> {
-                buf.putInt(1)
-                Unit
-            }
-            is WalletLedgerState.InitialScanIncomplete -> {
-                buf.putInt(2)
-                FfiConverterTypeInitialScanActivity.write(value.v1, buf)
-                Unit
-            }
-        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
-    }
-}
-
-
-
-
-
 sealed class WalletLoadState: Disposable  {
 
     object Loading : WalletLoadState()
@@ -53468,6 +53428,15 @@ sealed class WalletManagerAction: Disposable  {
     object SelectCurrentWalletAddressType : WalletManagerAction()
 
 
+    data class SelectDifferentWalletAddressType(
+        val v1: org.bitcoinppl.cove_core.WalletAddressType) : WalletManagerAction()
+
+    {
+
+
+        companion object
+    }
+
     object SelectedWalletDisappeared : WalletManagerAction()
 
 
@@ -53540,6 +53509,13 @@ sealed class WalletManagerAction: Disposable  {
             }
             is WalletManagerAction.SelectCurrentWalletAddressType -> {// Nothing to destroy
             }
+            is WalletManagerAction.SelectDifferentWalletAddressType -> {
+
+    Disposable.destroy(
+        this.v1
+    )
+
+            }
             is WalletManagerAction.SelectedWalletDisappeared -> {// Nothing to destroy
             }
             is WalletManagerAction.StartTransactionWatcher -> {
@@ -53595,13 +53571,16 @@ public object FfiConverterTypeWalletManagerAction : FfiConverterRustBuffer<Walle
             8 -> WalletManagerAction.ToggleFiatBtcPrimarySecondary
             9 -> WalletManagerAction.ToggleShowLabels
             10 -> WalletManagerAction.SelectCurrentWalletAddressType
-            11 -> WalletManagerAction.SelectedWalletDisappeared
-            12 -> WalletManagerAction.StartTransactionWatcher(
+            11 -> WalletManagerAction.SelectDifferentWalletAddressType(
+                FfiConverterTypeWalletAddressType.read(buf),
+                )
+            12 -> WalletManagerAction.SelectedWalletDisappeared
+            13 -> WalletManagerAction.StartTransactionWatcher(
                 FfiConverterTypeTxId.read(buf),
                 )
-            13 -> WalletManagerAction.OpenReceiveAddress
-            14 -> WalletManagerAction.CreateNewReceiveAddress
-            15 -> WalletManagerAction.CloseReceiveAddress(
+            14 -> WalletManagerAction.OpenReceiveAddress
+            15 -> WalletManagerAction.CreateNewReceiveAddress
+            16 -> WalletManagerAction.CloseReceiveAddress(
                 FfiConverterULong.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -53671,6 +53650,13 @@ public object FfiConverterTypeWalletManagerAction : FfiConverterRustBuffer<Walle
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
+            )
+        }
+        is WalletManagerAction.SelectDifferentWalletAddressType -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeWalletAddressType.allocationSize(value.v1)
             )
         }
         is WalletManagerAction.SelectedWalletDisappeared -> {
@@ -53753,25 +53739,30 @@ public object FfiConverterTypeWalletManagerAction : FfiConverterRustBuffer<Walle
                 buf.putInt(10)
                 Unit
             }
-            is WalletManagerAction.SelectedWalletDisappeared -> {
+            is WalletManagerAction.SelectDifferentWalletAddressType -> {
                 buf.putInt(11)
+                FfiConverterTypeWalletAddressType.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerAction.SelectedWalletDisappeared -> {
+                buf.putInt(12)
                 Unit
             }
             is WalletManagerAction.StartTransactionWatcher -> {
-                buf.putInt(12)
+                buf.putInt(13)
                 FfiConverterTypeTxId.write(value.v1, buf)
                 Unit
             }
             is WalletManagerAction.OpenReceiveAddress -> {
-                buf.putInt(13)
-                Unit
-            }
-            is WalletManagerAction.CreateNewReceiveAddress -> {
                 buf.putInt(14)
                 Unit
             }
-            is WalletManagerAction.CloseReceiveAddress -> {
+            is WalletManagerAction.CreateNewReceiveAddress -> {
                 buf.putInt(15)
+                Unit
+            }
+            is WalletManagerAction.CloseReceiveAddress -> {
+                buf.putInt(16)
                 FfiConverterULong.write(value.v1, buf)
                 Unit
             }
@@ -53919,12 +53910,6 @@ sealed class WalletManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
 
-    class InitialScanIncomplete(
-        ) : WalletManagerException() {
-        override val message
-            get() = ""
-    }
-
     class BuildTxException(
 
         val v1: kotlin.String
@@ -53998,6 +53983,14 @@ sealed class WalletManagerException: kotlin.Exception() {
     }
 
     class AddUtxosException(
+
+        val v1: kotlin.String
+        ) : WalletManagerException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+
+    class OutputLabelsException(
 
         val v1: kotlin.String
         ) : WalletManagerException() {
@@ -54097,35 +54090,37 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
             17 -> WalletManagerException.FeesException(
                 FfiConverterString.read(buf),
                 )
-            18 -> WalletManagerException.InitialScanIncomplete()
-            19 -> WalletManagerException.BuildTxException(
+            18 -> WalletManagerException.BuildTxException(
                 FfiConverterString.read(buf),
                 )
-            20 -> WalletManagerException.InsufficientFunds(
+            19 -> WalletManagerException.InsufficientFunds(
                 FfiConverterString.read(buf),
                 )
-            21 -> WalletManagerException.GetConfirmDetailsException(
+            20 -> WalletManagerException.GetConfirmDetailsException(
                 FfiConverterString.read(buf),
                 )
-            22 -> WalletManagerException.SignAndBroadcastException(
+            21 -> WalletManagerException.SignAndBroadcastException(
                 FfiConverterString.read(buf),
                 )
-            23 -> WalletManagerException.Converter(
+            22 -> WalletManagerException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            24 -> WalletManagerException.UnknownException(
+            23 -> WalletManagerException.UnknownException(
                 FfiConverterString.read(buf),
                 )
-            25 -> WalletManagerException.PsbtFinalizeException(
+            24 -> WalletManagerException.PsbtFinalizeException(
                 FfiConverterString.read(buf),
                 )
-            26 -> WalletManagerException.GetHistoricalPricesException(
+            25 -> WalletManagerException.GetHistoricalPricesException(
                 FfiConverterString.read(buf),
                 )
-            27 -> WalletManagerException.CsvCreationException(
+            26 -> WalletManagerException.CsvCreationException(
                 FfiConverterString.read(buf),
                 )
-            28 -> WalletManagerException.AddUtxosException(
+            27 -> WalletManagerException.AddUtxosException(
+                FfiConverterString.read(buf),
+                )
+            28 -> WalletManagerException.OutputLabelsException(
                 FfiConverterString.read(buf),
                 )
             29 -> WalletManagerException.DatabaseCorruption(
@@ -54224,10 +54219,6 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
             )
-            is WalletManagerException.InitialScanIncomplete -> (
-                // Add the size for the Int that specifies the variant plus the size needed for all fields
-                4UL
-            )
             is WalletManagerException.BuildTxException -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
@@ -54274,6 +54265,11 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 + FfiConverterString.allocationSize(value.v1)
             )
             is WalletManagerException.AddUtxosException -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.OutputLabelsException -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
@@ -54377,56 +54373,57 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.InitialScanIncomplete -> {
-                buf.putInt(18)
-                Unit
-            }
             is WalletManagerException.BuildTxException -> {
-                buf.putInt(19)
+                buf.putInt(18)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.InsufficientFunds -> {
-                buf.putInt(20)
+                buf.putInt(19)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.GetConfirmDetailsException -> {
-                buf.putInt(21)
+                buf.putInt(20)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.SignAndBroadcastException -> {
-                buf.putInt(22)
+                buf.putInt(21)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.Converter -> {
-                buf.putInt(23)
+                buf.putInt(22)
                 FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.UnknownException -> {
-                buf.putInt(24)
+                buf.putInt(23)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.PsbtFinalizeException -> {
-                buf.putInt(25)
+                buf.putInt(24)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.GetHistoricalPricesException -> {
-                buf.putInt(26)
+                buf.putInt(25)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.CsvCreationException -> {
-                buf.putInt(27)
+                buf.putInt(26)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.AddUtxosException -> {
+                buf.putInt(27)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.OutputLabelsException -> {
                 buf.putInt(28)
                 FfiConverterString.write(value.v1, buf)
                 Unit
@@ -54453,15 +54450,6 @@ sealed class WalletManagerReconcileMessage: Disposable  {
 
     data class WalletScanStatusChanged(
         val v1: org.bitcoinppl.cove_core.WalletScanStatus) : WalletManagerReconcileMessage()
-
-    {
-
-
-        companion object
-    }
-
-    data class LedgerStateChanged(
-        val v1: org.bitcoinppl.cove_core.WalletLedgerState) : WalletManagerReconcileMessage()
 
     {
 
@@ -54628,13 +54616,6 @@ sealed class WalletManagerReconcileMessage: Disposable  {
     )
 
             }
-            is WalletManagerReconcileMessage.LedgerStateChanged -> {
-
-    Disposable.destroy(
-        this.v1
-    )
-
-            }
             is WalletManagerReconcileMessage.AvailableTransactions -> {
 
     Disposable.destroy(
@@ -54769,56 +54750,53 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             1 -> WalletManagerReconcileMessage.WalletScanStatusChanged(
                 FfiConverterTypeWalletScanStatus.read(buf),
                 )
-            2 -> WalletManagerReconcileMessage.LedgerStateChanged(
-                FfiConverterTypeWalletLedgerState.read(buf),
-                )
-            3 -> WalletManagerReconcileMessage.AvailableTransactions(
+            2 -> WalletManagerReconcileMessage.AvailableTransactions(
                 FfiConverterSequenceTypeTransaction.read(buf),
                 )
-            4 -> WalletManagerReconcileMessage.ScanComplete(
+            3 -> WalletManagerReconcileMessage.ScanComplete(
                 FfiConverterSequenceTypeTransaction.read(buf),
                 )
-            5 -> WalletManagerReconcileMessage.UpdatedTransactions(
+            4 -> WalletManagerReconcileMessage.UpdatedTransactions(
                 FfiConverterSequenceTypeTransaction.read(buf),
                 )
-            6 -> WalletManagerReconcileMessage.NodeConnectionFailed(
+            5 -> WalletManagerReconcileMessage.NodeConnectionFailed(
                 FfiConverterString.read(buf),
                 )
-            7 -> WalletManagerReconcileMessage.WalletMetadataChanged(
+            6 -> WalletManagerReconcileMessage.WalletMetadataChanged(
                 FfiConverterTypeWalletMetadata.read(buf),
                 )
-            8 -> WalletManagerReconcileMessage.WalletBalanceChanged(
+            7 -> WalletManagerReconcileMessage.WalletBalanceChanged(
                 FfiConverterTypeBalance.read(buf),
                 )
-            9 -> WalletManagerReconcileMessage.WalletException(
+            8 -> WalletManagerReconcileMessage.WalletException(
                 FfiConverterTypeWalletManagerError.read(buf),
                 )
-            10 -> WalletManagerReconcileMessage.UnknownError(
+            9 -> WalletManagerReconcileMessage.UnknownError(
                 FfiConverterString.read(buf),
                 )
-            11 -> WalletManagerReconcileMessage.WalletScannerResponse(
+            10 -> WalletManagerReconcileMessage.WalletScannerResponse(
                 FfiConverterTypeScannerResponse.read(buf),
                 )
-            12 -> WalletManagerReconcileMessage.UnsignedTransactionsChanged
-            13 -> WalletManagerReconcileMessage.SendFlowException(
+            11 -> WalletManagerReconcileMessage.UnsignedTransactionsChanged
+            12 -> WalletManagerReconcileMessage.SendFlowException(
                 FfiConverterTypeSendFlowErrorAlert.read(buf),
                 )
-            14 -> WalletManagerReconcileMessage.HotWalletKeyMissing(
+            13 -> WalletManagerReconcileMessage.HotWalletKeyMissing(
                 FfiConverterTypeWalletId.read(buf),
                 )
-            15 -> WalletManagerReconcileMessage.ReceiveAddressUpdated(
+            14 -> WalletManagerReconcileMessage.ReceiveAddressUpdated(
                 FfiConverterTypeReceiveAddressState.read(buf),
                 )
-            16 -> WalletManagerReconcileMessage.ReceiveAddressPresentationUpdated(
+            15 -> WalletManagerReconcileMessage.ReceiveAddressPresentationUpdated(
                 FfiConverterTypeReceiveAddressPresentation.read(buf),
                 )
-            17 -> WalletManagerReconcileMessage.ReceiveAddressLoadingChanged(
+            16 -> WalletManagerReconcileMessage.ReceiveAddressLoadingChanged(
                 FfiConverterBoolean.read(buf),
                 )
-            18 -> WalletManagerReconcileMessage.ReceiveAddressError(
+            17 -> WalletManagerReconcileMessage.ReceiveAddressError(
                 FfiConverterString.read(buf),
                 )
-            19 -> WalletManagerReconcileMessage.ReceiveAddressClosed(
+            18 -> WalletManagerReconcileMessage.ReceiveAddressClosed(
                 FfiConverterULong.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -54831,13 +54809,6 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             (
                 4UL
                 + FfiConverterTypeWalletScanStatus.allocationSize(value.v1)
-            )
-        }
-        is WalletManagerReconcileMessage.LedgerStateChanged -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-                + FfiConverterTypeWalletLedgerState.allocationSize(value.v1)
             )
         }
         is WalletManagerReconcileMessage.AvailableTransactions -> {
@@ -54967,92 +54938,87 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 FfiConverterTypeWalletScanStatus.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerReconcileMessage.LedgerStateChanged -> {
-                buf.putInt(2)
-                FfiConverterTypeWalletLedgerState.write(value.v1, buf)
-                Unit
-            }
             is WalletManagerReconcileMessage.AvailableTransactions -> {
-                buf.putInt(3)
+                buf.putInt(2)
                 FfiConverterSequenceTypeTransaction.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ScanComplete -> {
-                buf.putInt(4)
+                buf.putInt(3)
                 FfiConverterSequenceTypeTransaction.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.UpdatedTransactions -> {
-                buf.putInt(5)
+                buf.putInt(4)
                 FfiConverterSequenceTypeTransaction.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.NodeConnectionFailed -> {
-                buf.putInt(6)
+                buf.putInt(5)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletMetadataChanged -> {
-                buf.putInt(7)
+                buf.putInt(6)
                 FfiConverterTypeWalletMetadata.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletBalanceChanged -> {
-                buf.putInt(8)
+                buf.putInt(7)
                 FfiConverterTypeBalance.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletException -> {
-                buf.putInt(9)
+                buf.putInt(8)
                 FfiConverterTypeWalletManagerError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.UnknownError -> {
-                buf.putInt(10)
+                buf.putInt(9)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletScannerResponse -> {
-                buf.putInt(11)
+                buf.putInt(10)
                 FfiConverterTypeScannerResponse.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.UnsignedTransactionsChanged -> {
-                buf.putInt(12)
+                buf.putInt(11)
                 Unit
             }
             is WalletManagerReconcileMessage.SendFlowException -> {
-                buf.putInt(13)
+                buf.putInt(12)
                 FfiConverterTypeSendFlowErrorAlert.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
-                buf.putInt(14)
+                buf.putInt(13)
                 FfiConverterTypeWalletId.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressUpdated -> {
-                buf.putInt(15)
+                buf.putInt(14)
                 FfiConverterTypeReceiveAddressState.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressPresentationUpdated -> {
-                buf.putInt(16)
+                buf.putInt(15)
                 FfiConverterTypeReceiveAddressPresentation.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressLoadingChanged -> {
-                buf.putInt(17)
+                buf.putInt(16)
                 FfiConverterBoolean.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressError -> {
-                buf.putInt(18)
+                buf.putInt(17)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressClosed -> {
-                buf.putInt(19)
+                buf.putInt(18)
                 FfiConverterULong.write(value.v1, buf)
                 Unit
             }
@@ -59311,107 +59277,6 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
 
         FfiConverterUByte.lower(`confirmed`),
         FfiConverterUByte.lower(`unconfirmed`),_status)
-}
-    )
-    }
-
- fun `walletAmountInFiatCached`(`amount`: Amount): kotlin.Double? {
-            return FfiConverterOptionalDouble.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_amount_in_fiat_cached(
-
-
-        FfiConverterTypeAmount.lower(`amount`),_status)
-}
-    )
-    }
-
- fun `walletDisplayAmount`(`metadata`: WalletMetadata, `amount`: Amount, `showUnit`: kotlin.Boolean): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_amount(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterTypeAmount.lower(`amount`),
-        FfiConverterBoolean.lower(`showUnit`),_status)
-}
-    )
-    }
-
- fun `walletDisplayAmountPendingFmt`(`metadata`: WalletMetadata, `amount`: Amount): kotlin.String? {
-            return FfiConverterOptionalString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_amount_pending_fmt(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterTypeAmount.lower(`amount`),_status)
-}
-    )
-    }
-
- fun `walletDisplayAmountWithDirection`(`metadata`: WalletMetadata, `amount`: Amount, `direction`: TransactionDirection): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_amount_with_direction(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterTypeAmount.lower(`amount`),
-        FfiConverterTypeTransactionDirection.lower(`direction`),_status)
-}
-    )
-    }
-
- fun `walletDisplayFiatAmount`(`metadata`: WalletMetadata, `amount`: kotlin.Double, `withSuffix`: kotlin.Boolean): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_fiat_amount(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterDouble.lower(`amount`),
-        FfiConverterBoolean.lower(`withSuffix`),_status)
-}
-    )
-    }
-
- fun `walletDisplayFiatAmountPendingFmt`(`metadata`: WalletMetadata, `amount`: kotlin.Double, `withSuffix`: kotlin.Boolean): kotlin.String? {
-            return FfiConverterOptionalString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_fiat_amount_pending_fmt(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterDouble.lower(`amount`),
-        FfiConverterBoolean.lower(`withSuffix`),_status)
-}
-    )
-    }
-
- fun `walletDisplayFiatAmountWithDirection`(`metadata`: WalletMetadata, `amount`: kotlin.Double, `direction`: TransactionDirection, `withSuffix`: kotlin.Boolean): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_fiat_amount_with_direction(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterDouble.lower(`amount`),
-        FfiConverterTypeTransactionDirection.lower(`direction`),
-        FfiConverterBoolean.lower(`withSuffix`),_status)
-}
-    )
-    }
-
- fun `walletDisplaySentAndReceivedAmount`(`metadata`: WalletMetadata, `sentAndReceived`: SentAndReceived): kotlin.String {
-            return FfiConverterString.lift(
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_wallet_display_sent_and_received_amount(
-
-
-        FfiConverterTypeWalletMetadata.lower(`metadata`),
-        FfiConverterTypeSentAndReceived.lower(`sentAndReceived`),_status)
 }
     )
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1161,6 +1161,22 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_func_transactions_preview_new(
     ): Short
+    external fun uniffi_cove_checksum_func_wallet_amount_in_fiat_cached(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_amount(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_amount_pending_fmt(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_amount_with_direction(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_fiat_amount(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_fiat_amount_pending_fmt(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_fiat_amount_with_direction(
+    ): Short
+    external fun uniffi_cove_checksum_func_wallet_display_sent_and_received_amount(
+    ): Short
     external fun uniffi_cove_checksum_func_ffi_min_send_amount(
     ): Short
     external fun uniffi_cove_checksum_func_ffi_min_send_sats(
@@ -1577,6 +1593,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_balance_presentation(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_balance_presentation_for_state(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_convert_and_display_fiat(
@@ -1644,6 +1662,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_rustwalletmanager_initiate_payment(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_label_manager(
+    ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_ledger_state(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_listen_for_updates(
     ): Short
@@ -1842,6 +1862,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_transactiondetails_block_number_fmt(
     ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_confirmation_date_time(
+    ): Short
+    external fun uniffi_cove_checksum_method_transactiondetails_display_amount(
     ): Short
     external fun uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt(
     ): Short
@@ -2697,6 +2719,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_balance_presentation(`ptr`: Long,`scanStatus`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(`ptr`: Long,`ledgerState`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(`ptr`: Long,`signedTransaction`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_convert_and_display_fiat(`ptr`: Long,`amount`: Long,`prices`: Long,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
@@ -2765,6 +2789,8 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_label_manager(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_ledger_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_listen_for_updates(`ptr`: Long,`reconciler`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
     external fun uniffi_cove_fn_method_rustwalletmanager_mark_wallet_as_verified(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -3066,6 +3092,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_transactiondetails_block_number_fmt(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_transactiondetails_confirmation_date_time(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_transactiondetails_display_amount(`ptr`: Long,`metadata`: RustBuffer.ByValue,`showUnit`: Byte,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_transactiondetails_fee_fiat_fmt(`ptr`: Long,
     ): Long
@@ -3489,6 +3517,22 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_transactions_preview_new(`confirmed`: Byte,`unconfirmed`: Byte,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_amount_in_fiat_cached(`amount`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_amount(`metadata`: RustBuffer.ByValue,`amount`: Long,`showUnit`: Byte,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_amount_pending_fmt(`metadata`: RustBuffer.ByValue,`amount`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_amount_with_direction(`metadata`: RustBuffer.ByValue,`amount`: Long,`direction`: RustBufferTransactionDirection.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_fiat_amount(`metadata`: RustBuffer.ByValue,`amount`: Double,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_fiat_amount_pending_fmt(`metadata`: RustBuffer.ByValue,`amount`: Double,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_fiat_amount_with_direction(`metadata`: RustBuffer.ByValue,`amount`: Double,`direction`: RustBufferTransactionDirection.ByValue,`withSuffix`: Byte,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_wallet_display_sent_and_received_amount(`metadata`: RustBuffer.ByValue,`sentAndReceived`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_ffi_min_send_amount(uniffi_out_err: UniffiRustCallStatus,
     ): Long
     external fun uniffi_cove_fn_func_ffi_min_send_sats(uniffi_out_err: UniffiRustCallStatus,
@@ -3756,6 +3800,30 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_transactions_preview_new() != 39646.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_amount_in_fiat_cached() != 26689.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_amount() != 61536.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_amount_pending_fmt() != 28974.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_amount_with_direction() != 31040.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_fiat_amount() != 19771.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_fiat_amount_pending_fmt() != 9763.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_fiat_amount_with_direction() != 59603.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_wallet_display_sent_and_received_amount() != 2923.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_ffi_min_send_amount() != 61138.toShort()) {
@@ -4382,6 +4450,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_balance_presentation() != 27753.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_balance_presentation_for_state() != 65105.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4484,6 +4555,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_label_manager() != 23571.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_ledger_state() != 45737.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_listen_for_updates() != 34012.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4493,10 +4567,10 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_master_fingerprint() != 64370.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 11951.toShort()) {
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 1459.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 55235.toShort()) {
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 10979.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_non_default_account_number() != 54959.toShort()) {
@@ -4779,6 +4853,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_transactiondetails_display_amount() != 46360.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt() != 57101.toShort()) {
@@ -21076,6 +21153,8 @@ public interface RustWalletManagerInterface {
 
     fun `balancePresentation`(`scanStatus`: WalletScanStatus): BalancePresentation
 
+    fun `balancePresentationForState`(`ledgerState`: WalletLedgerState): BalancePresentation
+
     suspend fun `broadcastTransaction`(`signedTransaction`: BitcoinTransaction)
 
     fun `convertAndDisplayFiat`(`amount`: Amount, `prices`: PriceResponse, `withSuffix`: kotlin.Boolean = true): kotlin.String
@@ -21209,6 +21288,11 @@ public interface RustWalletManagerInterface {
     suspend fun `initiatePayment`(`psbt`: Psbt, `payjoinEndpoint`: kotlin.String?)
 
     fun `labelManager`(): LabelManager
+
+    /**
+     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
+     */
+    fun `ledgerState`(): WalletLedgerState
 
     fun `listenForUpdates`(`reconciler`: WalletManagerReconciler)
 
@@ -21452,6 +21536,20 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
         it,
 
         FfiConverterTypeWalletScanStatus.lower(`scanStatus`),_status)
+}
+    }
+    )
+    }
+
+
+    override fun `balancePresentationForState`(`ledgerState`: WalletLedgerState): BalancePresentation {
+            return FfiConverterTypeBalancePresentation.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(
+        it,
+
+        FfiConverterTypeWalletLedgerState.lower(`ledgerState`),_status)
 }
     }
     )
@@ -22124,6 +22222,22 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
     }
 
 
+
+    /**
+     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
+     */override fun `ledgerState`(): WalletLedgerState {
+            return FfiConverterTypeWalletLedgerState.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_rustwalletmanager_ledger_state(
+        it,
+        _status)
+}
+    }
+    )
+    }
+
+
     override fun `listenForUpdates`(`reconciler`: WalletManagerReconciler)
         =
     callWithHandle {
@@ -22164,6 +22278,7 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
 
 
 
+    @Throws(WalletManagerException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
     override suspend fun `newCoinControlManager`() : RustCoinControlManager {
         return uniffiRustCallAsync(
@@ -22179,14 +22294,15 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
         // lift function
         { FfiConverterTypeRustCoinControlManager.lift(it) },
         // Error FFI converter
-        UniffiNullRustCallStatusErrorHandler,
+        WalletManagerException.ErrorHandler,
     )
     }
 
-    override fun `newSendFlowManager`(`balance`: Balance): RustSendFlowManager {
+
+    @Throws(WalletManagerException::class)override fun `newSendFlowManager`(`balance`: Balance): RustSendFlowManager {
             return FfiConverterTypeRustSendFlowManager.lift(
     callWithHandle {
-    uniffiRustCall() { _status ->
+    uniffiRustCallWithError(WalletManagerException) { _status ->
     UniffiLib.uniffi_cove_fn_method_rustwalletmanager_new_send_flow_manager(
         it,
 
@@ -23951,6 +24067,8 @@ public interface TransactionDetailsInterface {
 
     fun `confirmationDateTime`(): kotlin.String?
 
+    fun `displayAmount`(`metadata`: WalletMetadata, `showUnit`: kotlin.Boolean = true): kotlin.String
+
     suspend fun `feeFiatFmt`(): kotlin.String
 
     fun `feeFiatFmtCached`(): kotlin.String?
@@ -24238,6 +24356,21 @@ open class TransactionDetails: Disposable, AutoCloseable, TransactionDetailsInte
     UniffiLib.uniffi_cove_fn_method_transactiondetails_confirmation_date_time(
         it,
         _status)
+}
+    }
+    )
+    }
+
+
+    override fun `displayAmount`(`metadata`: WalletMetadata, `showUnit`: kotlin.Boolean): kotlin.String {
+            return FfiConverterString.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_transactiondetails_display_amount(
+        it,
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterBoolean.lower(`showUnit`),_status)
 }
     }
     )
@@ -42290,6 +42423,40 @@ public object FfiConverterTypeInitError : FfiConverterRustBuffer<InitException> 
 
 
 
+
+enum class InitialScanActivity {
+
+    ACTIVE,
+    IDLE;
+
+
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeInitialScanActivity: FfiConverterRustBuffer<InitialScanActivity> {
+    override fun read(buf: ByteBuffer) = try {
+        InitialScanActivity.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: InitialScanActivity) = 4UL
+
+    override fun write(value: InitialScanActivity, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
 sealed class InsertOrUpdate {
 
     data class Insert(
@@ -53256,6 +53423,79 @@ public object FfiConverterTypeWalletErrorAlert : FfiConverterRustBuffer<WalletEr
 
 
 
+sealed class WalletLedgerState {
+
+    object Complete : WalletLedgerState()
+
+
+    data class InitialScanIncomplete(
+        val v1: org.bitcoinppl.cove_core.InitialScanActivity) : WalletLedgerState()
+
+    {
+
+
+        companion object
+    }
+
+
+
+
+
+
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeWalletLedgerState : FfiConverterRustBuffer<WalletLedgerState>{
+    override fun read(buf: ByteBuffer): WalletLedgerState {
+        return when(buf.getInt()) {
+            1 -> WalletLedgerState.Complete
+            2 -> WalletLedgerState.InitialScanIncomplete(
+                FfiConverterTypeInitialScanActivity.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: WalletLedgerState): ULong = when(value) {
+        is WalletLedgerState.Complete -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is WalletLedgerState.InitialScanIncomplete -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeInitialScanActivity.allocationSize(value.v1)
+            )
+        }
+    }
+
+    override fun write(value: WalletLedgerState, buf: ByteBuffer) {
+        when(value) {
+            is WalletLedgerState.Complete -> {
+                buf.putInt(1)
+                Unit
+            }
+            is WalletLedgerState.InitialScanIncomplete -> {
+                buf.putInt(2)
+                FfiConverterTypeInitialScanActivity.write(value.v1, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
 sealed class WalletLoadState: Disposable  {
 
     object Loading : WalletLoadState()
@@ -53442,15 +53682,6 @@ sealed class WalletManagerAction: Disposable  {
     object SelectCurrentWalletAddressType : WalletManagerAction()
 
 
-    data class SelectDifferentWalletAddressType(
-        val v1: org.bitcoinppl.cove_core.WalletAddressType) : WalletManagerAction()
-
-    {
-
-
-        companion object
-    }
-
     object SelectedWalletDisappeared : WalletManagerAction()
 
 
@@ -53523,13 +53754,6 @@ sealed class WalletManagerAction: Disposable  {
             }
             is WalletManagerAction.SelectCurrentWalletAddressType -> {// Nothing to destroy
             }
-            is WalletManagerAction.SelectDifferentWalletAddressType -> {
-
-    Disposable.destroy(
-        this.v1
-    )
-
-            }
             is WalletManagerAction.SelectedWalletDisappeared -> {// Nothing to destroy
             }
             is WalletManagerAction.StartTransactionWatcher -> {
@@ -53585,16 +53809,13 @@ public object FfiConverterTypeWalletManagerAction : FfiConverterRustBuffer<Walle
             8 -> WalletManagerAction.ToggleFiatBtcPrimarySecondary
             9 -> WalletManagerAction.ToggleShowLabels
             10 -> WalletManagerAction.SelectCurrentWalletAddressType
-            11 -> WalletManagerAction.SelectDifferentWalletAddressType(
-                FfiConverterTypeWalletAddressType.read(buf),
-                )
-            12 -> WalletManagerAction.SelectedWalletDisappeared
-            13 -> WalletManagerAction.StartTransactionWatcher(
+            11 -> WalletManagerAction.SelectedWalletDisappeared
+            12 -> WalletManagerAction.StartTransactionWatcher(
                 FfiConverterTypeTxId.read(buf),
                 )
-            14 -> WalletManagerAction.OpenReceiveAddress
-            15 -> WalletManagerAction.CreateNewReceiveAddress
-            16 -> WalletManagerAction.CloseReceiveAddress(
+            13 -> WalletManagerAction.OpenReceiveAddress
+            14 -> WalletManagerAction.CreateNewReceiveAddress
+            15 -> WalletManagerAction.CloseReceiveAddress(
                 FfiConverterULong.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -53664,13 +53885,6 @@ public object FfiConverterTypeWalletManagerAction : FfiConverterRustBuffer<Walle
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
-            )
-        }
-        is WalletManagerAction.SelectDifferentWalletAddressType -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-                + FfiConverterTypeWalletAddressType.allocationSize(value.v1)
             )
         }
         is WalletManagerAction.SelectedWalletDisappeared -> {
@@ -53753,30 +53967,25 @@ public object FfiConverterTypeWalletManagerAction : FfiConverterRustBuffer<Walle
                 buf.putInt(10)
                 Unit
             }
-            is WalletManagerAction.SelectDifferentWalletAddressType -> {
-                buf.putInt(11)
-                FfiConverterTypeWalletAddressType.write(value.v1, buf)
-                Unit
-            }
             is WalletManagerAction.SelectedWalletDisappeared -> {
-                buf.putInt(12)
+                buf.putInt(11)
                 Unit
             }
             is WalletManagerAction.StartTransactionWatcher -> {
-                buf.putInt(13)
+                buf.putInt(12)
                 FfiConverterTypeTxId.write(value.v1, buf)
                 Unit
             }
             is WalletManagerAction.OpenReceiveAddress -> {
-                buf.putInt(14)
+                buf.putInt(13)
                 Unit
             }
             is WalletManagerAction.CreateNewReceiveAddress -> {
-                buf.putInt(15)
+                buf.putInt(14)
                 Unit
             }
             is WalletManagerAction.CloseReceiveAddress -> {
-                buf.putInt(16)
+                buf.putInt(15)
                 FfiConverterULong.write(value.v1, buf)
                 Unit
             }
@@ -53922,6 +54131,12 @@ sealed class WalletManagerException: kotlin.Exception() {
         ) : WalletManagerException() {
         override val message
             get() = "v1=${ v1 }"
+    }
+
+    class InitialScanIncomplete(
+        ) : WalletManagerException() {
+        override val message
+            get() = ""
     }
 
     class BuildTxException(
@@ -54110,45 +54325,46 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
             17 -> WalletManagerException.FeesException(
                 FfiConverterString.read(buf),
                 )
-            18 -> WalletManagerException.BuildTxException(
+            18 -> WalletManagerException.InitialScanIncomplete()
+            19 -> WalletManagerException.BuildTxException(
                 FfiConverterString.read(buf),
                 )
-            19 -> WalletManagerException.InsufficientFunds(
+            20 -> WalletManagerException.InsufficientFunds(
                 FfiConverterString.read(buf),
                 )
-            20 -> WalletManagerException.LockedOutputsSelected()
-            21 -> WalletManagerException.GetConfirmDetailsException(
+            21 -> WalletManagerException.LockedOutputsSelected()
+            22 -> WalletManagerException.GetConfirmDetailsException(
                 FfiConverterString.read(buf),
                 )
-            22 -> WalletManagerException.SignAndBroadcastException(
+            23 -> WalletManagerException.SignAndBroadcastException(
                 FfiConverterString.read(buf),
                 )
-            23 -> WalletManagerException.Converter(
+            24 -> WalletManagerException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            24 -> WalletManagerException.UnknownException(
+            25 -> WalletManagerException.UnknownException(
                 FfiConverterString.read(buf),
                 )
-            25 -> WalletManagerException.PsbtFinalizeException(
+            26 -> WalletManagerException.PsbtFinalizeException(
                 FfiConverterString.read(buf),
                 )
-            26 -> WalletManagerException.GetHistoricalPricesException(
+            27 -> WalletManagerException.GetHistoricalPricesException(
                 FfiConverterString.read(buf),
                 )
-            27 -> WalletManagerException.CsvCreationException(
+            28 -> WalletManagerException.CsvCreationException(
                 FfiConverterString.read(buf),
                 )
-            28 -> WalletManagerException.AddUtxosException(
+            29 -> WalletManagerException.AddUtxosException(
                 FfiConverterString.read(buf),
                 )
-            29 -> WalletManagerException.OutputLabelsException(
+            30 -> WalletManagerException.OutputLabelsException(
                 FfiConverterString.read(buf),
                 )
-            30 -> WalletManagerException.DatabaseCorruption(
+            31 -> WalletManagerException.DatabaseCorruption(
                 FfiConverterTypeWalletId.read(buf),
                 FfiConverterString.read(buf),
                 )
-            31 -> WalletManagerException.ReceiveAddressException(
+            32 -> WalletManagerException.ReceiveAddressException(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
@@ -54239,6 +54455,10 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.InitialScanIncomplete -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
             )
             is WalletManagerException.BuildTxException -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
@@ -54398,73 +54618,77 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.BuildTxException -> {
+            is WalletManagerException.InitialScanIncomplete -> {
                 buf.putInt(18)
-                FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.InsufficientFunds -> {
+            is WalletManagerException.BuildTxException -> {
                 buf.putInt(19)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.LockedOutputsSelected -> {
+            is WalletManagerException.InsufficientFunds -> {
                 buf.putInt(20)
-                Unit
-            }
-            is WalletManagerException.GetConfirmDetailsException -> {
-                buf.putInt(21)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.SignAndBroadcastException -> {
+            is WalletManagerException.LockedOutputsSelected -> {
+                buf.putInt(21)
+                Unit
+            }
+            is WalletManagerException.GetConfirmDetailsException -> {
                 buf.putInt(22)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.Converter -> {
+            is WalletManagerException.SignAndBroadcastException -> {
                 buf.putInt(23)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.Converter -> {
+                buf.putInt(24)
                 FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.UnknownException -> {
-                buf.putInt(24)
-                FfiConverterString.write(value.v1, buf)
-                Unit
-            }
-            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(25)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.GetHistoricalPricesException -> {
+            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(26)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.CsvCreationException -> {
+            is WalletManagerException.GetHistoricalPricesException -> {
                 buf.putInt(27)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.AddUtxosException -> {
+            is WalletManagerException.CsvCreationException -> {
                 buf.putInt(28)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.OutputLabelsException -> {
+            is WalletManagerException.AddUtxosException -> {
                 buf.putInt(29)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.DatabaseCorruption -> {
+            is WalletManagerException.OutputLabelsException -> {
                 buf.putInt(30)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.DatabaseCorruption -> {
+                buf.putInt(31)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
                 FfiConverterString.write(value.`error`, buf)
                 Unit
             }
             is WalletManagerException.ReceiveAddressException -> {
-                buf.putInt(31)
+                buf.putInt(32)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
@@ -54479,6 +54703,15 @@ sealed class WalletManagerReconcileMessage: Disposable  {
 
     data class WalletScanStatusChanged(
         val v1: org.bitcoinppl.cove_core.WalletScanStatus) : WalletManagerReconcileMessage()
+
+    {
+
+
+        companion object
+    }
+
+    data class LedgerStateChanged(
+        val v1: org.bitcoinppl.cove_core.WalletLedgerState) : WalletManagerReconcileMessage()
 
     {
 
@@ -54645,6 +54878,13 @@ sealed class WalletManagerReconcileMessage: Disposable  {
     )
 
             }
+            is WalletManagerReconcileMessage.LedgerStateChanged -> {
+
+    Disposable.destroy(
+        this.v1
+    )
+
+            }
             is WalletManagerReconcileMessage.AvailableTransactions -> {
 
     Disposable.destroy(
@@ -54779,53 +55019,56 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             1 -> WalletManagerReconcileMessage.WalletScanStatusChanged(
                 FfiConverterTypeWalletScanStatus.read(buf),
                 )
-            2 -> WalletManagerReconcileMessage.AvailableTransactions(
+            2 -> WalletManagerReconcileMessage.LedgerStateChanged(
+                FfiConverterTypeWalletLedgerState.read(buf),
+                )
+            3 -> WalletManagerReconcileMessage.AvailableTransactions(
                 FfiConverterSequenceTypeTransaction.read(buf),
                 )
-            3 -> WalletManagerReconcileMessage.ScanComplete(
+            4 -> WalletManagerReconcileMessage.ScanComplete(
                 FfiConverterSequenceTypeTransaction.read(buf),
                 )
-            4 -> WalletManagerReconcileMessage.UpdatedTransactions(
+            5 -> WalletManagerReconcileMessage.UpdatedTransactions(
                 FfiConverterSequenceTypeTransaction.read(buf),
                 )
-            5 -> WalletManagerReconcileMessage.NodeConnectionFailed(
+            6 -> WalletManagerReconcileMessage.NodeConnectionFailed(
                 FfiConverterString.read(buf),
                 )
-            6 -> WalletManagerReconcileMessage.WalletMetadataChanged(
+            7 -> WalletManagerReconcileMessage.WalletMetadataChanged(
                 FfiConverterTypeWalletMetadata.read(buf),
                 )
-            7 -> WalletManagerReconcileMessage.WalletBalanceChanged(
+            8 -> WalletManagerReconcileMessage.WalletBalanceChanged(
                 FfiConverterTypeBalance.read(buf),
                 )
-            8 -> WalletManagerReconcileMessage.WalletException(
+            9 -> WalletManagerReconcileMessage.WalletException(
                 FfiConverterTypeWalletManagerError.read(buf),
                 )
-            9 -> WalletManagerReconcileMessage.UnknownError(
+            10 -> WalletManagerReconcileMessage.UnknownError(
                 FfiConverterString.read(buf),
                 )
-            10 -> WalletManagerReconcileMessage.WalletScannerResponse(
+            11 -> WalletManagerReconcileMessage.WalletScannerResponse(
                 FfiConverterTypeScannerResponse.read(buf),
                 )
-            11 -> WalletManagerReconcileMessage.UnsignedTransactionsChanged
-            12 -> WalletManagerReconcileMessage.SendFlowException(
+            12 -> WalletManagerReconcileMessage.UnsignedTransactionsChanged
+            13 -> WalletManagerReconcileMessage.SendFlowException(
                 FfiConverterTypeSendFlowErrorAlert.read(buf),
                 )
-            13 -> WalletManagerReconcileMessage.HotWalletKeyMissing(
+            14 -> WalletManagerReconcileMessage.HotWalletKeyMissing(
                 FfiConverterTypeWalletId.read(buf),
                 )
-            14 -> WalletManagerReconcileMessage.ReceiveAddressUpdated(
+            15 -> WalletManagerReconcileMessage.ReceiveAddressUpdated(
                 FfiConverterTypeReceiveAddressState.read(buf),
                 )
-            15 -> WalletManagerReconcileMessage.ReceiveAddressPresentationUpdated(
+            16 -> WalletManagerReconcileMessage.ReceiveAddressPresentationUpdated(
                 FfiConverterTypeReceiveAddressPresentation.read(buf),
                 )
-            16 -> WalletManagerReconcileMessage.ReceiveAddressLoadingChanged(
+            17 -> WalletManagerReconcileMessage.ReceiveAddressLoadingChanged(
                 FfiConverterBoolean.read(buf),
                 )
-            17 -> WalletManagerReconcileMessage.ReceiveAddressError(
+            18 -> WalletManagerReconcileMessage.ReceiveAddressError(
                 FfiConverterString.read(buf),
                 )
-            18 -> WalletManagerReconcileMessage.ReceiveAddressClosed(
+            19 -> WalletManagerReconcileMessage.ReceiveAddressClosed(
                 FfiConverterULong.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -54838,6 +55081,13 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             (
                 4UL
                 + FfiConverterTypeWalletScanStatus.allocationSize(value.v1)
+            )
+        }
+        is WalletManagerReconcileMessage.LedgerStateChanged -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeWalletLedgerState.allocationSize(value.v1)
             )
         }
         is WalletManagerReconcileMessage.AvailableTransactions -> {
@@ -54967,87 +55217,92 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 FfiConverterTypeWalletScanStatus.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerReconcileMessage.AvailableTransactions -> {
+            is WalletManagerReconcileMessage.LedgerStateChanged -> {
                 buf.putInt(2)
-                FfiConverterSequenceTypeTransaction.write(value.v1, buf)
+                FfiConverterTypeWalletLedgerState.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerReconcileMessage.ScanComplete -> {
+            is WalletManagerReconcileMessage.AvailableTransactions -> {
                 buf.putInt(3)
                 FfiConverterSequenceTypeTransaction.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerReconcileMessage.UpdatedTransactions -> {
+            is WalletManagerReconcileMessage.ScanComplete -> {
                 buf.putInt(4)
                 FfiConverterSequenceTypeTransaction.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerReconcileMessage.NodeConnectionFailed -> {
+            is WalletManagerReconcileMessage.UpdatedTransactions -> {
                 buf.putInt(5)
+                FfiConverterSequenceTypeTransaction.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerReconcileMessage.NodeConnectionFailed -> {
+                buf.putInt(6)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletMetadataChanged -> {
-                buf.putInt(6)
+                buf.putInt(7)
                 FfiConverterTypeWalletMetadata.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletBalanceChanged -> {
-                buf.putInt(7)
+                buf.putInt(8)
                 FfiConverterTypeBalance.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletException -> {
-                buf.putInt(8)
+                buf.putInt(9)
                 FfiConverterTypeWalletManagerError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.UnknownError -> {
-                buf.putInt(9)
+                buf.putInt(10)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.WalletScannerResponse -> {
-                buf.putInt(10)
+                buf.putInt(11)
                 FfiConverterTypeScannerResponse.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.UnsignedTransactionsChanged -> {
-                buf.putInt(11)
+                buf.putInt(12)
                 Unit
             }
             is WalletManagerReconcileMessage.SendFlowException -> {
-                buf.putInt(12)
+                buf.putInt(13)
                 FfiConverterTypeSendFlowErrorAlert.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
-                buf.putInt(13)
+                buf.putInt(14)
                 FfiConverterTypeWalletId.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressUpdated -> {
-                buf.putInt(14)
+                buf.putInt(15)
                 FfiConverterTypeReceiveAddressState.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressPresentationUpdated -> {
-                buf.putInt(15)
+                buf.putInt(16)
                 FfiConverterTypeReceiveAddressPresentation.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressLoadingChanged -> {
-                buf.putInt(16)
+                buf.putInt(17)
                 FfiConverterBoolean.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressError -> {
-                buf.putInt(17)
+                buf.putInt(18)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerReconcileMessage.ReceiveAddressClosed -> {
-                buf.putInt(18)
+                buf.putInt(19)
                 FfiConverterULong.write(value.v1, buf)
                 Unit
             }
@@ -59306,6 +59561,107 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
 
         FfiConverterUByte.lower(`confirmed`),
         FfiConverterUByte.lower(`unconfirmed`),_status)
+}
+    )
+    }
+
+ fun `walletAmountInFiatCached`(`amount`: Amount): kotlin.Double? {
+            return FfiConverterOptionalDouble.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_amount_in_fiat_cached(
+
+
+        FfiConverterTypeAmount.lower(`amount`),_status)
+}
+    )
+    }
+
+ fun `walletDisplayAmount`(`metadata`: WalletMetadata, `amount`: Amount, `showUnit`: kotlin.Boolean): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_amount(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterTypeAmount.lower(`amount`),
+        FfiConverterBoolean.lower(`showUnit`),_status)
+}
+    )
+    }
+
+ fun `walletDisplayAmountPendingFmt`(`metadata`: WalletMetadata, `amount`: Amount): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_amount_pending_fmt(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterTypeAmount.lower(`amount`),_status)
+}
+    )
+    }
+
+ fun `walletDisplayAmountWithDirection`(`metadata`: WalletMetadata, `amount`: Amount, `direction`: TransactionDirection): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_amount_with_direction(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterTypeAmount.lower(`amount`),
+        FfiConverterTypeTransactionDirection.lower(`direction`),_status)
+}
+    )
+    }
+
+ fun `walletDisplayFiatAmount`(`metadata`: WalletMetadata, `amount`: kotlin.Double, `withSuffix`: kotlin.Boolean): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_fiat_amount(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterDouble.lower(`amount`),
+        FfiConverterBoolean.lower(`withSuffix`),_status)
+}
+    )
+    }
+
+ fun `walletDisplayFiatAmountPendingFmt`(`metadata`: WalletMetadata, `amount`: kotlin.Double, `withSuffix`: kotlin.Boolean): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_fiat_amount_pending_fmt(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterDouble.lower(`amount`),
+        FfiConverterBoolean.lower(`withSuffix`),_status)
+}
+    )
+    }
+
+ fun `walletDisplayFiatAmountWithDirection`(`metadata`: WalletMetadata, `amount`: kotlin.Double, `direction`: TransactionDirection, `withSuffix`: kotlin.Boolean): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_fiat_amount_with_direction(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterDouble.lower(`amount`),
+        FfiConverterTypeTransactionDirection.lower(`direction`),
+        FfiConverterBoolean.lower(`withSuffix`),_status)
+}
+    )
+    }
+
+ fun `walletDisplaySentAndReceivedAmount`(`metadata`: WalletMetadata, `sentAndReceived`: SentAndReceived): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_wallet_display_sent_and_received_amount(
+
+
+        FfiConverterTypeWalletMetadata.lower(`metadata`),
+        FfiConverterTypeSentAndReceived.lower(`sentAndReceived`),_status)
 }
     )
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -9426,6 +9426,8 @@ data class Utxo (
     var `blockHeight`: kotlin.UInt
     ,
     var `type`: UtxoType
+    ,
+    var `spendable`: kotlin.Boolean
 
 ): Disposable{
      fun `date`(): kotlin.String {
@@ -9505,7 +9507,8 @@ data class Utxo (
         this.`address`,
         this.`derivationIndex`,
         this.`blockHeight`,
-        this.`type`
+        this.`type`,
+        this.`spendable`
     )
     }
 
@@ -9526,6 +9529,7 @@ public object FfiConverterTypeUtxo: FfiConverterRustBuffer<Utxo> {
             FfiConverterUInt.read(buf),
             FfiConverterUInt.read(buf),
             FfiConverterTypeUtxoType.read(buf),
+            FfiConverterBoolean.read(buf),
         )
     }
 
@@ -9537,7 +9541,8 @@ public object FfiConverterTypeUtxo: FfiConverterRustBuffer<Utxo> {
             FfiConverterTypeAddress.allocationSize(value.`address`) +
             FfiConverterUInt.allocationSize(value.`derivationIndex`) +
             FfiConverterUInt.allocationSize(value.`blockHeight`) +
-            FfiConverterTypeUtxoType.allocationSize(value.`type`)
+            FfiConverterTypeUtxoType.allocationSize(value.`type`) +
+            FfiConverterBoolean.allocationSize(value.`spendable`)
     )
 
     override fun write(value: Utxo, buf: ByteBuffer) {
@@ -9549,6 +9554,7 @@ public object FfiConverterTypeUtxo: FfiConverterRustBuffer<Utxo> {
             FfiConverterUInt.write(value.`derivationIndex`, buf)
             FfiConverterUInt.write(value.`blockHeight`, buf)
             FfiConverterTypeUtxoType.write(value.`type`, buf)
+            FfiConverterBoolean.write(value.`spendable`, buf)
     }
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -9428,7 +9428,7 @@ data class Utxo (
     var `type`: UtxoType
     ,
     /**
-     * Cached lock state for display and selection filtering; transaction building rechecks the labels DB
+     * Cached lock state for display and selection filtering only; transaction building rechecks the labels DB
      */
     var `spendable`: kotlin.Boolean
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -9428,7 +9428,7 @@ data class Utxo (
     var `type`: UtxoType
     ,
     /**
-     * Populated by coin-control label loading; display cache only, not authoritative for spending
+     * Cached lock state for display and selection filtering; transaction building rechecks the labels DB
      */
     var `spendable`: kotlin.Boolean
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -9427,6 +9427,9 @@ data class Utxo (
     ,
     var `type`: UtxoType
     ,
+    /**
+     * Populated by coin-control label loading; display cache only, not authoritative for spending
+     */
     var `spendable`: kotlin.Boolean
 
 ): Disposable{

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="btn_hide_details">Hide Details</string>
     <string name="snackbar_transaction_lock_update_error">Unable to update transaction lock.</string>
     <string name="snackbar_transaction_lock_load_error">Unable to load transaction lock state.</string>
+    <string name="snackbar_label_refresh_failed">Changes saved, but the transaction list may need manual refresh.</string>
     <string name="label_transaction_lock_state_locked">Locked</string>
     <string name="label_transaction_lock_state_mixed">Mixed</string>
     <string name="label_transaction_lock_state_unlocked">Unlocked</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -93,6 +93,13 @@
     <string name="btn_view_in_explorer">View in Explorer</string>
     <string name="btn_show_details">Show Details</string>
     <string name="btn_hide_details">Hide Details</string>
+    <string name="snackbar_transaction_lock_update_error">Unable to update transaction lock.</string>
+    <string name="label_transaction_lock_state_locked">Locked</string>
+    <string name="label_transaction_lock_state_mixed">Mixed</string>
+    <string name="label_transaction_lock_state_unlocked">Unlocked</string>
+    <string name="label_transaction_lock_updating">Updating...</string>
+    <string name="btn_lock_transaction">Lock Transaction</string>
+    <string name="btn_unlock_transaction">Unlock Transaction</string>
     <string name="label_transaction_sent_on">Your transaction was sent on\n%1$s</string>
     <string name="label_transaction_received_on">Your transaction was received on\n%1$s</string>
     <string name="label_sent_to">Sent to</string>
@@ -124,6 +131,8 @@
     <string name="denotes_utxo_change">Denotes UTXO change</string>
     <string name="continue_button">Continue</string>
     <string name="continue_with_count">Continue (%1$d)</string>
+    <string name="snackbar_utxo_locked_selection">Unlock this UTXO before selecting it.</string>
+    <string name="snackbar_utxo_lock_update_error">Unable to update UTXO lock.</string>
     <string name="label_balance">Balance</string>
     <string name="label_enter_amount">Enter amount</string>
     <string name="label_how_much_to_send">How much would you like to send?</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -91,12 +91,15 @@
     <string name="label_delete_error">Failed to delete label: %s</string>
     <string name="label_update_error">Failed to update label: %s</string>
     <string name="btn_view_in_explorer">View in Explorer</string>
+    <string name="btn_retry">Retry</string>
     <string name="btn_show_details">Show Details</string>
     <string name="btn_hide_details">Hide Details</string>
     <string name="snackbar_transaction_lock_update_error">Unable to update transaction lock.</string>
+    <string name="snackbar_transaction_lock_load_error">Unable to load transaction lock state.</string>
     <string name="label_transaction_lock_state_locked">Locked</string>
     <string name="label_transaction_lock_state_mixed">Mixed</string>
     <string name="label_transaction_lock_state_unlocked">Unlocked</string>
+    <string name="label_transaction_lock_load_failed">Unable to load lock state</string>
     <string name="label_transaction_lock_updating">Updating...</string>
     <string name="btn_lock_transaction">Lock Transaction</string>
     <string name="btn_unlock_transaction">Unlock Transaction</string>
@@ -133,6 +136,7 @@
     <string name="continue_with_count">Continue (%1$d)</string>
     <string name="snackbar_utxo_locked_selection">Unlock this UTXO before selecting it.</string>
     <string name="snackbar_utxo_lock_update_error">Unable to update UTXO lock.</string>
+    <string name="warning_utxo_lock_state_load_failed">Unable to read UTXO lock state. UTXOs are shown locked for safety.</string>
     <string name="label_balance">Balance</string>
     <string name="label_enter_amount">Enter amount</string>
     <string name="label_how_much_to_send">How much would you like to send?</string>

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -64,6 +64,9 @@ private let navigationSettleDelayMs = 800
 
     private(set) var sendFlowManager: SendFlowManager?
 
+    @ObservationIgnored
+    weak var coinControlManager: CoinControlManager?
+
     public var colorScheme: ColorScheme? {
         switch colorSchemeSelection {
         case .light:
@@ -243,6 +246,30 @@ private let navigationSettleDelayMs = 800
         return sendFlowManager
     }
 
+    public func setCoinControlManager(_ manager: CoinControlManager) {
+        coinControlManager = manager
+    }
+
+    public func clearCoinControlManager(_ manager: CoinControlManager) {
+        if coinControlManager === manager {
+            coinControlManager = nil
+        }
+    }
+
+    public func reconcileAfterLabelImport(walletId: WalletId) {
+        if let walletManager, walletManager.id == walletId {
+            walletManager.reconcileAfterLabelImport()
+        }
+
+        if let coinControlManager, coinControlManager.id == walletId {
+            Task { await coinControlManager.reloadLabels() }
+        }
+
+        if let sendFlowManager, sendFlowManager.id == walletId {
+            sendFlowManager.reconcileAfterLabelImport()
+        }
+    }
+
     public var fullVersionId: String {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
@@ -296,6 +323,8 @@ private let navigationSettleDelayMs = 800
 
         database = Database()
         clearWalletManager()
+        coinControlManager?.close()
+        coinControlManager = nil
 
         let state = rust.state()
         router = state.router

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -270,9 +270,10 @@ private let navigationSettleDelayMs = 800
         clearCoinControlManager()
     }
 
-    public func reconcileAfterLabelImport(walletId: WalletId) {
+    @MainActor
+    public func reconcileAfterLabelsChanged(walletId: WalletId) {
         if let walletManager, walletManager.id == walletId {
-            walletManager.reconcileAfterLabelImport()
+            walletManager.reconcileAfterLabelsChanged()
         }
 
         if let coinControlManager, coinControlManager.id == walletId {
@@ -280,7 +281,7 @@ private let navigationSettleDelayMs = 800
         }
 
         if let sendFlowManager, sendFlowManager.id == walletId {
-            sendFlowManager.reconcileAfterLabelImport()
+            sendFlowManager.reconcileAfterLabelsChanged()
         }
     }
 

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -256,6 +256,20 @@ private let navigationSettleDelayMs = 800
         }
     }
 
+    private func clearCoinControlManager() {
+        guard let coinControlManager else { return }
+
+        self.coinControlManager = nil
+        coinControlManager.close()
+    }
+
+    private func reconcileCoinControlManagerOwnership() {
+        guard coinControlManager != nil else { return }
+        guard !router.containsCoinControlRoute else { return }
+
+        clearCoinControlManager()
+    }
+
     public func reconcileAfterLabelImport(walletId: WalletId) {
         if let walletManager, walletManager.id == walletId {
             walletManager.reconcileAfterLabelImport()
@@ -411,6 +425,7 @@ private let navigationSettleDelayMs = 800
         guard !isDuplicateTopRoute(route) else { return }
 
         router.routes.append(route)
+        reconcileCoinControlManagerOwnership()
     }
 
     func pushRoutes(_ routes: [Route]) {
@@ -421,6 +436,7 @@ private let navigationSettleDelayMs = 800
     private func pushRoutesWithoutNavigationGeneration(_ routes: [Route]) {
         isSidebarVisible = false
         router.routes.append(contentsOf: routes)
+        reconcileCoinControlManagerOwnership()
     }
 
     func popRoute() {
@@ -428,12 +444,14 @@ private let navigationSettleDelayMs = 800
 
         if !router.routes.isEmpty {
             router.routes.removeLast()
+            reconcileCoinControlManagerOwnership()
         }
     }
 
     func setRoute(_ routes: [Route]) {
         advanceNavigationGeneration()
         router.routes = routes
+        reconcileCoinControlManagerOwnership()
     }
 
     func scanQr() {
@@ -598,6 +616,8 @@ private let navigationSettleDelayMs = 800
             case let .routeUpdated(routes: routes):
                 let didChangeRoute = router.routes != routes
                 router.routes = routes
+                reconcileCoinControlManagerOwnership()
+
                 if didChangeRoute {
                     scheduleNavigationSettledForCurrentGeneration()
                 }
@@ -609,6 +629,7 @@ private let navigationSettleDelayMs = 800
                 }
 
                 router.routes.append(route)
+                reconcileCoinControlManagerOwnership()
                 scheduleNavigationSettledForCurrentGeneration()
 
             case .databaseUpdated:
@@ -628,6 +649,7 @@ private let navigationSettleDelayMs = 800
                 router.routes = nestedRoutes
                 router.default = route
                 routeId = UUID()
+                reconcileCoinControlManagerOwnership()
                 scheduleNavigationSettledForCurrentGeneration()
 
             case let .fiatPricesChanged(prices):
@@ -683,5 +705,18 @@ private let navigationSettleDelayMs = 800
         } catch {
             logger.error("Unable to dispatch app action \(action), error: \(error)")
         }
+    }
+}
+
+private extension Router {
+    var containsCoinControlRoute: Bool {
+        self.default.isCoinControlRoute || routes.contains { $0.isCoinControlRoute }
+    }
+}
+
+private extension Route {
+    var isCoinControlRoute: Bool {
+        if case .coinControl = self { return true }
+        return false
     }
 }

--- a/ios/Cove/CoinControlManager.swift
+++ b/ios/Cove/CoinControlManager.swift
@@ -15,12 +15,18 @@ private enum CoinControlManagerError: LocalizedError {
     typealias Message = CoinControlManagerReconcileMessage
     typealias Action = CoinControlManagerAction
 
+    private struct RustState {
+        var rust: RustCoinControlManager?
+        var isClosed = false
+    }
+
     private let logger = Log(id: "CoinControlManager")
     @ObservationIgnored
-    private var rust: RustCoinControlManager?
-    let id: WalletId
+    private let rustState = OSAllocatedUnfairLock(initialState: RustState())
     @ObservationIgnored
-    private let closeState = OSAllocatedUnfairLock(initialState: false)
+    private let rustBridge = DispatchQueue(label: "cove.CoinControlManager.rustbridge", qos: .userInitiated)
+
+    let id: WalletId
 
     private(set) var sort: CoinControlListSort? = .some(.date(.descending))
 
@@ -28,9 +34,14 @@ private enum CoinControlManagerError: LocalizedError {
     var totalSelected = Amount.fromSat(sats: 0)
     var selected: Set<Utxo.ID> = []
     var utxos: [Utxo]
+    var lockStateLoadFailed: Bool
     var unit: Unit = .sat
 
     private var updateSendFlowManagerTask: Task<Void, Never>? = nil
+
+    private var rust: RustCoinControlManager? {
+        rustState.withLock { $0.rust }
+    }
 
     @ObservationIgnored
     var searchBinding: Binding<String> {
@@ -48,8 +59,11 @@ private enum CoinControlManagerError: LocalizedError {
         Binding(
             get: { self.selected },
             set: {
-                let spendableIds = Set(self.utxos.filter(\.spendable).map(\.id))
-                let selected = $0.intersection(spendableIds)
+                let visibleIds = Set(self.utxos.map(\.id))
+                let visibleSpendableIds = Set(self.utxos.filter(\.spendable).map(\.id))
+                let selectedOutsideVisibleSearch = self.selected.subtracting(visibleIds)
+                let selected = selectedOutsideVisibleSearch.union($0.intersection(visibleSpendableIds))
+
                 self.selected = selected
                 self.dispatch(.notifySelectedUtxosChanged(Array(selected)))
             }
@@ -57,12 +71,13 @@ private enum CoinControlManagerError: LocalizedError {
     }
 
     public init(_ rust: RustCoinControlManager) {
-        self.rust = rust
         self.id = rust.id()
 
         self.utxos = rust.utxos()
+        self.lockStateLoadFailed = rust.lockStateLoadFailed()
         self.unit = rust.unit()
 
+        rustState.withLock { $0.rust = rust }
         rust.listenForUpdates(reconciler: WeakReconciler(self))
     }
 
@@ -71,19 +86,21 @@ private enum CoinControlManagerError: LocalizedError {
     }
 
     func close() {
-        guard markClosedIfNeeded() else { return }
+        guard takeRustForClose() != nil else { return }
 
         logger.debug("Closing CoinControlManager")
         updateSendFlowManagerTask?.cancel()
         updateSendFlowManagerTask = nil
-        rust = nil
     }
 
-    private func markClosedIfNeeded() -> Bool {
-        closeState.withLock { isClosed in
-            guard !isClosed else { return false }
-            isClosed = true
-            return true
+    private func takeRustForClose() -> RustCoinControlManager? {
+        rustState.withLock { state in
+            guard !state.isClosed else { return nil }
+
+            state.isClosed = true
+            let rust = state.rust
+            state.rust = nil
+            return rust
         }
     }
 
@@ -125,8 +142,7 @@ private enum CoinControlManagerError: LocalizedError {
         self.updateSendFlowManagerTask?.cancel()
         self.updateSendFlowManagerTask = nil
 
-        let selectedUtxos = self.utxos.filter { $0.spendable && self.selected.contains($0.id) }
-        sfm.dispatch(.setCoinControlMode(selectedUtxos))
+        sfm.dispatch(.setCoinControlMode(selectedUtxos()))
     }
 
     private func updateSendFlowManager() {
@@ -135,8 +151,7 @@ private enum CoinControlManagerError: LocalizedError {
         self.updateSendFlowManagerTask = Task {
             try? await Task.sleep(for: .milliseconds(100))
             guard !Task.isCancelled else { return }
-            let selectedUtxos = self.utxos.filter { $0.spendable && self.selected.contains($0.id) }
-            sfm.dispatch(.setCoinControlMode(selectedUtxos))
+            sfm.dispatch(.setCoinControlMode(selectedUtxos()))
         }
     }
 
@@ -156,6 +171,8 @@ private enum CoinControlManagerError: LocalizedError {
             withAnimation { self.totalSelected = totalSelected }
         case let .updateUnit(unit):
             withAnimation { self.unit = unit }
+        case let .updateLockStateLoadFailed(failed):
+            withAnimation { self.lockStateLoadFailed = failed }
         }
     }
 
@@ -183,8 +200,6 @@ private enum CoinControlManagerError: LocalizedError {
 
         try await rust.setUtxoSpendability(outpoint: outpoint, spendable: spendable)
     }
-
-    private let rustBridge = DispatchQueue(label: "cove.CoinControlManager.rustbridge", qos: .userInitiated)
 
     func reconcile(message: Message) {
         DispatchQueue.main.async { [weak self] in

--- a/ios/Cove/CoinControlManager.swift
+++ b/ios/Cove/CoinControlManager.swift
@@ -2,12 +2,22 @@ import SwiftUI
 
 extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinControlManager {}
 
+private enum CoinControlManagerError: LocalizedError {
+    case closed
+
+    var errorDescription: String? {
+        "Coin control manager is closed"
+    }
+}
+
 @Observable final class CoinControlManager: AnyReconciler, CoinControlManagerReconciler {
     typealias Message = CoinControlManagerReconcileMessage
     typealias Action = CoinControlManagerAction
 
     private let logger = Log(id: "CoinControlManager")
-    var rust: RustCoinControlManager
+    @ObservationIgnored
+    private var rust: RustCoinControlManager?
+    let id: WalletId
 
     private(set) var sort: CoinControlListSort? = .some(.date(.descending))
 
@@ -35,24 +45,33 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
         Binding(
             get: { self.selected },
             set: {
-                self.selected = $0
-                self.dispatch(.notifySelectedUtxosChanged(Array($0)))
+                let spendableIds = Set(self.utxos.filter(\.spendable).map(\.id))
+                let selected = $0.intersection(spendableIds)
+                self.selected = selected
+                self.dispatch(.notifySelectedUtxosChanged(Array(selected)))
             }
         )
     }
 
     public init(_ rust: RustCoinControlManager) {
         self.rust = rust
+        self.id = rust.id()
 
         self.utxos = rust.utxos()
         self.unit = rust.unit()
 
-        self.rust.listenForUpdates(reconciler: WeakReconciler(self))
+        rust.listenForUpdates(reconciler: WeakReconciler(self))
+    }
+
+    deinit {
+        close()
     }
 
     public func buttonArrow(_ key: CoinControlListSortKey) -> String? {
         _ = self.sort
-        return switch self.rust.buttonPresentation(button: key) {
+        guard let rust else { return nil }
+
+        return switch rust.buttonPresentation(button: key) {
         case .selected(.ascending):
             "arrow.up"
         case .selected(.descending):
@@ -60,6 +79,17 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
         case .notSelected:
             .none
         }
+    }
+
+    public func isSortSelected(_ key: CoinControlListSortKey) -> Bool {
+        guard let rust else { return false }
+
+        if case .selected = rust.buttonPresentation(button: key) { return true }
+        return false
+    }
+
+    public func selectedUtxos() -> [Utxo] {
+        rust?.selectedUtxos() ?? []
     }
 
     public var totalSelectedAmount: String {
@@ -75,7 +105,7 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
         self.updateSendFlowManagerTask?.cancel()
         self.updateSendFlowManagerTask = nil
 
-        let selectedUtxos = self.utxos.filter { self.selected.contains($0.id) }
+        let selectedUtxos = self.utxos.filter { $0.spendable && self.selected.contains($0.id) }
         sfm.dispatch(.setCoinControlMode(selectedUtxos))
     }
 
@@ -85,7 +115,7 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
         self.updateSendFlowManagerTask = Task {
             try? await Task.sleep(for: .milliseconds(100))
             guard !Task.isCancelled else { return }
-            let selectedUtxos = self.utxos.filter { self.selected.contains($0.id) }
+            let selectedUtxos = self.utxos.filter { $0.spendable && self.selected.contains($0.id) }
             sfm.dispatch(.setCoinControlMode(selectedUtxos))
         }
     }
@@ -125,11 +155,32 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
         }
     }
 
+    func reloadLabels() async {
+        guard let rust else { return }
+
+        await rust.reloadLabels()
+    }
+
+    func setSpendability(_ spendable: Bool, for outpoint: OutPoint) async throws {
+        guard let rust else { throw CoinControlManagerError.closed }
+
+        try await rust.setUtxoSpendability(outpoint: outpoint, spendable: spendable)
+    }
+
+    func close() {
+        guard rust != nil else { return }
+
+        logger.debug("Closing CoinControlManager")
+        updateSendFlowManagerTask?.cancel()
+        updateSendFlowManagerTask = nil
+        rust = nil
+    }
+
     private let rustBridge = DispatchQueue(label: "cove.CoinControlManager.rustbridge", qos: .userInitiated)
 
     func reconcile(message: Message) {
         DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
+            guard let self, self.rust != nil else { return }
             logger.debug("reconcile: \(message)")
             apply(message)
         }
@@ -137,7 +188,7 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
 
     func reconcileMany(messages: [Message]) {
         DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
+            guard let self, self.rust != nil else { return }
             logger.debug("reconcile_messages: \(messages)")
             messages.forEach { self.apply($0) }
         }
@@ -148,9 +199,11 @@ extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinC
     }
 
     public func dispatch(_ action: Action) {
-        rustBridge.async {
+        rustBridge.async { [weak self] in
+            guard let self, let rust = self.rust else { return }
+
             self.logger.debug("dispatch: \(action)")
-            self.rust.dispatch(action: action)
+            rust.dispatch(action: action)
         }
     }
 }

--- a/ios/Cove/CoinControlManager.swift
+++ b/ios/Cove/CoinControlManager.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 
 extension WeakReconciler: CoinControlManagerReconciler where Reconciler == CoinControlManager {}
@@ -18,6 +19,8 @@ private enum CoinControlManagerError: LocalizedError {
     @ObservationIgnored
     private var rust: RustCoinControlManager?
     let id: WalletId
+    @ObservationIgnored
+    private let closeState = OSAllocatedUnfairLock(initialState: false)
 
     private(set) var sort: CoinControlListSort? = .some(.date(.descending))
 
@@ -65,6 +68,23 @@ private enum CoinControlManagerError: LocalizedError {
 
     deinit {
         close()
+    }
+
+    func close() {
+        guard markClosedIfNeeded() else { return }
+
+        logger.debug("Closing CoinControlManager")
+        updateSendFlowManagerTask?.cancel()
+        updateSendFlowManagerTask = nil
+        rust = nil
+    }
+
+    private func markClosedIfNeeded() -> Bool {
+        closeState.withLock { isClosed in
+            guard !isClosed else { return false }
+            isClosed = true
+            return true
+        }
     }
 
     public func buttonArrow(_ key: CoinControlListSortKey) -> String? {
@@ -165,15 +185,6 @@ private enum CoinControlManagerError: LocalizedError {
         guard let rust else { throw CoinControlManagerError.closed }
 
         try await rust.setUtxoSpendability(outpoint: outpoint, spendable: spendable)
-    }
-
-    func close() {
-        guard rust != nil else { return }
-
-        logger.debug("Closing CoinControlManager")
-        updateSendFlowManagerTask?.cancel()
-        updateSendFlowManagerTask = nil
-        rust = nil
     }
 
     private let rustBridge = DispatchQueue(label: "cove.CoinControlManager.rustbridge", qos: .userInitiated)

--- a/ios/Cove/CoinControlManager.swift
+++ b/ios/Cove/CoinControlManager.swift
@@ -156,9 +156,6 @@ private enum CoinControlManagerError: LocalizedError {
             withAnimation { self.totalSelected = totalSelected }
         case let .updateUnit(unit):
             withAnimation { self.unit = unit }
-        case let .updateTotalSelectedAmount(amount):
-            updateSendFlowManager()
-            withAnimation { self.totalSelected = amount }
         }
     }
 

--- a/ios/Cove/Flows/CoinControlFlow/CoinControlContainer.swift
+++ b/ios/Cove/Flows/CoinControlFlow/CoinControlContainer.swift
@@ -59,14 +59,22 @@ private struct CoinControlLoadedView: View {
         .task(id: ObjectIdentifier(walletManager)) {
             await loadManager()
         }
+        .onDisappear {
+            closeManager()
+        }
     }
 
     @MainActor
     private func loadManager() async {
-        manager = nil
+        closeManager()
+
         do {
             let rustManager = try await walletManager.rust.newCoinControlManager()
-            manager = CoinControlManager(rustManager)
+            guard !Task.isCancelled else { return }
+
+            let manager = CoinControlManager(rustManager)
+            self.manager = manager
+            app.setCoinControlManager(manager)
         } catch {
             handleCoinControlManagerError(error)
         }
@@ -105,5 +113,14 @@ private struct CoinControlLoadedView: View {
             ))
             app.popRoute()
         }
+    }
+
+    @MainActor
+    private func closeManager() {
+        guard let manager else { return }
+
+        app.clearCoinControlManager(manager)
+        manager.close()
+        self.manager = nil
     }
 }

--- a/ios/Cove/Flows/CoinControlFlow/CoinControlContainer.swift
+++ b/ios/Cove/Flows/CoinControlFlow/CoinControlContainer.swift
@@ -59,13 +59,15 @@ private struct CoinControlLoadedView: View {
         .task(id: ObjectIdentifier(walletManager)) {
             await loadManager()
         }
-        .onDisappear {
-            closeManager()
-        }
     }
 
     @MainActor
     private func loadManager() async {
+        if let manager, manager.id == walletManager.id {
+            app.setCoinControlManager(manager)
+            return
+        }
+
         closeManager()
 
         do {

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -396,10 +396,12 @@ private struct UtxoRow: View {
         .padding(.vertical, 4)
         .opacity(utxo.spendable ? 1 : 0.58)
         .contentShape(Rectangle())
-        .onTapGesture {
-            guard !utxo.spendable else { return }
-            onLockedSelectionAttempt()
-        }
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                guard !utxo.spendable else { return }
+                onLockedSelectionAttempt()
+            }
+        )
     }
 }
 

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -18,6 +18,7 @@ struct UtxoListScreen: View {
     let manager: CoinControlManager
 
     @FocusState private var isFocused: Bool
+    @State private var showLockedSelectionAlert = false
 
     func goToTransactionDetails(_ utxo: Utxo) {
         let txId = utxo.id.txid()
@@ -30,27 +31,48 @@ struct UtxoListScreen: View {
         VStack(spacing: 0) {
             List(selection: manager.selectedBinding) {
                 ForEach(manager.utxos) { utxo in
-                    UtxoRow(manager: manager, utxo: utxo)
-                        .listRowBackground(Color.secondarySystemGroupedBackground)
-                        .contextMenu {
-                            Button(action: {
-                                UIPasteboard.general.string = utxo.address.unformatted()
-                            }) {
-                                Text("Copy Address")
-                            }
-
-                            Button(action: {
-                                UIPasteboard.general.string = utxo.outpoint.txidStr()
-                            }) {
-                                Text("Copy Transaction ID")
-                            }
-
-                            Button(action: { goToTransactionDetails(utxo) }) {
-                                Text("View Transaction Details")
-                            }
-                        } preview: {
-                            UtxoRowPreview(displayAmount: manager.displayAmount, utxo: utxo)
+                    UtxoRow(
+                        manager: manager,
+                        utxo: utxo,
+                        onLockedSelectionAttempt: {
+                            showLockedSelectionAlert = true
                         }
+                    )
+                    .listRowBackground(Color.secondarySystemGroupedBackground)
+                    .contextMenu {
+                        Button(action: {
+                            UIPasteboard.general.string = utxo.address.unformatted()
+                        }) {
+                            Text("Copy Address")
+                        }
+
+                        Button(action: {
+                            UIPasteboard.general.string = utxo.outpoint.txidStr()
+                        }) {
+                            Text("Copy Transaction ID")
+                        }
+
+                        Button(action: { goToTransactionDetails(utxo) }) {
+                            Text("View Transaction Details")
+                        }
+
+                        Button(action: {
+                            Task {
+                                do {
+                                    try await manager.setSpendability(
+                                        !utxo.spendable,
+                                        for: utxo.outpoint
+                                    )
+                                } catch {
+                                    Log.error("Unable to update UTXO spendability: \(error)")
+                                }
+                            }
+                        }) {
+                            Text(utxo.spendable ? "Lock UTXO" : "Unlock UTXO")
+                        }
+                    } preview: {
+                        UtxoRowPreview(displayAmount: manager.displayAmount, utxo: utxo)
+                    }
                 }
             }
             .scrollContentBackground(.hidden)
@@ -202,8 +224,8 @@ struct UtxoListScreen: View {
                     navigate(
                         RouteFactory()
                             .coinControlSend(
-                                id: manager.rust.id(),
-                                utxos: manager.rust.selectedUtxos()
+                                id: manager.id,
+                                utxos: manager.selectedUtxos()
                             )
                     )
                 }
@@ -252,18 +274,20 @@ struct UtxoListScreen: View {
             Color(.systemGroupedBackground)
                 .ignoresSafeArea()
         )
+        .alert("UTXO Locked", isPresented: $showLockedSelectionAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Unlock this UTXO before selecting it.")
+        }
         .environment(manager)
-        .task { await manager.rust.reloadLabels() }
+        .task { await manager.reloadLabels() }
     }
 
     // MARK: - Helpers
 
     private func sortButton(for key: CoinControlListSortKey) -> some View {
         let _ = manager.sort
-        let isSelected = {
-            if case .selected = manager.rust.buttonPresentation(button: key) { return true }
-            return false
-        }()
+        let isSelected = manager.isSortSelected(key)
 
         return Button {
             manager.dispatch(.changeSort(key))
@@ -297,6 +321,7 @@ struct UtxoListScreen: View {
 private struct UtxoRow: View {
     var manager: CoinControlManager
     let utxo: Utxo
+    let onLockedSelectionAttempt: () -> Void
 
     var body: some View {
         HStack(spacing: 20) {
@@ -312,6 +337,12 @@ private struct UtxoRow: View {
                         Image(systemName: "circlebadge.2")
                             .font(.caption)
                             .foregroundColor(.statusWarning.opacity(0.8))
+                    }
+
+                    if !utxo.spendable {
+                        Image(systemName: "lock.fill")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
                 }
 
@@ -340,6 +371,12 @@ private struct UtxoRow: View {
             }
         }
         .padding(.vertical, 4)
+        .opacity(utxo.spendable ? 1 : 0.58)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard !utxo.spendable else { return }
+            onLockedSelectionAttempt()
+        }
     }
 }
 

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -19,6 +19,7 @@ struct UtxoListScreen: View {
 
     @FocusState private var isFocused: Bool
     @State private var showLockedSelectionAlert = false
+    @State private var utxoLockUpdateError: String? = nil
 
     func goToTransactionDetails(_ utxo: Utxo) {
         let txId = utxo.id.txid()
@@ -65,6 +66,9 @@ struct UtxoListScreen: View {
                                     )
                                 } catch {
                                     Log.error("Unable to update UTXO spendability: \(error)")
+                                    await MainActor.run {
+                                        utxoLockUpdateError = error.localizedDescription
+                                    }
                                 }
                             }
                         }) {
@@ -179,6 +183,15 @@ struct UtxoListScreen: View {
                 // ─ UTXO list ─
                 VStack(spacing: 8) {
                     UtxoList()
+                    if manager.lockStateLoadFailed {
+                        Text("Unable to read UTXO lock state. UTXOs are shown locked for safety.")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.red)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+
                     Text(manager.totalSelectedAmount)
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
@@ -278,6 +291,16 @@ struct UtxoListScreen: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Unlock this UTXO before selecting it.")
+        }
+        .alert("Unable to Update UTXO Lock", isPresented: Binding(
+            get: { utxoLockUpdateError != nil },
+            set: { if !$0 { utxoLockUpdateError = nil } }
+        )) {
+            Button("OK", role: .cancel) {
+                utxoLockUpdateError = nil
+            }
+        } message: {
+            Text(utxoLockUpdateError ?? "")
         }
         .environment(manager)
         .task { await manager.reloadLabels() }

--- a/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SelectedWalletScreen.swift
@@ -485,7 +485,7 @@ struct SelectedWalletScreen: View {
         }
 
         do {
-            try labelManager.importLabels(labels: labels)
+            try manager.importLabels(labels: labels)
             app.alertState = .init(
                 .general(
                     title: "Success!",

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -256,7 +256,10 @@ struct TransactionDetailsView: View {
                     .foregroundStyle(.secondary)
 
                 Button(action: {
-                    Task { await toggleTransactionLockState() }
+                    if !isUpdatingLockState {
+                        isUpdatingLockState = true
+                        Task { await toggleTransactionLockState() }
+                    }
                 }) {
                     Label(lockStateButtonText, systemImage: lockStateButtonIcon)
                         .font(.footnote)
@@ -277,11 +280,11 @@ struct TransactionDetailsView: View {
     var lockStateText: String {
         switch lockState {
         case .some(.locked):
-            "Locked"
+            String(localized: "Locked")
         case .some(.mixed):
-            "Mixed"
+            String(localized: "Mixed")
         case .some(.unlocked):
-            "Unlocked"
+            String(localized: "Unlocked")
         case .some(.none), nil:
             ""
         }
@@ -290,11 +293,11 @@ struct TransactionDetailsView: View {
     var lockStateButtonText: String {
         switch lockState {
         case .some(.locked):
-            "Unlock Transaction"
+            String(localized: "Unlock Transaction")
         case .some(.mixed):
-            "Lock Transaction"
+            String(localized: "Lock Transaction")
         case .some(.unlocked):
-            "Lock Transaction"
+            String(localized: "Lock Transaction")
         case .some(.none), nil:
             ""
         }
@@ -470,12 +473,6 @@ struct TransactionDetailsView: View {
     }
 
     func toggleTransactionLockState() async {
-        guard !isUpdatingLockState else { return }
-
-        await MainActor.run {
-            isUpdatingLockState = true
-        }
-
         do {
             let state = try await manager.toggleTransactionLockState(for: initialDetails.txId())
             await MainActor.run {

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -247,59 +247,79 @@ struct TransactionDetailsView: View {
     @ViewBuilder
     var TransactionLockControl: some View {
         if lockStateLoadError != nil {
-            VStack(spacing: 8) {
-                Text("Unable to load lock state")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-
-                Button(action: {
-                    Task { await refreshTransactionLockState() }
-                }) {
-                    Label("Retry", systemImage: "arrow.clockwise")
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 12)
-                        .background(Color.systemGray5)
-                        .foregroundStyle(.primary)
-                        .clipShape(Capsule())
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(.top, 2)
+            transactionLockControlContent(
+                title: String(localized: "Unable to load lock state"),
+                buttonTitle: String(localized: "Retry"),
+                systemImage: "arrow.clockwise",
+                action: { Task { await refreshTransactionLockState() } }
+            )
         } else {
             switch lockState {
             case .some(.none), nil:
                 EmptyView()
             case .some(.unlocked), .some(.locked), .some(.mixed):
-                VStack(spacing: 8) {
-                    Text(lockStateText)
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.secondary)
+                transactionLockControlContent(
+                    title: lockStateText,
+                    buttonTitle: isUpdatingLockState
+                        ? String(localized: "Updating...")
+                        : lockStateButtonText,
+                    systemImage: lockStateButtonIcon,
+                    isUpdating: isUpdatingLockState,
+                    action: {
+                        guard !isUpdatingLockState else { return }
 
-                    Button(action: {
-                        if !isUpdatingLockState {
-                            isUpdatingLockState = true
-                            Task { await toggleTransactionLockState() }
-                        }
-                    }) {
-                        Label(lockStateButtonText, systemImage: lockStateButtonIcon)
-                            .font(.footnote)
-                            .fontWeight(.semibold)
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 12)
-                            .background(Color.systemGray5)
-                            .foregroundStyle(.primary)
-                            .clipShape(Capsule())
+                        isUpdatingLockState = true
+                        Task { await toggleTransactionLockState() }
                     }
-                    .buttonStyle(.plain)
-                    .disabled(isUpdatingLockState)
-                }
-                .padding(.top, 2)
+                )
             }
         }
+    }
+
+    func transactionLockControlContent(
+        title: String,
+        buttonTitle: String,
+        systemImage: String,
+        isUpdating: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Text(title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button(action: action) {
+                HStack(spacing: 6) {
+                    if isUpdating {
+                        ProgressView()
+                            .controlSize(.mini)
+                    } else {
+                        Image(systemName: systemImage)
+                            .font(.footnote.weight(.semibold))
+                    }
+
+                    Text(buttonTitle)
+                        .font(.footnote)
+                        .fontWeight(.semibold)
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .background(Color.systemGray5)
+                .foregroundStyle(.primary)
+                .clipShape(Capsule())
+                .opacity(isUpdating ? 0.72 : 1)
+            }
+            .buttonStyle(.plain)
+            .disabled(isUpdating)
+        }
+        .padding(.top, 2)
     }
 
     var lockStateText: String {

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -17,6 +17,9 @@ struct TransactionDetailsView: View {
 
     @State private var initialOffset: Double? = nil
     @State private var currentOffset: Double = 0
+    @State private var lockState: TransactionLockState? = nil
+    @State private var isUpdatingLockState = false
+    @State private var lockStateError: String? = nil
 
     // public
     let id: WalletId
@@ -130,6 +133,8 @@ struct TransactionDetailsView: View {
         }
         .padding(.top, 12)
 
+        TransactionLockControl
+
         // confirmations pills
         if let confirmations = numberOfConfirmations, confirmations < 3 {
             VStack {
@@ -220,6 +225,8 @@ struct TransactionDetailsView: View {
         }
         .padding(.top, 12)
 
+        TransactionLockControl
+
         if let confirmations = numberOfConfirmations, confirmations < 3 {
             VStack {
                 Divider().padding(.vertical, 18)
@@ -233,6 +240,74 @@ struct TransactionDetailsView: View {
                 manager: manager, transactionDetails: transactionDetails,
                 numberOfConfirmations: numberOfConfirmations
             )
+        }
+    }
+
+    @ViewBuilder
+    var TransactionLockControl: some View {
+        switch lockState {
+        case .some(.none), nil:
+            EmptyView()
+        case .some(.unlocked), .some(.locked), .some(.mixed):
+            VStack(spacing: 8) {
+                Text(lockStateText)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+
+                Button(action: {
+                    Task { await toggleTransactionLockState() }
+                }) {
+                    Label(lockStateButtonText, systemImage: lockStateButtonIcon)
+                        .font(.footnote)
+                        .fontWeight(.semibold)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .background(Color.systemGray5)
+                        .foregroundStyle(.primary)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(isUpdatingLockState)
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    var lockStateText: String {
+        switch lockState {
+        case .some(.locked):
+            "Locked"
+        case .some(.mixed):
+            "Mixed"
+        case .some(.unlocked):
+            "Unlocked"
+        case .some(.none), nil:
+            ""
+        }
+    }
+
+    var lockStateButtonText: String {
+        switch lockState {
+        case .some(.locked):
+            "Unlock Transaction"
+        case .some(.mixed):
+            "Lock Transaction"
+        case .some(.unlocked):
+            "Lock Transaction"
+        case .some(.none), nil:
+            ""
+        }
+    }
+
+    var lockStateButtonIcon: String {
+        switch lockState {
+        case .some(.locked):
+            "lock.open"
+        case .some(.mixed), .some(.unlocked):
+            "lock"
+        case .some(.none), nil:
+            "lock"
         }
     }
 
@@ -307,12 +382,15 @@ struct TransactionDetailsView: View {
         }
         .refreshable {
             await refreshTransactionDetails()
+            await refreshTransactionLockState()
         }
         .task(id: txId) {
             // fetch fresh details on load
             if refreshOnAppear {
                 await refreshTransactionDetails()
             }
+
+            await refreshTransactionLockState()
 
             // start watcher after a delay to avoid race condition with onDisappear
             if !transactionDetails.isConfirmed() {
@@ -344,6 +422,16 @@ struct TransactionDetailsView: View {
         .onDisappear {
             UIRefreshControl.appearance().tintColor = UIColor.secondaryLabel
         }
+        .alert("Unable to Update Lock", isPresented: Binding(
+            get: { lockStateError != nil },
+            set: { if !$0 { lockStateError = nil } }
+        )) {
+            Button("OK", role: .cancel) {
+                lockStateError = nil
+            }
+        } message: {
+            Text(lockStateError ?? "")
+        }
     }
 
     func refreshTransactionDetails() async {
@@ -365,6 +453,42 @@ struct TransactionDetailsView: View {
             }
         } catch {
             Log.error("Error refreshing transaction details: \(error)")
+        }
+    }
+
+    func refreshTransactionLockState() async {
+        do {
+            let state = try await manager.transactionLockState(for: initialDetails.txId())
+            await MainActor.run {
+                withAnimation {
+                    lockState = state
+                }
+            }
+        } catch {
+            Log.error("Error refreshing transaction lock state: \(error)")
+        }
+    }
+
+    func toggleTransactionLockState() async {
+        guard !isUpdatingLockState else { return }
+
+        await MainActor.run {
+            isUpdatingLockState = true
+        }
+
+        do {
+            let state = try await manager.toggleTransactionLockState(for: initialDetails.txId())
+            await MainActor.run {
+                withAnimation {
+                    lockState = state
+                }
+                isUpdatingLockState = false
+            }
+        } catch {
+            await MainActor.run {
+                lockStateError = error.localizedDescription
+                isUpdatingLockState = false
+            }
         }
     }
 

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -20,6 +20,7 @@ struct TransactionDetailsView: View {
     @State private var lockState: TransactionLockState? = nil
     @State private var isUpdatingLockState = false
     @State private var lockStateError: String? = nil
+    @State private var lockStateLoadError: String? = nil
 
     // public
     let id: WalletId
@@ -245,23 +246,17 @@ struct TransactionDetailsView: View {
 
     @ViewBuilder
     var TransactionLockControl: some View {
-        switch lockState {
-        case .some(.none), nil:
-            EmptyView()
-        case .some(.unlocked), .some(.locked), .some(.mixed):
+        if lockStateLoadError != nil {
             VStack(spacing: 8) {
-                Text(lockStateText)
+                Text("Unable to load lock state")
                     .font(.caption)
                     .fontWeight(.semibold)
                     .foregroundStyle(.secondary)
 
                 Button(action: {
-                    if !isUpdatingLockState {
-                        isUpdatingLockState = true
-                        Task { await toggleTransactionLockState() }
-                    }
+                    Task { await refreshTransactionLockState() }
                 }) {
-                    Label(lockStateButtonText, systemImage: lockStateButtonIcon)
+                    Label("Retry", systemImage: "arrow.clockwise")
                         .font(.footnote)
                         .fontWeight(.semibold)
                         .padding(.vertical, 8)
@@ -271,9 +266,39 @@ struct TransactionDetailsView: View {
                         .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
-                .disabled(isUpdatingLockState)
             }
             .padding(.top, 2)
+        } else {
+            switch lockState {
+            case .some(.none), nil:
+                EmptyView()
+            case .some(.unlocked), .some(.locked), .some(.mixed):
+                VStack(spacing: 8) {
+                    Text(lockStateText)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+
+                    Button(action: {
+                        if !isUpdatingLockState {
+                            isUpdatingLockState = true
+                            Task { await toggleTransactionLockState() }
+                        }
+                    }) {
+                        Label(lockStateButtonText, systemImage: lockStateButtonIcon)
+                            .font(.footnote)
+                            .fontWeight(.semibold)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 12)
+                            .background(Color.systemGray5)
+                            .foregroundStyle(.primary)
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isUpdatingLockState)
+                }
+                .padding(.top, 2)
+            }
         }
     }
 
@@ -465,10 +490,14 @@ struct TransactionDetailsView: View {
             await MainActor.run {
                 withAnimation {
                     lockState = state
+                    lockStateLoadError = nil
                 }
             }
         } catch {
             Log.error("Error refreshing transaction lock state: \(error)")
+            await MainActor.run {
+                lockStateLoadError = error.localizedDescription
+            }
         }
     }
 

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -114,6 +114,10 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
         self.sendAmountFiat = self.rust.sendAmountFiat()
     }
 
+    public func reconcileAfterLabelImport() {
+        dispatch(action: .refreshWalletBalance)
+    }
+
     public func getNewCustomFeeRateWithTotal(
         feeRate: FeeRate, feeSpeed: FeeSpeed
     ) async throws -> FeeRateOptionWithTotalFee {

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -114,7 +114,7 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
         self.sendAmountFiat = self.rust.sendAmountFiat()
     }
 
-    public func reconcileAfterLabelImport() {
+    public func reconcileAfterLabelsChanged() {
         dispatch(action: .refreshWalletBalance)
     }
 

--- a/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
@@ -82,6 +82,8 @@ import SwiftUI
             "Unable to get max send"
         case .UnableToSaveUnsignedTransaction:
             "Unable to Save Unsigned Transaction"
+        case .WalletManager(.LockedOutputsSelected):
+            "Insufficient Funds"
         case .WalletManager:
             "Error"
         case .UnableToGetFeeDetails:
@@ -119,6 +121,8 @@ import SwiftUI
             "Send amount is too low. Please send atleast 5000 sats"
         case .UnableToGetFeeRate:
             "Are you connected to the internet?"
+        case .WalletManager(.LockedOutputsSelected):
+            "Selected coins include locked coins. Unlock them or choose different coins."
         case let .WalletManager(msg):
             msg.description
         case let .UnableToGetFeeDetails(msg):

--- a/ios/Cove/ScanManager.swift
+++ b/ios/Cove/ScanManager.swift
@@ -31,7 +31,9 @@ import SwiftUI
                 }
             case let .bip329Labels(labels):
                 guard let manager = app.walletManager else { return setInvalidLabels() }
-                guard Database().globalConfig().selectedWallet() != nil else {
+                guard let selectedWallet = Database().globalConfig().selectedWallet(),
+                      selectedWallet == manager.id
+                else {
                     return setInvalidLabels()
                 }
 
@@ -95,18 +97,14 @@ import SwiftUI
                     "TAPSIGNER not implemented \(tapSigner) doesn't make sense for file import"
                 Log.error(panic)
             case let .bip329Labels(labels):
-                if let manager = app.walletManager,
-                   Database().globalConfig().selectedWallet() != nil
-                {
-                    return try manager.importLabels(labels: labels)
+                guard let manager = app.walletManager,
+                      let selectedWallet = Database().globalConfig().selectedWallet(),
+                      selectedWallet == manager.id
+                else {
+                    return setInvalidLabels()
                 }
 
-                app.alertState = TaggedItem(
-                    .invalidFileFormat(
-                        message:
-                        "Currently BIP329 labels must be imported through the wallet actions"
-                    )
-                )
+                return try manager.importLabels(labels: labels)
             case let .signedPsbt(psbt):
                 handleSignedPsbt(psbt)
             }

--- a/ios/Cove/ScanManager.swift
+++ b/ios/Cove/ScanManager.swift
@@ -31,13 +31,12 @@ import SwiftUI
                 }
             case let .bip329Labels(labels):
                 guard let manager = app.walletManager else { return setInvalidLabels() }
-                guard let selectedWallet = Database().globalConfig().selectedWallet() else {
+                guard Database().globalConfig().selectedWallet() != nil else {
                     return setInvalidLabels()
                 }
 
-                try LabelManager(id: selectedWallet).import(labels: labels)
+                try manager.importLabels(labels: labels)
                 app.alertState = .init(.importedLabelsSuccessfully)
-                Task { await manager.rust.getTransactions() }
             }
         } catch {
             switch error {
@@ -96,8 +95,10 @@ import SwiftUI
                     "TAPSIGNER not implemented \(tapSigner) doesn't make sense for file import"
                 Log.error(panic)
             case let .bip329Labels(labels):
-                if let selectedWallet = Database().globalConfig().selectedWallet() {
-                    return try LabelManager(id: selectedWallet).import(labels: labels)
+                if let manager = app.walletManager,
+                   Database().globalConfig().selectedWallet() != nil
+                {
+                    return try manager.importLabels(labels: labels)
                 }
 
                 app.alertState = TaggedItem(

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -296,6 +296,24 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
         return details
     }
 
+    func transactionLockState(for txId: TxId) async throws -> TransactionLockState {
+        try await rust.transactionLockState(txId: txId)
+    }
+
+    func toggleTransactionLockState(for txId: TxId) async throws -> TransactionLockState {
+        try await rust.toggleTransactionLockState(txId: txId)
+    }
+
+    func importLabels(labels: Bip329Labels) throws {
+        try LabelManager(id: id).import(labels: labels)
+        AppManager.shared.reconcileAfterLabelImport(walletId: id)
+    }
+
+    func reconcileAfterLabelImport() {
+        transactionDetails.removeAll()
+        Task { await rust.getTransactions() }
+    }
+
     func updateTransactionDetailsCache(txId: TxId, details: TransactionDetails) {
         transactionDetails[txId] = details
     }

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -301,15 +301,19 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
     }
 
     func toggleTransactionLockState(for txId: TxId) async throws -> TransactionLockState {
-        try await rust.toggleTransactionLockState(txId: txId)
+        let state = try await rust.toggleTransactionLockState(txId: txId)
+        await AppManager.shared.reconcileAfterLabelsChanged(walletId: id)
+
+        return state
     }
 
+    @MainActor
     func importLabels(labels: Bip329Labels) throws {
         try LabelManager(id: id).import(labels: labels)
-        AppManager.shared.reconcileAfterLabelImport(walletId: id)
+        AppManager.shared.reconcileAfterLabelsChanged(walletId: id)
     }
 
-    func reconcileAfterLabelImport() {
+    func reconcileAfterLabelsChanged() {
         transactionDetails.removeAll()
         Task { await rust.getTransactions() }
     }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -7700,6 +7700,8 @@ public protocol RustCoinControlManagerProtocol: AnyObject, Sendable {
 
     func listenForUpdates(reconciler: CoinControlManagerReconciler)
 
+    func lockStateLoadFailed()  -> Bool
+
     func reloadLabels() async
 
     func selectedUtxos()  -> [Utxo]
@@ -7812,6 +7814,15 @@ open func listenForUpdates(reconciler: CoinControlManagerReconciler)  {try! rust
         FfiConverterCallbackInterfaceCoinControlManagerReconciler_lower(reconciler),uniffiCallStatus
     )
 }
+}
+
+open func lockStateLoadFailed() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_rustcoincontrolmanager_lock_state_load_failed(
+            self.uniffiCloneHandle(),uniffiCallStatus
+    )
+})
 }
 
 open func reloadLabels()async   {
@@ -22692,6 +22703,8 @@ public enum CoinControlManagerReconcileMessage {
     )
     case updateUnit(BitcoinUnit
     )
+    case updateLockStateLoadFailed(Bool
+    )
 
 
 
@@ -22730,6 +22743,9 @@ public struct FfiConverterTypeCoinControlManagerReconcileMessage: FfiConverterRu
         case 6: return .updateUnit(try FfiConverterTypeBitcoinUnit.read(from: &buf)
         )
 
+        case 7: return .updateLockStateLoadFailed(try FfiConverterBool.read(from: &buf)
+        )
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
@@ -22766,6 +22782,11 @@ public struct FfiConverterTypeCoinControlManagerReconcileMessage: FfiConverterRu
         case let .updateUnit(v1):
             writeInt(&buf, Int32(6))
             FfiConverterTypeBitcoinUnit.write(v1, into: &buf)
+
+
+        case let .updateLockStateLoadFailed(v1):
+            writeInt(&buf, Int32(7))
+            FfiConverterBool.write(v1, into: &buf)
 
         }
     }
@@ -25954,6 +25975,7 @@ enum LabelManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedEr
     )
     case SaveAddressLabels(String
     )
+    case WalletNotSelected
 
 
 
@@ -26024,6 +26046,7 @@ public struct FfiConverterTypeLabelManagerError: FfiConverterRustBuffer {
         case 10: return .SaveAddressLabels(
             try FfiConverterString.read(from: &buf)
             )
+        case 11: return .WalletNotSelected
 
          default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -26084,6 +26107,10 @@ public struct FfiConverterTypeLabelManagerError: FfiConverterRustBuffer {
         case let .SaveAddressLabels(v1):
             writeInt(&buf, Int32(10))
             FfiConverterString.write(v1, into: &buf)
+
+
+        case .WalletNotSelected:
+            writeInt(&buf, Int32(11))
 
         }
     }
@@ -40300,6 +40327,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcoincontrolmanager_listen_for_updates() != 53354) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustcoincontrolmanager_lock_state_load_failed() != 30996) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcoincontrolmanager_reload_labels() != 44692) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -9058,6 +9058,8 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func balancePresentation(scanStatus: WalletScanStatus)  -> BalancePresentation
 
+    func balancePresentationForState(ledgerState: WalletLedgerState)  -> BalancePresentation
+
     func broadcastTransaction(signedTransaction: BitcoinTransaction) async throws
 
     func convertAndDisplayFiat(amount: Amount, prices: PriceResponse, withSuffix: Bool)  -> String
@@ -9192,15 +9194,20 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func labelManager()  -> LabelManager
 
+    /**
+     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
+     */
+    func ledgerState()  -> WalletLedgerState
+
     func listenForUpdates(reconciler: WalletManagerReconciler)
 
     func markWalletAsVerified() throws
 
     func masterFingerprint()  -> String?
 
-    func newCoinControlManager() async  -> RustCoinControlManager
+    func newCoinControlManager() async throws  -> RustCoinControlManager
 
-    func newSendFlowManager(balance: Balance)  -> RustSendFlowManager
+    func newSendFlowManager(balance: Balance) throws  -> RustSendFlowManager
 
     func nonDefaultAccountNumber()  -> UInt32?
 
@@ -9409,6 +9416,16 @@ open func balancePresentation(scanStatus: WalletScanStatus) -> BalancePresentati
     uniffi_cove_fn_method_rustwalletmanager_balance_presentation(
             self.uniffiCloneHandle(),
         FfiConverterTypeWalletScanStatus_lower(scanStatus),uniffiCallStatus
+    )
+})
+}
+
+open func balancePresentationForState(ledgerState: WalletLedgerState) -> BalancePresentation  {
+    return try!  FfiConverterTypeBalancePresentation_lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeWalletLedgerState_lower(ledgerState),uniffiCallStatus
     )
 })
 }
@@ -9934,6 +9951,18 @@ open func labelManager() -> LabelManager  {
 })
 }
 
+    /**
+     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
+     */
+open func ledgerState() -> WalletLedgerState  {
+    return try!  FfiConverterTypeWalletLedgerState_lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_rustwalletmanager_ledger_state(
+            self.uniffiCloneHandle(),uniffiCallStatus
+    )
+})
+}
+
 open func listenForUpdates(reconciler: WalletManagerReconciler)  {try! rustCall() {
         uniffiCallStatus in
     uniffi_cove_fn_method_rustwalletmanager_listen_for_updates(
@@ -9960,9 +9989,9 @@ open func masterFingerprint() -> String?  {
 })
 }
 
-open func newCoinControlManager()async  -> RustCoinControlManager  {
+open func newCoinControlManager()async throws  -> RustCoinControlManager  {
     return
-        try!  await uniffiRustCallAsync(
+        try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_cove_fn_method_rustwalletmanager_new_coin_control_manager(
                     self.uniffiCloneHandle()
@@ -9973,13 +10002,12 @@ open func newCoinControlManager()async  -> RustCoinControlManager  {
             completeFunc: ffi_cove_rust_future_complete_u64,
             freeFunc: ffi_cove_rust_future_free_u64,
             liftFunc: FfiConverterTypeRustCoinControlManager_lift,
-            errorHandler: nil
-
+            errorHandler: FfiConverterTypeWalletManagerError_lift
         )
 }
 
-open func newSendFlowManager(balance: Balance) -> RustSendFlowManager  {
-    return try!  FfiConverterTypeRustSendFlowManager_lift(try! rustCall() {
+open func newSendFlowManager(balance: Balance)throws  -> RustSendFlowManager  {
+    return try  FfiConverterTypeRustSendFlowManager_lift(try rustCallWithError(FfiConverterTypeWalletManagerError_lift) {
         uniffiCallStatus in
     uniffi_cove_fn_method_rustwalletmanager_new_send_flow_manager(
             self.uniffiCloneHandle(),
@@ -10929,6 +10957,8 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
 
     func confirmationDateTime()  -> String?
 
+    func displayAmount(metadata: WalletMetadata, showUnit: Bool)  -> String
+
     func feeFiatFmt() async throws  -> String
 
     func feeFiatFmtCached()  -> String?
@@ -11177,6 +11207,17 @@ open func confirmationDateTime() -> String?  {
         uniffiCallStatus in
     uniffi_cove_fn_method_transactiondetails_confirmation_date_time(
             self.uniffiCloneHandle(),uniffiCallStatus
+    )
+})
+}
+
+open func displayAmount(metadata: WalletMetadata, showUnit: Bool = true) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_transactiondetails_display_amount(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterBool.lower(showUnit),uniffiCallStatus
     )
 })
 }
@@ -25783,6 +25824,72 @@ public func FfiConverterTypeInitError_lower(_ value: InitError) -> RustBuffer {
 
 
 
+public enum InitialScanActivity: Equatable, Hashable {
+
+    case active
+    case idle
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension InitialScanActivity: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeInitialScanActivity: FfiConverterRustBuffer {
+    typealias SwiftType = InitialScanActivity
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> InitialScanActivity {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .active
+
+        case 2: return .idle
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: InitialScanActivity, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .active:
+            writeInt(&buf, Int32(1))
+
+
+        case .idle:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeInitialScanActivity_lift(_ buf: RustBuffer) throws -> InitialScanActivity {
+    return try FfiConverterTypeInitialScanActivity.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeInitialScanActivity_lower(_ value: InitialScanActivity) -> RustBuffer {
+    return FfiConverterTypeInitialScanActivity.lower(value)
+}
+
+
+
+
 public enum InsertOrUpdate: Equatable, Hashable {
 
     case insert(Timestamp
@@ -34152,6 +34259,75 @@ public func FfiConverterTypeWalletErrorAlert_lower(_ value: WalletErrorAlert) ->
 
 
 
+public enum WalletLedgerState: Equatable, Hashable {
+
+    case complete
+    case initialScanIncomplete(InitialScanActivity
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WalletLedgerState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWalletLedgerState: FfiConverterRustBuffer {
+    typealias SwiftType = WalletLedgerState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WalletLedgerState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .complete
+
+        case 2: return .initialScanIncomplete(try FfiConverterTypeInitialScanActivity.read(from: &buf)
+        )
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WalletLedgerState, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .complete:
+            writeInt(&buf, Int32(1))
+
+
+        case let .initialScanIncomplete(v1):
+            writeInt(&buf, Int32(2))
+            FfiConverterTypeInitialScanActivity.write(v1, into: &buf)
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWalletLedgerState_lift(_ buf: RustBuffer) throws -> WalletLedgerState {
+    return try FfiConverterTypeWalletLedgerState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWalletLedgerState_lower(_ value: WalletLedgerState) -> RustBuffer {
+    return FfiConverterTypeWalletLedgerState.lower(value)
+}
+
+
+
+
 public enum WalletLoadState {
 
     case loading
@@ -34257,8 +34433,6 @@ public enum WalletManagerAction {
     case toggleFiatBtcPrimarySecondary
     case toggleShowLabels
     case selectCurrentWalletAddressType
-    case selectDifferentWalletAddressType(WalletAddressType
-    )
     case selectedWalletDisappeared
     case startTransactionWatcher(TxId
     )
@@ -34311,19 +34485,16 @@ public struct FfiConverterTypeWalletManagerAction: FfiConverterRustBuffer {
 
         case 10: return .selectCurrentWalletAddressType
 
-        case 11: return .selectDifferentWalletAddressType(try FfiConverterTypeWalletAddressType.read(from: &buf)
+        case 11: return .selectedWalletDisappeared
+
+        case 12: return .startTransactionWatcher(try FfiConverterTypeTxId.read(from: &buf)
         )
 
-        case 12: return .selectedWalletDisappeared
+        case 13: return .openReceiveAddress
 
-        case 13: return .startTransactionWatcher(try FfiConverterTypeTxId.read(from: &buf)
-        )
+        case 14: return .createNewReceiveAddress
 
-        case 14: return .openReceiveAddress
-
-        case 15: return .createNewReceiveAddress
-
-        case 16: return .closeReceiveAddress(try FfiConverterUInt64.read(from: &buf)
+        case 15: return .closeReceiveAddress(try FfiConverterUInt64.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -34378,30 +34549,25 @@ public struct FfiConverterTypeWalletManagerAction: FfiConverterRustBuffer {
             writeInt(&buf, Int32(10))
 
 
-        case let .selectDifferentWalletAddressType(v1):
-            writeInt(&buf, Int32(11))
-            FfiConverterTypeWalletAddressType.write(v1, into: &buf)
-
-
         case .selectedWalletDisappeared:
-            writeInt(&buf, Int32(12))
+            writeInt(&buf, Int32(11))
 
 
         case let .startTransactionWatcher(v1):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(12))
             FfiConverterTypeTxId.write(v1, into: &buf)
 
 
         case .openReceiveAddress:
-            writeInt(&buf, Int32(14))
+            writeInt(&buf, Int32(13))
 
 
         case .createNewReceiveAddress:
-            writeInt(&buf, Int32(15))
+            writeInt(&buf, Int32(14))
 
 
         case let .closeReceiveAddress(v1):
-            writeInt(&buf, Int32(16))
+            writeInt(&buf, Int32(15))
             FfiConverterUInt64.write(v1, into: &buf)
 
         }
@@ -34461,6 +34627,7 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     )
     case FeesError(String
     )
+    case InitialScanIncomplete
     case BuildTxError(String
     )
     case InsufficientFunds(String
@@ -34574,45 +34741,46 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
         case 17: return .FeesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 18: return .BuildTxError(
+        case 18: return .InitialScanIncomplete
+        case 19: return .BuildTxError(
             try FfiConverterString.read(from: &buf)
             )
-        case 19: return .InsufficientFunds(
+        case 20: return .InsufficientFunds(
             try FfiConverterString.read(from: &buf)
             )
-        case 20: return .LockedOutputsSelected
-        case 21: return .GetConfirmDetailsError(
+        case 21: return .LockedOutputsSelected
+        case 22: return .GetConfirmDetailsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 22: return .SignAndBroadcastError(
+        case 23: return .SignAndBroadcastError(
             try FfiConverterString.read(from: &buf)
             )
-        case 23: return .Converter(
+        case 24: return .Converter(
             try FfiConverterTypeConverterError.read(from: &buf)
             )
-        case 24: return .UnknownError(
+        case 25: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
-        case 25: return .PsbtFinalizeError(
+        case 26: return .PsbtFinalizeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 26: return .GetHistoricalPricesError(
+        case 27: return .GetHistoricalPricesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 27: return .CsvCreationError(
+        case 28: return .CsvCreationError(
             try FfiConverterString.read(from: &buf)
             )
-        case 28: return .AddUtxosError(
+        case 29: return .AddUtxosError(
             try FfiConverterString.read(from: &buf)
             )
-        case 29: return .OutputLabelsError(
+        case 30: return .OutputLabelsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 30: return .DatabaseCorruption(
+        case 31: return .DatabaseCorruption(
             id: try FfiConverterTypeWalletId.read(from: &buf),
             error: try FfiConverterString.read(from: &buf)
             )
-        case 31: return .ReceiveAddressError(
+        case 32: return .ReceiveAddressError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -34710,73 +34878,77 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .BuildTxError(v1):
+        case .InitialScanIncomplete:
             writeInt(&buf, Int32(18))
-            FfiConverterString.write(v1, into: &buf)
 
 
-        case let .InsufficientFunds(v1):
+        case let .BuildTxError(v1):
             writeInt(&buf, Int32(19))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case .LockedOutputsSelected:
+        case let .InsufficientFunds(v1):
             writeInt(&buf, Int32(20))
-
-
-        case let .GetConfirmDetailsError(v1):
-            writeInt(&buf, Int32(21))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .SignAndBroadcastError(v1):
+        case .LockedOutputsSelected:
+            writeInt(&buf, Int32(21))
+
+
+        case let .GetConfirmDetailsError(v1):
             writeInt(&buf, Int32(22))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .Converter(v1):
+        case let .SignAndBroadcastError(v1):
             writeInt(&buf, Int32(23))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .Converter(v1):
+            writeInt(&buf, Int32(24))
             FfiConverterTypeConverterError.write(v1, into: &buf)
 
 
         case let .UnknownError(v1):
-            writeInt(&buf, Int32(24))
-            FfiConverterString.write(v1, into: &buf)
-
-
-        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(25))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .GetHistoricalPricesError(v1):
+        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(26))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .CsvCreationError(v1):
+        case let .GetHistoricalPricesError(v1):
             writeInt(&buf, Int32(27))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .AddUtxosError(v1):
+        case let .CsvCreationError(v1):
             writeInt(&buf, Int32(28))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .OutputLabelsError(v1):
+        case let .AddUtxosError(v1):
             writeInt(&buf, Int32(29))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .DatabaseCorruption(id,error):
+        case let .OutputLabelsError(v1):
             writeInt(&buf, Int32(30))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .DatabaseCorruption(id,error):
+            writeInt(&buf, Int32(31))
             FfiConverterTypeWalletId.write(id, into: &buf)
             FfiConverterString.write(error, into: &buf)
 
 
         case let .ReceiveAddressError(v1):
-            writeInt(&buf, Int32(31))
+            writeInt(&buf, Int32(32))
             FfiConverterString.write(v1, into: &buf)
 
         }
@@ -34803,6 +34975,8 @@ public func FfiConverterTypeWalletManagerError_lower(_ value: WalletManagerError
 public enum WalletManagerReconcileMessage {
 
     case walletScanStatusChanged(WalletScanStatus
+    )
+    case ledgerStateChanged(WalletLedgerState
     )
     case availableTransactions([Transaction]
     )
@@ -34861,54 +35035,57 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         case 1: return .walletScanStatusChanged(try FfiConverterTypeWalletScanStatus.read(from: &buf)
         )
 
-        case 2: return .availableTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
+        case 2: return .ledgerStateChanged(try FfiConverterTypeWalletLedgerState.read(from: &buf)
         )
 
-        case 3: return .scanComplete(try FfiConverterSequenceTypeTransaction.read(from: &buf)
+        case 3: return .availableTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
         )
 
-        case 4: return .updatedTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
+        case 4: return .scanComplete(try FfiConverterSequenceTypeTransaction.read(from: &buf)
         )
 
-        case 5: return .nodeConnectionFailed(try FfiConverterString.read(from: &buf)
+        case 5: return .updatedTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
         )
 
-        case 6: return .walletMetadataChanged(try FfiConverterTypeWalletMetadata.read(from: &buf)
+        case 6: return .nodeConnectionFailed(try FfiConverterString.read(from: &buf)
         )
 
-        case 7: return .walletBalanceChanged(try FfiConverterTypeBalance.read(from: &buf)
+        case 7: return .walletMetadataChanged(try FfiConverterTypeWalletMetadata.read(from: &buf)
         )
 
-        case 8: return .walletError(try FfiConverterTypeWalletManagerError.read(from: &buf)
+        case 8: return .walletBalanceChanged(try FfiConverterTypeBalance.read(from: &buf)
         )
 
-        case 9: return .unknownError(try FfiConverterString.read(from: &buf)
+        case 9: return .walletError(try FfiConverterTypeWalletManagerError.read(from: &buf)
         )
 
-        case 10: return .walletScannerResponse(try FfiConverterTypeScannerResponse.read(from: &buf)
+        case 10: return .unknownError(try FfiConverterString.read(from: &buf)
         )
 
-        case 11: return .unsignedTransactionsChanged
-
-        case 12: return .sendFlowError(try FfiConverterTypeSendFlowErrorAlert.read(from: &buf)
+        case 11: return .walletScannerResponse(try FfiConverterTypeScannerResponse.read(from: &buf)
         )
 
-        case 13: return .hotWalletKeyMissing(try FfiConverterTypeWalletId.read(from: &buf)
+        case 12: return .unsignedTransactionsChanged
+
+        case 13: return .sendFlowError(try FfiConverterTypeSendFlowErrorAlert.read(from: &buf)
         )
 
-        case 14: return .receiveAddressUpdated(try FfiConverterTypeReceiveAddressState.read(from: &buf)
+        case 14: return .hotWalletKeyMissing(try FfiConverterTypeWalletId.read(from: &buf)
         )
 
-        case 15: return .receiveAddressPresentationUpdated(try FfiConverterTypeReceiveAddressPresentation.read(from: &buf)
+        case 15: return .receiveAddressUpdated(try FfiConverterTypeReceiveAddressState.read(from: &buf)
         )
 
-        case 16: return .receiveAddressLoadingChanged(try FfiConverterBool.read(from: &buf)
+        case 16: return .receiveAddressPresentationUpdated(try FfiConverterTypeReceiveAddressPresentation.read(from: &buf)
         )
 
-        case 17: return .receiveAddressError(try FfiConverterString.read(from: &buf)
+        case 17: return .receiveAddressLoadingChanged(try FfiConverterBool.read(from: &buf)
         )
 
-        case 18: return .receiveAddressClosed(try FfiConverterUInt64.read(from: &buf)
+        case 18: return .receiveAddressError(try FfiConverterString.read(from: &buf)
+        )
+
+        case 19: return .receiveAddressClosed(try FfiConverterUInt64.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -34924,87 +35101,92 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
             FfiConverterTypeWalletScanStatus.write(v1, into: &buf)
 
 
-        case let .availableTransactions(v1):
+        case let .ledgerStateChanged(v1):
             writeInt(&buf, Int32(2))
-            FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
+            FfiConverterTypeWalletLedgerState.write(v1, into: &buf)
 
 
-        case let .scanComplete(v1):
+        case let .availableTransactions(v1):
             writeInt(&buf, Int32(3))
             FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
 
 
-        case let .updatedTransactions(v1):
+        case let .scanComplete(v1):
             writeInt(&buf, Int32(4))
             FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
 
 
-        case let .nodeConnectionFailed(v1):
+        case let .updatedTransactions(v1):
             writeInt(&buf, Int32(5))
+            FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
+
+
+        case let .nodeConnectionFailed(v1):
+            writeInt(&buf, Int32(6))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .walletMetadataChanged(v1):
-            writeInt(&buf, Int32(6))
+            writeInt(&buf, Int32(7))
             FfiConverterTypeWalletMetadata.write(v1, into: &buf)
 
 
         case let .walletBalanceChanged(v1):
-            writeInt(&buf, Int32(7))
+            writeInt(&buf, Int32(8))
             FfiConverterTypeBalance.write(v1, into: &buf)
 
 
         case let .walletError(v1):
-            writeInt(&buf, Int32(8))
+            writeInt(&buf, Int32(9))
             FfiConverterTypeWalletManagerError.write(v1, into: &buf)
 
 
         case let .unknownError(v1):
-            writeInt(&buf, Int32(9))
+            writeInt(&buf, Int32(10))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .walletScannerResponse(v1):
-            writeInt(&buf, Int32(10))
+            writeInt(&buf, Int32(11))
             FfiConverterTypeScannerResponse.write(v1, into: &buf)
 
 
         case .unsignedTransactionsChanged:
-            writeInt(&buf, Int32(11))
+            writeInt(&buf, Int32(12))
 
 
         case let .sendFlowError(v1):
-            writeInt(&buf, Int32(12))
+            writeInt(&buf, Int32(13))
             FfiConverterTypeSendFlowErrorAlert.write(v1, into: &buf)
 
 
         case let .hotWalletKeyMissing(v1):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(14))
             FfiConverterTypeWalletId.write(v1, into: &buf)
 
 
         case let .receiveAddressUpdated(v1):
-            writeInt(&buf, Int32(14))
+            writeInt(&buf, Int32(15))
             FfiConverterTypeReceiveAddressState.write(v1, into: &buf)
 
 
         case let .receiveAddressPresentationUpdated(v1):
-            writeInt(&buf, Int32(15))
+            writeInt(&buf, Int32(16))
             FfiConverterTypeReceiveAddressPresentation.write(v1, into: &buf)
 
 
         case let .receiveAddressLoadingChanged(v1):
-            writeInt(&buf, Int32(16))
+            writeInt(&buf, Int32(17))
             FfiConverterBool.write(v1, into: &buf)
 
 
         case let .receiveAddressError(v1):
-            writeInt(&buf, Int32(17))
+            writeInt(&buf, Int32(18))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .receiveAddressClosed(v1):
-            writeInt(&buf, Int32(18))
+            writeInt(&buf, Int32(19))
             FfiConverterUInt64.write(v1, into: &buf)
 
         }
@@ -39668,6 +39850,83 @@ public func transactionsPreviewNew(confirmed: UInt8, unconfirmed: UInt8) -> [Tra
     )
 })
 }
+public func walletAmountInFiatCached(amount: Amount) -> Double?  {
+    return try!  FfiConverterOptionDouble.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_amount_in_fiat_cached(
+        FfiConverterTypeAmount_lower(amount),uniffiCallStatus
+    )
+})
+}
+public func walletDisplayAmount(metadata: WalletMetadata, amount: Amount, showUnit: Bool) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_amount(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterTypeAmount_lower(amount),
+        FfiConverterBool.lower(showUnit),uniffiCallStatus
+    )
+})
+}
+public func walletDisplayAmountPendingFmt(metadata: WalletMetadata, amount: Amount) -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_amount_pending_fmt(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterTypeAmount_lower(amount),uniffiCallStatus
+    )
+})
+}
+public func walletDisplayAmountWithDirection(metadata: WalletMetadata, amount: Amount, direction: TransactionDirection) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_amount_with_direction(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterTypeAmount_lower(amount),
+        FfiConverterTypeTransactionDirection_lower(direction),uniffiCallStatus
+    )
+})
+}
+public func walletDisplayFiatAmount(metadata: WalletMetadata, amount: Double, withSuffix: Bool) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_fiat_amount(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterDouble.lower(amount),
+        FfiConverterBool.lower(withSuffix),uniffiCallStatus
+    )
+})
+}
+public func walletDisplayFiatAmountPendingFmt(metadata: WalletMetadata, amount: Double, withSuffix: Bool) -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_fiat_amount_pending_fmt(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterDouble.lower(amount),
+        FfiConverterBool.lower(withSuffix),uniffiCallStatus
+    )
+})
+}
+public func walletDisplayFiatAmountWithDirection(metadata: WalletMetadata, amount: Double, direction: TransactionDirection, withSuffix: Bool) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_fiat_amount_with_direction(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterDouble.lower(amount),
+        FfiConverterTypeTransactionDirection_lower(direction),
+        FfiConverterBool.lower(withSuffix),uniffiCallStatus
+    )
+})
+}
+public func walletDisplaySentAndReceivedAmount(metadata: WalletMetadata, sentAndReceived: SentAndReceived) -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_wallet_display_sent_and_received_amount(
+        FfiConverterTypeWalletMetadata_lower(metadata),
+        FfiConverterTypeSentAndReceived_lower(sentAndReceived),uniffiCallStatus
+    )
+})
+}
 public func ffiMinSendAmount() -> Amount  {
     return try!  FfiConverterTypeAmount_lift(try! rustCall() {
         uniffiCallStatus in
@@ -39862,6 +40121,30 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_transactions_preview_new() != 39646) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_amount_in_fiat_cached() != 26689) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_amount() != 61536) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_amount_pending_fmt() != 28974) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_amount_with_direction() != 31040) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_fiat_amount() != 19771) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_fiat_amount_pending_fmt() != 9763) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_fiat_amount_with_direction() != 59603) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_wallet_display_sent_and_received_amount() != 2923) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_ffi_min_send_amount() != 61138) {
@@ -40488,6 +40771,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_balance_presentation() != 27753) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_rustwalletmanager_balance_presentation_for_state() != 65105) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40590,6 +40876,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_label_manager() != 23571) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_rustwalletmanager_ledger_state() != 45737) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_rustwalletmanager_listen_for_updates() != 34012) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40599,10 +40888,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_master_fingerprint() != 64370) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 11951) {
+    if (uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 1459) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 55235) {
+    if (uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 10979) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_non_default_account_number() != 54959) {
@@ -40885,6 +41174,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_transactiondetails_display_amount() != 46360) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt() != 57101) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -5155,8 +5155,6 @@ public protocol LabelManagerProtocol: AnyObject, Sendable {
 
     func deleteLabelsForTxn(txId: TxId) throws
 
-    func deleteLabelsForTxnWithoutCloudBackupDirty(txId: TxId) throws
-
     func export() async throws  -> String
 
     func exportDefaultFileName(name: String)  -> String
@@ -5242,15 +5240,6 @@ public convenience init(id: WalletId) {
 open func deleteLabelsForTxn(txId: TxId)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
         uniffiCallStatus in
     uniffi_cove_fn_method_labelmanager_delete_labels_for_txn(
-            self.uniffiCloneHandle(),
-        FfiConverterTypeTxId_lower(txId),uniffiCallStatus
-    )
-}
-}
-
-open func deleteLabelsForTxnWithoutCloudBackupDirty(txId: TxId)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
-        uniffiCallStatus in
-    uniffi_cove_fn_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(
             self.uniffiCloneHandle(),
         FfiConverterTypeTxId_lower(txId),uniffiCallStatus
     )
@@ -22701,8 +22690,6 @@ public enum CoinControlManagerReconcileMessage {
     )
     case updateSelectedUtxos(utxos: [OutPoint], totalValue: Amount
     )
-    case updateTotalSelectedAmount(Amount
-    )
     case updateUnit(BitcoinUnit
     )
 
@@ -22740,10 +22727,7 @@ public struct FfiConverterTypeCoinControlManagerReconcileMessage: FfiConverterRu
         case 5: return .updateSelectedUtxos(utxos: try FfiConverterSequenceTypeOutPoint.read(from: &buf), totalValue: try FfiConverterTypeAmount.read(from: &buf)
         )
 
-        case 6: return .updateTotalSelectedAmount(try FfiConverterTypeAmount.read(from: &buf)
-        )
-
-        case 7: return .updateUnit(try FfiConverterTypeBitcoinUnit.read(from: &buf)
+        case 6: return .updateUnit(try FfiConverterTypeBitcoinUnit.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -22779,13 +22763,8 @@ public struct FfiConverterTypeCoinControlManagerReconcileMessage: FfiConverterRu
             FfiConverterTypeAmount.write(totalValue, into: &buf)
 
 
-        case let .updateTotalSelectedAmount(v1):
-            writeInt(&buf, Int32(6))
-            FfiConverterTypeAmount.write(v1, into: &buf)
-
-
         case let .updateUnit(v1):
-            writeInt(&buf, Int32(7))
+            writeInt(&buf, Int32(6))
             FfiConverterTypeBitcoinUnit.write(v1, into: &buf)
 
         }
@@ -34459,6 +34438,7 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     )
     case InsufficientFunds(String
     )
+    case LockedOutputsSelected
     case GetConfirmDetailsError(String
     )
     case SignAndBroadcastError(String
@@ -34573,38 +34553,39 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
         case 19: return .InsufficientFunds(
             try FfiConverterString.read(from: &buf)
             )
-        case 20: return .GetConfirmDetailsError(
+        case 20: return .LockedOutputsSelected
+        case 21: return .GetConfirmDetailsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 21: return .SignAndBroadcastError(
+        case 22: return .SignAndBroadcastError(
             try FfiConverterString.read(from: &buf)
             )
-        case 22: return .Converter(
+        case 23: return .Converter(
             try FfiConverterTypeConverterError.read(from: &buf)
             )
-        case 23: return .UnknownError(
+        case 24: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
-        case 24: return .PsbtFinalizeError(
+        case 25: return .PsbtFinalizeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 25: return .GetHistoricalPricesError(
+        case 26: return .GetHistoricalPricesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 26: return .CsvCreationError(
+        case 27: return .CsvCreationError(
             try FfiConverterString.read(from: &buf)
             )
-        case 27: return .AddUtxosError(
+        case 28: return .AddUtxosError(
             try FfiConverterString.read(from: &buf)
             )
-        case 28: return .OutputLabelsError(
+        case 29: return .OutputLabelsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 29: return .DatabaseCorruption(
+        case 30: return .DatabaseCorruption(
             id: try FfiConverterTypeWalletId.read(from: &buf),
             error: try FfiConverterString.read(from: &buf)
             )
-        case 30: return .ReceiveAddressError(
+        case 31: return .ReceiveAddressError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -34712,59 +34693,63 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .GetConfirmDetailsError(v1):
+        case .LockedOutputsSelected:
             writeInt(&buf, Int32(20))
-            FfiConverterString.write(v1, into: &buf)
 
 
-        case let .SignAndBroadcastError(v1):
+        case let .GetConfirmDetailsError(v1):
             writeInt(&buf, Int32(21))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .Converter(v1):
+        case let .SignAndBroadcastError(v1):
             writeInt(&buf, Int32(22))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .Converter(v1):
+            writeInt(&buf, Int32(23))
             FfiConverterTypeConverterError.write(v1, into: &buf)
 
 
         case let .UnknownError(v1):
-            writeInt(&buf, Int32(23))
-            FfiConverterString.write(v1, into: &buf)
-
-
-        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(24))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .GetHistoricalPricesError(v1):
+        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(25))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .CsvCreationError(v1):
+        case let .GetHistoricalPricesError(v1):
             writeInt(&buf, Int32(26))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .AddUtxosError(v1):
+        case let .CsvCreationError(v1):
             writeInt(&buf, Int32(27))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .OutputLabelsError(v1):
+        case let .AddUtxosError(v1):
             writeInt(&buf, Int32(28))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .DatabaseCorruption(id,error):
+        case let .OutputLabelsError(v1):
             writeInt(&buf, Int32(29))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .DatabaseCorruption(id,error):
+            writeInt(&buf, Int32(30))
             FfiConverterTypeWalletId.write(id, into: &buf)
             FfiConverterString.write(error, into: &buf)
 
 
         case let .ReceiveAddressError(v1):
-            writeInt(&buf, Int32(30))
+            writeInt(&buf, Int32(31))
             FfiConverterString.write(v1, into: &buf)
 
         }
@@ -40174,9 +40159,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn() != 18479) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty() != 47716) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_labelmanager_export() != 24203) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -5155,6 +5155,8 @@ public protocol LabelManagerProtocol: AnyObject, Sendable {
 
     func deleteLabelsForTxn(txId: TxId) throws
 
+    func deleteLabelsForTxnWithoutCloudBackupDirty(txId: TxId) throws
+
     func export() async throws  -> String
 
     func exportDefaultFileName(name: String)  -> String
@@ -5240,6 +5242,15 @@ public convenience init(id: WalletId) {
 open func deleteLabelsForTxn(txId: TxId)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
         uniffiCallStatus in
     uniffi_cove_fn_method_labelmanager_delete_labels_for_txn(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeTxId_lower(txId),uniffiCallStatus
+    )
+}
+}
+
+open func deleteLabelsForTxnWithoutCloudBackupDirty(txId: TxId)throws   {try rustCallWithError(FfiConverterTypeLabelManagerError_lift) {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty(
             self.uniffiCloneHandle(),
         FfiConverterTypeTxId_lower(txId),uniffiCallStatus
     )
@@ -7704,6 +7715,8 @@ public protocol RustCoinControlManagerProtocol: AnyObject, Sendable {
 
     func selectedUtxos()  -> [Utxo]
 
+    func setUtxoSpendability(outpoint: OutPoint, spendable: Bool) async throws
+
     func unit()  -> BitcoinUnit
 
     func utxos()  -> [Utxo]
@@ -7837,6 +7850,23 @@ open func selectedUtxos() -> [Utxo]  {
             self.uniffiCloneHandle(),uniffiCallStatus
     )
 })
+}
+
+open func setUtxoSpendability(outpoint: OutPoint, spendable: Bool)async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustcoincontrolmanager_set_utxo_spendability(
+                    self.uniffiCloneHandle(),
+                    FfiConverterTypeOutPoint_lower(outpoint),FfiConverterBool.lower(spendable)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_void,
+            completeFunc: ffi_cove_rust_future_complete_void,
+            freeFunc: ffi_cove_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeLabelManagerError_lift
+        )
 }
 
 open func unit() -> BitcoinUnit  {
@@ -9028,8 +9058,6 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func balancePresentation(scanStatus: WalletScanStatus)  -> BalancePresentation
 
-    func balancePresentationForState(ledgerState: WalletLedgerState)  -> BalancePresentation
-
     func broadcastTransaction(signedTransaction: BitcoinTransaction) async throws
 
     func convertAndDisplayFiat(amount: Amount, prices: PriceResponse, withSuffix: Bool)  -> String
@@ -9164,20 +9192,15 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func labelManager()  -> LabelManager
 
-    /**
-     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
-     */
-    func ledgerState()  -> WalletLedgerState
-
     func listenForUpdates(reconciler: WalletManagerReconciler)
 
     func markWalletAsVerified() throws
 
     func masterFingerprint()  -> String?
 
-    func newCoinControlManager() async throws  -> RustCoinControlManager
+    func newCoinControlManager() async  -> RustCoinControlManager
 
-    func newSendFlowManager(balance: Balance) throws  -> RustSendFlowManager
+    func newSendFlowManager(balance: Balance)  -> RustSendFlowManager
 
     func nonDefaultAccountNumber()  -> UInt32?
 
@@ -9214,7 +9237,13 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func switchToDifferentWalletAddressType(walletAddressType: WalletAddressType) async throws
 
+    func toggleTransactionLockState(txId: TxId) async throws  -> TransactionLockState
+
     func transactionDetails(txId: TxId) async throws  -> TransactionDetails
+
+    func transactionLockState(txId: TxId) async throws  -> TransactionLockState
+
+    func unlockedSpendableBalance() async throws  -> Amount
 
     func validateMetadata()
 
@@ -9380,16 +9409,6 @@ open func balancePresentation(scanStatus: WalletScanStatus) -> BalancePresentati
     uniffi_cove_fn_method_rustwalletmanager_balance_presentation(
             self.uniffiCloneHandle(),
         FfiConverterTypeWalletScanStatus_lower(scanStatus),uniffiCallStatus
-    )
-})
-}
-
-open func balancePresentationForState(ledgerState: WalletLedgerState) -> BalancePresentation  {
-    return try!  FfiConverterTypeBalancePresentation_lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(
-            self.uniffiCloneHandle(),
-        FfiConverterTypeWalletLedgerState_lower(ledgerState),uniffiCallStatus
     )
 })
 }
@@ -9915,18 +9934,6 @@ open func labelManager() -> LabelManager  {
 })
 }
 
-    /**
-     * Returns the metadata-derived bootstrap snapshot; live scan activity arrives through reconcile messages
-     */
-open func ledgerState() -> WalletLedgerState  {
-    return try!  FfiConverterTypeWalletLedgerState_lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_method_rustwalletmanager_ledger_state(
-            self.uniffiCloneHandle(),uniffiCallStatus
-    )
-})
-}
-
 open func listenForUpdates(reconciler: WalletManagerReconciler)  {try! rustCall() {
         uniffiCallStatus in
     uniffi_cove_fn_method_rustwalletmanager_listen_for_updates(
@@ -9953,9 +9960,9 @@ open func masterFingerprint() -> String?  {
 })
 }
 
-open func newCoinControlManager()async throws  -> RustCoinControlManager  {
+open func newCoinControlManager()async  -> RustCoinControlManager  {
     return
-        try  await uniffiRustCallAsync(
+        try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_cove_fn_method_rustwalletmanager_new_coin_control_manager(
                     self.uniffiCloneHandle()
@@ -9966,12 +9973,13 @@ open func newCoinControlManager()async throws  -> RustCoinControlManager  {
             completeFunc: ffi_cove_rust_future_complete_u64,
             freeFunc: ffi_cove_rust_future_free_u64,
             liftFunc: FfiConverterTypeRustCoinControlManager_lift,
-            errorHandler: FfiConverterTypeWalletManagerError_lift
+            errorHandler: nil
+
         )
 }
 
-open func newSendFlowManager(balance: Balance)throws  -> RustSendFlowManager  {
-    return try  FfiConverterTypeRustSendFlowManager_lift(try rustCallWithError(FfiConverterTypeWalletManagerError_lift) {
+open func newSendFlowManager(balance: Balance) -> RustSendFlowManager  {
+    return try!  FfiConverterTypeRustSendFlowManager_lift(try! rustCall() {
         uniffiCallStatus in
     uniffi_cove_fn_method_rustwalletmanager_new_send_flow_manager(
             self.uniffiCloneHandle(),
@@ -10174,6 +10182,23 @@ open func switchToDifferentWalletAddressType(walletAddressType: WalletAddressTyp
         )
 }
 
+open func toggleTransactionLockState(txId: TxId)async throws  -> TransactionLockState  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_toggle_transaction_lock_state(
+                    self.uniffiCloneHandle(),
+                    FfiConverterTypeTxId_lower(txId)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_rust_buffer,
+            completeFunc: ffi_cove_rust_future_complete_rust_buffer,
+            freeFunc: ffi_cove_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransactionLockState_lift,
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
+}
+
 open func transactionDetails(txId: TxId)async throws  -> TransactionDetails  {
     return
         try  await uniffiRustCallAsync(
@@ -10187,6 +10212,40 @@ open func transactionDetails(txId: TxId)async throws  -> TransactionDetails  {
             completeFunc: ffi_cove_rust_future_complete_u64,
             freeFunc: ffi_cove_rust_future_free_u64,
             liftFunc: FfiConverterTypeTransactionDetails_lift,
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
+}
+
+open func transactionLockState(txId: TxId)async throws  -> TransactionLockState  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_transaction_lock_state(
+                    self.uniffiCloneHandle(),
+                    FfiConverterTypeTxId_lower(txId)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_rust_buffer,
+            completeFunc: ffi_cove_rust_future_complete_rust_buffer,
+            freeFunc: ffi_cove_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransactionLockState_lift,
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
+}
+
+open func unlockedSpendableBalance()async throws  -> Amount  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_unlocked_spendable_balance(
+                    self.uniffiCloneHandle()
+
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_u64,
+            completeFunc: ffi_cove_rust_future_complete_u64,
+            freeFunc: ffi_cove_rust_future_free_u64,
+            liftFunc: FfiConverterTypeAmount_lift,
             errorHandler: FfiConverterTypeWalletManagerError_lift
         )
 }
@@ -10870,8 +10929,6 @@ public protocol TransactionDetailsProtocol: AnyObject, Sendable {
 
     func confirmationDateTime()  -> String?
 
-    func displayAmount(metadata: WalletMetadata, showUnit: Bool)  -> String
-
     func feeFiatFmt() async throws  -> String
 
     func feeFiatFmtCached()  -> String?
@@ -11120,17 +11177,6 @@ open func confirmationDateTime() -> String?  {
         uniffiCallStatus in
     uniffi_cove_fn_method_transactiondetails_confirmation_date_time(
             self.uniffiCloneHandle(),uniffiCallStatus
-    )
-})
-}
-
-open func displayAmount(metadata: WalletMetadata, showUnit: Bool = true) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_method_transactiondetails_display_amount(
-            self.uniffiCloneHandle(),
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterBool.lower(showUnit),uniffiCallStatus
     )
 })
 }
@@ -25737,72 +25783,6 @@ public func FfiConverterTypeInitError_lower(_ value: InitError) -> RustBuffer {
 
 
 
-public enum InitialScanActivity: Equatable, Hashable {
-
-    case active
-    case idle
-
-
-
-
-
-}
-
-#if compiler(>=6)
-extension InitialScanActivity: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeInitialScanActivity: FfiConverterRustBuffer {
-    typealias SwiftType = InitialScanActivity
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> InitialScanActivity {
-        let variant: Int32 = try readInt(&buf)
-        switch variant {
-
-        case 1: return .active
-
-        case 2: return .idle
-
-        default: throw UniffiInternalError.unexpectedEnumCase
-        }
-    }
-
-    public static func write(_ value: InitialScanActivity, into buf: inout [UInt8]) {
-        switch value {
-
-
-        case .active:
-            writeInt(&buf, Int32(1))
-
-
-        case .idle:
-            writeInt(&buf, Int32(2))
-
-        }
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeInitialScanActivity_lift(_ buf: RustBuffer) throws -> InitialScanActivity {
-    return try FfiConverterTypeInitialScanActivity.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeInitialScanActivity_lower(_ value: InitialScanActivity) -> RustBuffer {
-    return FfiConverterTypeInitialScanActivity.lower(value)
-}
-
-
-
-
 public enum InsertOrUpdate: Equatable, Hashable {
 
     case insert(Timestamp
@@ -30434,6 +30414,7 @@ public enum SendFlowManagerAction {
     case selectMaxSend
     case clearSendAmount
     case clearAddress
+    case refreshWalletBalance
     case setCoinControlMode([Utxo]
     )
     case disableCoinControlMode
@@ -30499,54 +30480,56 @@ public struct FfiConverterTypeSendFlowManagerAction: FfiConverterRustBuffer {
 
         case 5: return .clearAddress
 
-        case 6: return .setCoinControlMode(try FfiConverterSequenceTypeUtxo.read(from: &buf)
+        case 6: return .refreshWalletBalance
+
+        case 7: return .setCoinControlMode(try FfiConverterSequenceTypeUtxo.read(from: &buf)
         )
 
-        case 7: return .disableCoinControlMode
+        case 8: return .disableCoinControlMode
 
-        case 8: return .selectFeeRate(try FfiConverterTypeFeeRateOptionWithTotalFee.read(from: &buf)
+        case 9: return .selectFeeRate(try FfiConverterTypeFeeRateOptionWithTotalFee.read(from: &buf)
         )
 
-        case 9: return .notifyEnteringBtcAmountChanged(try FfiConverterString.read(from: &buf)
+        case 10: return .notifyEnteringBtcAmountChanged(try FfiConverterString.read(from: &buf)
         )
 
-        case 10: return .notifyEnteringFiatAmountChanged(try FfiConverterString.read(from: &buf)
+        case 11: return .notifyEnteringFiatAmountChanged(try FfiConverterString.read(from: &buf)
         )
 
-        case 11: return .notifyEnteringAddressChanged(try FfiConverterString.read(from: &buf)
+        case 12: return .notifyEnteringAddressChanged(try FfiConverterString.read(from: &buf)
         )
 
-        case 12: return .notifySelectedUnitedChanged(old: try FfiConverterTypeBitcoinUnit.read(from: &buf), new: try FfiConverterTypeBitcoinUnit.read(from: &buf)
+        case 13: return .notifySelectedUnitedChanged(old: try FfiConverterTypeBitcoinUnit.read(from: &buf), new: try FfiConverterTypeBitcoinUnit.read(from: &buf)
         )
 
-        case 13: return .notifyBtcOrFiatChanged(old: try FfiConverterTypeFiatOrBtc.read(from: &buf), new: try FfiConverterTypeFiatOrBtc.read(from: &buf)
+        case 14: return .notifyBtcOrFiatChanged(old: try FfiConverterTypeFiatOrBtc.read(from: &buf), new: try FfiConverterTypeFiatOrBtc.read(from: &buf)
         )
 
-        case 14: return .notifyScanCodeChanged(old: try FfiConverterString.read(from: &buf), new: try FfiConverterString.read(from: &buf)
+        case 15: return .notifyScanCodeChanged(old: try FfiConverterString.read(from: &buf), new: try FfiConverterString.read(from: &buf)
         )
 
-        case 15: return .notifyPricesChanged(try FfiConverterTypePriceResponse.read(from: &buf)
+        case 16: return .notifyPricesChanged(try FfiConverterTypePriceResponse.read(from: &buf)
         )
 
-        case 16: return .notifyFocusFieldChanged(old: try FfiConverterOptionTypeSetAmountFocusField.read(from: &buf), new: try FfiConverterOptionTypeSetAmountFocusField.read(from: &buf)
+        case 17: return .notifyFocusFieldChanged(old: try FfiConverterOptionTypeSetAmountFocusField.read(from: &buf), new: try FfiConverterOptionTypeSetAmountFocusField.read(from: &buf)
         )
 
-        case 17: return .notifyAddressChanged(try FfiConverterTypeAddress.read(from: &buf)
+        case 18: return .notifyAddressChanged(try FfiConverterTypeAddress.read(from: &buf)
         )
 
-        case 18: return .notifyAmountChanged(try FfiConverterTypeAmount.read(from: &buf)
+        case 19: return .notifyAmountChanged(try FfiConverterTypeAmount.read(from: &buf)
         )
 
-        case 19: return .notifyCoinControlAmountChanged(try FfiConverterDouble.read(from: &buf)
+        case 20: return .notifyCoinControlAmountChanged(try FfiConverterDouble.read(from: &buf)
         )
 
-        case 20: return .notifyCoinControlEnteredAmountChanged(try FfiConverterString.read(from: &buf), try FfiConverterBool.read(from: &buf)
+        case 21: return .notifyCoinControlEnteredAmountChanged(try FfiConverterString.read(from: &buf), try FfiConverterBool.read(from: &buf)
         )
 
-        case 21: return .changeFeeRateOptions(try FfiConverterTypeFeeRateOptionsWithTotalFee.read(from: &buf)
+        case 22: return .changeFeeRateOptions(try FfiConverterTypeFeeRateOptionsWithTotalFee.read(from: &buf)
         )
 
-        case 22: return .finalizeAndGoToNextScreen
+        case 23: return .finalizeAndGoToNextScreen
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -30578,92 +30561,96 @@ public struct FfiConverterTypeSendFlowManagerAction: FfiConverterRustBuffer {
             writeInt(&buf, Int32(5))
 
 
-        case let .setCoinControlMode(v1):
+        case .refreshWalletBalance:
             writeInt(&buf, Int32(6))
+
+
+        case let .setCoinControlMode(v1):
+            writeInt(&buf, Int32(7))
             FfiConverterSequenceTypeUtxo.write(v1, into: &buf)
 
 
         case .disableCoinControlMode:
-            writeInt(&buf, Int32(7))
+            writeInt(&buf, Int32(8))
 
 
         case let .selectFeeRate(v1):
-            writeInt(&buf, Int32(8))
+            writeInt(&buf, Int32(9))
             FfiConverterTypeFeeRateOptionWithTotalFee.write(v1, into: &buf)
 
 
         case let .notifyEnteringBtcAmountChanged(v1):
-            writeInt(&buf, Int32(9))
-            FfiConverterString.write(v1, into: &buf)
-
-
-        case let .notifyEnteringFiatAmountChanged(v1):
             writeInt(&buf, Int32(10))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .notifyEnteringAddressChanged(v1):
+        case let .notifyEnteringFiatAmountChanged(v1):
             writeInt(&buf, Int32(11))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .notifySelectedUnitedChanged(old,new):
+        case let .notifyEnteringAddressChanged(v1):
             writeInt(&buf, Int32(12))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .notifySelectedUnitedChanged(old,new):
+            writeInt(&buf, Int32(13))
             FfiConverterTypeBitcoinUnit.write(old, into: &buf)
             FfiConverterTypeBitcoinUnit.write(new, into: &buf)
 
 
         case let .notifyBtcOrFiatChanged(old,new):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(14))
             FfiConverterTypeFiatOrBtc.write(old, into: &buf)
             FfiConverterTypeFiatOrBtc.write(new, into: &buf)
 
 
         case let .notifyScanCodeChanged(old,new):
-            writeInt(&buf, Int32(14))
+            writeInt(&buf, Int32(15))
             FfiConverterString.write(old, into: &buf)
             FfiConverterString.write(new, into: &buf)
 
 
         case let .notifyPricesChanged(v1):
-            writeInt(&buf, Int32(15))
+            writeInt(&buf, Int32(16))
             FfiConverterTypePriceResponse.write(v1, into: &buf)
 
 
         case let .notifyFocusFieldChanged(old,new):
-            writeInt(&buf, Int32(16))
+            writeInt(&buf, Int32(17))
             FfiConverterOptionTypeSetAmountFocusField.write(old, into: &buf)
             FfiConverterOptionTypeSetAmountFocusField.write(new, into: &buf)
 
 
         case let .notifyAddressChanged(v1):
-            writeInt(&buf, Int32(17))
+            writeInt(&buf, Int32(18))
             FfiConverterTypeAddress.write(v1, into: &buf)
 
 
         case let .notifyAmountChanged(v1):
-            writeInt(&buf, Int32(18))
+            writeInt(&buf, Int32(19))
             FfiConverterTypeAmount.write(v1, into: &buf)
 
 
         case let .notifyCoinControlAmountChanged(v1):
-            writeInt(&buf, Int32(19))
+            writeInt(&buf, Int32(20))
             FfiConverterDouble.write(v1, into: &buf)
 
 
         case let .notifyCoinControlEnteredAmountChanged(v1,v2):
-            writeInt(&buf, Int32(20))
+            writeInt(&buf, Int32(21))
             FfiConverterString.write(v1, into: &buf)
             FfiConverterBool.write(v2, into: &buf)
 
 
         case let .changeFeeRateOptions(v1):
-            writeInt(&buf, Int32(21))
+            writeInt(&buf, Int32(22))
             FfiConverterTypeFeeRateOptionsWithTotalFee.write(v1, into: &buf)
 
 
         case .finalizeAndGoToNextScreen:
-            writeInt(&buf, Int32(22))
+            writeInt(&buf, Int32(23))
 
         }
     }
@@ -32577,6 +32564,86 @@ public func FfiConverterTypeTransactionDetailError_lower(_ value: TransactionDet
 
 
 
+public enum TransactionLockState: Equatable, Hashable {
+
+    case none
+    case unlocked
+    case locked
+    case mixed
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension TransactionLockState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeTransactionLockState: FfiConverterRustBuffer {
+    typealias SwiftType = TransactionLockState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TransactionLockState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .none
+
+        case 2: return .unlocked
+
+        case 3: return .locked
+
+        case 4: return .mixed
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: TransactionLockState, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .none:
+            writeInt(&buf, Int32(1))
+
+
+        case .unlocked:
+            writeInt(&buf, Int32(2))
+
+
+        case .locked:
+            writeInt(&buf, Int32(3))
+
+
+        case .mixed:
+            writeInt(&buf, Int32(4))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTransactionLockState_lift(_ buf: RustBuffer) throws -> TransactionLockState {
+    return try FfiConverterTypeTransactionLockState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTransactionLockState_lower(_ value: TransactionLockState) -> RustBuffer {
+    return FfiConverterTypeTransactionLockState.lower(value)
+}
+
+
+
+
 public enum TransactionState: Equatable, Hashable {
 
     case pending
@@ -34079,75 +34146,6 @@ public func FfiConverterTypeWalletErrorAlert_lower(_ value: WalletErrorAlert) ->
 
 
 
-public enum WalletLedgerState: Equatable, Hashable {
-
-    case complete
-    case initialScanIncomplete(InitialScanActivity
-    )
-
-
-
-
-
-}
-
-#if compiler(>=6)
-extension WalletLedgerState: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeWalletLedgerState: FfiConverterRustBuffer {
-    typealias SwiftType = WalletLedgerState
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WalletLedgerState {
-        let variant: Int32 = try readInt(&buf)
-        switch variant {
-
-        case 1: return .complete
-
-        case 2: return .initialScanIncomplete(try FfiConverterTypeInitialScanActivity.read(from: &buf)
-        )
-
-        default: throw UniffiInternalError.unexpectedEnumCase
-        }
-    }
-
-    public static func write(_ value: WalletLedgerState, into buf: inout [UInt8]) {
-        switch value {
-
-
-        case .complete:
-            writeInt(&buf, Int32(1))
-
-
-        case let .initialScanIncomplete(v1):
-            writeInt(&buf, Int32(2))
-            FfiConverterTypeInitialScanActivity.write(v1, into: &buf)
-
-        }
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeWalletLedgerState_lift(_ buf: RustBuffer) throws -> WalletLedgerState {
-    return try FfiConverterTypeWalletLedgerState.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeWalletLedgerState_lower(_ value: WalletLedgerState) -> RustBuffer {
-    return FfiConverterTypeWalletLedgerState.lower(value)
-}
-
-
-
-
 public enum WalletLoadState {
 
     case loading
@@ -34253,6 +34251,8 @@ public enum WalletManagerAction {
     case toggleFiatBtcPrimarySecondary
     case toggleShowLabels
     case selectCurrentWalletAddressType
+    case selectDifferentWalletAddressType(WalletAddressType
+    )
     case selectedWalletDisappeared
     case startTransactionWatcher(TxId
     )
@@ -34305,16 +34305,19 @@ public struct FfiConverterTypeWalletManagerAction: FfiConverterRustBuffer {
 
         case 10: return .selectCurrentWalletAddressType
 
-        case 11: return .selectedWalletDisappeared
-
-        case 12: return .startTransactionWatcher(try FfiConverterTypeTxId.read(from: &buf)
+        case 11: return .selectDifferentWalletAddressType(try FfiConverterTypeWalletAddressType.read(from: &buf)
         )
 
-        case 13: return .openReceiveAddress
+        case 12: return .selectedWalletDisappeared
 
-        case 14: return .createNewReceiveAddress
+        case 13: return .startTransactionWatcher(try FfiConverterTypeTxId.read(from: &buf)
+        )
 
-        case 15: return .closeReceiveAddress(try FfiConverterUInt64.read(from: &buf)
+        case 14: return .openReceiveAddress
+
+        case 15: return .createNewReceiveAddress
+
+        case 16: return .closeReceiveAddress(try FfiConverterUInt64.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -34369,25 +34372,30 @@ public struct FfiConverterTypeWalletManagerAction: FfiConverterRustBuffer {
             writeInt(&buf, Int32(10))
 
 
-        case .selectedWalletDisappeared:
+        case let .selectDifferentWalletAddressType(v1):
             writeInt(&buf, Int32(11))
+            FfiConverterTypeWalletAddressType.write(v1, into: &buf)
+
+
+        case .selectedWalletDisappeared:
+            writeInt(&buf, Int32(12))
 
 
         case let .startTransactionWatcher(v1):
-            writeInt(&buf, Int32(12))
+            writeInt(&buf, Int32(13))
             FfiConverterTypeTxId.write(v1, into: &buf)
 
 
         case .openReceiveAddress:
-            writeInt(&buf, Int32(13))
-
-
-        case .createNewReceiveAddress:
             writeInt(&buf, Int32(14))
 
 
-        case let .closeReceiveAddress(v1):
+        case .createNewReceiveAddress:
             writeInt(&buf, Int32(15))
+
+
+        case let .closeReceiveAddress(v1):
+            writeInt(&buf, Int32(16))
             FfiConverterUInt64.write(v1, into: &buf)
 
         }
@@ -34447,7 +34455,6 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     )
     case FeesError(String
     )
-    case InitialScanIncomplete
     case BuildTxError(String
     )
     case InsufficientFunds(String
@@ -34467,6 +34474,8 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     case CsvCreationError(String
     )
     case AddUtxosError(String
+    )
+    case OutputLabelsError(String
     )
     case DatabaseCorruption(id: WalletId, error: String
     )
@@ -34558,35 +34567,37 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
         case 17: return .FeesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 18: return .InitialScanIncomplete
-        case 19: return .BuildTxError(
+        case 18: return .BuildTxError(
             try FfiConverterString.read(from: &buf)
             )
-        case 20: return .InsufficientFunds(
+        case 19: return .InsufficientFunds(
             try FfiConverterString.read(from: &buf)
             )
-        case 21: return .GetConfirmDetailsError(
+        case 20: return .GetConfirmDetailsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 22: return .SignAndBroadcastError(
+        case 21: return .SignAndBroadcastError(
             try FfiConverterString.read(from: &buf)
             )
-        case 23: return .Converter(
+        case 22: return .Converter(
             try FfiConverterTypeConverterError.read(from: &buf)
             )
-        case 24: return .UnknownError(
+        case 23: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
-        case 25: return .PsbtFinalizeError(
+        case 24: return .PsbtFinalizeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 26: return .GetHistoricalPricesError(
+        case 25: return .GetHistoricalPricesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 27: return .CsvCreationError(
+        case 26: return .CsvCreationError(
             try FfiConverterString.read(from: &buf)
             )
-        case 28: return .AddUtxosError(
+        case 27: return .AddUtxosError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 28: return .OutputLabelsError(
             try FfiConverterString.read(from: &buf)
             )
         case 29: return .DatabaseCorruption(
@@ -34691,56 +34702,57 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
 
 
-        case .InitialScanIncomplete:
-            writeInt(&buf, Int32(18))
-
-
         case let .BuildTxError(v1):
-            writeInt(&buf, Int32(19))
+            writeInt(&buf, Int32(18))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .InsufficientFunds(v1):
-            writeInt(&buf, Int32(20))
+            writeInt(&buf, Int32(19))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .GetConfirmDetailsError(v1):
-            writeInt(&buf, Int32(21))
+            writeInt(&buf, Int32(20))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .SignAndBroadcastError(v1):
-            writeInt(&buf, Int32(22))
+            writeInt(&buf, Int32(21))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .Converter(v1):
-            writeInt(&buf, Int32(23))
+            writeInt(&buf, Int32(22))
             FfiConverterTypeConverterError.write(v1, into: &buf)
 
 
         case let .UnknownError(v1):
-            writeInt(&buf, Int32(24))
+            writeInt(&buf, Int32(23))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .PsbtFinalizeError(v1):
-            writeInt(&buf, Int32(25))
+            writeInt(&buf, Int32(24))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .GetHistoricalPricesError(v1):
-            writeInt(&buf, Int32(26))
+            writeInt(&buf, Int32(25))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .CsvCreationError(v1):
-            writeInt(&buf, Int32(27))
+            writeInt(&buf, Int32(26))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .AddUtxosError(v1):
+            writeInt(&buf, Int32(27))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .OutputLabelsError(v1):
             writeInt(&buf, Int32(28))
             FfiConverterString.write(v1, into: &buf)
 
@@ -34779,8 +34791,6 @@ public func FfiConverterTypeWalletManagerError_lower(_ value: WalletManagerError
 public enum WalletManagerReconcileMessage {
 
     case walletScanStatusChanged(WalletScanStatus
-    )
-    case ledgerStateChanged(WalletLedgerState
     )
     case availableTransactions([Transaction]
     )
@@ -34839,57 +34849,54 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         case 1: return .walletScanStatusChanged(try FfiConverterTypeWalletScanStatus.read(from: &buf)
         )
 
-        case 2: return .ledgerStateChanged(try FfiConverterTypeWalletLedgerState.read(from: &buf)
+        case 2: return .availableTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
         )
 
-        case 3: return .availableTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
+        case 3: return .scanComplete(try FfiConverterSequenceTypeTransaction.read(from: &buf)
         )
 
-        case 4: return .scanComplete(try FfiConverterSequenceTypeTransaction.read(from: &buf)
+        case 4: return .updatedTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
         )
 
-        case 5: return .updatedTransactions(try FfiConverterSequenceTypeTransaction.read(from: &buf)
+        case 5: return .nodeConnectionFailed(try FfiConverterString.read(from: &buf)
         )
 
-        case 6: return .nodeConnectionFailed(try FfiConverterString.read(from: &buf)
+        case 6: return .walletMetadataChanged(try FfiConverterTypeWalletMetadata.read(from: &buf)
         )
 
-        case 7: return .walletMetadataChanged(try FfiConverterTypeWalletMetadata.read(from: &buf)
+        case 7: return .walletBalanceChanged(try FfiConverterTypeBalance.read(from: &buf)
         )
 
-        case 8: return .walletBalanceChanged(try FfiConverterTypeBalance.read(from: &buf)
+        case 8: return .walletError(try FfiConverterTypeWalletManagerError.read(from: &buf)
         )
 
-        case 9: return .walletError(try FfiConverterTypeWalletManagerError.read(from: &buf)
+        case 9: return .unknownError(try FfiConverterString.read(from: &buf)
         )
 
-        case 10: return .unknownError(try FfiConverterString.read(from: &buf)
+        case 10: return .walletScannerResponse(try FfiConverterTypeScannerResponse.read(from: &buf)
         )
 
-        case 11: return .walletScannerResponse(try FfiConverterTypeScannerResponse.read(from: &buf)
+        case 11: return .unsignedTransactionsChanged
+
+        case 12: return .sendFlowError(try FfiConverterTypeSendFlowErrorAlert.read(from: &buf)
         )
 
-        case 12: return .unsignedTransactionsChanged
-
-        case 13: return .sendFlowError(try FfiConverterTypeSendFlowErrorAlert.read(from: &buf)
+        case 13: return .hotWalletKeyMissing(try FfiConverterTypeWalletId.read(from: &buf)
         )
 
-        case 14: return .hotWalletKeyMissing(try FfiConverterTypeWalletId.read(from: &buf)
+        case 14: return .receiveAddressUpdated(try FfiConverterTypeReceiveAddressState.read(from: &buf)
         )
 
-        case 15: return .receiveAddressUpdated(try FfiConverterTypeReceiveAddressState.read(from: &buf)
+        case 15: return .receiveAddressPresentationUpdated(try FfiConverterTypeReceiveAddressPresentation.read(from: &buf)
         )
 
-        case 16: return .receiveAddressPresentationUpdated(try FfiConverterTypeReceiveAddressPresentation.read(from: &buf)
+        case 16: return .receiveAddressLoadingChanged(try FfiConverterBool.read(from: &buf)
         )
 
-        case 17: return .receiveAddressLoadingChanged(try FfiConverterBool.read(from: &buf)
+        case 17: return .receiveAddressError(try FfiConverterString.read(from: &buf)
         )
 
-        case 18: return .receiveAddressError(try FfiConverterString.read(from: &buf)
-        )
-
-        case 19: return .receiveAddressClosed(try FfiConverterUInt64.read(from: &buf)
+        case 18: return .receiveAddressClosed(try FfiConverterUInt64.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -34905,92 +34912,87 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
             FfiConverterTypeWalletScanStatus.write(v1, into: &buf)
 
 
-        case let .ledgerStateChanged(v1):
-            writeInt(&buf, Int32(2))
-            FfiConverterTypeWalletLedgerState.write(v1, into: &buf)
-
-
         case let .availableTransactions(v1):
-            writeInt(&buf, Int32(3))
+            writeInt(&buf, Int32(2))
             FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
 
 
         case let .scanComplete(v1):
-            writeInt(&buf, Int32(4))
+            writeInt(&buf, Int32(3))
             FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
 
 
         case let .updatedTransactions(v1):
-            writeInt(&buf, Int32(5))
+            writeInt(&buf, Int32(4))
             FfiConverterSequenceTypeTransaction.write(v1, into: &buf)
 
 
         case let .nodeConnectionFailed(v1):
-            writeInt(&buf, Int32(6))
+            writeInt(&buf, Int32(5))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .walletMetadataChanged(v1):
-            writeInt(&buf, Int32(7))
+            writeInt(&buf, Int32(6))
             FfiConverterTypeWalletMetadata.write(v1, into: &buf)
 
 
         case let .walletBalanceChanged(v1):
-            writeInt(&buf, Int32(8))
+            writeInt(&buf, Int32(7))
             FfiConverterTypeBalance.write(v1, into: &buf)
 
 
         case let .walletError(v1):
-            writeInt(&buf, Int32(9))
+            writeInt(&buf, Int32(8))
             FfiConverterTypeWalletManagerError.write(v1, into: &buf)
 
 
         case let .unknownError(v1):
-            writeInt(&buf, Int32(10))
+            writeInt(&buf, Int32(9))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .walletScannerResponse(v1):
-            writeInt(&buf, Int32(11))
+            writeInt(&buf, Int32(10))
             FfiConverterTypeScannerResponse.write(v1, into: &buf)
 
 
         case .unsignedTransactionsChanged:
-            writeInt(&buf, Int32(12))
+            writeInt(&buf, Int32(11))
 
 
         case let .sendFlowError(v1):
-            writeInt(&buf, Int32(13))
+            writeInt(&buf, Int32(12))
             FfiConverterTypeSendFlowErrorAlert.write(v1, into: &buf)
 
 
         case let .hotWalletKeyMissing(v1):
-            writeInt(&buf, Int32(14))
+            writeInt(&buf, Int32(13))
             FfiConverterTypeWalletId.write(v1, into: &buf)
 
 
         case let .receiveAddressUpdated(v1):
-            writeInt(&buf, Int32(15))
+            writeInt(&buf, Int32(14))
             FfiConverterTypeReceiveAddressState.write(v1, into: &buf)
 
 
         case let .receiveAddressPresentationUpdated(v1):
-            writeInt(&buf, Int32(16))
+            writeInt(&buf, Int32(15))
             FfiConverterTypeReceiveAddressPresentation.write(v1, into: &buf)
 
 
         case let .receiveAddressLoadingChanged(v1):
-            writeInt(&buf, Int32(17))
+            writeInt(&buf, Int32(16))
             FfiConverterBool.write(v1, into: &buf)
 
 
         case let .receiveAddressError(v1):
-            writeInt(&buf, Int32(18))
+            writeInt(&buf, Int32(17))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .receiveAddressClosed(v1):
-            writeInt(&buf, Int32(19))
+            writeInt(&buf, Int32(18))
             FfiConverterUInt64.write(v1, into: &buf)
 
         }
@@ -39654,83 +39656,6 @@ public func transactionsPreviewNew(confirmed: UInt8, unconfirmed: UInt8) -> [Tra
     )
 })
 }
-public func walletAmountInFiatCached(amount: Amount) -> Double?  {
-    return try!  FfiConverterOptionDouble.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_amount_in_fiat_cached(
-        FfiConverterTypeAmount_lower(amount),uniffiCallStatus
-    )
-})
-}
-public func walletDisplayAmount(metadata: WalletMetadata, amount: Amount, showUnit: Bool) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_amount(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterTypeAmount_lower(amount),
-        FfiConverterBool.lower(showUnit),uniffiCallStatus
-    )
-})
-}
-public func walletDisplayAmountPendingFmt(metadata: WalletMetadata, amount: Amount) -> String?  {
-    return try!  FfiConverterOptionString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_amount_pending_fmt(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterTypeAmount_lower(amount),uniffiCallStatus
-    )
-})
-}
-public func walletDisplayAmountWithDirection(metadata: WalletMetadata, amount: Amount, direction: TransactionDirection) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_amount_with_direction(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterTypeAmount_lower(amount),
-        FfiConverterTypeTransactionDirection_lower(direction),uniffiCallStatus
-    )
-})
-}
-public func walletDisplayFiatAmount(metadata: WalletMetadata, amount: Double, withSuffix: Bool) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_fiat_amount(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterDouble.lower(amount),
-        FfiConverterBool.lower(withSuffix),uniffiCallStatus
-    )
-})
-}
-public func walletDisplayFiatAmountPendingFmt(metadata: WalletMetadata, amount: Double, withSuffix: Bool) -> String?  {
-    return try!  FfiConverterOptionString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_fiat_amount_pending_fmt(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterDouble.lower(amount),
-        FfiConverterBool.lower(withSuffix),uniffiCallStatus
-    )
-})
-}
-public func walletDisplayFiatAmountWithDirection(metadata: WalletMetadata, amount: Double, direction: TransactionDirection, withSuffix: Bool) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_fiat_amount_with_direction(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterDouble.lower(amount),
-        FfiConverterTypeTransactionDirection_lower(direction),
-        FfiConverterBool.lower(withSuffix),uniffiCallStatus
-    )
-})
-}
-public func walletDisplaySentAndReceivedAmount(metadata: WalletMetadata, sentAndReceived: SentAndReceived) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_func_wallet_display_sent_and_received_amount(
-        FfiConverterTypeWalletMetadata_lower(metadata),
-        FfiConverterTypeSentAndReceived_lower(sentAndReceived),uniffiCallStatus
-    )
-})
-}
 public func ffiMinSendAmount() -> Amount  {
     return try!  FfiConverterTypeAmount_lift(try! rustCall() {
         uniffiCallStatus in
@@ -39925,30 +39850,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_transactions_preview_new() != 39646) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_amount_in_fiat_cached() != 26689) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_amount() != 61536) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_amount_pending_fmt() != 28974) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_amount_with_direction() != 31040) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_fiat_amount() != 19771) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_fiat_amount_pending_fmt() != 9763) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_fiat_amount_with_direction() != 59603) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_func_wallet_display_sent_and_received_amount() != 2923) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_ffi_min_send_amount() != 61138) {
@@ -40275,6 +40176,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn() != 18479) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_labelmanager_delete_labels_for_txn_without_cloud_backup_dirty() != 47716) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_labelmanager_export() != 24203) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40420,6 +40324,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcoincontrolmanager_selected_utxos() != 30072) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustcoincontrolmanager_set_utxo_spendability() != 52265) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustcoincontrolmanager_unit() != 17965) {
@@ -40569,9 +40476,6 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_balance_presentation() != 27753) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_balance_presentation_for_state() != 65105) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40674,9 +40578,6 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_label_manager() != 23571) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_ledger_state() != 45737) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_cove_checksum_method_rustwalletmanager_listen_for_updates() != 34012) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40686,10 +40587,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_master_fingerprint() != 64370) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 1459) {
+    if (uniffi_cove_checksum_method_rustwalletmanager_new_coin_control_manager() != 11951) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 10979) {
+    if (uniffi_cove_checksum_method_rustwalletmanager_new_send_flow_manager() != 55235) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_non_default_account_number() != 54959) {
@@ -40737,7 +40638,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_switch_to_different_wallet_address_type() != 37401) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_rustwalletmanager_toggle_transaction_lock_state() != 4815) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_rustwalletmanager_transaction_details() != 34155) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_transaction_lock_state() != 22037) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_unlocked_spendable_balance() != 11834) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_validate_metadata() != 36684) {
@@ -40963,9 +40873,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_confirmation_date_time() != 59432) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_method_transactiondetails_display_amount() != 46360) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_transactiondetails_fee_fiat_fmt() != 57101) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -4691,10 +4691,11 @@ public struct Utxo: Equatable, Hashable {
     public var derivationIndex: UInt32
     public var blockHeight: UInt32
     public var type: UtxoType
+    public var spendable: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(outpoint: OutPoint, label: String?, datetime: UInt64, amount: Amount, address: Address, derivationIndex: UInt32, blockHeight: UInt32, type: UtxoType) {
+    public init(outpoint: OutPoint, label: String?, datetime: UInt64, amount: Amount, address: Address, derivationIndex: UInt32, blockHeight: UInt32, type: UtxoType, spendable: Bool) {
         self.outpoint = outpoint
         self.label = label
         self.datetime = datetime
@@ -4703,6 +4704,7 @@ public struct Utxo: Equatable, Hashable {
         self.derivationIndex = derivationIndex
         self.blockHeight = blockHeight
         self.type = type
+        self.spendable = spendable
     }
 
 
@@ -4789,7 +4791,8 @@ public struct FfiConverterTypeUtxo: FfiConverterRustBuffer {
                 address: FfiConverterTypeAddress.read(from: &buf),
                 derivationIndex: FfiConverterUInt32.read(from: &buf),
                 blockHeight: FfiConverterUInt32.read(from: &buf),
-                type: FfiConverterTypeUtxoType.read(from: &buf)
+                type: FfiConverterTypeUtxoType.read(from: &buf),
+                spendable: FfiConverterBool.read(from: &buf)
         )
     }
 
@@ -4802,6 +4805,7 @@ public struct FfiConverterTypeUtxo: FfiConverterRustBuffer {
         FfiConverterUInt32.write(value.derivationIndex, into: &buf)
         FfiConverterUInt32.write(value.blockHeight, into: &buf)
         FfiConverterTypeUtxoType.write(value.type, into: &buf)
+        FfiConverterBool.write(value.spendable, into: &buf)
     }
 }
 

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -4692,7 +4692,7 @@ public struct Utxo: Equatable, Hashable {
     public var blockHeight: UInt32
     public var type: UtxoType
     /**
-     * Cached lock state for display and selection filtering; transaction building rechecks the labels DB
+     * Cached lock state for display and selection filtering only; transaction building rechecks the labels DB
      */
     public var spendable: Bool
 
@@ -4700,7 +4700,7 @@ public struct Utxo: Equatable, Hashable {
     // declare one manually.
     public init(outpoint: OutPoint, label: String?, datetime: UInt64, amount: Amount, address: Address, derivationIndex: UInt32, blockHeight: UInt32, type: UtxoType,
         /**
-         * Cached lock state for display and selection filtering; transaction building rechecks the labels DB
+         * Cached lock state for display and selection filtering only; transaction building rechecks the labels DB
          */spendable: Bool) {
         self.outpoint = outpoint
         self.label = label

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -4691,11 +4691,17 @@ public struct Utxo: Equatable, Hashable {
     public var derivationIndex: UInt32
     public var blockHeight: UInt32
     public var type: UtxoType
+    /**
+     * Cached lock state for display and selection filtering; transaction building rechecks the labels DB
+     */
     public var spendable: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(outpoint: OutPoint, label: String?, datetime: UInt64, amount: Amount, address: Address, derivationIndex: UInt32, blockHeight: UInt32, type: UtxoType, spendable: Bool) {
+    public init(outpoint: OutPoint, label: String?, datetime: UInt64, amount: Amount, address: Address, derivationIndex: UInt32, blockHeight: UInt32, type: UtxoType,
+        /**
+         * Cached lock state for display and selection filtering; transaction building rechecks the labels DB
+         */spendable: Bool) {
         self.outpoint = outpoint
         self.label = label
         self.datetime = datetime

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "bip329"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689260fce0f6e366877a624be4c87518e80f99951c421ae80c3be6523a51bc9d"
+checksum = "cce169d603a933ddeb594bc6a312ee22b257ed6135d7370574e17d4f47826274"
 dependencies = [
  "bitcoin",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,7 +56,7 @@ ruzstd = "0.8.3"
 bitcoin = { version = "0.32.9" }
 bdk_wallet = { version = "3.0.0", features = ["keys-bip39", "file_store", "rusqlite"] }
 bip39 = { version = "2.2.2", features = ["zeroize"] }
-bip329 = { version = "0.4.0" }
+bip329 = { version = "0.5.0" }
 payjoin = { version = "0.25.0", default-features = false, features = ["v2"] }
 pubport = { version = "0.5.0" }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,7 +56,7 @@ ruzstd = "0.8.3"
 bitcoin = { version = "0.32.9" }
 bdk_wallet = { version = "3.0.0", features = ["keys-bip39", "file_store", "rusqlite"] }
 bip39 = { version = "2.2.2", features = ["zeroize"] }
-bip329 = { version = "0.5.0" }
+bip329 = "0.5.0"
 payjoin = { version = "0.25.0", default-features = false, features = ["v2"] }
 pubport = { version = "0.5.0" }
 

--- a/rust/crates/cove-types/src/utxo.rs
+++ b/rust/crates/cove-types/src/utxo.rs
@@ -40,7 +40,7 @@ pub struct Utxo {
     pub derivation_index: u32,
     pub block_height: u32,
     pub type_: UtxoType,
-    /// Cached lock state for display and selection filtering; transaction building rechecks the labels DB
+    /// Cached lock state for display and selection filtering only; transaction building rechecks the labels DB
     pub spendable: bool,
 }
 

--- a/rust/crates/cove-types/src/utxo.rs
+++ b/rust/crates/cove-types/src/utxo.rs
@@ -40,6 +40,7 @@ pub struct Utxo {
     pub derivation_index: u32,
     pub block_height: u32,
     pub type_: UtxoType,
+    pub spendable: bool,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Object)]
@@ -106,6 +107,7 @@ impl Utxo {
             derivation_index,
             block_height,
             type_,
+            spendable: true,
         };
 
         Ok(utxo)
@@ -238,6 +240,7 @@ pub mod ffi_preview {
                 derivation_index: 0,
                 block_height,
                 type_,
+                spendable: true,
             }
         }
     }

--- a/rust/crates/cove-types/src/utxo.rs
+++ b/rust/crates/cove-types/src/utxo.rs
@@ -40,6 +40,7 @@ pub struct Utxo {
     pub derivation_index: u32,
     pub block_height: u32,
     pub type_: UtxoType,
+    /// Populated by coin-control label loading; display cache only, not authoritative for spending
     pub spendable: bool,
 }
 

--- a/rust/crates/cove-types/src/utxo.rs
+++ b/rust/crates/cove-types/src/utxo.rs
@@ -40,7 +40,7 @@ pub struct Utxo {
     pub derivation_index: u32,
     pub block_height: u32,
     pub type_: UtxoType,
-    /// Populated by coin-control label loading; display cache only, not authoritative for spending
+    /// Cached lock state for display and selection filtering; transaction building rechecks the labels DB
     pub spendable: bool,
 }
 

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -538,7 +538,7 @@ mod tests {
         "#;
 
         let labels = Labels::try_from_str(jsonl).expect("failed to parse labels");
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(labels).expect("failed to insert labels");
@@ -566,7 +566,7 @@ mod tests {
         );
 
         let labels = Labels::try_from_str(&jsonl).expect("failed to parse labels");
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(labels).expect("failed to insert labels");
@@ -591,7 +591,7 @@ mod tests {
         .expect("failed to parse outpoint");
         let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"locked","spendable":false}"#;
         let imported = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"renamed"}"#;
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
@@ -618,7 +618,7 @@ mod tests {
         .expect("failed to parse outpoint");
         let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"locked","spendable":false}"#;
         let imported = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"unlocked","spendable":true}"#;
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
@@ -645,7 +645,7 @@ mod tests {
         .expect("failed to parse outpoint");
         let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"unlocked","spendable":true}"#;
         let imported = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"locked","spendable":false}"#;
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
@@ -673,7 +673,7 @@ mod tests {
             "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
         )
         .expect("failed to parse outpoint");
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.set_output_spendability(outpoint, false).expect("failed to lock output");
@@ -695,7 +695,7 @@ mod tests {
             "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
         )
         .expect("failed to parse outpoint");
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.set_output_spendability(outpoint, false).expect("failed to lock output");
@@ -715,7 +715,7 @@ mod tests {
             "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
         )
         .expect("failed to parse outpoint");
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.set_output_spendability(outpoint, false).expect("failed to lock output");
@@ -732,7 +732,7 @@ mod tests {
         )
         .expect("failed to parse outpoint");
         let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"keep me","spendable":false}"#;
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
@@ -762,7 +762,7 @@ mod tests {
             {"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"requested","spendable":true}
             {"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:2","label":"untouched","spendable":true}
         "#;
-        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
         let db = &wallet_db.labels;
 
         db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -383,32 +383,32 @@ impl LabelsTable {
         {
             let mut table = write_txn.open_table(OUTPUT_TABLE)?;
 
-            for outpoint in outpoints {
+            outpoints.into_iter().try_for_each(|outpoint| -> Result<(), Error> {
                 let key = OutPointKey::from(outpoint);
-                let current = table.get(key.clone())?.map(|record| record.value());
+                let Some(mut current) = table.get(key.clone())?.map(|record| record.value()) else {
+                    if spendable {
+                        return Ok(());
+                    }
 
-                match (current, spendable) {
-                    (Some(mut current), true) if current.item.label.is_some() => {
-                        current.item.spendable = true;
-                        current.timestamps.updated_at = now;
-                        table.insert(key, current)?;
-                    }
-                    (Some(_current), true) => {
-                        table.remove(key)?;
-                    }
-                    (Some(mut current), false) => {
-                        current.item.spendable = false;
-                        current.timestamps.updated_at = now;
-                        table.insert(key, current)?;
-                    }
-                    (None, true) => {}
-                    (None, false) => {
-                        let record = OutputRecord { ref_: outpoint, label: None, spendable: false };
-                        let record = Record::with_timestamps(record, Timestamps::new(now, now));
-                        table.insert(key, record)?;
-                    }
+                    let record = OutputRecord { ref_: outpoint, label: None, spendable: false };
+                    let record = Record::with_timestamps(record, Timestamps::new(now, now));
+                    table.insert(key, record)?;
+
+                    return Ok(());
+                };
+
+                if spendable && current.item.label.is_none() {
+                    table.remove(key)?;
+
+                    return Ok(());
                 }
-            }
+
+                current.item.spendable = spendable;
+                current.timestamps.updated_at = now;
+                table.insert(key, current)?;
+
+                Ok(())
+            })?;
         }
 
         write_txn.commit().map_err_str(DatabaseError::DatabaseAccess)?;

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -539,6 +539,39 @@ impl From<redb::StorageError> for Error {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::Arc;
+
+    use redb::TableDefinition;
+
+    use super::LabelsTable;
+    use crate::{database::wallet_data::WalletDataDb, wallet::metadata::WalletId};
+
+    const MISMATCHED_OUTPUT_TABLE: TableDefinition<&'static str, &'static str> =
+        TableDefinition::new("output_records_v2.cbor");
+
+    pub(crate) fn wallet_data_db_with_mismatched_output_table(
+        id: WalletId,
+    ) -> (WalletDataDb, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let db_path = tmp.path().join("wallet_data.encrypted.json.redb");
+        let db = Arc::new(redb::Database::create(db_path).expect("failed to create test db"));
+        let write_txn = db.begin_write().expect("failed to begin write transaction");
+        {
+            let mut table =
+                write_txn.open_table(MISMATCHED_OUTPUT_TABLE).expect("failed to create table");
+            table.insert("key", "value").expect("failed to insert mismatched value");
+        }
+        write_txn.commit().expect("failed to commit write transaction");
+
+        let labels = LabelsTable { db: db.clone() };
+        let wallet_db = WalletDataDb { id, db, labels };
+
+        (wallet_db, tmp)
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::str::FromStr as _;
 

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -345,6 +345,25 @@ impl LabelsTable {
         Ok(())
     }
 
+    pub fn delete_labels_and_insert_records(
+        &self,
+        labels: impl IntoIterator<Item = Label>,
+        records: impl IntoIterator<Item = Record<Label>>,
+    ) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err_str(DatabaseError::DatabaseAccess)?;
+
+        labels
+            .into_iter()
+            .try_for_each(|label| self.delete_label_with_write_txn(label, &write_txn))?;
+        records.into_iter().try_for_each(|record| {
+            self.insert_label_with_write_txn(record.item, record.timestamps, &write_txn)
+        })?;
+
+        write_txn.commit().map_err_str(DatabaseError::DatabaseAccess)?;
+
+        Ok(())
+    }
+
     pub fn set_output_spendability(
         &self,
         outpoint: bitcoin::OutPoint,

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -470,23 +470,6 @@ impl LabelsTable {
         Ok(())
     }
 
-    pub fn delete_labels_and_insert_records(
-        &self,
-        labels: impl IntoIterator<Item = Label>,
-        records: impl IntoIterator<Item = Record<Label>>,
-    ) -> Result<(), Error> {
-        let write_txn = self.db.begin_write().map_err_str(DatabaseError::DatabaseAccess)?;
-
-        labels.into_iter().try_for_each(|l| self.delete_label_with_write_txn(l, &write_txn))?;
-        records.into_iter().try_for_each(|record| {
-            self.insert_label_with_write_txn(record.item, record.timestamps, &write_txn)
-        })?;
-
-        write_txn.commit().map_err_str(DatabaseError::DatabaseAccess)?;
-
-        Ok(())
-    }
-
     fn delete_label_with_write_txn(
         &self,
         label: Label,

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -731,6 +731,41 @@ mod tests {
     }
 
     #[test]
+    fn export_import_round_trip_preserves_lock_only_output_record() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let (source_wallet_db, _source_tmp) =
+            new_test_wallet_data_db(WalletId::preview_new_random());
+        let source_db = &source_wallet_db.labels;
+
+        source_db.set_output_spendability(outpoint, false).expect("failed to lock output");
+        let exported = source_db.all_labels().expect("failed to load labels").export().unwrap();
+
+        let (destination_wallet_db, _destination_tmp) =
+            new_test_wallet_data_db(WalletId::preview_new_random());
+        let destination_db = &destination_wallet_db.labels;
+        destination_db
+            .insert_imported_labels(
+                Labels::try_from_str_with_metadata(&exported)
+                    .expect("failed to parse exported labels"),
+            )
+            .expect("failed to import exported labels");
+
+        let record = destination_db
+            .get_output_record(outpoint)
+            .expect("failed to get imported output record")
+            .expect("missing imported output record");
+        let locked =
+            destination_db.locked_output_outpoints().expect("failed to get locked outputs");
+
+        assert_eq!(record.item.label, None);
+        assert!(!record.item.spendable);
+        assert!(locked.contains(&outpoint));
+    }
+
+    #[test]
     fn unlocking_lock_only_record_removes_output_record() {
         let outpoint = OutPoint::from_str(
             "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -227,13 +227,15 @@ impl LabelsTable {
 
     pub fn locked_output_outpoints(&self) -> Result<HashSet<bitcoin::OutPoint>, Error> {
         let table = self.read_table(OUTPUT_TABLE)?;
-        let outpoints = table
-            .iter()?
-            .filter_map(Result::ok)
-            .map(|(_key, record)| record.value().item)
-            .filter(|record| !record.spendable)
-            .map(|record| record.ref_)
-            .collect();
+        let mut outpoints = HashSet::new();
+
+        for row in table.iter()? {
+            let (_key, record) = row?;
+            let record = record.value().item;
+            if !record.spendable {
+                outpoints.insert(record.ref_);
+            }
+        }
 
         Ok(outpoints)
     }

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -1,7 +1,9 @@
-use std::{borrow::Borrow, fmt::Debug, sync::Arc};
+use std::{borrow::Borrow, collections::HashSet, fmt::Debug, sync::Arc};
 
 use crate::database::{Record, error::DatabaseError, record::Timestamps};
-use bip329::{AddressRecord, InputRecord, Label, Labels, OutputRecord, TransactionRecord};
+use bip329::{
+    AddressRecord, InputRecord, Label, Labels, OutputRecord, ParsedLabels, TransactionRecord,
+};
 use bitcoin::{Address, address::NetworkUnchecked};
 use cove_util::result_ext::ResultExt as _;
 use redb::{ReadOnlyTable, ReadableTable as _, ReadableTableMetadata as _, TableDefinition};
@@ -144,11 +146,13 @@ impl LabelsTable {
     ) -> Result<impl Iterator<Item = Record<InputRecord>>, Error> {
         let table = self.read_table(INPUT_TABLE)?;
 
-        let start_inout_id = OutPointKey { id: *txid.as_ref(), index: 0 };
+        let txid = *txid.as_ref();
+        let start_inout_id = OutPointKey { id: txid, index: 0 };
 
         let inputs = table
             .range(start_inout_id..)?
             .filter_map(Result::ok)
+            .take_while(move |(key, _record)| key.value().id == txid)
             .map(|(_key, record)| record.value());
 
         Ok(inputs)
@@ -160,11 +164,13 @@ impl LabelsTable {
     ) -> Result<impl Iterator<Item = Record<OutputRecord>>, Error> {
         let table = self.read_table(OUTPUT_TABLE)?;
 
-        let start_inout_id = OutPointKey { id: *txid.as_ref(), index: 0 };
+        let txid = *txid.as_ref();
+        let start_inout_id = OutPointKey { id: txid, index: 0 };
 
         let outputs = table
             .range(start_inout_id..)?
             .filter_map(Result::ok)
+            .take_while(move |(key, _record)| key.value().id == txid)
             .map(|(_key, record)| record.value());
 
         Ok(outputs)
@@ -208,7 +214,64 @@ impl LabelsTable {
         Ok(label)
     }
 
+    pub fn get_output_record(
+        &self,
+        outpoint: impl Borrow<bitcoin::OutPoint>,
+    ) -> Result<Option<Record<OutputRecord>>, Error> {
+        let outpoint = outpoint.borrow();
+        let table = self.read_table(OUTPUT_TABLE)?;
+        let label = table.get(OutPointKey::from(outpoint))?.map(|record| record.value());
+
+        Ok(label)
+    }
+
+    pub fn locked_output_outpoints(&self) -> Result<HashSet<bitcoin::OutPoint>, Error> {
+        let table = self.read_table(OUTPUT_TABLE)?;
+        let outpoints = table
+            .iter()?
+            .filter_map(Result::ok)
+            .map(|(_key, record)| record.value().item)
+            .filter(|record| !record.spendable)
+            .map(|record| record.ref_)
+            .collect();
+
+        Ok(outpoints)
+    }
+
     // MARK: INSERT
+
+    pub fn insert_imported_labels(&self, parsed: ParsedLabels) -> Result<(), Error> {
+        let spendable_by_outpoint = parsed
+            .output_spendable
+            .into_iter()
+            .map(|field| (field.ref_, field.value))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let labels = parsed
+            .labels
+            .into_vec()
+            .into_iter()
+            .map(|label| {
+                let Label::Output(mut output) = label else { return Ok(label) };
+
+                match spendable_by_outpoint
+                    .get(&output.ref_)
+                    .and_then(|field| field.explicit_value())
+                {
+                    Some(spendable) => output.spendable = spendable,
+                    None => {
+                        if let Some(current) = self.get_output_record(output.ref_)? {
+                            output.spendable = current.item.spendable;
+                        }
+                    }
+                }
+
+                Ok(Label::Output(output))
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        self.insert_labels(labels)
+    }
 
     pub fn insert_labels(&self, labels: impl IntoIterator<Item = Label>) -> Result<(), Error> {
         self.insert_labels_with_timestamps(labels, Timestamps::now())
@@ -274,6 +337,58 @@ impl LabelsTable {
         records.into_iter().try_for_each(|record| {
             self.insert_label_with_write_txn(record.item, record.timestamps, &write_txn)
         })?;
+
+        write_txn.commit().map_err_str(DatabaseError::DatabaseAccess)?;
+
+        Ok(())
+    }
+
+    pub fn set_output_spendability(
+        &self,
+        outpoint: bitcoin::OutPoint,
+        spendable: bool,
+    ) -> Result<(), Error> {
+        self.set_output_spendability_for_outpoints([outpoint], spendable)
+    }
+
+    pub fn set_output_spendability_for_outpoints(
+        &self,
+        outpoints: impl IntoIterator<Item = bitcoin::OutPoint>,
+        spendable: bool,
+    ) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err_str(DatabaseError::DatabaseAccess)?;
+        let now = jiff::Timestamp::now().as_second().cast_unsigned();
+
+        {
+            let mut table = write_txn.open_table(OUTPUT_TABLE)?;
+
+            for outpoint in outpoints {
+                let key = OutPointKey::from(outpoint);
+                let current = table.get(key.clone())?.map(|record| record.value());
+
+                match (current, spendable) {
+                    (Some(mut current), true) if current.item.label.is_some() => {
+                        current.item.spendable = true;
+                        current.timestamps.updated_at = now;
+                        table.insert(key, current)?;
+                    }
+                    (Some(_current), true) => {
+                        table.remove(key)?;
+                    }
+                    (Some(mut current), false) => {
+                        current.item.spendable = false;
+                        current.timestamps.updated_at = now;
+                        table.insert(key, current)?;
+                    }
+                    (None, true) => {}
+                    (None, false) => {
+                        let record = OutputRecord { ref_: outpoint, label: None, spendable: false };
+                        let record = Record::with_timestamps(record, Timestamps::new(now, now));
+                        table.insert(key, record)?;
+                    }
+                }
+            }
+        }
 
         write_txn.commit().map_err_str(DatabaseError::DatabaseAccess)?;
 
@@ -404,10 +519,13 @@ impl From<redb::StorageError> for Error {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr as _;
+
     use crate::{
         database::wallet_data::test_support::new_test_wallet_data_db, wallet::metadata::WalletId,
     };
     use bip329::Labels;
+    use bitcoin::OutPoint;
 
     #[test]
     fn test_all_labels_for_txn() {
@@ -431,5 +549,239 @@ mod tests {
         let labels = db.all_labels_for_txn(txn[0].ref_).expect("failed to get labels");
 
         assert_eq!(labels.len(), 5);
+    }
+
+    #[test]
+    fn txn_record_iters_are_bounded_to_requested_txid() {
+        let first_txid = "0000000000000000000000000000000000000000000000000000000000000001";
+        let second_txid = "0000000000000000000000000000000000000000000000000000000000000002";
+        let jsonl = format!(
+            r#"
+            {{"type":"tx","ref":"{first_txid}","label":"first"}}
+            {{"type":"output","ref":"{first_txid}:0","label":"first output"}}
+            {{"type":"input","ref":"{first_txid}:0","label":"first input"}}
+            {{"type":"output","ref":"{second_txid}:0","label":"second output"}}
+            {{"type":"input","ref":"{second_txid}:0","label":"second input"}}
+        "#
+        );
+
+        let labels = Labels::try_from_str(&jsonl).expect("failed to parse labels");
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.insert_labels(labels).expect("failed to insert labels");
+
+        let txid = bitcoin::Txid::from_str(first_txid).expect("failed to parse txid");
+        let inputs =
+            db.txn_input_records_iter(txid).expect("failed to get inputs").collect::<Vec<_>>();
+        let outputs =
+            db.txn_output_records_iter(txid).expect("failed to get outputs").collect::<Vec<_>>();
+
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(inputs[0].item.ref_.txid, txid);
+        assert_eq!(outputs[0].item.ref_.txid, txid);
+    }
+
+    #[test]
+    fn imported_output_with_omitted_spendable_preserves_current_spendability() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"locked","spendable":false}"#;
+        let imported = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"renamed"}"#;
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
+            .expect("failed to insert existing labels");
+        db.insert_imported_labels(
+            Labels::try_from_str_with_metadata(imported).expect("failed to parse imported labels"),
+        )
+        .expect("failed to insert imported labels");
+
+        let record = db
+            .get_output_record(outpoint)
+            .expect("failed to get output record")
+            .expect("missing output record");
+
+        assert_eq!(record.item.label, Some("renamed".to_string()));
+        assert!(!record.item.spendable);
+    }
+
+    #[test]
+    fn imported_explicit_output_spendable_overrides_current_spendability() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"locked","spendable":false}"#;
+        let imported = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"unlocked","spendable":true}"#;
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
+            .expect("failed to insert existing labels");
+        db.insert_imported_labels(
+            Labels::try_from_str_with_metadata(imported).expect("failed to parse imported labels"),
+        )
+        .expect("failed to insert imported labels");
+
+        let record = db
+            .get_output_record(outpoint)
+            .expect("failed to get output record")
+            .expect("missing output record");
+
+        assert_eq!(record.item.label, Some("unlocked".to_string()));
+        assert!(record.item.spendable);
+    }
+
+    #[test]
+    fn imported_explicit_locked_output_locks_current_output() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"unlocked","spendable":true}"#;
+        let imported = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"locked","spendable":false}"#;
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
+            .expect("failed to insert existing labels");
+        db.insert_imported_labels(
+            Labels::try_from_str_with_metadata(imported).expect("failed to parse imported labels"),
+        )
+        .expect("failed to insert imported labels");
+
+        let record = db
+            .get_output_record(outpoint)
+            .expect("failed to get output record")
+            .expect("missing output record");
+
+        assert_eq!(record.item.label, Some("locked".to_string()));
+        assert!(!record.item.spendable);
+        assert!(
+            db.locked_output_outpoints().expect("failed to get locked outputs").contains(&outpoint)
+        );
+    }
+
+    #[test]
+    fn setting_output_unspendable_creates_lock_only_record() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.set_output_spendability(outpoint, false).expect("failed to lock output");
+
+        let record = db
+            .get_output_record(outpoint)
+            .expect("failed to get output record")
+            .expect("missing output record");
+        let locked = db.locked_output_outpoints().expect("failed to get locked outputs");
+
+        assert_eq!(record.item.label, None);
+        assert!(!record.item.spendable);
+        assert!(locked.contains(&outpoint));
+    }
+
+    #[test]
+    fn export_includes_lock_only_output_record() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.set_output_spendability(outpoint, false).expect("failed to lock output");
+
+        let exported = db.all_labels().expect("failed to load labels").export().unwrap();
+
+        assert!(exported.contains(r#""type":"output""#));
+        assert!(exported.contains(
+            r#""ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1""#
+        ));
+        assert!(exported.contains(r#""spendable":false"#));
+    }
+
+    #[test]
+    fn unlocking_lock_only_record_removes_output_record() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.set_output_spendability(outpoint, false).expect("failed to lock output");
+        db.set_output_spendability(outpoint, true).expect("failed to unlock output");
+
+        assert!(db.get_output_record(outpoint).expect("failed to get output record").is_none());
+        assert!(db.locked_output_outpoints().expect("failed to get locked outputs").is_empty());
+    }
+
+    #[test]
+    fn unlocking_labeled_output_preserves_label() {
+        let outpoint = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse outpoint");
+        let existing = r#"{"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"keep me","spendable":false}"#;
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
+            .expect("failed to insert existing labels");
+        db.set_output_spendability(outpoint, true).expect("failed to unlock output");
+
+        let record = db
+            .get_output_record(outpoint)
+            .expect("failed to get output record")
+            .expect("missing output record");
+
+        assert_eq!(record.item.label, Some("keep me".to_string()));
+        assert!(record.item.spendable);
+    }
+
+    #[test]
+    fn bulk_spendability_update_only_changes_requested_outpoints() {
+        let requested = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1",
+        )
+        .expect("failed to parse requested outpoint");
+        let untouched = OutPoint::from_str(
+            "f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:2",
+        )
+        .expect("failed to parse untouched outpoint");
+        let existing = r#"
+            {"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:1","label":"requested","spendable":true}
+            {"type":"output","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd:2","label":"untouched","spendable":true}
+        "#;
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let db = &wallet_db.labels;
+
+        db.insert_labels(Labels::try_from_str(existing).expect("failed to parse existing labels"))
+            .expect("failed to insert existing labels");
+        db.set_output_spendability_for_outpoints([requested], false)
+            .expect("failed to lock requested output");
+
+        let requested = db
+            .get_output_record(requested)
+            .expect("failed to get requested output")
+            .expect("missing requested output")
+            .item;
+        let untouched = db
+            .get_output_record(untouched)
+            .expect("failed to get untouched output")
+            .expect("missing untouched output")
+            .item;
+
+        assert!(!requested.spendable);
+        assert!(untouched.spendable);
     }
 }

--- a/rust/src/database/wallet_data/label.rs
+++ b/rust/src/database/wallet_data/label.rs
@@ -451,6 +451,23 @@ impl LabelsTable {
         Ok(())
     }
 
+    pub fn delete_labels_and_insert_records(
+        &self,
+        labels: impl IntoIterator<Item = Label>,
+        records: impl IntoIterator<Item = Record<Label>>,
+    ) -> Result<(), Error> {
+        let write_txn = self.db.begin_write().map_err_str(DatabaseError::DatabaseAccess)?;
+
+        labels.into_iter().try_for_each(|l| self.delete_label_with_write_txn(l, &write_txn))?;
+        records.into_iter().try_for_each(|record| {
+            self.insert_label_with_write_txn(record.item, record.timestamps, &write_txn)
+        })?;
+
+        write_txn.commit().map_err_str(DatabaseError::DatabaseAccess)?;
+
+        Ok(())
+    }
+
     fn delete_label_with_write_txn(
         &self,
         label: Label,

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use cove_util::result_ext::ResultExt as _;
 
 use crate::{
+    database::Database,
     database::{InsertOrUpdate, Record, record::Timestamps, wallet_data::WalletDataDb},
     manager::cloud_backup_manager::CLOUD_BACKUP_MANAGER,
     multi_format::Bip329Labels,
@@ -54,6 +55,9 @@ pub enum LabelManagerError {
 
     #[error("Unable to save address labels: {0}")]
     SaveAddressLabels(String),
+
+    #[error("BIP329 labels can only be imported into the selected wallet")]
+    WalletNotSelected,
 }
 
 pub type Error = LabelManagerError;
@@ -197,7 +201,9 @@ impl LabelManager {
     #[uniffi::method(name = "importLabels")]
     pub fn _import_labels(&self, labels: Arc<Bip329Labels>) -> Result<(), LabelManagerError> {
         let labels = Arc::unwrap_or_clone(labels);
-        self.save_imported_labels(labels.parsed, true)
+        self.ensure_selected_wallet()?;
+
+        self.save_imported_labels(labels.0, true)
     }
 
     pub fn import(&self, jsonl: &str) -> Result<(), LabelManagerError> {
@@ -372,6 +378,18 @@ impl LabelManager {
 
     fn mark_cloud_backup_dirty(&self) {
         CLOUD_BACKUP_MANAGER.handle_wallet_backup_change(self.db.id.clone());
+    }
+
+    fn ensure_selected_wallet(&self) -> Result<(), LabelManagerError> {
+        let Some(selected_wallet) = Database::global().global_config.selected_wallet() else {
+            return Err(LabelManagerError::WalletNotSelected);
+        };
+
+        if selected_wallet != self.db.id {
+            return Err(LabelManagerError::WalletNotSelected);
+        }
+
+        Ok(())
     }
 
     fn update_labels_for_txn(
@@ -605,11 +623,15 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{
-        database::wallet_data::test_support::new_test_wallet_data_db,
-        transaction::TransactionDetails, wallet::metadata::WalletId,
+        database::{Database, wallet_data::test_support::new_test_wallet_data_db},
+        multi_format::Bip329Labels,
+        transaction::TransactionDetails,
+        wallet::metadata::WalletId,
     };
 
     use super::*;
+
+    static SELECTED_WALLET_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn test_manager() -> (LabelManager, tempfile::TempDir) {
         let (db, tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
@@ -637,6 +659,15 @@ mod tests {
             .labels
             .insert_label_with_timestamps(record.item, record.timestamps)
             .expect("failed to update output record");
+    }
+
+    fn sample_bip329_labels() -> Arc<Bip329Labels> {
+        Arc::new(
+            Bip329Labels::try_from_str(
+                r#"{"type":"tx","ref":"f91d0a8a78462bc59398f2c5d7a84fcff491c26ba54c4833478b202796c8aafd","label":"imported"}"#,
+            )
+            .expect("labels parse"),
+        )
     }
 
     fn insert_or_update_auto_labels(
@@ -763,5 +794,52 @@ mod tests {
         assert!(is_auto_output_label(Some("original"), Some("original (change)")));
         assert!(!is_auto_output_label(Some("original"), Some("custom label")));
         assert!(!is_auto_output_label(Some("original"), None));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn parsed_label_import_rejects_unselected_wallet() {
+        let _guard = SELECTED_WALLET_TEST_LOCK.lock().expect("test lock is acquired");
+        cove_tokio::init();
+        crate::database::test_support::init_test_database();
+
+        let selected_wallet = WalletId::preview_new_random();
+        let (manager, _tmp) = test_manager();
+        Database::global()
+            .global_config
+            .select_wallet(selected_wallet)
+            .expect("selected wallet is set");
+
+        let error = manager
+            ._import_labels(sample_bip329_labels())
+            .expect_err("import into unselected wallet is rejected");
+
+        assert!(matches!(error, LabelManagerError::WalletNotSelected));
+        Database::global()
+            .global_config
+            .clear_selected_wallet()
+            .expect("selected wallet is cleared");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn parsed_label_import_accepts_selected_wallet() {
+        let _guard = SELECTED_WALLET_TEST_LOCK.lock().expect("test lock is acquired");
+        cove_tokio::init();
+        crate::database::test_support::init_test_database();
+
+        let (manager, _tmp) = test_manager();
+        Database::global()
+            .global_config
+            .select_wallet(manager.db.id.clone())
+            .expect("selected wallet is set");
+
+        manager
+            ._import_labels(sample_bip329_labels())
+            .expect("import into selected wallet succeeds");
+
+        assert!(manager.db.labels.number_of_labels().expect("labels count loads") > 0);
+        Database::global()
+            .global_config
+            .clear_selected_wallet()
+            .expect("selected wallet is cleared");
     }
 }

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -187,81 +187,9 @@ impl LabelManager {
     }
 
     pub fn delete_labels_for_txn(&self, tx_id: Arc<TxId>) -> Result<(), LabelManagerError> {
-        self.delete_labels_for_txn_without_cloud_backup_dirty(tx_id)?;
-        self.mark_cloud_backup_dirty();
-
-        Ok(())
-    }
-
-    fn delete_labels_for_txn_without_cloud_backup_dirty(
-        &self,
-        tx_id: Arc<TxId>,
-    ) -> Result<(), LabelManagerError> {
-        let Some(txn_label) =
-            self.db.labels.get_txn_label_record(tx_id.0).map_err_str(LabelManagerError::Get)?
-        else {
-            return Ok(());
-        };
-
-        let txn_label_created_at = txn_label.timestamps.created_at;
-        let txn_label_text = txn_label.item.label.clone();
-
-        let input_records = self
-            .db
-            .labels
-            .txn_input_records_iter(tx_id.0)
-            .map_err_str(LabelManagerError::GetInputRecords)?;
-
-        let output_records = self
-            .db
-            .labels
-            .txn_output_records_iter(tx_id.0)
-            .map_err_str(LabelManagerError::GetOutputRecords)?;
-
-        // create list of labels to delete
-        let mut labels_to_delete = vec![Label::from(txn_label.item)];
-        let mut lock_only_records = Vec::new();
-
-        // only delete the input record if it hasn't changed since being created with the txn label
-        for record in input_records {
-            if txn_label_created_at == record.timestamps.created_at
-                && txn_label_created_at == record.timestamps.updated_at
-            {
-                labels_to_delete.push(Label::from(record.item));
-            }
+        if self.delete_labels_for_txn_without_cloud_backup_dirty(tx_id)? {
+            self.mark_cloud_backup_dirty();
         }
-
-        // only delete the output record if it still has the txn-label generated output label
-        for record in output_records {
-            if txn_label_created_at != record.timestamps.created_at
-                || !is_auto_output_label(txn_label_text.as_deref(), record.item.label.as_deref())
-            {
-                continue;
-            }
-
-            if record.item.spendable {
-                labels_to_delete.push(Label::from(record.item));
-            } else {
-                labels_to_delete.push(Label::from(record.item.clone()));
-
-                let mut item = record.item;
-                item.label = None;
-
-                let mut timestamps = record.timestamps;
-                timestamps.updated_at = jiff::Timestamp::now().as_second() as u64;
-                lock_only_records.push(Record::with_timestamps(Label::from(item), timestamps));
-            }
-        }
-
-        self.db
-            .labels
-            .delete_labels(labels_to_delete)
-            .map_err_str(LabelManagerError::DeleteLabels)?;
-
-        self.db
-            .labels
-            .insert_records(lock_only_records)
-            .map_err_str(LabelManagerError::SaveOutputLabels)?;
 
         Ok(())
     }
@@ -354,6 +282,79 @@ impl LabelManager {
         jsonl: &str,
     ) -> Result<(), LabelManagerError> {
         self.save_imported_labels(parse_labels(jsonl)?, false)
+    }
+
+    fn delete_labels_for_txn_without_cloud_backup_dirty(
+        &self,
+        tx_id: Arc<TxId>,
+    ) -> Result<bool, LabelManagerError> {
+        let Some(txn_label) =
+            self.db.labels.get_txn_label_record(tx_id.0).map_err_str(LabelManagerError::Get)?
+        else {
+            return Ok(false);
+        };
+
+        let txn_label_created_at = txn_label.timestamps.created_at;
+        let txn_label_text = txn_label.item.label.clone();
+
+        let input_records = self
+            .db
+            .labels
+            .txn_input_records_iter(tx_id.0)
+            .map_err_str(LabelManagerError::GetInputRecords)?;
+
+        let output_records = self
+            .db
+            .labels
+            .txn_output_records_iter(tx_id.0)
+            .map_err_str(LabelManagerError::GetOutputRecords)?;
+
+        // collect txn-generated labels to delete while preserving lock-only output records
+        let mut labels_to_delete = vec![Label::from(txn_label.item)];
+        let mut lock_only_records = Vec::new();
+
+        // only delete the input record if it hasn't changed since being created with the txn label
+        for record in input_records {
+            if txn_label_created_at == record.timestamps.created_at
+                && txn_label_created_at == record.timestamps.updated_at
+            {
+                labels_to_delete.push(Label::from(record.item));
+            }
+        }
+
+        // only delete output labels that were still generated from the txn label
+        for record in output_records {
+            if txn_label_created_at != record.timestamps.created_at
+                || !is_auto_output_label(txn_label_text.as_deref(), record.item.label.as_deref())
+            {
+                continue;
+            }
+
+            if record.item.spendable {
+                labels_to_delete.push(Label::from(record.item));
+            } else {
+                labels_to_delete.push(Label::from(record.item.clone()));
+
+                let mut item = record.item;
+                item.label = None;
+
+                let mut timestamps = record.timestamps;
+                timestamps.updated_at = jiff::Timestamp::now().as_second() as u64;
+                lock_only_records.push(Record::with_timestamps(Label::from(item), timestamps));
+            }
+        }
+
+        self.db
+            .labels
+            .delete_labels(labels_to_delete)
+            .map_err_str(LabelManagerError::DeleteLabels)?;
+
+        self.db
+            .labels
+            .insert_records(lock_only_records)
+            .map_err_str(LabelManagerError::SaveOutputLabels)?;
+
+        Ok(true)
     }
 
     fn save_imported_labels(
@@ -726,7 +727,7 @@ mod tests {
         insert_or_update_auto_labels(&manager, &details, "first");
         set_output_spendable(&manager, outpoint, false);
 
-        manager
+        let changed = manager
             .delete_labels_for_txn_without_cloud_backup_dirty(Arc::new(tx_id))
             .expect("failed to delete labels");
 
@@ -738,9 +739,22 @@ mod tests {
             .expect("missing output")
             .item;
 
+        assert!(changed);
         assert_eq!(output.label, None);
         assert!(!output.spendable);
         assert!(manager.db.labels.get_txn_label_record(tx_id.0).unwrap().is_none());
+    }
+
+    #[test]
+    fn deleting_missing_transaction_label_reports_no_change() {
+        let (manager, _tmp) = test_manager();
+        let tx_id = TxId::preview_new();
+
+        let changed = manager
+            .delete_labels_for_txn_without_cloud_backup_dirty(Arc::new(tx_id))
+            .expect("missing txn delete should succeed");
+
+        assert!(!changed);
     }
 
     #[test]

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -794,7 +794,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn parsed_label_import_rejects_unselected_wallet() {
         let _guard = SELECTED_WALLET_TEST_LOCK.lock().expect("test lock is acquired");
-        cove_tokio::init();
+        crate::test_support::ensure_tokio_runtime();
         crate::database::test_support::init_test_database();
 
         let selected_wallet = WalletId::preview_new_random();
@@ -818,7 +818,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn parsed_label_import_accepts_selected_wallet() {
         let _guard = SELECTED_WALLET_TEST_LOCK.lock().expect("test lock is acquired");
-        cove_tokio::init();
+        crate::test_support::ensure_tokio_runtime();
         crate::database::test_support::init_test_database();
 
         let (manager, _tmp) = test_manager();

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -333,21 +333,25 @@ impl LabelManager {
             if txn_label_created_at != record.timestamps.created_at
                 || !is_auto_output_label(txn_label_text.as_deref(), record.item.label.as_deref())
             {
+                // skip output labels that were changed independently
                 continue;
             }
 
             if record.item.spendable {
                 labels_to_delete.push(Label::from(record.item));
-            } else {
-                labels_to_delete.push(Label::from(record.item.clone()));
 
-                let mut item = record.item;
-                item.label = None;
-
-                let mut timestamps = record.timestamps;
-                timestamps.updated_at = jiff::Timestamp::now().as_second() as u64;
-                lock_only_records.push(Record::with_timestamps(Label::from(item), timestamps));
+                // spendable outputs do not need a lock-only replacement record
+                continue;
             }
+
+            labels_to_delete.push(Label::from(record.item.clone()));
+
+            let mut item = record.item;
+            item.label = None;
+
+            let mut timestamps = record.timestamps;
+            timestamps.updated_at = jiff::Timestamp::now().as_second() as u64;
+            lock_only_records.push(Record::with_timestamps(Label::from(item), timestamps));
         }
 
         self.db

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 
 use ahash::AHashMap as HashMap;
-use bip329::{AddressRecord, InputRecord, Label, Labels, OutputRecord, TransactionRecord};
+use bip329::{
+    AddressRecord, InputRecord, Label, Labels, OutputRecord, ParsedLabels, TransactionRecord,
+};
+use bitcoin::OutPoint;
 use cove_types::{TxId, confirm::QrDensity};
 
 #[derive(Debug, Clone, uniffi::Object)]
@@ -153,7 +156,12 @@ impl LabelManager {
         // if it's a new transaction, we need to insert input and output labels for each
         if let InsertOrUpdate::Insert(now) = insert_or_update {
             let input_labels = input_records_iter.map(Into::into).collect::<Vec<Label>>();
-            let output_labels = output_records_iter.map(Into::into).collect::<Vec<Label>>();
+            let output_labels = self
+                .preserve_output_spendability(output_records_iter)
+                .map_err_str(LabelManagerError::GetOutputRecords)?
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<Label>>();
             let timestamps = Timestamps::new(now.into(), now.into());
 
             self.db
@@ -179,6 +187,16 @@ impl LabelManager {
     }
 
     pub fn delete_labels_for_txn(&self, tx_id: Arc<TxId>) -> Result<(), LabelManagerError> {
+        self.delete_labels_for_txn_without_cloud_backup_dirty(tx_id)?;
+        self.mark_cloud_backup_dirty();
+
+        Ok(())
+    }
+
+    fn delete_labels_for_txn_without_cloud_backup_dirty(
+        &self,
+        tx_id: Arc<TxId>,
+    ) -> Result<(), LabelManagerError> {
         let Some(txn_label) =
             self.db.labels.get_txn_label_record(tx_id.0).map_err_str(LabelManagerError::Get)?
         else {
@@ -186,6 +204,7 @@ impl LabelManager {
         };
 
         let txn_label_created_at = txn_label.timestamps.created_at;
+        let txn_label_text = txn_label.item.label.clone();
 
         let input_records = self
             .db
@@ -201,6 +220,7 @@ impl LabelManager {
 
         // create list of labels to delete
         let mut labels_to_delete = vec![Label::from(txn_label.item)];
+        let mut lock_only_records = Vec::new();
 
         // only delete the input record if it hasn't changed since being created with the txn label
         for record in input_records {
@@ -211,12 +231,25 @@ impl LabelManager {
             }
         }
 
-        // only delete the output record if it hasn't changed since being created with the txn label
+        // only delete the output record if it still has the txn-label generated output label
         for record in output_records {
-            if txn_label_created_at == record.timestamps.created_at
-                && txn_label_created_at == record.timestamps.updated_at
+            if txn_label_created_at != record.timestamps.created_at
+                || !is_auto_output_label(txn_label_text.as_deref(), record.item.label.as_deref())
             {
+                continue;
+            }
+
+            if record.item.spendable {
                 labels_to_delete.push(Label::from(record.item));
+            } else {
+                labels_to_delete.push(Label::from(record.item.clone()));
+
+                let mut item = record.item;
+                item.label = None;
+
+                let mut timestamps = record.timestamps;
+                timestamps.updated_at = jiff::Timestamp::now().as_second() as u64;
+                lock_only_records.push(Record::with_timestamps(Label::from(item), timestamps));
             }
         }
 
@@ -225,7 +258,10 @@ impl LabelManager {
             .delete_labels(labels_to_delete)
             .map_err_str(LabelManagerError::DeleteLabels)?;
 
-        self.mark_cloud_backup_dirty();
+        self.db
+            .labels
+            .insert_records(lock_only_records)
+            .map_err_str(LabelManagerError::SaveOutputLabels)?;
 
         Ok(())
     }
@@ -233,7 +269,7 @@ impl LabelManager {
     #[uniffi::method(name = "importLabels")]
     pub fn _import_labels(&self, labels: Arc<Bip329Labels>) -> Result<(), LabelManagerError> {
         let labels = Arc::unwrap_or_clone(labels);
-        self.import_labels(labels.0)
+        self.save_imported_labels(labels.parsed, true)
     }
 
     pub fn import(&self, jsonl: &str) -> Result<(), LabelManagerError> {
@@ -299,8 +335,18 @@ impl LabelManager {
         Ok(Self { db })
     }
 
-    pub fn import_labels(&self, labels: impl Into<Labels>) -> Result<(), LabelManagerError> {
-        self.save_imported_labels(labels.into(), true)
+    pub(crate) fn set_output_spendability_for_outpoints(
+        &self,
+        outpoints: Vec<OutPoint>,
+        spendable: bool,
+    ) -> Result<()> {
+        self.db
+            .labels
+            .set_output_spendability_for_outpoints(outpoints, spendable)
+            .map_err_str(LabelManagerError::SaveOutputLabels)?;
+        self.mark_cloud_backup_dirty();
+
+        Ok(())
     }
 
     pub(crate) fn import_without_cloud_backup_dirty(
@@ -312,10 +358,10 @@ impl LabelManager {
 
     fn save_imported_labels(
         &self,
-        labels: Labels,
+        parsed: ParsedLabels,
         mark_cloud_backup_dirty: bool,
     ) -> Result<(), LabelManagerError> {
-        self.db.labels.insert_labels(labels).map_err_str(LabelManagerError::Save)?;
+        self.db.labels.insert_imported_labels(parsed).map_err_str(LabelManagerError::Save)?;
         if mark_cloud_backup_dirty {
             self.mark_cloud_backup_dirty();
         }
@@ -363,17 +409,18 @@ impl LabelManager {
             }
         });
 
-        let output_records = new_output_records_iter.into_iter().map(|record| {
+        let output_records = new_output_records_iter.into_iter().map(|mut record| {
             let vout = record.ref_.vout;
-            let label: Label = record.into();
 
             match current_output_records.remove(&vout) {
                 Some(current) => {
+                    record.spendable = current.item.spendable;
+                    let label: Label = record.into();
                     let mut timestamps = current.timestamps;
                     timestamps.updated_at = jiff::Timestamp::now().as_second() as u64;
                     Record::with_timestamps(label, timestamps)
                 }
-                None => Record::new(label),
+                None => Record::new(Label::from(record)),
             }
         });
 
@@ -470,6 +517,21 @@ impl LabelManager {
         Ok(InsertOrUpdate::Insert(now.into()))
     }
 
+    fn preserve_output_spendability(
+        &self,
+        records: impl Iterator<Item = OutputRecord>,
+    ) -> std::result::Result<Vec<OutputRecord>, crate::database::wallet_data::label::Error> {
+        records
+            .map(|mut record| {
+                if let Some(current) = self.db.labels.get_output_record(record.ref_)? {
+                    record.spendable = current.item.spendable;
+                }
+
+                Ok(record)
+            })
+            .collect()
+    }
+
     // create input labels for a transaction to match sparrow auto-generated input labels
     fn create_input_records(
         &self,
@@ -524,6 +586,168 @@ impl LabelManager {
     }
 }
 
-fn parse_labels(jsonl: &str) -> Result<Labels, LabelManagerError> {
-    Labels::try_from_str(jsonl).map_err_str(LabelManagerError::Parse)
+fn parse_labels(jsonl: &str) -> Result<ParsedLabels, LabelManagerError> {
+    Labels::try_from_str_with_metadata(jsonl).map_err_str(LabelManagerError::Parse)
+}
+
+fn is_auto_output_label(txn_label: Option<&str>, output_label: Option<&str>) -> bool {
+    let (Some(txn_label), Some(output_label)) = (txn_label, output_label) else {
+        return false;
+    };
+
+    output_label == format!("{txn_label} (received)")
+        || output_label == format!("{txn_label} (change)")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        database::wallet_data::test_support::new_test_wallet_data_db,
+        transaction::TransactionDetails, wallet::metadata::WalletId,
+    };
+
+    use super::*;
+
+    fn test_manager() -> (LabelManager, tempfile::TempDir) {
+        let (db, tmp) = new_test_wallet_data_db(WalletId::preview_new());
+
+        (LabelManager { db }, tmp)
+    }
+
+    fn received_details_with_output(vout: u32) -> TransactionDetails {
+        let mut details = TransactionDetails::preview_confirmed_received();
+        details.output_indexes = vec![vout];
+        details
+    }
+
+    fn set_output_spendable(manager: &LabelManager, outpoint: bitcoin::OutPoint, spendable: bool) {
+        let mut record = manager
+            .db
+            .labels
+            .get_output_record(outpoint)
+            .expect("failed to get output record")
+            .expect("missing output record");
+        record.item.spendable = spendable;
+
+        manager
+            .db
+            .labels
+            .insert_label_with_timestamps(record.item, record.timestamps)
+            .expect("failed to update output record");
+    }
+
+    fn insert_or_update_auto_labels(
+        manager: &LabelManager,
+        details: &TransactionDetails,
+        label: &str,
+    ) {
+        let tx_id = details.tx_id;
+        let insert_or_update = manager
+            .insert_or_update_transaction_label(&tx_id, label.to_string(), None)
+            .expect("failed to insert transaction label");
+        let input_records = manager.create_input_records(
+            &tx_id,
+            label,
+            &details.input_indexes,
+            details.sent_and_received.direction,
+        );
+        let output_records = manager.create_output_records(
+            &tx_id,
+            label,
+            &details.output_indexes,
+            details.sent_and_received.direction,
+        );
+
+        match insert_or_update {
+            InsertOrUpdate::Insert(now) => {
+                let now = now.into();
+                let timestamps = Timestamps::new(now, now);
+                let input_labels = input_records.into_iter().map(Label::from).collect::<Vec<_>>();
+                let output_labels = manager
+                    .preserve_output_spendability(output_records.into_iter())
+                    .expect("failed to preserve output spendability")
+                    .into_iter()
+                    .map(Label::from)
+                    .collect::<Vec<_>>();
+
+                manager
+                    .db
+                    .labels
+                    .insert_labels_with_timestamps(input_labels, timestamps)
+                    .expect("failed to insert input labels");
+                manager
+                    .db
+                    .labels
+                    .insert_labels_with_timestamps(output_labels, timestamps)
+                    .expect("failed to insert output labels");
+            }
+            InsertOrUpdate::Update(_) => manager
+                .update_labels_for_txn(
+                    &tx_id,
+                    input_records.into_iter(),
+                    output_records.into_iter(),
+                )
+                .expect("failed to update labels"),
+        }
+    }
+
+    #[test]
+    fn editing_transaction_label_preserves_existing_output_spendability() {
+        let (manager, _tmp) = test_manager();
+        let details = received_details_with_output(0);
+        let outpoint = bitcoin::OutPoint { txid: details.tx_id.0, vout: 0 };
+
+        insert_or_update_auto_labels(&manager, &details, "first");
+        set_output_spendable(&manager, outpoint, false);
+
+        insert_or_update_auto_labels(&manager, &details, "second");
+
+        let output = manager
+            .db
+            .labels
+            .get_output_record(outpoint)
+            .expect("failed to get output")
+            .expect("missing output")
+            .item;
+
+        assert_eq!(output.label, Some("second (received)".to_string()));
+        assert!(!output.spendable);
+    }
+
+    #[test]
+    fn deleting_transaction_label_preserves_locked_auto_output_as_lock_only_record() {
+        let (manager, _tmp) = test_manager();
+        let details = received_details_with_output(0);
+        let tx_id = details.tx_id;
+        let outpoint = bitcoin::OutPoint { txid: tx_id.0, vout: 0 };
+
+        insert_or_update_auto_labels(&manager, &details, "first");
+        set_output_spendable(&manager, outpoint, false);
+
+        manager
+            .delete_labels_for_txn_without_cloud_backup_dirty(Arc::new(tx_id))
+            .expect("failed to delete labels");
+
+        let output = manager
+            .db
+            .labels
+            .get_output_record(outpoint)
+            .expect("failed to get output")
+            .expect("missing output")
+            .item;
+
+        assert_eq!(output.label, None);
+        assert!(!output.spendable);
+        assert!(manager.db.labels.get_txn_label_record(tx_id.0).unwrap().is_none());
+    }
+
+    #[test]
+    fn auto_output_label_detection_rejects_user_edited_labels() {
+        assert!(is_auto_output_label(Some("original"), Some("original (received)")));
+        assert!(is_auto_output_label(Some("original"), Some("original (change)")));
+        assert!(!is_auto_output_label(Some("original"), Some("custom label")));
+        assert!(!is_auto_output_label(Some("original"), None));
+    }
 }

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -352,13 +352,8 @@ impl LabelManager {
 
         self.db
             .labels
-            .delete_labels(labels_to_delete)
+            .delete_labels_and_insert_records(labels_to_delete, lock_only_records)
             .map_err_str(LabelManagerError::DeleteLabels)?;
-
-        self.db
-            .labels
-            .insert_records(lock_only_records)
-            .map_err_str(LabelManagerError::SaveOutputLabels)?;
 
         Ok(true)
     }

--- a/rust/src/label_manager.rs
+++ b/rust/src/label_manager.rs
@@ -611,7 +611,7 @@ mod tests {
     use super::*;
 
     fn test_manager() -> (LabelManager, tempfile::TempDir) {
-        let (db, tmp) = new_test_wallet_data_db(WalletId::preview_new());
+        let (db, tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
 
         (LabelManager { db }, tmp)
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -31,6 +31,9 @@
 
 mod database;
 
+#[cfg(test)]
+mod test_support;
+
 mod app;
 mod bootstrap;
 mod router;

--- a/rust/src/manager/cloud_backup_manager/actors/write/worker.rs
+++ b/rust/src/manager/cloud_backup_manager/actors/write/worker.rs
@@ -126,7 +126,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn delete_active_wallet_fails_closed_when_listing_is_missing() {
         let _guard = async_test_lock().lock().await;
-        cove_tokio::init();
+        crate::test_support::ensure_tokio_runtime();
         let globals = test_globals();
         globals.cloud.reset();
 

--- a/rust/src/manager/cloud_backup_manager/ops/test_support.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/test_support.rs
@@ -829,27 +829,7 @@ impl TestGlobals {
 }
 
 pub(crate) fn ensure_cloud_backup_test_tokio_runtime() {
-    static INIT: OnceLock<()> = OnceLock::new();
-    INIT.get_or_init(|| {
-        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
-        std::thread::Builder::new()
-            .name("cloud-backup-test-tokio".into())
-            .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("create cloud backup test tokio runtime");
-
-                let drive_runtime = tokio::runtime::Runtime::block_on;
-                drive_runtime(&runtime, async move {
-                    cove_tokio::init();
-                    sender.send(()).expect("signal cloud backup test tokio runtime");
-                    std::future::pending::<()>().await;
-                });
-            })
-            .expect("spawn cloud backup test tokio runtime thread");
-        receiver.recv().expect("wait for cloud backup test tokio runtime");
-    });
+    crate::test_support::ensure_tokio_runtime();
 }
 
 pub(crate) fn test_globals() -> &'static TestGlobals {

--- a/rust/src/manager/cloud_backup_manager/ops/tests.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/tests.rs
@@ -1014,10 +1014,15 @@ async fn restore_downloaded_wallet_restores_labels_without_marking_cloud_backup_
     let manager = init_manager();
     configure_enabled_cloud_backup(&manager, globals, 5);
 
+    let locked_output_ref = "d97bf8892657980426c879e4ab2001f09342f1ab61cfa602741a7715a3d60290:0";
+    let labels_jsonl = format!(
+        "{}\n{{\"type\":\"output\",\"ref\":\"{locked_output_ref}\",\"spendable\":false}}",
+        sample_labels_jsonl()
+    );
     let metadata = xpub_only_wallet_metadata();
     let wallet = DownloadedWalletBackup {
         metadata: metadata.clone(),
-        entry: wallet_entry_with_labels(&metadata, Some(sample_labels_jsonl())),
+        entry: wallet_entry_with_labels(&metadata, Some(&labels_jsonl)),
     };
 
     let outcome =
@@ -1035,6 +1040,8 @@ async fn restore_downloaded_wallet_restores_labels_without_marking_cloud_backup_
 
     let exported = LabelManager::new(metadata.id.clone()).export().await.unwrap();
     assert!(exported.contains("\"label\":\"last txn received\""));
+    assert!(exported.contains(&format!("\"ref\":\"{locked_output_ref}\"")));
+    assert!(exported.contains("\"spendable\":false"));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -13,6 +13,7 @@ use cove_types::{
     unit::BitcoinUnit,
     utxo::{Utxo, UtxoType},
 };
+use cove_util::result_ext::ResultExt as _;
 use parking_lot::Mutex;
 
 use crate::{
@@ -142,7 +143,8 @@ impl RustCoinControlManager {
         let wallet_id = self.state.lock().wallet_id.clone();
         let outpoint = bitcoin::OutPoint::from(outpoint.as_ref());
 
-        LabelManager::new(wallet_id)
+        LabelManager::try_new(wallet_id)
+            .map_err_str(LabelManagerError::SaveOutputLabels)?
             .set_output_spendability_for_outpoints(vec![outpoint], spendable)?;
 
         self.reload_labels().await;

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -54,6 +54,7 @@ pub enum CoinControlManagerReconcileMessage {
     UpdateSearch(String),
     UpdateSelectedUtxos { utxos: Vec<Arc<OutPoint>>, total_value: Arc<Amount> },
     UpdateUnit(BitcoinUnit),
+    UpdateLockStateLoadFailed(bool),
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
@@ -87,8 +88,13 @@ impl RustCoinControlManager {
     }
 
     #[uniffi::method]
+    pub fn lock_state_load_failed(&self) -> bool {
+        self.state.lock().lock_state_load_failed
+    }
+
+    #[uniffi::method]
     pub async fn reload_labels(&self) {
-        let (utxos, selected_utxos, total_value) = {
+        let (utxos, selected_utxos, total_value, lock_state_load_failed) = {
             let mut state = self.state.lock();
 
             let old_utxos_hash = {
@@ -96,10 +102,12 @@ impl RustCoinControlManager {
                 state.utxos.hash(&mut hasher);
                 hasher.finish()
             };
+            let old_lock_state_load_failed = state.lock_state_load_failed;
 
             let selection_changed = state.load_utxo_labels();
 
             let new_utxos = state.utxos.clone();
+            let lock_state_load_failed = state.lock_state_load_failed;
 
             let new_utxos_hash = {
                 let mut hasher = DefaultHasher::new();
@@ -107,19 +115,25 @@ impl RustCoinControlManager {
                 hasher.finish()
             };
 
-            if old_utxos_hash == new_utxos_hash && !selection_changed {
+            if old_utxos_hash == new_utxos_hash
+                && !selection_changed
+                && old_lock_state_load_failed == lock_state_load_failed
+            {
                 return;
             }
 
             let selected_utxos = state.selected_utxos.clone();
             let total_value = total_value_of_spendable_utxos(&new_utxos, &selected_utxos).into();
 
-            (new_utxos, selected_utxos, total_value)
+            (new_utxos, selected_utxos, total_value, lock_state_load_failed)
         };
 
         self.reconciler.send_async(Message::UpdateUtxos(utxos)).await;
         self.reconciler
             .send_async(Message::UpdateSelectedUtxos { utxos: selected_utxos, total_value })
+            .await;
+        self.reconciler
+            .send_async(Message::UpdateLockStateLoadFailed(lock_state_load_failed))
             .await;
     }
 
@@ -147,12 +161,15 @@ impl RustCoinControlManager {
 
     #[uniffi::method]
     pub fn selected_utxos(&self) -> Vec<Utxo> {
+        let state = self.state.lock();
         let selected_utxos_ids: HashSet<Arc<OutPoint>> =
-            self.state.lock().selected_utxos.iter().cloned().collect();
+            state.selected_utxos.iter().cloned().collect();
 
-        self.utxos()
-            .into_iter()
+        state
+            .utxos
+            .iter()
             .filter(|utxo| utxo.spendable && selected_utxos_ids.contains(&utxo.outpoint))
+            .cloned()
             .collect()
     }
 
@@ -248,7 +265,8 @@ impl RustCoinControlManager {
     }
 
     pub fn total_value_of_utxos(&self, selected_utxo_ids: &[Arc<OutPoint>]) -> Amount {
-        total_value_of_spendable_utxos(&self.utxos(), selected_utxo_ids)
+        let state = self.state.lock();
+        total_value_of_spendable_utxos(&state.utxos, selected_utxo_ids)
     }
 
     fn sort_button_pressed(self: Arc<Self>, sort_button_pressed: CoinControlListSortKey) {
@@ -313,19 +331,25 @@ impl RustCoinControlManager {
     }
 
     fn notify_selected_utxos_changed(self: Arc<Self>, selected_utxos: Vec<Arc<OutPoint>>) {
-        let spendable_outpoints = self
-            .utxos()
-            .into_iter()
-            .filter(|utxo| utxo.spendable)
-            .map(|utxo| utxo.outpoint)
-            .collect::<HashSet<_>>();
-        let selected_utxos = selected_utxos
-            .into_iter()
-            .filter(|outpoint| spendable_outpoints.contains(outpoint))
-            .collect::<Vec<_>>();
-        let total_value = self.total_value_of_utxos(&selected_utxos).into();
+        let (selected_utxos, total_value) = {
+            let mut state = self.state.lock();
+            let spendable_outpoints = state
+                .utxos
+                .iter()
+                .filter(|utxo| utxo.spendable)
+                .map(|utxo| utxo.outpoint.clone())
+                .collect::<HashSet<_>>();
+            let selected_utxos = selected_utxos
+                .into_iter()
+                .filter(|outpoint| spendable_outpoints.contains(outpoint))
+                .collect::<Vec<_>>();
+            let total_value = total_value_of_spendable_utxos(&state.utxos, &selected_utxos).into();
 
-        self.state.lock().selected_utxos = selected_utxos.clone();
+            state.selected_utxos = selected_utxos.clone();
+
+            (selected_utxos, total_value)
+        };
+
         self.reconciler.send(Message::UpdateSelectedUtxos { utxos: selected_utxos, total_value });
     }
 
@@ -485,6 +509,33 @@ mod tests {
         manager.clone().notify_selected_utxos_changed(vec![locked, unlocked.clone()]);
 
         assert_eq!(manager.state.lock().selected_utxos, vec![unlocked]);
+    }
+
+    #[test]
+    fn direct_selection_preserves_selected_utxos_outside_active_search() {
+        let manager = Arc::new(RustCoinControlManager::preview_new(2, 0));
+        let hidden = manager.state.lock().utxos[0].outpoint.clone();
+        let visible = manager.state.lock().utxos[1].outpoint.clone();
+        let expected_total = {
+            let mut state = manager.state.lock();
+            state.utxos[0].label = Some("outside active search".to_string());
+            state.utxos[1].label = Some("needle".to_string());
+            state.utxos[0].amount.as_sats() + state.utxos[1].amount.as_sats()
+        };
+
+        manager.clone().notify_search_changed("needle".to_string());
+
+        let visible_outpoints =
+            manager.utxos().into_iter().map(|utxo| utxo.outpoint).collect::<Vec<_>>();
+        assert_eq!(visible_outpoints, vec![visible.clone()]);
+
+        manager.clone().notify_selected_utxos_changed(vec![hidden.clone(), visible.clone()]);
+
+        let selected_utxos = manager.state.lock().selected_utxos.clone();
+
+        assert_eq!(selected_utxos, vec![hidden, visible]);
+        assert_eq!(manager.total_value_of_utxos(&selected_utxos).as_sats(), expected_total);
+        assert_eq!(manager.selected_utxos().len(), 2);
     }
 
     #[test]

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -16,6 +16,7 @@ use cove_types::{
 use parking_lot::Mutex;
 
 use crate::{
+    label_manager::{LabelManager, LabelManagerError},
     manager::deferred_sender::{self, DeferredSender},
     wallet::metadata::WalletMetadata,
 };
@@ -88,7 +89,7 @@ impl RustCoinControlManager {
 
     #[uniffi::method]
     pub async fn reload_labels(&self) {
-        let utxos = {
+        let (utxos, selected_utxos, total_value) = {
             let mut state = self.state.lock();
 
             let old_utxos_hash = {
@@ -97,7 +98,7 @@ impl RustCoinControlManager {
                 hasher.finish()
             };
 
-            state.load_utxo_labels();
+            let selection_changed = state.load_utxo_labels();
 
             let new_utxos = state.utxos.clone();
 
@@ -107,19 +108,42 @@ impl RustCoinControlManager {
                 hasher.finish()
             };
 
-            if old_utxos_hash == new_utxos_hash {
+            if old_utxos_hash == new_utxos_hash && !selection_changed {
                 return;
             }
 
-            new_utxos
+            let selected_utxos = state.selected_utxos.clone();
+            let total_value = total_value_of_spendable_utxos(&new_utxos, &selected_utxos).into();
+
+            (new_utxos, selected_utxos, total_value)
         };
 
         self.reconciler.send_async(Message::UpdateUtxos(utxos)).await;
+        self.reconciler
+            .send_async(Message::UpdateSelectedUtxos { utxos: selected_utxos, total_value })
+            .await;
     }
 
     #[uniffi::method]
     pub fn id(&self) -> WalletId {
         self.state.lock().wallet_id.clone()
+    }
+
+    #[uniffi::method]
+    pub async fn set_utxo_spendability(
+        &self,
+        outpoint: Arc<OutPoint>,
+        spendable: bool,
+    ) -> Result<(), LabelManagerError> {
+        let wallet_id = self.state.lock().wallet_id.clone();
+        let outpoint = bitcoin::OutPoint::from(outpoint.as_ref());
+
+        LabelManager::new(wallet_id)
+            .set_output_spendability_for_outpoints(vec![outpoint], spendable)?;
+
+        self.reload_labels().await;
+
+        Ok(())
     }
 
     #[uniffi::method]
@@ -129,7 +153,7 @@ impl RustCoinControlManager {
 
         self.utxos()
             .into_iter()
-            .filter(|utxo| selected_utxos_ids.contains(&utxo.outpoint))
+            .filter(|utxo| utxo.spendable && selected_utxos_ids.contains(&utxo.outpoint))
             .collect()
     }
 
@@ -225,16 +249,7 @@ impl RustCoinControlManager {
     }
 
     pub fn total_value_of_utxos(&self, selected_utxo_ids: &[Arc<OutPoint>]) -> Amount {
-        let selected_ids: HashSet<Arc<OutPoint>> = selected_utxo_ids.iter().cloned().collect();
-
-        let final_amount_sats = self
-            .utxos()
-            .into_iter()
-            .filter(|utxo| selected_ids.contains(&utxo.outpoint))
-            .map(|utxo| utxo.amount.as_sats())
-            .sum();
-
-        Amount::from_sat(final_amount_sats)
+        total_value_of_spendable_utxos(&self.utxos(), selected_utxo_ids)
     }
 
     fn sort_button_pressed(self: Arc<Self>, sort_button_pressed: CoinControlListSortKey) {
@@ -280,7 +295,11 @@ impl RustCoinControlManager {
         let old_selected_utxos = self.state.lock().selected_utxos.clone();
 
         let new_selected_utxos = if old_selected_utxos.is_empty() {
-            self.utxos().into_iter().map(|utxo| utxo.outpoint).collect()
+            self.utxos()
+                .into_iter()
+                .filter(|utxo| utxo.spendable)
+                .map(|utxo| utxo.outpoint)
+                .collect()
         } else {
             vec![]
         };
@@ -295,9 +314,20 @@ impl RustCoinControlManager {
     }
 
     fn notify_selected_utxos_changed(self: Arc<Self>, selected_utxos: Vec<Arc<OutPoint>>) {
+        let spendable_outpoints = self
+            .utxos()
+            .into_iter()
+            .filter(|utxo| utxo.spendable)
+            .map(|utxo| utxo.outpoint)
+            .collect::<HashSet<_>>();
+        let selected_utxos = selected_utxos
+            .into_iter()
+            .filter(|outpoint| spendable_outpoints.contains(outpoint))
+            .collect::<Vec<_>>();
         let total_value = self.total_value_of_utxos(&selected_utxos).into();
-        self.state.lock().selected_utxos = selected_utxos;
-        self.reconciler.send(Message::UpdateTotalSelectedAmount(total_value));
+
+        self.state.lock().selected_utxos = selected_utxos.clone();
+        self.reconciler.send(Message::UpdateSelectedUtxos { utxos: selected_utxos, total_value });
     }
 
     fn notify_search_changed(self: Arc<Self>, search: String) {
@@ -337,6 +367,167 @@ impl RustCoinControlManager {
             self.state.lock().sort = SortState::Inactive(sort);
             sender.queue(Message::ClearSort);
         }
+    }
+}
+
+fn total_value_of_spendable_utxos(utxos: &[Utxo], selected_utxo_ids: &[Arc<OutPoint>]) -> Amount {
+    let selected_ids: HashSet<Arc<OutPoint>> = selected_utxo_ids.iter().cloned().collect();
+
+    let final_amount_sats = utxos
+        .iter()
+        .filter(|utxo| utxo.spendable && selected_ids.contains(&utxo.outpoint))
+        .map(|utxo| utxo.amount.as_sats())
+        .sum();
+
+    Amount::from_sat(final_amount_sats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::wallet_data::test_support::new_test_wallet_data_db;
+    use bdk_wallet::{
+        KeychainKind,
+        chain::{BlockId, ChainPosition, ConfirmationBlockTime},
+    };
+    use bitcoin::{
+        BlockHash, CompressedPublicKey, OutPoint as BitcoinOutPoint, PrivateKey, ScriptBuf, TxOut,
+        Txid, hashes::Hash as _, secp256k1::SecretKey,
+    };
+
+    fn preview_manager_with_locked_first_utxo() -> Arc<RustCoinControlManager> {
+        let manager = Arc::new(RustCoinControlManager::preview_new(2, 0));
+        manager.state.lock().utxos[0].spendable = false;
+
+        manager
+    }
+
+    fn confirmed_position() -> ChainPosition<ConfirmationBlockTime> {
+        ChainPosition::Confirmed {
+            anchor: ConfirmationBlockTime {
+                block_id: BlockId { height: 1, hash: BlockHash::all_zeros() },
+                confirmation_time: 1,
+            },
+            transitively: None,
+        }
+    }
+
+    fn mainnet_script() -> ScriptBuf {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[1; 32]).expect("failed to create secret key");
+        let private_key = PrivateKey::new(secret_key, bitcoin::Network::Bitcoin);
+        let public_key = CompressedPublicKey::from_private_key(&secp, &private_key)
+            .expect("failed to create public key");
+
+        bitcoin::Address::p2wpkh(&public_key, bitcoin::Network::Bitcoin).script_pubkey()
+    }
+
+    fn local_output(
+        outpoint: BitcoinOutPoint,
+        chain_position: ChainPosition<ConfirmationBlockTime>,
+    ) -> LocalOutput {
+        LocalOutput {
+            outpoint,
+            txout: TxOut {
+                value: bitcoin::Amount::from_sat(1_000),
+                script_pubkey: mainnet_script(),
+            },
+            keychain: KeychainKind::External,
+            is_spent: false,
+            derivation_index: 0,
+            chain_position,
+        }
+    }
+
+    #[test]
+    fn load_utxo_labels_loads_spendability_and_prunes_locked_selection() {
+        let manager = RustCoinControlManager::preview_new(2, 0);
+        let wallet_id = manager.state.lock().wallet_id.clone();
+        let locked = manager.state.lock().utxos[0].outpoint.clone();
+        let unlocked = manager.state.lock().utxos[1].outpoint.clone();
+        let (wallet_db, _tmp) = new_test_wallet_data_db(wallet_id);
+
+        wallet_db
+            .labels
+            .set_output_spendability(bitcoin::OutPoint::from(locked.as_ref()), false)
+            .expect("failed to lock output");
+
+        {
+            let mut state = manager.state.lock();
+            state.selected_utxos = vec![locked.clone(), unlocked.clone()];
+            state.load_utxo_labels();
+        }
+
+        let state = manager.state.lock();
+
+        assert!(!state.utxos[0].spendable);
+        assert_eq!(state.selected_utxos, vec![unlocked]);
+    }
+
+    #[test]
+    fn select_all_skips_locked_utxos() {
+        let manager = preview_manager_with_locked_first_utxo();
+        let locked = manager.state.lock().utxos[0].outpoint.clone();
+
+        manager.clone().toggle_select_all();
+
+        let selected = manager.state.lock().selected_utxos.clone();
+        assert_eq!(selected.len(), 1);
+        assert!(!selected.contains(&locked));
+    }
+
+    #[test]
+    fn direct_selection_prunes_locked_utxos() {
+        let manager = preview_manager_with_locked_first_utxo();
+        let locked = manager.state.lock().utxos[0].outpoint.clone();
+        let unlocked = manager.state.lock().utxos[1].outpoint.clone();
+
+        manager.clone().notify_selected_utxos_changed(vec![locked, unlocked.clone()]);
+
+        assert_eq!(manager.state.lock().selected_utxos, vec![unlocked]);
+    }
+
+    #[test]
+    fn selected_total_excludes_locked_utxos() {
+        let manager = preview_manager_with_locked_first_utxo();
+        let locked = manager.state.lock().utxos[0].outpoint.clone();
+        let unlocked = manager.state.lock().utxos[1].outpoint.clone();
+        let unlocked_amount = manager.state.lock().utxos[1].amount.as_sats();
+
+        let total = manager.total_value_of_utxos(&[locked, unlocked]);
+
+        assert_eq!(total.as_sats(), unlocked_amount);
+    }
+
+    #[test]
+    fn pending_locked_output_appears_locked_after_confirmation() {
+        let metadata = WalletMetadata::preview_new();
+        let wallet_id = metadata.id.clone();
+        let outpoint = BitcoinOutPoint { txid: Txid::from_byte_array([3; 32]), vout: 0 };
+        let (wallet_db, _tmp) = new_test_wallet_data_db(wallet_id);
+
+        wallet_db
+            .labels
+            .set_output_spendability(outpoint, false)
+            .expect("failed to lock pending output");
+
+        let mut pending_state = State::new(
+            metadata.clone(),
+            vec![local_output(
+                outpoint,
+                ChainPosition::Unconfirmed { first_seen: Some(1), last_seen: Some(1) },
+            )],
+        );
+        pending_state.load_utxo_labels();
+
+        assert!(pending_state.utxos.is_empty());
+
+        let mut confirmed_state =
+            State::new(metadata, vec![local_output(outpoint, confirmed_position())]);
+        confirmed_state.load_utxo_labels();
+
+        assert_eq!(confirmed_state.utxos.len(), 1);
+        assert!(!confirmed_state.utxos[0].spendable);
     }
 }
 

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -53,7 +53,6 @@ pub enum CoinControlManagerReconcileMessage {
     UpdateUtxos(Vec<Utxo>),
     UpdateSearch(String),
     UpdateSelectedUtxos { utxos: Vec<Arc<OutPoint>>, total_value: Arc<Amount> },
-    UpdateTotalSelectedAmount(Arc<Amount>),
     UpdateUnit(BitcoinUnit),
 }
 

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -525,6 +525,19 @@ mod tests {
     }
 
     #[test]
+    fn selected_utxos_excludes_locked_utxos() {
+        let manager = preview_manager_with_locked_first_utxo();
+        let locked = manager.state.lock().utxos[0].outpoint.clone();
+        let unlocked = manager.state.lock().utxos[1].outpoint.clone();
+        manager.state.lock().selected_utxos = vec![locked, unlocked.clone()];
+
+        let selected = manager.selected_utxos();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].outpoint, unlocked);
+    }
+
+    #[test]
     fn direct_selection_preserves_selected_utxos_outside_active_search() {
         let manager = Arc::new(RustCoinControlManager::preview_new(2, 0));
         let hidden = manager.state.lock().utxos[0].outpoint.clone();

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -97,23 +97,14 @@ impl RustCoinControlManager {
         let (utxos, selected_utxos, total_value, lock_state_load_failed) = {
             let mut state = self.state.lock();
 
-            let old_utxos_hash = {
-                let mut hasher = DefaultHasher::new();
-                state.utxos.hash(&mut hasher);
-                hasher.finish()
-            };
+            let old_utxos_hash = hash_utxos(&state.utxos());
             let old_lock_state_load_failed = state.lock_state_load_failed;
 
             let selection_changed = state.load_utxo_labels();
 
-            let new_utxos = state.utxos.clone();
+            let new_utxos = state.utxos();
             let lock_state_load_failed = state.lock_state_load_failed;
-
-            let new_utxos_hash = {
-                let mut hasher = DefaultHasher::new();
-                new_utxos.hash(&mut hasher);
-                hasher.finish()
-            };
+            let new_utxos_hash = hash_utxos(&new_utxos);
 
             if old_utxos_hash == new_utxos_hash
                 && !selection_changed
@@ -123,7 +114,7 @@ impl RustCoinControlManager {
             }
 
             let selected_utxos = state.selected_utxos.clone();
-            let total_value = total_value_of_spendable_utxos(&new_utxos, &selected_utxos).into();
+            let total_value = total_value_of_spendable_utxos(&state.utxos, &selected_utxos).into();
 
             (new_utxos, selected_utxos, total_value, lock_state_load_failed)
         };
@@ -405,6 +396,12 @@ fn total_value_of_spendable_utxos(utxos: &[Utxo], selected_utxo_ids: &[Arc<OutPo
     Amount::from_sat(final_amount_sats)
 }
 
+fn hash_utxos(utxos: &[Utxo]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    utxos.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -489,6 +486,20 @@ mod tests {
     }
 
     #[test]
+    fn load_utxo_labels_fails_closed_when_wallet_database_cannot_open() {
+        let mut state = State::preview_new(2, 0);
+        state.wallet_id = WalletId::from("invalid\0wallet-id");
+        state.selected_utxos = vec![state.utxos[0].outpoint.clone()];
+
+        let selection_changed = state.load_utxo_labels();
+
+        assert!(selection_changed);
+        assert!(state.lock_state_load_failed);
+        assert!(state.selected_utxos.is_empty());
+        assert!(state.utxos.iter().all(|utxo| !utxo.spendable));
+    }
+
+    #[test]
     fn select_all_skips_locked_utxos() {
         let manager = preview_manager_with_locked_first_utxo();
         let locked = manager.state.lock().utxos[0].outpoint.clone();
@@ -548,6 +559,34 @@ mod tests {
         let total = manager.total_value_of_utxos(&[locked, unlocked]);
 
         assert_eq!(total.as_sats(), unlocked_amount);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reload_labels_preserves_active_search_results() {
+        let manager = Arc::new(RustCoinControlManager::preview_new(2, 0));
+        let wallet_id = manager.state.lock().wallet_id.clone();
+        let visible = manager.state.lock().utxos[1].outpoint.clone();
+        let search = visible.txid.to_string();
+        let (wallet_db, _tmp) = new_test_wallet_data_db(wallet_id);
+
+        manager.clone().notify_search_changed(search);
+        while manager.reconcile_receiver.try_recv().is_ok() {}
+
+        wallet_db
+            .labels
+            .set_output_spendability(bitcoin::OutPoint::from(visible.as_ref()), false)
+            .expect("failed to lock searched output");
+
+        manager.reload_labels().await;
+
+        let message = manager.reconcile_receiver.recv_async().await.expect("reconcile message");
+        let SingleOrMany::Single(Message::UpdateUtxos(utxos)) = message else {
+            panic!("expected utxo update");
+        };
+
+        assert_eq!(utxos.len(), 1);
+        assert_eq!(utxos[0].outpoint, visible);
+        assert!(!utxos[0].spendable);
     }
 
     #[test]

--- a/rust/src/manager/coin_control_manager.rs
+++ b/rust/src/manager/coin_control_manager.rs
@@ -452,14 +452,15 @@ mod tests {
             .set_output_spendability(bitcoin::OutPoint::from(locked.as_ref()), false)
             .expect("failed to lock output");
 
-        {
+        let selection_changed = {
             let mut state = manager.state.lock();
             state.selected_utxos = vec![locked.clone(), unlocked.clone()];
-            state.load_utxo_labels();
-        }
+            state.load_utxo_labels()
+        };
 
         let state = manager.state.lock();
 
+        assert!(selection_changed);
         assert!(!state.utxos[0].spendable);
         assert_eq!(state.selected_utxos, vec![unlocked]);
     }

--- a/rust/src/manager/coin_control_manager/state.rs
+++ b/rust/src/manager/coin_control_manager/state.rs
@@ -28,6 +28,7 @@ pub struct CoinControlManagerState {
     pub sort: SortState,
     pub selected_utxos: Vec<Arc<OutPoint>>,
     pub search: String,
+    pub lock_state_load_failed: bool,
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, uniffi::Object)]
@@ -48,6 +49,7 @@ impl State {
         let sort = SortState::default();
         let selected_utxos = vec![];
         let search = String::new();
+        let lock_state_load_failed = false;
 
         Self {
             wallet_id,
@@ -58,6 +60,7 @@ impl State {
             selected_utxos,
             search,
             filtered_utxos: FilteredUtxos::All,
+            lock_state_load_failed,
         }
     }
 
@@ -76,6 +79,10 @@ impl State {
             Err(error) => {
                 let wallet_id = &self.wallet_id;
                 error!("failed to open wallet label database wallet_id={wallet_id}: {error}");
+
+                self.lock_state_load_failed = true;
+
+                // fail closed so a lock-state read failure cannot make locked UTXOs selectable
                 for utxo in utxos {
                     utxo.spendable = false;
                 }
@@ -84,6 +91,7 @@ impl State {
             }
         };
         let labels_db = wallet_db.labels;
+        let mut lock_state_load_failed = false;
 
         for utxo in utxos.iter_mut() {
             let outpoint = bitcoin::OutPoint::from(utxo.outpoint.as_ref());
@@ -91,6 +99,9 @@ impl State {
                 Ok(record) => record,
                 Err(error) => {
                     error!("failed to load output lock state outpoint={outpoint}: {error}");
+                    lock_state_load_failed = true;
+
+                    // fail closed so a single read failure cannot make this output selectable
                     utxo.spendable = false;
                     utxo.label = None;
                     continue;
@@ -120,6 +131,8 @@ impl State {
             utxo.label = label;
             utxo.spendable = output_record.map(|record| record.item.spendable).unwrap_or(true);
         }
+
+        self.lock_state_load_failed = lock_state_load_failed;
 
         self.prune_locked_selected_utxos()
     }
@@ -286,7 +299,18 @@ impl CoinControlManagerState {
         let selected_utxos = vec![];
         let search = String::new();
         let filtered_utxos = FilteredUtxos::All;
+        let lock_state_load_failed = false;
 
-        Self { wallet_id, unit, network, utxos, filtered_utxos, sort, selected_utxos, search }
+        Self {
+            wallet_id,
+            unit,
+            network,
+            utxos,
+            filtered_utxos,
+            sort,
+            selected_utxos,
+            search,
+            lock_state_load_failed,
+        }
     }
 }

--- a/rust/src/manager/coin_control_manager/state.rs
+++ b/rust/src/manager/coin_control_manager/state.rs
@@ -87,7 +87,10 @@ impl State {
                     utxo.spendable = false;
                 }
 
-                return self.prune_locked_selected_utxos();
+                let selection_changed = self.prune_locked_selected_utxos();
+                self.refresh_search_results();
+
+                return selection_changed;
             }
         };
         let labels_db = wallet_db.labels;
@@ -134,7 +137,10 @@ impl State {
 
         self.lock_state_load_failed = lock_state_load_failed;
 
-        self.prune_locked_selected_utxos()
+        let selection_changed = self.prune_locked_selected_utxos();
+        self.refresh_search_results();
+
+        selection_changed
     }
 
     pub fn prune_locked_selected_utxos(&mut self) -> bool {
@@ -195,6 +201,16 @@ impl State {
         self.search = String::new();
         self.filtered_utxos = FilteredUtxos::All;
         self.sort_utxos(sort);
+    }
+
+    fn refresh_search_results(&mut self) {
+        if self.search.is_empty() {
+            self.filtered_utxos = FilteredUtxos::All;
+            return;
+        }
+
+        let search = self.search.clone();
+        self.filter_utxos(&search);
     }
 
     pub fn filter_utxos(&mut self, search: &str) {

--- a/rust/src/manager/coin_control_manager/state.rs
+++ b/rust/src/manager/coin_control_manager/state.rs
@@ -67,15 +67,17 @@ impl State {
         }
     }
 
-    pub fn load_utxo_labels(&mut self) {
+    pub fn load_utxo_labels(&mut self) -> bool {
         let utxos = &mut self.utxos;
 
         let Some(wallet_db) = WalletDataDb::new_or_existing(self.wallet_id.clone()).ok() else {
-            return;
+            return false;
         };
         let labels_db = wallet_db.labels;
 
         for utxo in utxos.iter_mut() {
+            let outpoint = bitcoin::OutPoint::from(utxo.outpoint.as_ref());
+            let output_record = labels_db.get_output_record(outpoint).ok().flatten();
             let label = labels_db
                 .get_txn_label_record(utxo.outpoint.txid)
                 .ok()
@@ -90,7 +92,24 @@ impl State {
                 });
 
             utxo.label = label;
+            utxo.spendable = output_record.map(|record| record.item.spendable).unwrap_or(true);
         }
+
+        self.prune_locked_selected_utxos()
+    }
+
+    pub fn prune_locked_selected_utxos(&mut self) -> bool {
+        let old_selected_utxos = self.selected_utxos.clone();
+        let spendable_outpoints = self
+            .utxos
+            .iter()
+            .filter(|utxo| utxo.spendable)
+            .map(|utxo| utxo.outpoint.clone())
+            .collect::<std::collections::HashSet<_>>();
+
+        self.selected_utxos.retain(|outpoint| spendable_outpoints.contains(outpoint));
+
+        self.selected_utxos != old_selected_utxos
     }
 
     pub fn sort_utxos(&mut self, sort: ListSort) {

--- a/rust/src/manager/coin_control_manager/state.rs
+++ b/rust/src/manager/coin_control_manager/state.rs
@@ -7,6 +7,7 @@ use cove_types::{
     unit::BitcoinUnit,
     utxo::{Utxo, UtxoType},
 };
+use tracing::error;
 
 use crate::{database::wallet_data::WalletDataDb, wallet::metadata::WalletMetadata};
 
@@ -70,26 +71,51 @@ impl State {
     pub fn load_utxo_labels(&mut self) -> bool {
         let utxos = &mut self.utxos;
 
-        let Some(wallet_db) = WalletDataDb::new_or_existing(self.wallet_id.clone()).ok() else {
-            return false;
+        let wallet_db = match WalletDataDb::new_or_existing(self.wallet_id.clone()) {
+            Ok(wallet_db) => wallet_db,
+            Err(error) => {
+                let wallet_id = &self.wallet_id;
+                error!("failed to open wallet label database wallet_id={wallet_id}: {error}");
+                for utxo in utxos {
+                    utxo.spendable = false;
+                }
+
+                return self.prune_locked_selected_utxos();
+            }
         };
         let labels_db = wallet_db.labels;
 
         for utxo in utxos.iter_mut() {
             let outpoint = bitcoin::OutPoint::from(utxo.outpoint.as_ref());
-            let output_record = labels_db.get_output_record(outpoint).ok().flatten();
-            let label = labels_db
-                .get_txn_label_record(utxo.outpoint.txid)
-                .ok()
-                .flatten()
-                .map(|record| record.item.label)
-                .unwrap_or_else(|| {
-                    labels_db
-                        .get_address_record(utxo.address.as_unchecked())
-                        .ok()
-                        .flatten()
-                        .and_then(|record| record.item.label)
-                });
+            let output_record = match labels_db.get_output_record(outpoint) {
+                Ok(record) => record,
+                Err(error) => {
+                    error!("failed to load output lock state outpoint={outpoint}: {error}");
+                    utxo.spendable = false;
+                    utxo.label = None;
+                    continue;
+                }
+            };
+
+            let txn_label = match labels_db.get_txn_label_record(utxo.outpoint.txid) {
+                Ok(record) => record.and_then(|record| record.item.label),
+                Err(error) => {
+                    let txid = utxo.outpoint.txid;
+                    error!("failed to load transaction label txid={txid}: {error}");
+                    None
+                }
+            };
+
+            let label = txn_label.or_else(|| {
+                match labels_db.get_address_record(utxo.address.as_unchecked()) {
+                    Ok(record) => record.and_then(|record| record.item.label),
+                    Err(error) => {
+                        let address = utxo.address.as_unchecked();
+                        error!("failed to load address label address={address:?}: {error}");
+                        None
+                    }
+                }
+            });
 
             utxo.label = label;
             utxo.spendable = output_record.map(|record| record.item.spendable).unwrap_or(true);

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -714,22 +714,6 @@ impl RustSendFlowManager {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn amount_exceeds_spendable_balance_uses_unlocked_balance() {
-        assert!(super::amount_exceeds_spendable_balance(Some(6_000), Some(5_000)));
-        assert!(!super::amount_exceeds_spendable_balance(Some(5_000), Some(5_000)));
-        assert!(!super::amount_exceeds_spendable_balance(Some(0), Some(0)));
-    }
-
-    #[test]
-    fn validation_spendable_balance_prefers_unlocked_balance_over_wallet_fallback() {
-        assert_eq!(super::spendable_balance_for_validation(Some(5_000), 10_000), 5_000);
-        assert_eq!(super::spendable_balance_for_validation(None, 10_000), 10_000);
-    }
-}
-
 // MARK: Private getters
 impl RustSendFlowManager {
     fn selected_fee_rate(&self) -> Option<Arc<FeeRateOptionWithTotalFee>> {
@@ -2039,5 +2023,21 @@ impl RustSendFlowManager {
         let mut state = self.state.lock();
         state.wallet_balance = Some(wallet_balance);
         state.unlocked_spendable_sats = Some(unlocked_spendable_sats);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn amount_exceeds_spendable_balance_uses_unlocked_balance() {
+        assert!(super::amount_exceeds_spendable_balance(Some(6_000), Some(5_000)));
+        assert!(!super::amount_exceeds_spendable_balance(Some(5_000), Some(5_000)));
+        assert!(!super::amount_exceeds_spendable_balance(Some(0), Some(0)));
+    }
+
+    #[test]
+    fn validation_spendable_balance_prefers_unlocked_balance_over_wallet_fallback() {
+        assert_eq!(super::spendable_balance_for_validation(Some(5_000), 10_000), 5_000);
+        assert_eq!(super::spendable_balance_for_validation(None, 10_000), 10_000);
     }
 }

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -61,6 +61,8 @@ type Reconciler = dyn SendFlowManagerReconciler;
 type SingleOrMany = deferred_sender::SingleOrMany<Message>;
 type DeferredSender = deferred_sender::DeferredSender<Message>;
 
+const LOCK_STATE_LOAD_FAILED_ERROR_ID: &str = "send_flow_lock_state_load_failed";
+
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
 pub enum SetAmountFocusField {
     Amount,
@@ -91,8 +93,9 @@ fn amount_exceeds_spendable_balance(amount: Option<u64>, spendable_balance: Opti
         return false;
     }
 
-    // fail closed when the unlocked balance cannot be loaded
-    let spendable = spendable_balance.unwrap_or(0);
+    let Some(spendable) = spendable_balance else {
+        return false;
+    };
 
     amount > spendable
 }
@@ -100,6 +103,28 @@ fn amount_exceeds_spendable_balance(amount: Option<u64>, spendable_balance: Opti
 fn spendable_balance_for_validation(unlocked_spendable_sats: Option<u64>) -> u64 {
     // fail closed so amount validation cannot overspend locked or unknown UTXOs
     unlocked_spendable_sats.unwrap_or(0)
+}
+
+fn unavailable_spendable_balance_alert(
+    unlocked_spendable_sats: Option<u64>,
+    lock_state_load_failed: bool,
+) -> Option<SendFlowAlertState> {
+    if lock_state_load_failed {
+        return Some(SendFlowAlertState::General {
+            title: "Unable to Read Locked Coins".to_string(),
+            message: "Cove could not read the lock state for this wallet. Locked coins are excluded for safety. Please try again shortly.".to_string(),
+        });
+    }
+
+    if unlocked_spendable_sats.is_none() {
+        return Some(SendFlowAlertState::General {
+            title: "Balance Still Loading".to_string(),
+            message: "Cove is still checking which coins are unlocked. Please try again shortly."
+                .to_string(),
+        });
+    }
+
+    None
 }
 
 #[uniffi::export(callback_interface)]
@@ -531,13 +556,30 @@ impl RustSendFlowManager {
             return false;
         }
 
-        let spendable_balance = {
+        let (spendable_balance, unavailable_balance_alert, is_max_selected) = {
             let state = self.state.lock();
-            spendable_balance_for_validation(state.unlocked_spendable_sats)
+            (
+                spendable_balance_for_validation(state.unlocked_spendable_sats),
+                unavailable_spendable_balance_alert(
+                    state.unlocked_spendable_sats,
+                    state.lock_state_load_failed,
+                ),
+                state.max_selected.is_some(),
+            )
         };
 
         if spendable_balance < amount {
-            let is_max_selected = self.state.lock().max_selected.is_some();
+            if let Some(alert) = unavailable_balance_alert {
+                let msg = Message::SetAlert(alert);
+                if display_alert {
+                    sender.queue(msg);
+                } else {
+                    debug!("validate_amount_failed: {msg:?}");
+                }
+
+                return false;
+            }
+
             if is_max_selected {
                 let me = self.clone();
                 cove_tokio::task::spawn(async move { me.select_max_send_report_error().await });
@@ -2006,13 +2048,25 @@ impl RustSendFlowManager {
         let unlocked_spendable_sats =
             self.wallet_manager.unlocked_spendable_balance().await.map(|amount| amount.as_sats());
         if let Err(error) = &unlocked_spendable_sats {
-            error!("failed to get unlocked spendable balance: {error}");
+            error!(
+                error_id = LOCK_STATE_LOAD_FAILED_ERROR_ID,
+                "failed to get unlocked spendable balance: {error}"
+            );
         }
 
         let wallet_balance = Arc::new(balance);
         let mut state = self.state.lock();
         state.wallet_balance = Some(wallet_balance);
-        state.unlocked_spendable_sats = unlocked_spendable_sats.ok();
+        match unlocked_spendable_sats {
+            Ok(unlocked_spendable_sats) => {
+                state.unlocked_spendable_sats = Some(unlocked_spendable_sats);
+                state.lock_state_load_failed = false;
+            }
+            Err(_) => {
+                state.unlocked_spendable_sats = None;
+                state.lock_state_load_failed = true;
+            }
+        }
     }
 }
 
@@ -2023,7 +2077,7 @@ mod tests {
         assert!(super::amount_exceeds_spendable_balance(Some(6_000), Some(5_000)));
         assert!(!super::amount_exceeds_spendable_balance(Some(5_000), Some(5_000)));
         assert!(!super::amount_exceeds_spendable_balance(Some(0), Some(0)));
-        assert!(super::amount_exceeds_spendable_balance(Some(1), None));
+        assert!(!super::amount_exceeds_spendable_balance(Some(1), None));
         assert!(!super::amount_exceeds_spendable_balance(Some(0), None));
     }
 
@@ -2031,5 +2085,26 @@ mod tests {
     fn validation_spendable_balance_uses_zero_when_unlocked_balance_is_unknown() {
         assert_eq!(super::spendable_balance_for_validation(Some(5_000)), 5_000);
         assert_eq!(super::spendable_balance_for_validation(None), 0);
+    }
+
+    #[test]
+    fn unavailable_balance_alert_distinguishes_lock_state_failures() {
+        let alert = super::unavailable_spendable_balance_alert(None, true);
+
+        assert!(matches!(
+            alert,
+            Some(super::SendFlowAlertState::General { title, .. }) if title.contains("Locked")
+        ));
+    }
+
+    #[test]
+    fn unavailable_balance_alert_distinguishes_loading_state() {
+        let alert = super::unavailable_spendable_balance_alert(None, false);
+
+        assert!(matches!(
+            alert,
+            Some(super::SendFlowAlertState::General { title, .. }) if title.contains("Loading")
+        ));
+        assert_eq!(super::unavailable_spendable_balance_alert(Some(5_000), false), None);
     }
 }

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -91,12 +91,14 @@ fn amount_exceeds_spendable_balance(amount: Option<u64>, spendable_balance: Opti
         return false;
     }
 
+    // fail closed when the unlocked balance cannot be loaded
     let spendable = spendable_balance.unwrap_or(0);
 
     amount > spendable
 }
 
 fn spendable_balance_for_validation(unlocked_spendable_sats: Option<u64>) -> u64 {
+    // fail closed so amount validation cannot overspend locked or unknown UTXOs
     unlocked_spendable_sats.unwrap_or(0)
 }
 

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -2072,6 +2072,34 @@ impl RustSendFlowManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        manager::{deferred_sender::SingleOrMany, wallet_manager::RustWalletManager},
+        wallet::{balance::Balance, metadata::WalletMetadata},
+    };
+    fn manager_for_validation() -> Arc<super::RustSendFlowManager> {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+
+        let (sender, receiver) = flume::bounded(50);
+        let balance = Arc::new(Balance::default());
+        let state = super::State::new(WalletMetadata::preview_new(), balance);
+        let wallet_manager = Arc::new(RustWalletManager::preview_new_wallet());
+
+        Arc::new(super::RustSendFlowManager {
+            app: super::App::global().clone(),
+            wallet_manager,
+            state: state.into_inner(),
+            reconciler: super::MessageSender::new(sender),
+            reconcile_receiver: Arc::new(receiver),
+            fee_check_task: super::DebouncedTask::new(
+                "fee_check",
+                super::Duration::from_millis(200),
+            ),
+        })
+    }
+
     #[test]
     fn amount_exceeds_spendable_balance_uses_unlocked_balance() {
         assert!(super::amount_exceeds_spendable_balance(Some(6_000), Some(5_000)));
@@ -2106,5 +2134,28 @@ mod tests {
             Some(super::SendFlowAlertState::General { title, .. }) if title.contains("Loading")
         ));
         assert_eq!(super::unavailable_spendable_balance_alert(Some(5_000), false), None);
+    }
+
+    #[test]
+    fn validate_amount_blocks_send_when_lock_state_load_failed() {
+        let manager = manager_for_validation();
+        {
+            let mut state = manager.state.lock();
+            state.amount_sats = Some(50_000);
+            state.unlocked_spendable_sats = None;
+            state.lock_state_load_failed = true;
+        }
+
+        assert!(!manager.validate_amount(true));
+
+        let message = manager.reconcile_receiver.try_recv().expect("alert is reconciled");
+        let SingleOrMany::Single(super::Message::SetAlert(alert)) = message else {
+            panic!("expected a single lock-state load failure alert");
+        };
+
+        assert!(matches!(
+            alert,
+            super::SendFlowAlertState::General { title, .. } if title.contains("Locked")
+        ));
     }
 }

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -85,6 +85,24 @@ fn selected_fee_rate_for_options(
     }
 }
 
+fn amount_exceeds_spendable_balance(amount: Option<u64>, spendable_balance: Option<u64>) -> bool {
+    let amount = amount.unwrap_or(0);
+    if amount == 0 {
+        return false;
+    }
+
+    let spendable = spendable_balance.unwrap_or(u64::MAX);
+
+    amount > spendable
+}
+
+fn spendable_balance_for_validation(
+    unlocked_spendable_sats: Option<u64>,
+    fallback_trusted_spendable_sats: u64,
+) -> u64 {
+    unlocked_spendable_sats.unwrap_or(fallback_trusted_spendable_sats)
+}
+
 #[uniffi::export(callback_interface)]
 pub trait SendFlowManagerReconciler: Send + Sync + std::fmt::Debug + 'static {
     /// tells the frontend to reconcile the manager changes
@@ -139,6 +157,7 @@ pub enum SendFlowManagerAction {
     SelectMaxSend,
     ClearSendAmount,
     ClearAddress,
+    RefreshWalletBalance,
 
     SetCoinControlMode(Vec<Utxo>),
     DisableCoinControlMode,
@@ -319,19 +338,9 @@ impl RustSendFlowManager {
 
     #[uniffi::method]
     pub fn amount_exceeds_balance(&self) -> bool {
-        let amount = self.state.lock().amount_sats.unwrap_or(0);
-        if amount == 0 {
-            return false;
-        }
+        let state = self.state.lock();
 
-        let spendable = self
-            .state
-            .lock()
-            .wallet_balance
-            .as_ref()
-            .map_or(u64::MAX, |b| b.trusted_spendable().to_sat());
-
-        amount > spendable
+        amount_exceeds_spendable_balance(state.amount_sats, state.unlocked_spendable_sats)
     }
 
     #[uniffi::method]
@@ -523,14 +532,16 @@ impl RustSendFlowManager {
             return false;
         }
 
-        let spendable_balance = self
-            .state
-            .lock()
-            .wallet_balance
-            .clone()
-            .unwrap_or_default()
-            .trusted_spendable()
-            .to_sat();
+        let spendable_balance = {
+            let state = self.state.lock();
+            let fallback_trusted_spendable_sats =
+                state.wallet_balance.clone().unwrap_or_default().trusted_spendable().to_sat();
+
+            spendable_balance_for_validation(
+                state.unlocked_spendable_sats,
+                fallback_trusted_spendable_sats,
+            )
+        };
 
         if spendable_balance < amount {
             let is_max_selected = self.state.lock().max_selected.is_some();
@@ -642,6 +653,14 @@ impl RustSendFlowManager {
 
             Action::ClearSendAmount => self.clear_send_amount(),
             Action::ClearAddress => self.clear_address(),
+            Action::RefreshWalletBalance => {
+                let me = self.clone();
+                cove_tokio::task::spawn(async move {
+                    me.get_wallet_balance().await;
+                    me.get_or_update_fee_rate_options().await;
+                    me.reconciler.send(Message::RefreshPresenters);
+                });
+            }
 
             Action::NotifySelectedUnitedChanged { old, new } => {
                 self.handle_selected_unit_changed(old, new);
@@ -692,6 +711,22 @@ impl RustSendFlowManager {
                 self.handle_coin_control_entered_amount_changed(amount, is_focused);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn amount_exceeds_spendable_balance_uses_unlocked_balance() {
+        assert!(super::amount_exceeds_spendable_balance(Some(6_000), Some(5_000)));
+        assert!(!super::amount_exceeds_spendable_balance(Some(5_000), Some(5_000)));
+        assert!(!super::amount_exceeds_spendable_balance(Some(0), Some(0)));
+    }
+
+    #[test]
+    fn validation_spendable_balance_prefers_unlocked_balance_over_wallet_fallback() {
+        assert_eq!(super::spendable_balance_for_validation(Some(5_000), 10_000), 5_000);
+        assert_eq!(super::spendable_balance_for_validation(None, 10_000), 10_000);
     }
 }
 
@@ -1991,7 +2026,18 @@ impl RustSendFlowManager {
 
     async fn get_wallet_balance(self: &Arc<Self>) {
         let balance = self.wallet_manager.balance().await;
+        let unlocked_spendable_sats = self
+            .wallet_manager
+            .unlocked_spendable_balance()
+            .await
+            .map(|amount| amount.as_sats())
+            .unwrap_or_else(|error| {
+                warn!("failed to get unlocked spendable balance: {error}");
+                balance.spendable().as_sats()
+            });
         let wallet_balance = Arc::new(balance);
-        self.state.lock().wallet_balance = Some(wallet_balance.clone());
+        let mut state = self.state.lock();
+        state.wallet_balance = Some(wallet_balance);
+        state.unlocked_spendable_sats = Some(unlocked_spendable_sats);
     }
 }

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -91,16 +91,13 @@ fn amount_exceeds_spendable_balance(amount: Option<u64>, spendable_balance: Opti
         return false;
     }
 
-    let spendable = spendable_balance.unwrap_or(u64::MAX);
+    let spendable = spendable_balance.unwrap_or(0);
 
     amount > spendable
 }
 
-fn spendable_balance_for_validation(
-    unlocked_spendable_sats: Option<u64>,
-    fallback_trusted_spendable_sats: u64,
-) -> u64 {
-    unlocked_spendable_sats.unwrap_or(fallback_trusted_spendable_sats)
+fn spendable_balance_for_validation(unlocked_spendable_sats: Option<u64>) -> u64 {
+    unlocked_spendable_sats.unwrap_or(0)
 }
 
 #[uniffi::export(callback_interface)]
@@ -534,13 +531,7 @@ impl RustSendFlowManager {
 
         let spendable_balance = {
             let state = self.state.lock();
-            let fallback_trusted_spendable_sats =
-                state.wallet_balance.clone().unwrap_or_default().trusted_spendable().to_sat();
-
-            spendable_balance_for_validation(
-                state.unlocked_spendable_sats,
-                fallback_trusted_spendable_sats,
-            )
+            spendable_balance_for_validation(state.unlocked_spendable_sats)
         };
 
         if spendable_balance < amount {
@@ -2010,19 +2001,16 @@ impl RustSendFlowManager {
 
     async fn get_wallet_balance(self: &Arc<Self>) {
         let balance = self.wallet_manager.balance().await;
-        let unlocked_spendable_sats = self
-            .wallet_manager
-            .unlocked_spendable_balance()
-            .await
-            .map(|amount| amount.as_sats())
-            .unwrap_or_else(|error| {
-                warn!("failed to get unlocked spendable balance: {error}");
-                balance.spendable().as_sats()
-            });
+        let unlocked_spendable_sats =
+            self.wallet_manager.unlocked_spendable_balance().await.map(|amount| amount.as_sats());
+        if let Err(error) = &unlocked_spendable_sats {
+            error!("failed to get unlocked spendable balance: {error}");
+        }
+
         let wallet_balance = Arc::new(balance);
         let mut state = self.state.lock();
         state.wallet_balance = Some(wallet_balance);
-        state.unlocked_spendable_sats = Some(unlocked_spendable_sats);
+        state.unlocked_spendable_sats = unlocked_spendable_sats.ok();
     }
 }
 
@@ -2033,11 +2021,13 @@ mod tests {
         assert!(super::amount_exceeds_spendable_balance(Some(6_000), Some(5_000)));
         assert!(!super::amount_exceeds_spendable_balance(Some(5_000), Some(5_000)));
         assert!(!super::amount_exceeds_spendable_balance(Some(0), Some(0)));
+        assert!(super::amount_exceeds_spendable_balance(Some(1), None));
+        assert!(!super::amount_exceeds_spendable_balance(Some(0), None));
     }
 
     #[test]
-    fn validation_spendable_balance_prefers_unlocked_balance_over_wallet_fallback() {
-        assert_eq!(super::spendable_balance_for_validation(Some(5_000), 10_000), 5_000);
-        assert_eq!(super::spendable_balance_for_validation(None, 10_000), 10_000);
+    fn validation_spendable_balance_uses_zero_when_unlocked_balance_is_unknown() {
+        assert_eq!(super::spendable_balance_for_validation(Some(5_000)), 5_000);
+        assert_eq!(super::spendable_balance_for_validation(None), 0);
     }
 }

--- a/rust/src/manager/send_flow_manager/state.rs
+++ b/rust/src/manager/send_flow_manager/state.rs
@@ -29,6 +29,7 @@ pub struct SendFlowManagerState {
     pub(crate) first_address: Option<Arc<Address>>,
     pub(crate) wallet_balance: Option<Arc<Balance>>,
     pub(crate) unlocked_spendable_sats: Option<u64>,
+    pub(crate) lock_state_load_failed: bool,
     /// True once we have base fee rates (either from cache or network)
     /// UI can show immediately once this is true (total fees pending calculation)
     pub(crate) has_base_fees: bool,
@@ -145,6 +146,7 @@ impl SendFlowManagerState {
             address: None,
             wallet_balance: Some(balance),
             unlocked_spendable_sats: None,
+            lock_state_load_failed: false,
             fee_selection: None,
             btc_price_in_fiat,
             selected_fiat_currency,
@@ -197,5 +199,6 @@ mod tests {
 
         assert_eq!(state.wallet_balance.as_ref().unwrap().spendable().as_sats(), 50_000);
         assert_eq!(state.unlocked_spendable_sats, None);
+        assert!(!state.lock_state_load_failed);
     }
 }

--- a/rust/src/manager/send_flow_manager/state.rs
+++ b/rust/src/manager/send_flow_manager/state.rs
@@ -130,8 +130,6 @@ impl SendFlowManagerState {
 
         let btc_price_in_fiat = App::global().prices().map(|prices| prices.get());
 
-        let unlocked_spendable_sats = Some(balance.spendable().as_sats());
-
         Self {
             metadata,
             fee_rate_options_base: None,
@@ -146,7 +144,7 @@ impl SendFlowManagerState {
             focus_field: None,
             address: None,
             wallet_balance: Some(balance),
-            unlocked_spendable_sats,
+            unlocked_spendable_sats: None,
             fee_selection: None,
             btc_price_in_fiat,
             selected_fiat_currency,
@@ -174,5 +172,30 @@ impl From<SendFlowManagerState> for State {
 impl From<Arc<Mutex<SendFlowManagerState>>> for State {
     fn from(state: Arc<Mutex<SendFlowManagerState>>) -> Self {
         Self(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bitcoin::Amount as BdkAmount;
+
+    use super::*;
+
+    #[test]
+    fn new_starts_with_unknown_unlocked_spendable_balance() {
+        crate::database::test_support::init_test_database();
+
+        let metadata = WalletMetadata::preview_new();
+        let balance = Arc::new(Balance(bdk_wallet::Balance {
+            confirmed: BdkAmount::from_sat(50_000),
+            ..Default::default()
+        }));
+
+        let state = SendFlowManagerState::new(metadata, balance);
+
+        assert_eq!(state.wallet_balance.as_ref().unwrap().spendable().as_sats(), 50_000);
+        assert_eq!(state.unlocked_spendable_sats, None);
     }
 }

--- a/rust/src/manager/send_flow_manager/state.rs
+++ b/rust/src/manager/send_flow_manager/state.rs
@@ -28,6 +28,7 @@ pub struct SendFlowManagerState {
     pub(crate) selected_fiat_currency: FiatCurrency,
     pub(crate) first_address: Option<Arc<Address>>,
     pub(crate) wallet_balance: Option<Arc<Balance>>,
+    pub(crate) unlocked_spendable_sats: Option<u64>,
     /// True once we have base fee rates (either from cache or network)
     /// UI can show immediately once this is true (total fees pending calculation)
     pub(crate) has_base_fees: bool,
@@ -129,6 +130,8 @@ impl SendFlowManagerState {
 
         let btc_price_in_fiat = App::global().prices().map(|prices| prices.get());
 
+        let unlocked_spendable_sats = Some(balance.spendable().as_sats());
+
         Self {
             metadata,
             fee_rate_options_base: None,
@@ -143,6 +146,7 @@ impl SendFlowManagerState {
             focus_field: None,
             address: None,
             wallet_balance: Some(balance),
+            unlocked_spendable_sats,
             fee_selection: None,
             btc_price_in_fiat,
             selected_fiat_currency,

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -1649,22 +1649,6 @@ impl RustWalletManager {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn preview_wallet_metadata_is_ledger_ready_for_spend() {
-        let metadata = preview_ledger_ready_metadata(WalletMetadata::preview_new());
-
-        assert_eq!(metadata.internal.performed_full_scan_at, Some(PREVIEW_FULL_SCAN_COMPLETED_AT));
-        assert_eq!(
-            WalletLedgerState::from_metadata_and_scan_status(&metadata, &WalletScanStatus::Idle),
-            WalletLedgerState::Complete
-        );
-    }
-}
-
 impl Drop for RustWalletManager {
     fn drop(&mut self) {
         self.shutdown();
@@ -1777,12 +1761,26 @@ mod tests {
     use bitcoin::{OutPoint, Txid, hashes::Hash as _};
 
     use super::{
-        TransactionLockState, spendability_for_transaction_lock_toggle,
+        PREVIEW_FULL_SCAN_COMPLETED_AT, TransactionLockState, WalletLedgerState, WalletScanStatus,
+        preview_ledger_ready_metadata, spendability_for_transaction_lock_toggle,
         transaction_lock_toggle_update,
     };
 
+    use crate::wallet::metadata::WalletMetadata;
+
     fn outpoint(vout: u32) -> OutPoint {
         OutPoint { txid: Txid::from_byte_array([1; 32]), vout }
+    }
+
+    #[test]
+    fn preview_wallet_metadata_is_ledger_ready_for_spend() {
+        let metadata = preview_ledger_ready_metadata(WalletMetadata::preview_new());
+
+        assert_eq!(metadata.internal.performed_full_scan_at, Some(PREVIEW_FULL_SCAN_COMPLETED_AT));
+        assert_eq!(
+            WalletLedgerState::from_metadata_and_scan_status(&metadata, &WalletScanStatus::Idle),
+            WalletLedgerState::Complete
+        );
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -274,6 +274,9 @@ pub enum WalletManagerError {
     #[error("insufficient funds: {0}")]
     InsufficientFunds(String),
 
+    #[error("selected UTXOs include locked outputs")]
+    LockedOutputsSelected,
+
     #[error("Unable to get confirm details, {0}")]
     GetConfirmDetailsError(String),
 
@@ -994,7 +997,7 @@ impl RustWalletManager {
         tx_id: Arc<TxId>,
     ) -> Result<TransactionLockState, Error> {
         let tx_id = Arc::unwrap_or_clone(tx_id);
-        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap();
+        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap()?;
 
         Ok(state)
     }
@@ -1005,7 +1008,7 @@ impl RustWalletManager {
         tx_id: Arc<TxId>,
     ) -> Result<TransactionLockState, Error> {
         let tx_id = Arc::unwrap_or_clone(tx_id);
-        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap();
+        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap()?;
         let outpoints =
             call!(self.actor.current_wallet_unspent_outpoints_for_txn(tx_id)).await.unwrap();
         let Some((outpoints, spendable)) = transaction_lock_toggle_update(state, outpoints) else {
@@ -1014,9 +1017,9 @@ impl RustWalletManager {
 
         self.label_manager
             .set_output_spendability_for_outpoints(outpoints, spendable)
-            .map_err(|error| Error::OutputLabelsError(error.to_string()))?;
+            .map_err_str(Error::OutputLabelsError)?;
 
-        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap();
+        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap()?;
 
         Ok(state)
     }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -999,7 +999,9 @@ impl RustWalletManager {
         tx_id: Arc<TxId>,
     ) -> Result<TransactionLockState, Error> {
         let tx_id = Arc::unwrap_or_clone(tx_id);
-        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap()?;
+        let state = call!(self.actor.transaction_lock_state(tx_id))
+            .await
+            .map_err(|_| Error::ActorNotFound)??;
 
         Ok(state)
     }
@@ -1010,9 +1012,12 @@ impl RustWalletManager {
         tx_id: Arc<TxId>,
     ) -> Result<TransactionLockState, Error> {
         let tx_id = Arc::unwrap_or_clone(tx_id);
-        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap()?;
-        let outpoints =
-            call!(self.actor.current_wallet_unspent_outpoints_for_txn(tx_id)).await.unwrap();
+        let state = call!(self.actor.transaction_lock_state(tx_id))
+            .await
+            .map_err(|_| Error::ActorNotFound)??;
+        let outpoints = call!(self.actor.current_wallet_unspent_outpoints_for_txn(tx_id))
+            .await
+            .map_err(|_| Error::ActorNotFound)?;
         let Some((outpoints, spendable)) = transaction_lock_toggle_update(state, outpoints) else {
             return Ok(TransactionLockState::None);
         };
@@ -1021,7 +1026,9 @@ impl RustWalletManager {
             .set_output_spendability_for_outpoints(outpoints, spendable)
             .map_err_str(Error::OutputLabelsError)?;
 
-        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap()?;
+        let state = call!(self.actor.transaction_lock_state(tx_id))
+            .await
+            .map_err(|_| Error::ActorNotFound)??;
 
         Ok(state)
     }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -784,7 +784,9 @@ impl RustWalletManager {
 
     #[uniffi::method]
     pub async fn unlocked_spendable_balance(&self) -> Result<Amount, Error> {
-        let amount = call!(self.actor.unlocked_trusted_spendable_balance()).await.unwrap()?;
+        let amount = call!(self.actor.unlocked_trusted_spendable_balance())
+            .await
+            .map_err(|_| Error::ActorNotFound)??;
 
         Ok(amount.into())
     }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -56,6 +56,7 @@ use crate::{
     word_validator::WordValidator,
 };
 
+use bitcoin::OutPoint;
 use cove_types::confirm::{ConfirmDetails, QrDensity, SplitOutput};
 use cove_types::{confirm::AddressAndAmount, fees::FeeRateOptions};
 
@@ -169,6 +170,14 @@ pub struct LabelExportResult {
 pub struct TransactionExportResult {
     pub content: String,
     pub filename: String,
+}
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum TransactionLockState {
+    None,
+    Unlocked,
+    Locked,
+    Mixed,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -288,6 +297,9 @@ pub enum WalletManagerError {
 
     #[error("Unable to add UTXOs to PSBT: {0}")]
     AddUtxosError(String),
+
+    #[error("Unable to get output labels: {0}")]
+    OutputLabelsError(String),
 
     #[error("Wallet database corrupted for {id}: {error}")]
     DatabaseCorruption { id: WalletId, error: String },
@@ -767,6 +779,13 @@ impl RustWalletManager {
         call!(self.actor.balance()).await.unwrap_or_default()
     }
 
+    #[uniffi::method]
+    pub async fn unlocked_spendable_balance(&self) -> Result<Amount, Error> {
+        let amount = call!(self.actor.unlocked_trusted_spendable_balance()).await.unwrap()?;
+
+        Ok(amount.into())
+    }
+
     /// Send entry point for unsigned hot wallet PSBTs
     ///
     /// Currently signs and broadcasts directly regardless of `payjoin_endpoint`.
@@ -967,6 +986,39 @@ impl RustWalletManager {
         }
 
         Ok(details)
+    }
+
+    #[uniffi::method]
+    pub async fn transaction_lock_state(
+        &self,
+        tx_id: Arc<TxId>,
+    ) -> Result<TransactionLockState, Error> {
+        let tx_id = Arc::unwrap_or_clone(tx_id);
+        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap();
+
+        Ok(state)
+    }
+
+    #[uniffi::method]
+    pub async fn toggle_transaction_lock_state(
+        &self,
+        tx_id: Arc<TxId>,
+    ) -> Result<TransactionLockState, Error> {
+        let tx_id = Arc::unwrap_or_clone(tx_id);
+        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap();
+        let outpoints =
+            call!(self.actor.current_wallet_unspent_outpoints_for_txn(tx_id)).await.unwrap();
+        let Some((outpoints, spendable)) = transaction_lock_toggle_update(state, outpoints) else {
+            return Ok(TransactionLockState::None);
+        };
+
+        self.label_manager
+            .set_output_spendability_for_outpoints(outpoints, spendable)
+            .map_err(|error| Error::OutputLabelsError(error.to_string()))?;
+
+        let state = call!(self.actor.transaction_lock_state(tx_id)).await.unwrap();
+
+        Ok(state)
     }
 
     #[uniffi::method]
@@ -1685,6 +1737,82 @@ fn wallet_account_number(id: &WalletId) -> Option<u32> {
             .ok()
             .flatten()
             .and_then(|(external, _)| external.account_index()),
+    }
+}
+
+fn spendability_for_transaction_lock_toggle(state: TransactionLockState) -> Option<bool> {
+    match state {
+        TransactionLockState::None => None,
+        TransactionLockState::Locked => Some(true),
+        TransactionLockState::Unlocked | TransactionLockState::Mixed => Some(false),
+    }
+}
+
+fn transaction_lock_toggle_update(
+    state: TransactionLockState,
+    outpoints: Vec<OutPoint>,
+) -> Option<(Vec<OutPoint>, bool)> {
+    let spendable = spendability_for_transaction_lock_toggle(state)?;
+    if outpoints.is_empty() {
+        return None;
+    }
+
+    Some((outpoints, spendable))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{OutPoint, Txid, hashes::Hash as _};
+
+    use super::{
+        TransactionLockState, spendability_for_transaction_lock_toggle,
+        transaction_lock_toggle_update,
+    };
+
+    fn outpoint(vout: u32) -> OutPoint {
+        OutPoint { txid: Txid::from_byte_array([1; 32]), vout }
+    }
+
+    #[test]
+    fn transaction_lock_toggle_decides_target_spendability_from_state() {
+        assert_eq!(spendability_for_transaction_lock_toggle(TransactionLockState::None), None);
+        assert_eq!(
+            spendability_for_transaction_lock_toggle(TransactionLockState::Unlocked),
+            Some(false)
+        );
+        assert_eq!(
+            spendability_for_transaction_lock_toggle(TransactionLockState::Mixed),
+            Some(false)
+        );
+        assert_eq!(
+            spendability_for_transaction_lock_toggle(TransactionLockState::Locked),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn transaction_lock_toggle_uses_current_outpoints_for_bulk_label_update() {
+        let outpoints = vec![outpoint(0), outpoint(2)];
+
+        assert_eq!(
+            transaction_lock_toggle_update(TransactionLockState::Unlocked, outpoints.clone()),
+            Some((outpoints.clone(), false))
+        );
+        assert_eq!(
+            transaction_lock_toggle_update(TransactionLockState::Mixed, outpoints.clone()),
+            Some((outpoints.clone(), false))
+        );
+        assert_eq!(
+            transaction_lock_toggle_update(TransactionLockState::Locked, outpoints.clone()),
+            Some((outpoints, true))
+        );
+    }
+
+    #[test]
+    fn transaction_lock_toggle_noops_without_current_outpoints() {
+        assert_eq!(transaction_lock_toggle_update(TransactionLockState::None, vec![]), None);
+        assert_eq!(transaction_lock_toggle_update(TransactionLockState::Unlocked, vec![]), None);
+        assert_eq!(transaction_lock_toggle_update(TransactionLockState::Locked, vec![]), None);
     }
 }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -49,7 +49,7 @@ use bdk_wallet::{
 #[allow(deprecated)]
 use bdk_wallet::SignOptions;
 use bdk_wallet::{KeychainKind, LocalOutput, TxOrdering};
-use bitcoin::{Amount, FeeRate as BdkFeeRate, OutPoint, TxIn, Txid};
+use bitcoin::{Amount, FeeRate as BdkFeeRate, OutPoint, TxIn, Txid, constants::COINBASE_MATURITY};
 use bitcoin::{Transaction as BdkTransaction, params::Params};
 use cove_bdk::coin_selection::CoveDefaultCoinSelection;
 use cove_bdk_progressive_scan::ScanUpdate;
@@ -1150,14 +1150,15 @@ impl WalletActor {
         Produces::ok(self.current_wallet_unspent_outpoints_for_txid(tx_id.0))
     }
 
+    #[into_actor_result]
     pub async fn transaction_lock_state(
         &mut self,
         tx_id: TxId,
-    ) -> ActorResult<TransactionLockState> {
+    ) -> Result<TransactionLockState, Error> {
         let outpoints = self.current_wallet_unspent_outpoints_for_txid(tx_id.0);
         let state = self.lock_state_for_outpoints(&outpoints)?;
 
-        Produces::ok(state)
+        Ok(state)
     }
 
     pub async fn start_transaction_watcher(&mut self, tx_id: Txid) -> ActorResult<()> {
@@ -1286,6 +1287,8 @@ impl WalletActor {
         utxos: &[bitcoin::OutPoint],
     ) -> Result<Amount, Error> {
         let fee_rate = fee_rate.into();
+
+        // bdk manually selected UTXOs can bypass `unspendable`
         self.reject_locked_outpoints(utxos)?;
 
         let (utxo_total_amount, fee_estimate) = {
@@ -1412,15 +1415,24 @@ impl WalletActor {
         let spendable = self.wallet.balance().0.trusted_spendable();
         let locked_outpoints =
             self.db.labels.locked_output_outpoints().map_err_str(Error::OutputLabelsError)?;
+        let chain_tip_height = self.wallet.bdk.local_chain().tip().height();
         let locked_amount = self
             .wallet
             .bdk
             .list_unspent()
             .filter(|output| locked_outpoints.contains(&output.outpoint))
-            .filter(trusted_spendable_output)
+            .filter(|output| {
+                let is_coinbase = self
+                    .wallet
+                    .bdk
+                    .get_tx(output.outpoint.txid)
+                    .is_some_and(|tx| tx.tx_node.tx.is_coinbase());
+
+                trusted_spendable_output(output, is_coinbase, chain_tip_height)
+            })
             .fold(Amount::ZERO, |total, output| total + output.txout.value);
 
-        Ok(spendable.checked_sub(locked_amount).unwrap_or(Amount::ZERO))
+        Ok(unlocked_spendable_amount(spendable, locked_amount))
     }
 
     fn locked_output_outpoints(&self) -> Result<Vec<OutPoint>, Error> {
@@ -2353,10 +2365,23 @@ impl Drop for WalletActor {
     }
 }
 
-fn trusted_spendable_output(output: &LocalOutput) -> bool {
-    output.chain_position.is_confirmed()
-        || matches!(output.chain_position, ChainPosition::Unconfirmed { .. })
-            && output.keychain == KeychainKind::Internal
+fn trusted_spendable_output(
+    output: &LocalOutput,
+    is_coinbase: bool,
+    chain_tip_height: u32,
+) -> bool {
+    match output.chain_position {
+        ChainPosition::Confirmed { anchor, .. } if is_coinbase => {
+            let age = chain_tip_height.saturating_sub(anchor.block_id.height);
+            age + 1 >= COINBASE_MATURITY
+        }
+        ChainPosition::Confirmed { .. } => true,
+        ChainPosition::Unconfirmed { .. } => output.keychain == KeychainKind::Internal,
+    }
+}
+
+fn unlocked_spendable_amount(spendable: Amount, locked_amount: Amount) -> Amount {
+    spendable.checked_sub(locked_amount).unwrap_or(Amount::ZERO)
 }
 
 fn lock_state_for_outpoints(
@@ -2400,7 +2425,7 @@ fn reject_locked_selected_outpoints(
     locked_outpoints: &std::collections::HashSet<OutPoint>,
 ) -> Result<(), Error> {
     if selected_outpoints_include_locked(outpoints, locked_outpoints) {
-        return Err(Error::InsufficientFunds("selected UTXOs include locked outputs".into()));
+        return Err(Error::LockedOutputsSelected);
     }
 
     Ok(())
@@ -2466,7 +2491,10 @@ mod tests {
         reset_scan_lifecycle_state_for_address_type_switch, should_accept_wallet_scan_generation,
         should_skip_recent_scan, trusted_spendable_output, wallet_scan_progress_start,
     };
-    use crate::manager::wallet_manager::TransactionLockState;
+    use crate::{
+        database::wallet_data::test_support::new_test_wallet_data_db,
+        manager::wallet_manager::TransactionLockState, wallet::metadata::WalletId,
+    };
 
     fn local_output_with_outpoint(
         keychain: KeychainKind,
@@ -2535,9 +2563,33 @@ mod tests {
         let unconfirmed_internal = local_output(KeychainKind::Internal, unconfirmed_position());
         let unconfirmed_external = local_output(KeychainKind::External, unconfirmed_position());
 
-        assert!(trusted_spendable_output(&confirmed_external));
-        assert!(trusted_spendable_output(&unconfirmed_internal));
-        assert!(!trusted_spendable_output(&unconfirmed_external));
+        assert!(trusted_spendable_output(&confirmed_external, false, 1));
+        assert!(trusted_spendable_output(&unconfirmed_internal, false, 1));
+        assert!(!trusted_spendable_output(&unconfirmed_external, false, 1));
+    }
+
+    #[test]
+    fn trusted_spendable_output_excludes_immature_coinbase_outputs() {
+        let confirmed_external = local_output(KeychainKind::External, confirmed_position());
+
+        assert!(!trusted_spendable_output(&confirmed_external, true, 99));
+        assert!(trusted_spendable_output(&confirmed_external, true, 100));
+    }
+
+    #[test]
+    fn unlocked_spendable_amount_saturates_when_locked_amount_exceeds_spendable() {
+        assert_eq!(
+            super::unlocked_spendable_amount(Amount::from_sat(10_000), Amount::from_sat(4_000)),
+            Amount::from_sat(6_000)
+        );
+        assert_eq!(
+            super::unlocked_spendable_amount(Amount::from_sat(10_000), Amount::from_sat(10_000)),
+            Amount::ZERO
+        );
+        assert_eq!(
+            super::unlocked_spendable_amount(Amount::from_sat(10_000), Amount::from_sat(12_000)),
+            Amount::ZERO
+        );
     }
 
     #[test]
@@ -2659,7 +2711,44 @@ mod tests {
         let error = super::reject_locked_selected_outpoints(&selected, &locked)
             .expect_err("locked manual selection must be rejected");
 
-        assert!(matches!(error, super::Error::InsufficientFunds(_)));
+        assert!(matches!(error, super::Error::LockedOutputsSelected));
+    }
+
+    #[test]
+    fn db_locked_outputs_feed_builder_guards() {
+        let (mut wallet, initial_txid) = get_funded_wallet_wpkh();
+        let locked = OutPoint { txid: initial_txid, vout: 0 };
+        let unlocked = receive_output_in_latest_block(&mut wallet, Amount::from_sat(80_000));
+        let (wallet_db, _tmp) = new_test_wallet_data_db(WalletId::preview_new_random());
+
+        wallet_db.labels.set_output_spendability(locked, false).expect("output is locked");
+
+        let locked_outpoints =
+            wallet_db.labels.locked_output_outpoints().expect("locked outpoints load");
+        let address = regtest_address();
+        let mut tx_builder = wallet.build_tx();
+        super::exclude_locked_outpoints(
+            &mut tx_builder,
+            locked_outpoints.iter().copied().collect(),
+        );
+        tx_builder.add_recipient(address.script_pubkey(), Amount::from_sat(40_000));
+        tx_builder.fee_absolute(Amount::from_sat(500));
+
+        let psbt = tx_builder.finish().expect("unlocked output can fund transaction");
+        let spent_outpoints = psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|input| input.previous_output)
+            .collect::<HashSet<_>>();
+
+        assert!(!spent_outpoints.contains(&locked));
+        assert!(spent_outpoints.contains(&unlocked));
+
+        let error = super::reject_locked_selected_outpoints(&[locked], &locked_outpoints)
+            .expect_err("manual locked output selection is rejected");
+
+        assert!(matches!(error, super::Error::LockedOutputsSelected));
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2482,8 +2482,10 @@ mod tests {
         hashes::Hash as _,
     };
     use cove_bdk_progressive_scan::ScanUpdate;
+    use parking_lot::RwLock;
     use std::{
         collections::{BTreeMap, HashSet},
+        sync::Arc,
         time::UNIX_EPOCH,
     };
 
@@ -2502,7 +2504,7 @@ mod tests {
             label::test_support::wallet_data_db_with_mismatched_output_table,
             test_support::new_test_wallet_data_db,
         },
-        manager::wallet_manager::TransactionLockState,
+        manager::wallet_manager::{TransactionLockState, WalletScanStatus},
         wallet::{Address, Wallet, metadata::WalletId},
     };
 
@@ -2568,10 +2570,19 @@ mod tests {
             .expect("address is regtest")
     }
 
+    fn test_scan_status() -> Arc<RwLock<WalletScanStatus>> {
+        Arc::new(RwLock::new(WalletScanStatus::Idle))
+    }
+
+    fn mark_wallet_ledger_ready(wallet: &mut Wallet) {
+        wallet.metadata.internal.performed_full_scan_at = Some(1);
+    }
+
     fn locked_actor_fixture() -> LockedActorFixture {
         crate::database::test_support::init_test_database();
 
         let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
         insert_checkpoint(
             &mut wallet.bdk,
             BlockId { height: 1, hash: BlockHash::from_byte_array([2; 32]) },
@@ -2580,7 +2591,8 @@ mod tests {
         let unlocked = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(80_000));
 
         let (sender, _receiver) = flume::bounded(10);
-        let mut actor = super::WalletActor::new(wallet, sender).expect("actor is created");
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
         let (db, tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
         db.labels.set_output_spendability(locked, false).expect("output is locked");
         actor.db = db;
@@ -2672,7 +2684,8 @@ mod tests {
             receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(80_000));
 
         let (sender, _receiver) = flume::bounded(10);
-        let mut actor = super::WalletActor::new(wallet, sender).expect("actor is created");
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
         let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
         actor.db = db;
 
@@ -2693,7 +2706,8 @@ mod tests {
 
         let wallet = Wallet::preview_new_wallet();
         let (sender, _receiver) = flume::bounded(10);
-        let mut actor = super::WalletActor::new(wallet, sender).expect("actor is created");
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
         let (db, _tmp) = wallet_data_db_with_mismatched_output_table(actor.wallet.id.clone());
         actor.db = db;
 
@@ -3021,7 +3035,7 @@ mod tests {
 
     #[test]
     fn spend_guard_rejects_incomplete_initial_scan() {
-        assert_eq!(ledger_ready_for_spend(false), Err(Error::InitialScanIncomplete));
+        assert_eq!(ledger_ready_for_spend(false), Err(super::Error::InitialScanIncomplete));
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2498,7 +2498,10 @@ mod tests {
         should_skip_recent_scan, trusted_spendable_output, wallet_scan_progress_start,
     };
     use crate::{
-        database::wallet_data::test_support::new_test_wallet_data_db,
+        database::wallet_data::{
+            label::test_support::wallet_data_db_with_mismatched_output_table,
+            test_support::new_test_wallet_data_db,
+        },
         manager::wallet_manager::TransactionLockState,
         wallet::{Address, Wallet, metadata::WalletId},
     };
@@ -2682,6 +2685,23 @@ mod tests {
         let expected = bdk_spendable - expected_locked_spendable;
 
         assert_eq!(actor.unlocked_trusted_spendable_balance_inner().unwrap(), expected);
+    }
+
+    #[test]
+    fn unlocked_trusted_spendable_balance_propagates_lock_state_read_errors() {
+        crate::database::test_support::init_test_database();
+
+        let wallet = Wallet::preview_new_wallet();
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor = super::WalletActor::new(wallet, sender).expect("actor is created");
+        let (db, _tmp) = wallet_data_db_with_mismatched_output_table(actor.wallet.id.clone());
+        actor.db = db;
+
+        let error = actor
+            .unlocked_trusted_spendable_balance_inner()
+            .expect_err("lock-state read errors must block spendable balance calculation");
+
+        assert!(matches!(error, super::Error::OutputLabelsError(_)));
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2472,7 +2472,10 @@ mod tests {
     use bdk_wallet::{
         KeychainKind, LocalOutput,
         chain::{ChainPosition, ConfirmationBlockTime},
-        test_utils::{get_funded_wallet_wpkh, insert_checkpoint, receive_output_in_latest_block},
+        test_utils::{
+            ReceiveTo, get_funded_wallet_wpkh, insert_checkpoint, receive_output,
+            receive_output_in_latest_block, receive_output_to_address,
+        },
     };
     use bitcoin::{
         Address as BdkAddress, Amount, BlockHash, Network, OutPoint, ScriptBuf, TxOut, Txid,
@@ -2582,6 +2585,10 @@ mod tests {
         LockedActorFixture { actor, locked, unlocked, _tmp: tmp }
     }
 
+    fn lock_output(actor: &super::WalletActor, outpoint: OutPoint) {
+        actor.db.labels.set_output_spendability(outpoint, false).expect("output is locked");
+    }
+
     fn spent_outpoints(psbt: &bdk_wallet::bitcoin::Psbt) -> HashSet<OutPoint> {
         psbt.unsigned_tx.input.iter().map(|input| input.previous_output).collect()
     }
@@ -2636,6 +2643,45 @@ mod tests {
             super::unlocked_spendable_amount(Amount::from_sat(10_000), Amount::from_sat(12_000)),
             Amount::ZERO
         );
+    }
+
+    #[test]
+    fn unlocked_trusted_spendable_balance_subtracts_locked_bdk_spendable_outputs() {
+        crate::database::test_support::init_test_database();
+
+        let mut wallet = Wallet::preview_new_wallet();
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([2; 32]) },
+        );
+        let locked_confirmed =
+            receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(76_000));
+        let locked_untrusted_pending =
+            receive_output(&mut wallet.bdk, Amount::from_sat(20_000), ReceiveTo::Mempool(1));
+        let internal_address = wallet.bdk.next_unused_address(KeychainKind::Internal).address;
+        let locked_trusted_pending = receive_output_to_address(
+            &mut wallet.bdk,
+            internal_address,
+            Amount::from_sat(30_000),
+            ReceiveTo::Mempool(2),
+        );
+        let _unlocked_confirmed =
+            receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(80_000));
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor = super::WalletActor::new(wallet, sender).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        actor.db = db;
+
+        lock_output(&actor, locked_confirmed);
+        lock_output(&actor, locked_untrusted_pending);
+        lock_output(&actor, locked_trusted_pending);
+
+        let bdk_spendable = actor.wallet.balance().0.trusted_spendable();
+        let expected_locked_spendable = Amount::from_sat(76_000 + 30_000);
+        let expected = bdk_spendable - expected_locked_spendable;
+
+        assert_eq!(actor.unlocked_trusted_spendable_balance_inner().unwrap(), expected);
     }
 
     #[test]
@@ -2825,6 +2871,37 @@ mod tests {
 
         assert!(!spent_outpoints.contains(&fixture.locked));
         assert!(spent_outpoints.contains(&fixture.unlocked));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actor_build_tx_fails_when_all_outputs_are_locked() {
+        let fixture = locked_actor_fixture();
+        let mut actor = fixture.actor;
+        lock_output(&actor, fixture.unlocked);
+
+        let result = actor
+            .build_tx(Amount::from_sat(40_000), Address::preview_new(), one_sat_vbyte_fee_rate())
+            .await;
+        let error =
+            actor_value(result).await.expect_err("all locked outputs cannot fund transaction");
+
+        assert!(matches!(error, super::Error::BuildTxError(_)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actor_drain_tx_fails_when_all_outputs_are_locked() {
+        let fixture = locked_actor_fixture();
+        let mut actor = fixture.actor;
+        lock_output(&actor, fixture.unlocked);
+
+        let result = actor
+            .build_ephemeral_drain_tx(Address::preview_new(), one_sat_vbyte_fee_rate().into())
+            .await;
+        let error = actor_value(result)
+            .await
+            .expect_err("all locked outputs cannot fund drain transaction");
+
+        assert!(matches!(error, super::Error::BuildTxError(_)));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -5,8 +5,8 @@ use crate::{
     },
     historical_price_service::HistoricalPriceService,
     manager::wallet_manager::{
-        Error, SendFlowErrorAlert, WalletLedgerState, WalletManagerError, WalletScanPhase,
-        WalletScanStatus,
+        Error, SendFlowErrorAlert, TransactionLockState, WalletLedgerState, WalletManagerError,
+        WalletScanPhase, WalletScanStatus,
         receive_address::{
             CACHE_WINDOW, ReceiveAddressPresentation, ReceiveAddressRefreshState,
             ReceiveAddressSession, ReceiveAddressState, ReceiveAddressStatus,
@@ -35,11 +35,12 @@ use ahash::HashMap;
 use bdk_wallet::{
     AddUtxoError, Utxo, WeightedUtxo,
     chain::{
-        BlockId, TxGraph,
+        BlockId, ChainPosition, TxGraph,
         bitcoin::Psbt,
         spk_client::{FullScanResponse, SyncRequest, SyncResponse},
     },
     error::CreateTxError,
+    tx_builder::TxBuilder,
 };
 // Note: SignOptions is marked deprecated in bdk_wallet 2.2.0 with a misleading message
 // saying it moved to bitcoin::psbt, but no replacement exists there yet. bdk_wallet itself
@@ -65,6 +66,7 @@ use flume::Sender;
 use parking_lot::RwLock;
 use rand::RngExt as _;
 use std::{
+    collections::HashSet,
     sync::Arc,
     time::{Duration, UNIX_EPOCH},
 };
@@ -212,6 +214,11 @@ impl WalletActor {
         Produces::ok(balance)
     }
 
+    #[into_actor_result]
+    pub async fn unlocked_trusted_spendable_balance(&mut self) -> Result<Amount, Error> {
+        self.unlocked_trusted_spendable_balance_inner()
+    }
+
     // Build a transaction but don't advance the change address index
     #[into_actor_result]
     pub async fn build_ephemeral_drain_tx(
@@ -223,8 +230,10 @@ impl WalletActor {
 
         debug!("build_ephemeral_drain_tx for fee rate {}", fee.sat_per_vb());
         let script_pubkey = address.script_pubkey();
+        let locked_outpoints = self.locked_output_outpoints()?;
         let mut tx_builder = self.wallet.bdk.build_tx();
 
+        exclude_locked_outpoints(&mut tx_builder, locked_outpoints);
         tx_builder.drain_wallet().drain_to(script_pubkey).fee_rate(fee.into());
         let psbt = tx_builder.finish().map_err_str(Error::BuildTxError)?;
         self.wallet.unreserve_tx_change_addresses(&psbt.unsigned_tx);
@@ -247,8 +256,10 @@ impl WalletActor {
         let script_pubkey = address.script_pubkey();
 
         let coin_selection = CoveDefaultCoinSelection::new(self.seed);
+        let locked_outpoints = self.locked_output_outpoints()?;
         let mut tx_builder = self.wallet.bdk.build_tx().coin_selection(coin_selection);
 
+        exclude_locked_outpoints(&mut tx_builder, locked_outpoints);
         tx_builder.ordering(TxOrdering::Untouched);
         tx_builder.add_recipient(script_pubkey, amount);
         tx_builder.fee_rate(fee_rate);
@@ -1132,6 +1143,23 @@ impl WalletActor {
         Produces::ok(details)
     }
 
+    pub async fn current_wallet_unspent_outpoints_for_txn(
+        &mut self,
+        tx_id: TxId,
+    ) -> ActorResult<Vec<OutPoint>> {
+        Produces::ok(self.current_wallet_unspent_outpoints_for_txid(tx_id.0))
+    }
+
+    pub async fn transaction_lock_state(
+        &mut self,
+        tx_id: TxId,
+    ) -> ActorResult<TransactionLockState> {
+        let outpoints = self.current_wallet_unspent_outpoints_for_txid(tx_id.0);
+        let state = self.lock_state_for_outpoints(&outpoints)?;
+
+        Produces::ok(state)
+    }
+
     pub async fn start_transaction_watcher(&mut self, tx_id: Txid) -> ActorResult<()> {
         debug!("start_transaction_watcher for txn: {tx_id}");
         if self.transaction_watchers.contains_key(&tx_id) {
@@ -1258,6 +1286,7 @@ impl WalletActor {
         utxos: &[bitcoin::OutPoint],
     ) -> Result<Amount, Error> {
         let fee_rate = fee_rate.into();
+        self.reject_locked_outpoints(utxos)?;
 
         let (utxo_total_amount, fee_estimate) = {
             let mut utxo_total_amount = Amount::ZERO;
@@ -1360,6 +1389,57 @@ impl WalletActor {
                 )
             })
             .collect()
+    }
+
+    fn current_wallet_unspent_outpoints_for_txid(&self, txid: Txid) -> Vec<OutPoint> {
+        current_wallet_unspent_outpoints_for_txid(self.wallet.bdk.list_unspent(), txid)
+    }
+
+    fn lock_state_for_outpoints(
+        &self,
+        outpoints: &[OutPoint],
+    ) -> Result<TransactionLockState, Error> {
+        if outpoints.is_empty() {
+            return Ok(TransactionLockState::None);
+        }
+
+        let locked_outpoints =
+            self.db.labels.locked_output_outpoints().map_err_str(Error::OutputLabelsError)?;
+        Ok(lock_state_for_outpoints(outpoints, &locked_outpoints))
+    }
+
+    fn unlocked_trusted_spendable_balance_inner(&self) -> Result<Amount, Error> {
+        let spendable = self.wallet.balance().0.trusted_spendable();
+        let locked_outpoints =
+            self.db.labels.locked_output_outpoints().map_err_str(Error::OutputLabelsError)?;
+        let locked_amount = self
+            .wallet
+            .bdk
+            .list_unspent()
+            .filter(|output| locked_outpoints.contains(&output.outpoint))
+            .filter(trusted_spendable_output)
+            .fold(Amount::ZERO, |total, output| total + output.txout.value);
+
+        Ok(spendable.checked_sub(locked_amount).unwrap_or(Amount::ZERO))
+    }
+
+    fn locked_output_outpoints(&self) -> Result<Vec<OutPoint>, Error> {
+        let outpoints = self
+            .db
+            .labels
+            .locked_output_outpoints()
+            .map_err_str(Error::OutputLabelsError)?
+            .into_iter()
+            .collect();
+
+        Ok(outpoints)
+    }
+
+    fn reject_locked_outpoints(&self, outpoints: &[OutPoint]) -> Result<(), Error> {
+        let locked_outpoints =
+            self.db.labels.locked_output_outpoints().map_err_str(Error::OutputLabelsError)?;
+
+        reject_locked_selected_outpoints(outpoints, &locked_outpoints)
     }
 
     /// Perform a full scan with a user-supplied gap limit to recover missed addresses.
@@ -2273,6 +2353,66 @@ impl Drop for WalletActor {
     }
 }
 
+fn trusted_spendable_output(output: &LocalOutput) -> bool {
+    output.chain_position.is_confirmed()
+        || matches!(output.chain_position, ChainPosition::Unconfirmed { .. })
+            && output.keychain == KeychainKind::Internal
+}
+
+fn lock_state_for_outpoints(
+    outpoints: &[OutPoint],
+    locked_outpoints: &HashSet<OutPoint>,
+) -> TransactionLockState {
+    if outpoints.is_empty() {
+        return TransactionLockState::None;
+    }
+
+    let locked_count =
+        outpoints.iter().filter(|outpoint| locked_outpoints.contains(outpoint)).count();
+
+    match locked_count {
+        0 => TransactionLockState::Unlocked,
+        count if count == outpoints.len() => TransactionLockState::Locked,
+        _ => TransactionLockState::Mixed,
+    }
+}
+
+fn current_wallet_unspent_outpoints_for_txid(
+    outputs: impl IntoIterator<Item = LocalOutput>,
+    txid: Txid,
+) -> Vec<OutPoint> {
+    outputs
+        .into_iter()
+        .filter(|output| output.outpoint.txid == txid)
+        .map(|output| output.outpoint)
+        .collect()
+}
+
+fn selected_outpoints_include_locked(
+    outpoints: &[OutPoint],
+    locked_outpoints: &std::collections::HashSet<OutPoint>,
+) -> bool {
+    outpoints.iter().any(|outpoint| locked_outpoints.contains(outpoint))
+}
+
+fn reject_locked_selected_outpoints(
+    outpoints: &[OutPoint],
+    locked_outpoints: &std::collections::HashSet<OutPoint>,
+) -> Result<(), Error> {
+    if selected_outpoints_include_locked(outpoints, locked_outpoints) {
+        return Err(Error::InsufficientFunds("selected UTXOs include locked outputs".into()));
+    }
+
+    Ok(())
+}
+
+fn exclude_locked_outpoints<Cs>(
+    tx_builder: &mut TxBuilder<'_, Cs>,
+    locked_outpoints: Vec<OutPoint>,
+) {
+    tx_builder.unspendable(locked_outpoints);
+}
+
 async fn check_node_connection_inner(node: &Node) -> Result<(), String> {
     // Create a fresh client with its own TCP connection for this background check.
     // We cannot reuse the actor's cached client because:
@@ -2301,20 +2441,80 @@ async fn check_node_connection_inner(node: &Node) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use bdk_wallet::KeychainKind;
+    use bdk_wallet::{
+        KeychainKind, LocalOutput,
+        chain::{ChainPosition, ConfirmationBlockTime},
+        test_utils::{get_funded_wallet_wpkh, receive_output_in_latest_block},
+    };
+    use bitcoin::{
+        Address as BdkAddress, Amount, BlockHash, Network, OutPoint, ScriptBuf, TxOut, Txid,
+        hashes::Hash as _,
+    };
     use cove_bdk_progressive_scan::ScanUpdate;
-    use std::{collections::BTreeMap, time::UNIX_EPOCH};
+    use std::{
+        collections::{BTreeMap, HashSet},
+        time::UNIX_EPOCH,
+    };
 
     use crate::wallet::metadata::WalletMetadata;
 
     use super::{
-        ActorState, EMPTY_WALLET_SCAN_PROGRESS_DELAY, Error, FullScanType, InitialScanRoute,
-        RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart,
+        ActorState, BlockId, EMPTY_WALLET_SCAN_PROGRESS_DELAY, FullScanType,
+        InitialScanRoute, RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart,
         full_scan_updates_initial_metadata, initial_scan_route, ledger_ready_for_spend,
         metadata_with_full_scan_performed, progressive_scan_update_response,
         reset_scan_lifecycle_state_for_address_type_switch, should_accept_wallet_scan_generation,
-        should_skip_recent_scan, wallet_scan_progress_start,
+        should_skip_recent_scan, trusted_spendable_output, wallet_scan_progress_start,
     };
+    use crate::manager::wallet_manager::TransactionLockState;
+
+    fn local_output_with_outpoint(
+        keychain: KeychainKind,
+        chain_position: ChainPosition<ConfirmationBlockTime>,
+        outpoint: OutPoint,
+    ) -> LocalOutput {
+        LocalOutput {
+            outpoint,
+            txout: TxOut { value: Amount::from_sat(1_000), script_pubkey: ScriptBuf::new() },
+            keychain,
+            is_spent: false,
+            derivation_index: 0,
+            chain_position,
+        }
+    }
+
+    fn local_output(
+        keychain: KeychainKind,
+        chain_position: ChainPosition<ConfirmationBlockTime>,
+    ) -> LocalOutput {
+        local_output_with_outpoint(keychain, chain_position, OutPoint::null())
+    }
+
+    fn confirmed_position() -> ChainPosition<ConfirmationBlockTime> {
+        ChainPosition::Confirmed {
+            anchor: ConfirmationBlockTime {
+                block_id: BlockId { height: 1, hash: BlockHash::all_zeros() },
+                confirmation_time: 1,
+            },
+            transitively: None,
+        }
+    }
+
+    fn unconfirmed_position() -> ChainPosition<ConfirmationBlockTime> {
+        ChainPosition::Unconfirmed { first_seen: Some(1), last_seen: Some(1) }
+    }
+
+    fn outpoint(vout: u32) -> OutPoint {
+        OutPoint { txid: Txid::from_byte_array([1; 32]), vout }
+    }
+
+    fn regtest_address() -> BdkAddress {
+        "bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5"
+            .parse::<BdkAddress<_>>()
+            .expect("address parses")
+            .require_network(Network::Regtest)
+            .expect("address is regtest")
+    }
 
     #[test]
     fn progressive_scan_update_response_preserves_last_active_indices() {
@@ -2327,6 +2527,139 @@ mod tests {
         let response = progressive_scan_update_response(scan_update);
 
         assert_eq!(response.last_active_indices, BTreeMap::from([(KeychainKind::External, 7)]));
+    }
+
+    #[test]
+    fn trusted_spendable_output_matches_bdk_balance_categories() {
+        let confirmed_external = local_output(KeychainKind::External, confirmed_position());
+        let unconfirmed_internal = local_output(KeychainKind::Internal, unconfirmed_position());
+        let unconfirmed_external = local_output(KeychainKind::External, unconfirmed_position());
+
+        assert!(trusted_spendable_output(&confirmed_external));
+        assert!(trusted_spendable_output(&unconfirmed_internal));
+        assert!(!trusted_spendable_output(&unconfirmed_external));
+    }
+
+    #[test]
+    fn lock_state_for_outpoints_returns_none_without_relevant_outputs() {
+        assert_eq!(
+            super::lock_state_for_outpoints(&[], &HashSet::new()),
+            TransactionLockState::None
+        );
+    }
+
+    #[test]
+    fn lock_state_for_outpoints_returns_unlocked_when_no_outputs_are_locked() {
+        let outpoints = [outpoint(0), outpoint(1)];
+
+        assert_eq!(
+            super::lock_state_for_outpoints(&outpoints, &HashSet::new()),
+            TransactionLockState::Unlocked
+        );
+    }
+
+    #[test]
+    fn lock_state_for_outpoints_returns_locked_when_all_outputs_are_locked() {
+        let outpoints = [outpoint(0), outpoint(1)];
+        let locked = HashSet::from(outpoints);
+
+        assert_eq!(
+            super::lock_state_for_outpoints(&outpoints, &locked),
+            TransactionLockState::Locked
+        );
+    }
+
+    #[test]
+    fn lock_state_for_outpoints_returns_mixed_when_some_outputs_are_locked() {
+        let outpoints = [outpoint(0), outpoint(1)];
+        let locked = HashSet::from([outpoint(1)]);
+
+        assert_eq!(
+            super::lock_state_for_outpoints(&outpoints, &locked),
+            TransactionLockState::Mixed
+        );
+    }
+
+    #[test]
+    fn current_wallet_unspent_outpoints_for_txid_ignores_other_transactions() {
+        let matching = outpoint(0);
+        let other = OutPoint { txid: Txid::from_byte_array([2; 32]), vout: 0 };
+        let outputs = [
+            local_output_with_outpoint(KeychainKind::External, confirmed_position(), matching),
+            local_output_with_outpoint(KeychainKind::External, confirmed_position(), other),
+        ];
+
+        assert_eq!(
+            super::current_wallet_unspent_outpoints_for_txid(outputs, matching.txid),
+            vec![matching]
+        );
+    }
+
+    #[test]
+    fn selected_outpoints_include_locked_detects_locked_manual_selection() {
+        let selected = [outpoint(0), outpoint(1)];
+        let locked = HashSet::from([outpoint(1), outpoint(2)]);
+
+        assert!(super::selected_outpoints_include_locked(&selected, &locked));
+        assert!(!super::selected_outpoints_include_locked(&selected, &HashSet::new()));
+    }
+
+    #[test]
+    fn automatic_builder_excludes_locked_outpoints_from_psbt_inputs() {
+        let (mut wallet, initial_txid) = get_funded_wallet_wpkh();
+        let locked = OutPoint { txid: initial_txid, vout: 0 };
+        let unlocked = receive_output_in_latest_block(&mut wallet, Amount::from_sat(80_000));
+        let address = regtest_address();
+
+        let mut tx_builder = wallet.build_tx();
+        super::exclude_locked_outpoints(&mut tx_builder, vec![locked]);
+        tx_builder.add_recipient(address.script_pubkey(), Amount::from_sat(40_000));
+        tx_builder.fee_absolute(Amount::from_sat(500));
+
+        let psbt = tx_builder.finish().expect("unlocked output can fund transaction");
+        let spent_outpoints = psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|input| input.previous_output)
+            .collect::<HashSet<_>>();
+
+        assert!(!spent_outpoints.contains(&locked));
+        assert!(spent_outpoints.contains(&unlocked));
+    }
+
+    #[test]
+    fn drain_builder_excludes_locked_outpoints_from_psbt_inputs() {
+        let (mut wallet, initial_txid) = get_funded_wallet_wpkh();
+        let locked = OutPoint { txid: initial_txid, vout: 0 };
+        let unlocked = receive_output_in_latest_block(&mut wallet, Amount::from_sat(80_000));
+        let address = regtest_address();
+
+        let mut tx_builder = wallet.build_tx();
+        super::exclude_locked_outpoints(&mut tx_builder, vec![locked]);
+        tx_builder.drain_wallet().drain_to(address.script_pubkey());
+        tx_builder.fee_absolute(Amount::from_sat(500));
+
+        let psbt = tx_builder.finish().expect("unlocked output can fund drain transaction");
+        let spent_outpoints = psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|input| input.previous_output)
+            .collect::<HashSet<_>>();
+
+        assert!(!spent_outpoints.contains(&locked));
+        assert!(spent_outpoints.contains(&unlocked));
+    }
+
+    #[test]
+    fn manual_builder_rejects_locked_outpoints_before_bdk_can_override_unspendable() {
+        let selected = [outpoint(0)];
+        let locked = HashSet::from(selected);
+        let error = super::reject_locked_selected_outpoints(&selected, &locked)
+            .expect_err("locked manual selection must be rejected");
+
+        assert!(matches!(error, super::Error::InsufficientFunds(_)));
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2490,8 +2490,8 @@ mod tests {
     use crate::wallet::metadata::WalletMetadata;
 
     use super::{
-        ActorState, BlockId, EMPTY_WALLET_SCAN_PROGRESS_DELAY, FullScanType,
-        InitialScanRoute, RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart,
+        ActorState, BlockId, EMPTY_WALLET_SCAN_PROGRESS_DELAY, FullScanType, InitialScanRoute,
+        RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart,
         full_scan_updates_initial_metadata, initial_scan_route, ledger_ready_for_spend,
         metadata_with_full_scan_performed, progressive_scan_update_response,
         reset_scan_lifecycle_state_for_address_type_switch, should_accept_wallet_scan_generation,

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2370,9 +2370,12 @@ fn trusted_spendable_output(
     is_coinbase: bool,
     chain_tip_height: u32,
 ) -> bool {
+    // keep this in lockstep with bdk's trusted_spendable balance categories
     match output.chain_position {
         ChainPosition::Confirmed { anchor, .. } if is_coinbase => {
             let age = chain_tip_height.saturating_sub(anchor.block_id.height);
+
+            // bdk counts the confirmation block itself in coinbase maturity
             age + 1 >= COINBASE_MATURITY
         }
         ChainPosition::Confirmed { .. } => true,
@@ -2469,7 +2472,7 @@ mod tests {
     use bdk_wallet::{
         KeychainKind, LocalOutput,
         chain::{ChainPosition, ConfirmationBlockTime},
-        test_utils::{get_funded_wallet_wpkh, receive_output_in_latest_block},
+        test_utils::{get_funded_wallet_wpkh, insert_checkpoint, receive_output_in_latest_block},
     };
     use bitcoin::{
         Address as BdkAddress, Amount, BlockHash, Network, OutPoint, ScriptBuf, TxOut, Txid,
@@ -2493,8 +2496,23 @@ mod tests {
     };
     use crate::{
         database::wallet_data::test_support::new_test_wallet_data_db,
-        manager::wallet_manager::TransactionLockState, wallet::metadata::WalletId,
+        manager::wallet_manager::TransactionLockState,
+        wallet::{Address, Wallet, metadata::WalletId},
     };
+
+    struct LockedActorFixture {
+        actor: super::WalletActor,
+        locked: OutPoint,
+        unlocked: OutPoint,
+        _tmp: tempfile::TempDir,
+    }
+
+    async fn actor_value<T>(result: act_zero::ActorResult<T>) -> T {
+        result
+            .expect("actor method should not fail")
+            .await
+            .expect("actor method should produce a value")
+    }
 
     fn local_output_with_outpoint(
         keychain: KeychainKind,
@@ -2542,6 +2560,34 @@ mod tests {
             .expect("address parses")
             .require_network(Network::Regtest)
             .expect("address is regtest")
+    }
+
+    fn locked_actor_fixture() -> LockedActorFixture {
+        crate::database::test_support::init_test_database();
+
+        let mut wallet = Wallet::preview_new_wallet();
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([2; 32]) },
+        );
+        let locked = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(76_000));
+        let unlocked = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(80_000));
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor = super::WalletActor::new(wallet, sender).expect("actor is created");
+        let (db, tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        db.labels.set_output_spendability(locked, false).expect("output is locked");
+        actor.db = db;
+
+        LockedActorFixture { actor, locked, unlocked, _tmp: tmp }
+    }
+
+    fn spent_outpoints(psbt: &bdk_wallet::bitcoin::Psbt) -> HashSet<OutPoint> {
+        psbt.unsigned_tx.input.iter().map(|input| input.previous_output).collect()
+    }
+
+    fn one_sat_vbyte_fee_rate() -> bitcoin::FeeRate {
+        bitcoin::FeeRate::from_sat_per_vb(1).expect("fee rate")
     }
 
     #[test]
@@ -2747,6 +2793,55 @@ mod tests {
 
         let error = super::reject_locked_selected_outpoints(&[locked], &locked_outpoints)
             .expect_err("manual locked output selection is rejected");
+
+        assert!(matches!(error, super::Error::LockedOutputsSelected));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actor_build_tx_excludes_db_locked_outpoints_from_psbt_inputs() {
+        let fixture = locked_actor_fixture();
+        let mut actor = fixture.actor;
+
+        let result = actor
+            .build_tx(Amount::from_sat(40_000), Address::preview_new(), one_sat_vbyte_fee_rate())
+            .await;
+        let psbt = actor_value(result).await.expect("unlocked output funds transaction");
+        let spent_outpoints = spent_outpoints(&psbt);
+
+        assert!(!spent_outpoints.contains(&fixture.locked));
+        assert!(spent_outpoints.contains(&fixture.unlocked));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actor_drain_tx_excludes_db_locked_outpoints_from_psbt_inputs() {
+        let fixture = locked_actor_fixture();
+        let mut actor = fixture.actor;
+
+        let result = actor
+            .build_ephemeral_drain_tx(Address::preview_new(), one_sat_vbyte_fee_rate().into())
+            .await;
+        let psbt = actor_value(result).await.expect("unlocked output funds drain transaction");
+        let spent_outpoints = spent_outpoints(&psbt);
+
+        assert!(!spent_outpoints.contains(&fixture.locked));
+        assert!(spent_outpoints.contains(&fixture.unlocked));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actor_manual_tx_rejects_db_locked_outpoints() {
+        let fixture = locked_actor_fixture();
+        let mut actor = fixture.actor;
+
+        let result = actor
+            .build_manual_tx(
+                vec![fixture.locked],
+                Amount::from_sat(76_000),
+                Address::preview_new(),
+                one_sat_vbyte_fee_rate(),
+            )
+            .await;
+        let error =
+            actor_value(result).await.expect_err("locked manual output selection is rejected");
 
         assert!(matches!(error, super::Error::LockedOutputsSelected));
     }

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -345,15 +345,13 @@ impl StringOrData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
-pub struct Bip329Labels {
-    pub(crate) parsed: bip329::ParsedLabels,
-}
+pub struct Bip329Labels(pub(crate) bip329::ParsedLabels);
 
 impl Bip329Labels {
     pub(crate) fn try_from_str(string: &str) -> Result<Self, bip329::error::ParseError> {
         let parsed = bip329::Labels::try_from_str_with_metadata(string)?;
 
-        Ok(Self { parsed })
+        Ok(Self(parsed))
     }
 }
 

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -143,8 +143,8 @@ impl MultiFormat {
         }
 
         // try and parse bip329 labels
-        if let Ok(labels) = bip329::Labels::try_from_str(string) {
-            return Ok(Self::Bip329Labels(Arc::new(labels.into())));
+        if let Ok(labels) = Bip329Labels::try_from_str(string) {
+            return Ok(Self::Bip329Labels(Arc::new(labels)));
         }
 
         if string.contains("tapsigner.com/start") {
@@ -344,19 +344,24 @@ impl StringOrData {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    uniffi::Object,
-    derive_more::Into,
-    derive_more::From,
-    derive_more::Deref,
-    derive_more::AsRef,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+pub struct Bip329Labels {
+    pub(crate) parsed: bip329::ParsedLabels,
+}
 
-pub struct Bip329Labels(pub bip329::Labels);
+impl Bip329Labels {
+    pub(crate) fn try_from_str(string: &str) -> Result<Self, bip329::error::ParseError> {
+        let parsed = bip329::Labels::try_from_str_with_metadata(string)?;
+
+        Ok(Self { parsed })
+    }
+}
+
+impl From<bip329::Labels> for Bip329Labels {
+    fn from(labels: bip329::Labels) -> Self {
+        Self { parsed: bip329::ParsedLabels { labels, output_spendable: Vec::new() } }
+    }
+}
 
 impl From<cove_tap_card::TapSigner> for MultiFormat {
     fn from(tap_signer: cove_tap_card::TapSigner) -> Self {

--- a/rust/src/multi_format.rs
+++ b/rust/src/multi_format.rs
@@ -357,12 +357,6 @@ impl Bip329Labels {
     }
 }
 
-impl From<bip329::Labels> for Bip329Labels {
-    fn from(labels: bip329::Labels) -> Self {
-        Self { parsed: bip329::ParsedLabels { labels, output_spendable: Vec::new() } }
-    }
-}
-
 impl From<cove_tap_card::TapSigner> for MultiFormat {
     fn from(tap_signer: cove_tap_card::TapSigner) -> Self {
         Self::from(Arc::new(tap_signer))

--- a/rust/src/node/client/electrum.rs
+++ b/rust/src/node/client/electrum.rs
@@ -334,7 +334,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // requires external network connection to blockstream electrum server
     async fn test_get_confirmed_transaction_fallback() {
-        cove_tokio::init();
+        crate::test_support::ensure_tokio_runtime();
 
         // blockstream.info does not support verbose transactions
         let client = ElectrumClient::new_from_node(&crate::node::Node {

--- a/rust/src/test_support.rs
+++ b/rust/src/test_support.rs
@@ -1,0 +1,28 @@
+use std::sync::OnceLock;
+
+/// Starts a process-long Tokio runtime for tests that need the shared cove_tokio handle
+pub(crate) fn ensure_tokio_runtime() {
+    static INIT: OnceLock<()> = OnceLock::new();
+
+    INIT.get_or_init(|| {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+
+        std::thread::Builder::new()
+            .name("cove-test-tokio".into())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("create cove test tokio runtime");
+
+                runtime.block_on(async move {
+                    cove_tokio::init();
+                    sender.send(()).expect("signal cove test tokio runtime");
+                    std::future::pending::<()>().await;
+                });
+            })
+            .expect("spawn cove test tokio runtime thread");
+
+        receiver.recv().expect("wait for cove test tokio runtime");
+    });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction lock/unlock controls with retry, progress states, and dedicated load/update error messaging.
  * Added UTXO locking improvements: per-row lock/unlock, locked-selection warnings, and clearer notices when lock state can’t be read.
  * Enhanced label import to reconcile wallet and send-flow state after import, showing accurate “manual refresh may be needed” feedback.
* **Bug Fixes**
  * Prevent sending when selected inputs include locked coins; improved “Insufficient Funds” guidance for locked selections.
  * Hardened coin control selection/spendability so totals and navigation only consider spendable UTXOs.
  * Improved label import validation and refreshed error notifications when label refresh fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->