### PR TITLE
Add shared block explorer presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "10"
+
 jobs:
   rustfmt:
     runs-on: ubuntu-latest

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -179,6 +179,7 @@ fun BlockExplorerSettingsScreen(
                 }
             }
 
+            SectionHeader(stringResource(R.string.title_settings_block_explorer), showDivider = false)
             MaterialSection {
                 Text(
                     text = stringResource(R.string.block_explorer_description),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -98,11 +98,11 @@ fun BlockExplorerSettingsScreen(
     fun updatePreview(value: String) {
         try {
             preview = config.previewCustomBlockExplorer(selectedNetwork, value)
-        } catch (_: Exception) {
-            // keep save as the validation point while the user is still typing
+            validationError = null
+        } catch (error: Exception) {
+            preview = ""
+            validationError = error.message ?: error.toString()
         }
-
-        validationError = null
     }
 
     fun save() {
@@ -119,10 +119,7 @@ fun BlockExplorerSettingsScreen(
                     }
                 input = normalized ?: ""
                 preview = config.effectiveBlockExplorerPreview(networkToSave)
-                selectedOption = BlockExplorerOption.CUSTOM
-                if (normalized == null) {
-                    selectedOption = config.selectedBlockExplorerOption(networkToSave)
-                }
+                selectedOption = config.selectedBlockExplorerOption(networkToSave)
                 validationError = null
                 keyboardController?.hide()
                 isSaving = false

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -89,9 +89,13 @@ fun BlockExplorerSettingsScreen(
 
     fun save() {
         try {
-            input = config.setCustomBlockExplorer(selectedNetwork, input) ?: ""
+            val normalized = config.setCustomBlockExplorer(selectedNetwork, input)
+            input = normalized ?: ""
             preview = config.effectiveBlockExplorerPreview(selectedNetwork)
-            selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
+            selectedOption = BlockExplorerOption.CUSTOM
+            if (normalized == null) {
+                selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
+            }
             validationError = null
         } catch (error: Exception) {
             validationError = error.message ?: error.toString()

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -80,10 +80,11 @@ fun BlockExplorerSettingsScreen(
     fun updatePreview(value: String) {
         try {
             preview = config.previewCustomBlockExplorer(selectedNetwork, value)
-            validationError = null
-        } catch (error: Exception) {
-            validationError = error.message ?: error.toString()
+        } catch (_: Exception) {
+            // keep save as the validation point while the user is still typing
         }
+
+        validationError = null
     }
 
     fun save() {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -48,9 +48,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.views.MaterialDivider
@@ -128,10 +126,7 @@ fun BlockExplorerSettingsScreen(
         scope.launch {
             isSaving = true
             try {
-                val normalized =
-                    withContext(Dispatchers.IO) {
-                        config.setCustomBlockExplorer(networkToSave, inputToSave)
-                    }
+                val normalized = config.setCustomBlockExplorer(networkToSave, inputToSave)
                 input = normalized ?: ""
                 preview = config.effectiveBlockExplorerPreview(networkToSave)
                 selectedOption = config.selectedBlockExplorerOption(networkToSave)
@@ -170,6 +165,10 @@ fun BlockExplorerSettingsScreen(
     fun selectOption(option: BlockExplorerOption) {
         when (option) {
             BlockExplorerOption.CUSTOM -> {
+                if (selectedOption == BlockExplorerOption.CUSTOM) {
+                    return
+                }
+
                 selectedOption = BlockExplorerOption.CUSTOM
                 input = ""
                 updatePreview(input)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -52,9 +52,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove.R
+import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.views.MaterialDivider
 import org.bitcoinppl.cove.views.MaterialSection
 import org.bitcoinppl.cove.views.SectionHeader
+import org.bitcoinppl.cove_core.AppAlertState
 import org.bitcoinppl.cove_core.BlockExplorerOption
 import org.bitcoinppl.cove_core.Database
 import org.bitcoinppl.cove_core.allBlockExplorerOptions
@@ -71,6 +73,10 @@ fun BlockExplorerSettingsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val keyboardController = LocalSoftwareKeyboardController.current
     val savedMessage = stringResource(R.string.block_explorer_saved)
+    val invalidUrlTitle = stringResource(R.string.block_explorer_invalid_url_title)
+    val invalidUrlMessage = stringResource(R.string.block_explorer_invalid_url_message)
+    val updateFailedTitle = stringResource(R.string.block_explorer_update_failed_title)
+    val updateFailedMessage = stringResource(R.string.block_explorer_update_failed_message)
 
     // only Bitcoin explorer overrides are editable; other networks use built-in defaults
     val editableNetworks = remember { listOf(Network.BITCOIN) }
@@ -84,24 +90,33 @@ fun BlockExplorerSettingsScreen(
     var selectedOption by remember(selectedNetwork) {
         mutableStateOf(config.selectedBlockExplorerOption(selectedNetwork))
     }
-    var validationError by remember(selectedNetwork) { mutableStateOf<String?>(null) }
     var isSaving by remember(selectedNetwork) { mutableStateOf(false) }
     val blockExplorerOptions = remember { allBlockExplorerOptions() }
+
+    fun showAlert(
+        title: String,
+        message: String,
+    ) {
+        app.alertState =
+            TaggedItem(
+                AppAlertState.General(
+                    title = title,
+                    message = message,
+                ),
+            )
+    }
 
     fun reload() {
         input = config.customBlockExplorer(selectedNetwork) ?: ""
         preview = config.effectiveBlockExplorerPreview(selectedNetwork)
         selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
-        validationError = null
     }
 
     fun updatePreview(value: String) {
         try {
             preview = config.previewCustomBlockExplorer(selectedNetwork, value)
-            validationError = null
-        } catch (error: Exception) {
+        } catch (e: Exception) {
             preview = ""
-            validationError = error.message ?: error.toString()
         }
     }
 
@@ -120,15 +135,14 @@ fun BlockExplorerSettingsScreen(
                 input = normalized ?: ""
                 preview = config.effectiveBlockExplorerPreview(networkToSave)
                 selectedOption = config.selectedBlockExplorerOption(networkToSave)
-                validationError = null
                 keyboardController?.hide()
                 isSaving = false
 
                 launch {
                     snackbarHostState.showSnackbar(savedMessage)
                 }
-            } catch (error: Exception) {
-                validationError = error.message ?: error.toString()
+            } catch (e: Exception) {
+                showAlert(invalidUrlTitle, invalidUrlMessage)
                 isSaving = false
             }
         }
@@ -139,9 +153,8 @@ fun BlockExplorerSettingsScreen(
             input = config.setBlockExplorerOption(selectedNetwork, option) ?: ""
             preview = config.effectiveBlockExplorerPreview(selectedNetwork)
             selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
-            validationError = null
-        } catch (error: Exception) {
-            validationError = error.message ?: error.toString()
+        } catch (e: Exception) {
+            showAlert(updateFailedTitle, updateFailedMessage)
         }
     }
 
@@ -149,8 +162,8 @@ fun BlockExplorerSettingsScreen(
         try {
             config.clearCustomBlockExplorer(selectedNetwork)
             reload()
-        } catch (error: Exception) {
-            validationError = error.message ?: error.toString()
+        } catch (e: Exception) {
+            showAlert(updateFailedTitle, updateFailedMessage)
         }
     }
 
@@ -286,8 +299,6 @@ fun BlockExplorerSettingsScreen(
                                 ),
                             keyboardActions = KeyboardActions(onDone = { save() }),
                             singleLine = true,
-                            isError = validationError != null,
-                            supportingText = validationError?.let { error -> { Text(error) } },
                             modifier = Modifier.fillMaxWidth(),
                         )
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -180,7 +180,7 @@ fun BlockExplorerSettingsScreen(
                 }
             }
 
-            SectionHeader(stringResource(R.string.title_settings_block_explorer), showDivider = false)
+            SectionHeader(stringResource(R.string.block_explorer_description_title), showDivider = false)
             MaterialSection {
                 Text(
                     text = stringResource(R.string.block_explorer_description),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -1,14 +1,17 @@
 package org.bitcoinppl.cove.flows.SettingsFlow
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -16,12 +19,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -29,15 +35,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.views.MaterialDivider
 import org.bitcoinppl.cove.views.MaterialSection
@@ -54,6 +65,10 @@ fun BlockExplorerSettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     val config = remember { Database().globalConfig() }
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val savedMessage = stringResource(R.string.block_explorer_saved)
 
     // only Bitcoin explorer overrides are editable; other networks use built-in defaults
     val editableNetworks = remember { listOf(Network.BITCOIN) }
@@ -68,6 +83,7 @@ fun BlockExplorerSettingsScreen(
         mutableStateOf(config.selectedBlockExplorerOption(selectedNetwork))
     }
     var validationError by remember(selectedNetwork) { mutableStateOf<String?>(null) }
+    var isSaving by remember(selectedNetwork) { mutableStateOf(false) }
     val blockExplorerOptions = remember { allBlockExplorerOptions() }
 
     fun reload() {
@@ -88,17 +104,34 @@ fun BlockExplorerSettingsScreen(
     }
 
     fun save() {
-        try {
-            val normalized = config.setCustomBlockExplorer(selectedNetwork, input)
-            input = normalized ?: ""
-            preview = config.effectiveBlockExplorerPreview(selectedNetwork)
-            selectedOption = BlockExplorerOption.CUSTOM
-            if (normalized == null) {
-                selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
+        if (isSaving) return
+
+        val inputToSave = input
+        val networkToSave = selectedNetwork
+        scope.launch {
+            isSaving = true
+            try {
+                val normalized =
+                    withContext(Dispatchers.IO) {
+                        config.setCustomBlockExplorer(networkToSave, inputToSave)
+                    }
+                input = normalized ?: ""
+                preview = config.effectiveBlockExplorerPreview(networkToSave)
+                selectedOption = BlockExplorerOption.CUSTOM
+                if (normalized == null) {
+                    selectedOption = config.selectedBlockExplorerOption(networkToSave)
+                }
+                validationError = null
+                keyboardController?.hide()
+                isSaving = false
+
+                launch {
+                    snackbarHostState.showSnackbar(savedMessage)
+                }
+            } catch (error: Exception) {
+                validationError = error.message ?: error.toString()
+                isSaving = false
             }
-            validationError = null
-        } catch (error: Exception) {
-            validationError = error.message ?: error.toString()
         }
     }
 
@@ -137,6 +170,7 @@ fun BlockExplorerSettingsScreen(
             modifier
                 .fillMaxSize()
                 .padding(WindowInsets.safeDrawing.asPaddingValues()),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {
@@ -152,7 +186,18 @@ fun BlockExplorerSettingsScreen(
                         Icon(Icons.AutoMirrored.Default.ArrowBack, contentDescription = "Back")
                     }
                 },
-                actions = { },
+                actions = {
+                    if (isSaving) {
+                        Box(
+                            modifier = Modifier.padding(end = 16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.width(24.dp).height(24.dp),
+                            )
+                        }
+                    }
+                },
             )
         },
     ) { paddingValues ->
@@ -252,7 +297,10 @@ fun BlockExplorerSettingsScreen(
                                     .padding(top = 12.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Button(onClick = ::save) {
+                            Button(
+                                onClick = ::save,
+                                enabled = !isSaving,
+                            ) {
                                 Text(stringResource(R.string.block_explorer_save))
                             }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -44,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
@@ -159,6 +161,7 @@ fun BlockExplorerSettingsScreen(
         when (option) {
             BlockExplorerOption.CUSTOM -> {
                 selectedOption = BlockExplorerOption.CUSTOM
+                input = ""
                 updatePreview(input)
             }
             else -> savePreset(option)
@@ -281,10 +284,11 @@ fun BlockExplorerSettingsScreen(
                             keyboardOptions =
                                 KeyboardOptions(
                                     capitalization = KeyboardCapitalization.None,
+                                    imeAction = ImeAction.Done,
                                     keyboardType = KeyboardType.Uri,
                                 ),
-                            minLines = 1,
-                            maxLines = 4,
+                            keyboardActions = KeyboardActions(onDone = { save() }),
+                            singleLine = true,
                             isError = validationError != null,
                             supportingText = validationError?.let { error -> { Text(error) } },
                             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/BlockExplorerSettingsScreen.kt
@@ -42,7 +42,9 @@ import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.views.MaterialDivider
 import org.bitcoinppl.cove.views.MaterialSection
 import org.bitcoinppl.cove.views.SectionHeader
+import org.bitcoinppl.cove_core.BlockExplorerOption
 import org.bitcoinppl.cove_core.Database
+import org.bitcoinppl.cove_core.allBlockExplorerOptions
 import org.bitcoinppl.cove_core.types.Network
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -62,11 +64,16 @@ fun BlockExplorerSettingsScreen(
     var preview by remember(selectedNetwork) {
         mutableStateOf(config.effectiveBlockExplorerPreview(selectedNetwork))
     }
+    var selectedOption by remember(selectedNetwork) {
+        mutableStateOf(config.selectedBlockExplorerOption(selectedNetwork))
+    }
     var validationError by remember(selectedNetwork) { mutableStateOf<String?>(null) }
+    val blockExplorerOptions = remember { allBlockExplorerOptions() }
 
     fun reload() {
         input = config.customBlockExplorer(selectedNetwork) ?: ""
         preview = config.effectiveBlockExplorerPreview(selectedNetwork)
+        selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
         validationError = null
     }
 
@@ -83,6 +90,18 @@ fun BlockExplorerSettingsScreen(
         try {
             input = config.setCustomBlockExplorer(selectedNetwork, input) ?: ""
             preview = config.effectiveBlockExplorerPreview(selectedNetwork)
+            selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
+            validationError = null
+        } catch (error: Exception) {
+            validationError = error.message ?: error.toString()
+        }
+    }
+
+    fun savePreset(option: BlockExplorerOption) {
+        try {
+            input = config.setBlockExplorerOption(selectedNetwork, option) ?: ""
+            preview = config.effectiveBlockExplorerPreview(selectedNetwork)
+            selectedOption = config.selectedBlockExplorerOption(selectedNetwork)
             validationError = null
         } catch (error: Exception) {
             validationError = error.message ?: error.toString()
@@ -95,6 +114,16 @@ fun BlockExplorerSettingsScreen(
             reload()
         } catch (error: Exception) {
             validationError = error.message ?: error.toString()
+        }
+    }
+
+    fun selectOption(option: BlockExplorerOption) {
+        when (option) {
+            BlockExplorerOption.CUSTOM -> {
+                selectedOption = BlockExplorerOption.CUSTOM
+                updatePreview(input)
+            }
+            else -> savePreset(option)
         }
     }
 
@@ -150,6 +179,15 @@ fun BlockExplorerSettingsScreen(
                 }
             }
 
+            MaterialSection {
+                Text(
+                    text = stringResource(R.string.block_explorer_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+            }
+
             SectionHeader(stringResource(R.string.block_explorer_preview), showDivider = false)
             MaterialSection {
                 Text(
@@ -160,44 +198,95 @@ fun BlockExplorerSettingsScreen(
                 )
             }
 
+            SectionHeader(stringResource(R.string.block_explorer_options))
             MaterialSection {
-                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
-                    OutlinedTextField(
-                        value = input,
-                        onValueChange = {
-                            input = it
-                            updatePreview(it)
-                        },
-                        label = { Text(stringResource(R.string.block_explorer_url_placeholder)) },
-                        keyboardOptions =
-                            KeyboardOptions(
-                                capitalization = KeyboardCapitalization.None,
-                                keyboardType = KeyboardType.Uri,
-                            ),
-                        minLines = 1,
-                        maxLines = 4,
-                        isError = validationError != null,
-                        supportingText = validationError?.let { error -> { Text(error) } },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                Column {
+                    blockExplorerOptions.forEachIndexed { index, option ->
+                        BlockExplorerOptionRow(
+                            option = option,
+                            isSelected = selectedOption == option,
+                            onClick = { selectOption(option) },
+                        )
 
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(top = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Button(onClick = ::save) {
-                            Text(stringResource(R.string.block_explorer_save))
-                        }
-
-                        TextButton(onClick = ::reset) {
-                            Text(stringResource(R.string.block_explorer_reset))
+                        if (index < blockExplorerOptions.size - 1) {
+                            MaterialDivider()
                         }
                     }
                 }
             }
+
+            if (selectedOption == BlockExplorerOption.CUSTOM) {
+                SectionHeader(BlockExplorerOption.CUSTOM.displayName())
+                MaterialSection {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                        OutlinedTextField(
+                            value = input,
+                            onValueChange = {
+                                input = it
+                                selectedOption = BlockExplorerOption.CUSTOM
+                                updatePreview(it)
+                            },
+                            label = { Text(stringResource(R.string.block_explorer_url_placeholder)) },
+                            keyboardOptions =
+                                KeyboardOptions(
+                                    capitalization = KeyboardCapitalization.None,
+                                    keyboardType = KeyboardType.Uri,
+                                ),
+                            minLines = 1,
+                            maxLines = 4,
+                            isError = validationError != null,
+                            supportingText = validationError?.let { error -> { Text(error) } },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Button(onClick = ::save) {
+                                Text(stringResource(R.string.block_explorer_save))
+                            }
+
+                            TextButton(onClick = ::reset) {
+                                Text(stringResource(R.string.block_explorer_reset))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlockExplorerOptionRow(
+    option: BlockExplorerOption,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = option.displayName(),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/MainSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/MainSettingsScreen.kt
@@ -94,7 +94,6 @@ import org.bitcoinppl.cove_core.SecuritySheetState
 import org.bitcoinppl.cove_core.SettingsRoute
 import org.bitcoinppl.cove_core.WalletMetadata
 import org.bitcoinppl.cove_core.WalletSettingsRoute
-import org.bitcoinppl.cove_core.types.Network
 
 internal fun shouldShowCloudBackupSettings(
     isInDecoyMode: Boolean,
@@ -239,7 +238,6 @@ fun MainSettingsScreen(
                         MaterialDivider()
                         MaterialSettingsItem(
                             title = stringResource(R.string.title_settings_block_explorer),
-                            subtitle = Database().globalConfig().effectiveBlockExplorerHost(Network.BITCOIN),
                             icon = Icons.Default.Public,
                             onClick = {
                                 app.pushRoute(

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
@@ -133,6 +133,10 @@ fun NodeSettingsScreen(
     }
 
     fun selectPresetNode(nodeName: String) {
+        if (selectedNodeName == nodeName) {
+            return
+        }
+
         selectedNodeName = nodeName
         customUrl = ""
         customNodeName = ""

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/NodeSettingsScreen.kt
@@ -133,7 +133,7 @@ fun NodeSettingsScreen(
     }
 
     fun selectPresetNode(nodeName: String) {
-        if (selectedNodeName == nodeName) {
+        if (selectedNodeSelection is NodeSelection.Preset && selectedNodeName == nodeName) {
             return
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -3705,7 +3705,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_func_active_migration() != 29388.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_func_all_block_explorer_options() != 48219.toShort()) {
+    if (lib.uniffi_cove_checksum_func_all_block_explorer_options() != 60996.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_all_fiat_currencies() != 53482.toShort()) {
@@ -34659,7 +34659,10 @@ enum class BlockExplorerOption {
     BLOCKSTREAM,
     CUSTOM;
 
-     fun `displayName`(): kotlin.String {
+
+    /**
+     * Returns the user-visible label for this explorer option.
+     */ fun `displayName`(): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_method_blockexploreroption_display_name(FfiConverterTypeBlockExplorerOption.lower(this),
@@ -59266,7 +59269,10 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
     )
     }
 
- fun `allBlockExplorerOptions`(): List<BlockExplorerOption> {
+
+        /**
+         * Returns every block explorer option exposed to mobile clients.
+         */ fun `allBlockExplorerOptions`(): List<BlockExplorerOption> {
             return FfiConverterSequenceTypeBlockExplorerOption.lift(
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_func_all_block_explorer_options(

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1087,6 +1087,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_func_active_migration(
     ): Short
+    external fun uniffi_cove_checksum_func_all_block_explorer_options(
+    ): Short
     external fun uniffi_cove_checksum_func_all_fiat_currencies(
     ): Short
     external fun uniffi_cove_checksum_func_is_fiat_currency_symbol(
@@ -1331,6 +1333,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_selectedfiatcurrency(
     ): Short
+    external fun uniffi_cove_checksum_method_globalconfigtable_selected_block_explorer_option(
+    ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_selected_network(
     ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_selected_node(
@@ -1340,6 +1344,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_globalconfigtable_set(
     ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_setcolorscheme(
+    ): Short
+    external fun uniffi_cove_checksum_method_globalconfigtable_set_block_explorer_option(
     ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_set_custom_block_explorer(
     ): Short
@@ -2317,6 +2323,8 @@ internal object UniffiLib {
     ): Unit
     external fun uniffi_cove_fn_method_globalconfigtable_selectedfiatcurrency(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_globalconfigtable_selected_block_explorer_option(`ptr`: Long,`network`: RustBufferNetwork.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_globalconfigtable_selected_network(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBufferNetwork.ByValue
     external fun uniffi_cove_fn_method_globalconfigtable_selected_node(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -2327,6 +2335,8 @@ internal object UniffiLib {
     ): Unit
     external fun uniffi_cove_fn_method_globalconfigtable_setcolorscheme(`ptr`: Long,`colorScheme`: RustBufferColorSchemeSelection.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
+    external fun uniffi_cove_fn_method_globalconfigtable_set_block_explorer_option(`ptr`: Long,`network`: RustBufferNetwork.ByValue,`option`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_globalconfigtable_set_custom_block_explorer(`ptr`: Long,`network`: RustBufferNetwork.ByValue,`input`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_globalconfigtable_set_hashed_pin_code(`ptr`: Long,`hashedPinCode`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
@@ -3275,6 +3285,8 @@ internal object UniffiLib {
     ): Byte
     external fun uniffi_cove_fn_method_convertererror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_blockexploreroption_display_name(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_databaseerror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_serdeerror_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
@@ -3442,6 +3454,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_func_startup_diagnostic_text_report(uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_active_migration(uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_func_all_block_explorer_options(uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_all_fiat_currencies(uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
@@ -3689,6 +3703,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_active_migration() != 29388.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_all_block_explorer_options() != 48219.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_all_fiat_currencies() != 53482.toShort()) {
@@ -4057,6 +4074,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_globalconfigtable_selectedfiatcurrency() != 11234.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_cove_checksum_method_globalconfigtable_selected_block_explorer_option() != 31659.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_cove_checksum_method_globalconfigtable_selected_network() != 17475.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -4070,6 +4090,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_globalconfigtable_setcolorscheme() != 42967.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_globalconfigtable_set_block_explorer_option() != 32847.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_globalconfigtable_set_custom_block_explorer() != 26335.toShort()) {
@@ -12296,6 +12319,8 @@ public interface GlobalConfigTableInterface {
 
     fun `selectedFiatCurrency`(): FiatCurrency
 
+    fun `selectedBlockExplorerOption`(`network`: Network): BlockExplorerOption
+
     fun `selectedNetwork`(): Network
 
     fun `selectedNode`(): Node
@@ -12305,6 +12330,8 @@ public interface GlobalConfigTableInterface {
     fun `set`(`key`: GlobalConfigKey, `value`: kotlin.String)
 
     fun `setColorScheme`(`colorScheme`: ColorSchemeSelection)
+
+    fun `setBlockExplorerOption`(`network`: Network, `option`: BlockExplorerOption): kotlin.String?
 
     fun `setCustomBlockExplorer`(`network`: Network, `input`: kotlin.String): kotlin.String?
 
@@ -12640,6 +12667,20 @@ open class GlobalConfigTable: Disposable, AutoCloseable, GlobalConfigTableInterf
     }
 
 
+    override fun `selectedBlockExplorerOption`(`network`: Network): BlockExplorerOption {
+            return FfiConverterTypeBlockExplorerOption.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_globalconfigtable_selected_block_explorer_option(
+        it,
+
+        FfiConverterTypeNetwork.lower(`network`),_status)
+}
+    }
+    )
+    }
+
+
     override fun `selectedNetwork`(): Network {
             return FfiConverterTypeNetwork.lift(
     callWithHandle {
@@ -12706,6 +12747,22 @@ open class GlobalConfigTable: Disposable, AutoCloseable, GlobalConfigTableInterf
 }
     }
 
+
+
+
+    @Throws(DatabaseException::class)override fun `setBlockExplorerOption`(`network`: Network, `option`: BlockExplorerOption): kotlin.String? {
+            return FfiConverterOptionalString.lift(
+    callWithHandle {
+    uniffiRustCallWithError(DatabaseException) { _status ->
+    UniffiLib.uniffi_cove_fn_method_globalconfigtable_set_block_explorer_option(
+        it,
+
+        FfiConverterTypeNetwork.lower(`network`),
+        FfiConverterTypeBlockExplorerOption.lower(`option`),_status)
+}
+    }
+    )
+    }
 
 
 
@@ -34590,6 +34647,53 @@ public object FfiConverterTypeBitcoinTransactionError : FfiConverterRustBuffer<B
     }
 
 }
+
+
+
+
+enum class BlockExplorerOption {
+
+    MEMPOOL_SPACE,
+    MEMPOOL_GUIDE,
+    BULL_BITCOIN,
+    BLOCKSTREAM,
+    CUSTOM;
+
+     fun `displayName`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_blockexploreroption_display_name(FfiConverterTypeBlockExplorerOption.lower(this),
+        _status)
+}
+    )
+    }
+
+
+
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeBlockExplorerOption: FfiConverterRustBuffer<BlockExplorerOption> {
+    override fun read(buf: ByteBuffer) = try {
+        BlockExplorerOption.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: BlockExplorerOption) = 4UL
+
+    override fun write(value: BlockExplorerOption, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
 
 
 
@@ -58551,6 +58655,34 @@ public object FfiConverterSequenceTypeUtxo: FfiConverterRustBuffer<List<Utxo>> {
 /**
  * @suppress
  */
+public object FfiConverterSequenceTypeBlockExplorerOption: FfiConverterRustBuffer<List<BlockExplorerOption>> {
+    override fun read(buf: ByteBuffer): List<BlockExplorerOption> {
+        val len = buf.getInt()
+        return List<BlockExplorerOption>(len) {
+            FfiConverterTypeBlockExplorerOption.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<BlockExplorerOption>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeBlockExplorerOption.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<BlockExplorerOption>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeBlockExplorerOption.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterSequenceTypeCoinControlManagerReconcileMessage: FfiConverterRustBuffer<List<CoinControlManagerReconcileMessage>> {
     override fun read(buf: ByteBuffer): List<CoinControlManagerReconcileMessage> {
         val len = buf.getInt()
@@ -59128,6 +59260,16 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
             return FfiConverterOptionalTypeMigration.lift(
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_func_active_migration(
+
+        _status)
+}
+    )
+    }
+
+ fun `allBlockExplorerOptions`(): List<BlockExplorerOption> {
+            return FfiConverterSequenceTypeBlockExplorerOption.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_all_block_explorer_options(
 
         _status)
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1315,8 +1315,6 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_delete_hashed_pin_code(
     ): Short
-    external fun uniffi_cove_checksum_method_globalconfigtable_effective_block_explorer_host(
-    ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_effective_block_explorer_preview(
     ): Short
     external fun uniffi_cove_checksum_method_globalconfigtable_get(
@@ -2305,8 +2303,6 @@ internal object UniffiLib {
     ): Unit
     external fun uniffi_cove_fn_method_globalconfigtable_delete_hashed_pin_code(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Unit
-    external fun uniffi_cove_fn_method_globalconfigtable_effective_block_explorer_host(`ptr`: Long,`network`: RustBufferNetwork.ByValue,uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_globalconfigtable_effective_block_explorer_preview(`ptr`: Long,`network`: RustBufferNetwork.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_globalconfigtable_get(`ptr`: Long,`key`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
@@ -3705,7 +3701,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_func_active_migration() != 29388.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_func_all_block_explorer_options() != 60996.toShort()) {
+    if (lib.uniffi_cove_checksum_func_all_block_explorer_options() != 40123.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_all_fiat_currencies() != 53482.toShort()) {
@@ -4045,9 +4041,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_globalconfigtable_delete_hashed_pin_code() != 24897.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_method_globalconfigtable_effective_block_explorer_host() != 22806.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_globalconfigtable_effective_block_explorer_preview() != 21192.toShort()) {
@@ -12301,8 +12294,6 @@ public interface GlobalConfigTableInterface {
 
     fun `deleteHashedPinCode`()
 
-    fun `effectiveBlockExplorerHost`(`network`: Network): kotlin.String
-
     fun `effectiveBlockExplorerPreview`(`network`: Network): kotlin.String
 
     fun `get`(`key`: GlobalConfigKey): kotlin.String?
@@ -12539,20 +12530,6 @@ open class GlobalConfigTable: Disposable, AutoCloseable, GlobalConfigTableInterf
 }
     }
 
-
-
-    override fun `effectiveBlockExplorerHost`(`network`: Network): kotlin.String {
-            return FfiConverterString.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_method_globalconfigtable_effective_block_explorer_host(
-        it,
-
-        FfiConverterTypeNetwork.lower(`network`),_status)
-}
-    }
-    )
-    }
 
 
     override fun `effectiveBlockExplorerPreview`(`network`: Network): kotlin.String {
@@ -34661,7 +34638,7 @@ enum class BlockExplorerOption {
 
 
     /**
-     * Returns the user-visible label for this explorer option.
+     * Returns the user-visible label for this explorer option
      */ fun `displayName`(): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCall() { _status ->
@@ -59271,7 +59248,7 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
 
 
         /**
-         * Returns every block explorer option exposed to mobile clients.
+         * Returns every block explorer option exposed to mobile clients
          */ fun `allBlockExplorerOptions`(): List<BlockExplorerOption> {
             return FfiConverterSequenceTypeBlockExplorerOption.lift(
     uniffiRustCall() { _status ->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="block_explorer_options">Explorer</string>
     <string name="block_explorer_url_placeholder">URL or template</string>
     <string name="block_explorer_save">Save</string>
+    <string name="block_explorer_saved">Block explorer saved successfully</string>
     <string name="block_explorer_reset">Reset to Default</string>
     <string name="title_wallet_information">Wallet information</string>
     <string name="label_wallet_network">Network</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -34,6 +34,10 @@
     <string name="block_explorer_save">Save</string>
     <string name="block_explorer_saved">Block explorer saved successfully</string>
     <string name="block_explorer_reset">Reset to Default</string>
+    <string name="block_explorer_invalid_url_title">Invalid URL</string>
+    <string name="block_explorer_invalid_url_message">Enter a valid URL, IP address, or block explorer template.</string>
+    <string name="block_explorer_update_failed_title">Unable to Update Block Explorer</string>
+    <string name="block_explorer_update_failed_message">Try again later.</string>
     <string name="title_wallet_information">Wallet information</string>
     <string name="label_wallet_network">Network</string>
     <string name="label_wallet_birthday">Birthday</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="title_settings_node">Node</string>
     <string name="title_settings_currency">Currency</string>
     <string name="block_explorer_preview">Preview</string>
+    <string name="block_explorer_description_title">Description</string>
     <string name="block_explorer_description">Block explorers are public websites for checking Bitcoin transaction details and confirmations. Cove opens the selected explorer when you view a transaction.</string>
     <string name="block_explorer_options">Explorer</string>
     <string name="block_explorer_url_placeholder">URL or template</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="title_settings_node">Node</string>
     <string name="title_settings_currency">Currency</string>
     <string name="block_explorer_preview">Preview</string>
+    <string name="block_explorer_description">Block explorers are public websites for checking Bitcoin transaction details and confirmations. Cove opens the selected explorer when you view a transaction.</string>
+    <string name="block_explorer_options">Explorer</string>
     <string name="block_explorer_url_placeholder">URL or template</string>
     <string name="block_explorer_save">Save</string>
     <string name="block_explorer_reset">Reset to Default</string>

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 struct BlockExplorerSettingsView: View {
     private let config = Database().globalConfig()
+    private static let previewTransactionId = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    private static let knownBitcoinTransactionId = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
 
     @State private var selectedNetwork: Network
     @State private var input: String
@@ -10,6 +12,7 @@ struct BlockExplorerSettingsView: View {
     @State private var selectedOption: BlockExplorerOption
     @State private var validationError: String?
     @State private var isSaving = false
+    @State private var saveTask: Task<Void, Never>?
     @State private var showInvalidUrlAlert = false
     @FocusState private var isInputFocused: Bool
 
@@ -95,6 +98,9 @@ struct BlockExplorerSettingsView: View {
         .onChange(of: selectedNetwork) { _, _ in
             reload()
         }
+        .onDisappear {
+            saveTask?.cancel()
+        }
         .alert("Invalid URL", isPresented: $showInvalidUrlAlert) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -172,9 +178,10 @@ struct BlockExplorerSettingsView: View {
 
         let inputToSave = input
         let networkToSave = selectedNetwork
+        let checkUrl: URL
 
         do {
-            _ = try config.previewCustomBlockExplorer(
+            checkUrl = try blockExplorerCheckUrl(
                 network: networkToSave,
                 input: inputToSave
             )
@@ -185,30 +192,85 @@ struct BlockExplorerSettingsView: View {
         }
 
         isSaving = true
-        defer { isSaving = false }
+        isInputFocused = false
 
-        do {
-            let normalized = try config.setCustomBlockExplorer(
-                network: networkToSave,
-                input: inputToSave
-            )
-            input = normalized ?? ""
-            preview = config.effectiveBlockExplorerPreview(network: networkToSave)
-            selectedOption = .custom
-            if normalized == nil {
-                selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
-            }
-            validationError = nil
-            isInputFocused = false
+        saveTask = Task { @MainActor in
+            await MiddlePopup(state: .loading, message: "Checking URL").present()
 
-            Task { @MainActor in
+            do {
+                try await checkBlockExplorerUrl(checkUrl)
+
+                let normalized = try config.setCustomBlockExplorer(
+                    network: networkToSave,
+                    input: inputToSave
+                )
+                input = normalized ?? ""
+                preview = config.effectiveBlockExplorerPreview(network: networkToSave)
+                selectedOption = .custom
+                if normalized == nil {
+                    selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
+                }
+                validationError = nil
+
+                await dismissAllPopups()
+                try? await Task.sleep(for: .milliseconds(250))
                 await MiddlePopup(state: .success("Block explorer saved successfully"))
                     .dismissAfter(2)
                     .present()
+            } catch is CancellationError {
+                await dismissAllPopups()
+            } catch {
+                let message = error.localizedDescription
+                validationError = message
+
+                await dismissAllPopups()
+                try? await Task.sleep(for: .milliseconds(250))
+                await MiddlePopup(state: .failure(message))
+                    .dismissAfter(7)
+                    .present()
             }
-        } catch {
-            validationError = error.localizedDescription
-            showInvalidUrlAlert = true
+
+            isSaving = false
+            saveTask = nil
+        }
+    }
+
+    private func blockExplorerCheckUrl(network: Network, input: String) throws -> URL {
+        let previewUrl = try config.previewCustomBlockExplorer(network: network, input: input)
+        let checkUrl = previewUrl.replacingOccurrences(
+            of: Self.previewTransactionId,
+            with: knownTransactionId(for: network)
+        )
+
+        guard let url = URL(string: checkUrl) else {
+            throw BlockExplorerCheckError.invalidUrl
+        }
+
+        return url
+    }
+
+    private func knownTransactionId(for network: Network) -> String {
+        switch network {
+        case .bitcoin:
+            Self.knownBitcoinTransactionId
+        case .testnet, .testnet4, .signet:
+            Self.knownBitcoinTransactionId
+        }
+    }
+
+    private func checkBlockExplorerUrl(_ url: URL) async throws {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.timeoutInterval = 10
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw BlockExplorerCheckError.invalidResponse
+        }
+
+        guard 200 ..< 300 ~= httpResponse.statusCode else {
+            throw BlockExplorerCheckError.unsuccessfulStatus(httpResponse.statusCode)
         }
     }
 
@@ -218,6 +280,23 @@ struct BlockExplorerSettingsView: View {
             reload()
         } catch {
             validationError = error.localizedDescription
+        }
+    }
+}
+
+private enum BlockExplorerCheckError: LocalizedError {
+    case invalidUrl
+    case invalidResponse
+    case unsuccessfulStatus(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidUrl:
+            "Invalid URL"
+        case .invalidResponse:
+            "Block explorer check did not return an HTTP response"
+        case let .unsuccessfulStatus(statusCode):
+            "Block explorer returned HTTP \(statusCode) for the test transaction"
         }
     }
 }

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 
 struct BlockExplorerSettingsView: View {
     private let config = Database().globalConfig()
-    private static let previewTransactionId = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-    private static let knownBitcoinTransactionId = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
 
     @State private var selectedNetwork: Network
     @State private var input: String
@@ -237,25 +235,12 @@ struct BlockExplorerSettingsView: View {
 
     private func blockExplorerCheckUrl(network: Network, input: String) throws -> URL {
         let previewUrl = try config.previewCustomBlockExplorer(network: network, input: input)
-        let checkUrl = previewUrl.replacingOccurrences(
-            of: Self.previewTransactionId,
-            with: knownTransactionId(for: network)
-        )
 
-        guard let url = URL(string: checkUrl) else {
+        guard let url = URL(string: previewUrl) else {
             throw BlockExplorerCheckError.invalidUrl
         }
 
         return url
-    }
-
-    private func knownTransactionId(for network: Network) -> String {
-        switch network {
-        case .bitcoin:
-            Self.knownBitcoinTransactionId
-        case .testnet, .testnet4, .signet:
-            Self.knownBitcoinTransactionId
-        }
     }
 
     private func checkBlockExplorerUrl(_ url: URL) async throws {

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -37,7 +37,7 @@ struct BlockExplorerSettingsView: View {
                 }
             }
 
-            Section {
+            Section("Block Explorer") {
                 Text(
                     "Block explorers are public websites for checking Bitcoin transaction details and confirmations. Cove opens the selected explorer when you view a transaction."
                 )

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -10,6 +10,7 @@ struct BlockExplorerSettingsView: View {
     @State private var selectedOption: BlockExplorerOption
     @State private var validationError: String?
     @State private var isSaving = false
+    @State private var showInvalidUrlAlert = false
     @FocusState private var isInputFocused: Bool
 
     init() {
@@ -94,6 +95,11 @@ struct BlockExplorerSettingsView: View {
         .onChange(of: selectedNetwork) { _, _ in
             reload()
         }
+        .alert("Invalid URL", isPresented: $showInvalidUrlAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Enter a valid URL, IP address, or block explorer template.")
+        }
     }
 
     private func blockExplorerOptionRow(_ option: BlockExplorerOption) -> some View {
@@ -166,35 +172,43 @@ struct BlockExplorerSettingsView: View {
 
         let inputToSave = input
         let networkToSave = selectedNetwork
-        Task { @MainActor in
-            isSaving = true
-            Task { await MiddlePopup(state: .loading).present() }
 
-            do {
-                let normalized = try config.setCustomBlockExplorer(
-                    network: networkToSave,
-                    input: inputToSave
-                )
-                input = normalized ?? ""
-                preview = config.effectiveBlockExplorerPreview(network: networkToSave)
-                selectedOption = .custom
-                if normalized == nil {
-                    selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
-                }
-                validationError = nil
-                isInputFocused = false
+        do {
+            _ = try config.previewCustomBlockExplorer(
+                network: networkToSave,
+                input: inputToSave
+            )
+        } catch {
+            validationError = error.localizedDescription
+            showInvalidUrlAlert = true
+            return
+        }
 
-                await dismissAllPopups()
-                try? await Task.sleep(for: .milliseconds(250))
+        isSaving = true
+        defer { isSaving = false }
+
+        do {
+            let normalized = try config.setCustomBlockExplorer(
+                network: networkToSave,
+                input: inputToSave
+            )
+            input = normalized ?? ""
+            preview = config.effectiveBlockExplorerPreview(network: networkToSave)
+            selectedOption = .custom
+            if normalized == nil {
+                selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
+            }
+            validationError = nil
+            isInputFocused = false
+
+            Task { @MainActor in
                 await MiddlePopup(state: .success("Block explorer saved successfully"))
                     .dismissAfter(2)
                     .present()
-            } catch {
-                validationError = error.localizedDescription
-                await dismissAllPopups()
             }
-
-            isSaving = false
+        } catch {
+            validationError = error.localizedDescription
+            showInvalidUrlAlert = true
         }
     }
 

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -64,15 +64,17 @@ struct BlockExplorerSettingsView: View {
 
             if selectedOption == .custom {
                 Section("Custom") {
-                    TextField("URL or template", text: $input, axis: .vertical)
+                    TextField("URL or template", text: $input)
                         .keyboardType(.URL)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
-                        .lineLimit(2 ... 5)
+                        .lineLimit(1)
+                        .submitLabel(.done)
                         .focused($isInputFocused)
                         .onChange(of: input) { _, newValue in
                             updatePreview(for: newValue)
                         }
+                        .onSubmit(save)
 
                     if let validationError {
                         Text(validationError)
@@ -117,6 +119,7 @@ struct BlockExplorerSettingsView: View {
         switch option {
         case .custom:
             selectedOption = .custom
+            input = ""
             updatePreview(for: input)
         default:
             savePreset(option)
@@ -165,7 +168,7 @@ struct BlockExplorerSettingsView: View {
         let networkToSave = selectedNetwork
         Task { @MainActor in
             isSaving = true
-            await MiddlePopup(state: .loading).present()
+            Task { await MiddlePopup(state: .loading).present() }
 
             do {
                 let normalized = try config.setCustomBlockExplorer(

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -162,7 +162,10 @@ struct BlockExplorerSettingsView: View {
             )
             input = normalized ?? ""
             preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
-            selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
+            selectedOption = .custom
+            if normalized == nil {
+                selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
+            }
             validationError = nil
         } catch {
             validationError = error.localizedDescription

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -8,9 +8,9 @@ struct BlockExplorerSettingsView: View {
     @State private var input: String
     @State private var preview: String
     @State private var selectedOption: BlockExplorerOption
-    @State private var validationError: String?
     @State private var isSaving = false
     @State private var showInvalidUrlAlert = false
+    @State private var showUpdateFailedAlert = false
     @FocusState private var isInputFocused: Bool
 
     init() {
@@ -77,12 +77,6 @@ struct BlockExplorerSettingsView: View {
                         }
                         .onSubmit(save)
 
-                    if let validationError {
-                        Text(validationError)
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-
                     Button("Save", action: save)
                         .disabled(isSaving || input == (config.customBlockExplorer(network: selectedNetwork) ?? ""))
 
@@ -99,6 +93,11 @@ struct BlockExplorerSettingsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Enter a valid URL, IP address, or block explorer template.")
+        }
+        .alert("Unable to Update Block Explorer", isPresented: $showUpdateFailedAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Try again later.")
         }
     }
 
@@ -141,9 +140,8 @@ struct BlockExplorerSettingsView: View {
             input = normalized ?? ""
             preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
             selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
-            validationError = nil
         } catch {
-            validationError = error.localizedDescription
+            showUpdateFailedAlert = true
         }
     }
 
@@ -151,7 +149,6 @@ struct BlockExplorerSettingsView: View {
         input = config.customBlockExplorer(network: selectedNetwork) ?? ""
         preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
         selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
-        validationError = nil
     }
 
     private func updatePreview(for value: String) {
@@ -160,10 +157,8 @@ struct BlockExplorerSettingsView: View {
                 network: selectedNetwork,
                 input: value
             )
-            validationError = nil
         } catch {
             preview = ""
-            validationError = error.localizedDescription
         }
     }
 
@@ -184,7 +179,6 @@ struct BlockExplorerSettingsView: View {
             input = normalized ?? ""
             preview = config.effectiveBlockExplorerPreview(network: networkToSave)
             selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
-            validationError = nil
 
             Task { @MainActor in
                 await dismissAllPopups()
@@ -194,7 +188,6 @@ struct BlockExplorerSettingsView: View {
                     .present()
             }
         } catch {
-            validationError = error.localizedDescription
             showInvalidUrlAlert = true
         }
 
@@ -206,7 +199,7 @@ struct BlockExplorerSettingsView: View {
             try config.clearCustomBlockExplorer(network: selectedNetwork)
             reload()
         } catch {
-            validationError = error.localizedDescription
+            showUpdateFailedAlert = true
         }
     }
 }

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -6,15 +6,18 @@ struct BlockExplorerSettingsView: View {
     @State private var selectedNetwork: Network
     @State private var input: String
     @State private var preview: String
+    @State private var selectedOption: BlockExplorerOption
     @State private var validationError: String?
 
     init() {
         // only Bitcoin explorer overrides are editable; other networks use built-in defaults
         let network = Network.bitcoin
         let config = Database().globalConfig()
+        let input = config.customBlockExplorer(network: network) ?? ""
         _selectedNetwork = State(initialValue: network)
-        _input = State(initialValue: config.customBlockExplorer(network: network) ?? "")
+        _input = State(initialValue: input)
         _preview = State(initialValue: config.effectiveBlockExplorerPreview(network: network))
+        _selectedOption = State(initialValue: config.selectedBlockExplorerOption(network: network))
     }
 
     private var editableNetworks: [Network] {
@@ -34,32 +37,48 @@ struct BlockExplorerSettingsView: View {
                 }
             }
 
+            Section {
+                Text(
+                    "Block explorers are public websites for checking Bitcoin transaction details and confirmations. Cove opens the selected explorer when you view a transaction."
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+
             Section("Preview") {
                 Text(preview)
                     .font(.footnote.monospaced())
                     .textSelection(.enabled)
             }
 
-            Section {
-                TextField("URL or template", text: $input, axis: .vertical)
-                    .keyboardType(.URL)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .lineLimit(2 ... 5)
-                    .onChange(of: input) { _, newValue in
-                        updatePreview(for: newValue)
+            Section("Explorer") {
+                ForEach(allBlockExplorerOptions(), id: \.self) { option in
+                    blockExplorerOptionRow(option)
+                }
+            }
+
+            if selectedOption == .custom {
+                Section("Custom") {
+                    TextField("URL or template", text: $input, axis: .vertical)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .lineLimit(2 ... 5)
+                        .onChange(of: input) { _, newValue in
+                            updatePreview(for: newValue)
+                        }
+
+                    if let validationError {
+                        Text(validationError)
+                            .font(.caption)
+                            .foregroundStyle(.red)
                     }
 
-                if let validationError {
-                    Text(validationError)
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    Button("Save", action: save)
+                        .disabled(input == (config.customBlockExplorer(network: selectedNetwork) ?? ""))
+
+                    Button("Reset to Default", role: .destructive, action: reset)
                 }
-
-                Button("Save", action: save)
-                    .disabled(input == (config.customBlockExplorer(network: selectedNetwork) ?? ""))
-
-                Button("Reset to Default", role: .destructive, action: reset)
             }
         }
         .scrollContentBackground(.hidden)
@@ -69,9 +88,54 @@ struct BlockExplorerSettingsView: View {
         }
     }
 
+    private func blockExplorerOptionRow(_ option: BlockExplorerOption) -> some View {
+        HStack {
+            Text(option.displayName())
+
+            Spacer()
+
+            if selectedOption == option {
+                Image(systemName: "checkmark")
+                    .foregroundStyle(.blue)
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            select(option)
+        }
+    }
+
+    private func select(_ option: BlockExplorerOption) {
+        switch option {
+        case .custom:
+            selectedOption = .custom
+            updatePreview(for: input)
+        default:
+            savePreset(option)
+        }
+    }
+
+    private func savePreset(_ option: BlockExplorerOption) {
+        do {
+            let normalized = try config.setBlockExplorerOption(
+                network: selectedNetwork,
+                option: option
+            )
+            input = normalized ?? ""
+            preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
+            selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
+            validationError = nil
+        } catch {
+            validationError = error.localizedDescription
+        }
+    }
+
     private func reload() {
         input = config.customBlockExplorer(network: selectedNetwork) ?? ""
         preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
+        selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
         validationError = nil
     }
 
@@ -95,6 +159,7 @@ struct BlockExplorerSettingsView: View {
             )
             input = normalized ?? ""
             preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
+            selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
             validationError = nil
         } catch {
             validationError = error.localizedDescription

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -37,12 +37,14 @@ struct BlockExplorerSettingsView: View {
                 }
             }
 
-            Section("Block Explorer") {
+            Section {
                 Text(
                     "Block explorers are public websites for checking Bitcoin transaction details and confirmations. Cove opens the selected explorer when you view a transaction."
                 )
                 .font(.footnote)
                 .foregroundStyle(.secondary)
+            } header: {
+                Text("Description")
             }
 
             Section("Preview") {

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -145,10 +145,11 @@ struct BlockExplorerSettingsView: View {
                 network: selectedNetwork,
                 input: value
             )
-            validationError = nil
         } catch {
-            validationError = error.localizedDescription
+            // keep save as the validation point while the user is still typing
         }
+
+        validationError = nil
     }
 
     private func save() {

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -121,6 +121,10 @@ struct BlockExplorerSettingsView: View {
     }
 
     private func select(_ option: BlockExplorerOption) {
+        if selectedOption == option {
+            return
+        }
+
         switch option {
         case .custom:
             selectedOption = .custom

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -1,3 +1,4 @@
+import MijickPopups
 import SwiftUI
 
 struct BlockExplorerSettingsView: View {
@@ -8,6 +9,8 @@ struct BlockExplorerSettingsView: View {
     @State private var preview: String
     @State private var selectedOption: BlockExplorerOption
     @State private var validationError: String?
+    @State private var isSaving = false
+    @FocusState private var isInputFocused: Bool
 
     init() {
         // only Bitcoin explorer overrides are editable; other networks use built-in defaults
@@ -66,6 +69,7 @@ struct BlockExplorerSettingsView: View {
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                         .lineLimit(2 ... 5)
+                        .focused($isInputFocused)
                         .onChange(of: input) { _, newValue in
                             updatePreview(for: newValue)
                         }
@@ -77,7 +81,7 @@ struct BlockExplorerSettingsView: View {
                     }
 
                     Button("Save", action: save)
-                        .disabled(input == (config.customBlockExplorer(network: selectedNetwork) ?? ""))
+                        .disabled(isSaving || input == (config.customBlockExplorer(network: selectedNetwork) ?? ""))
 
                     Button("Reset to Default", role: .destructive, action: reset)
                 }
@@ -155,20 +159,39 @@ struct BlockExplorerSettingsView: View {
     }
 
     private func save() {
-        do {
-            let normalized = try config.setCustomBlockExplorer(
-                network: selectedNetwork,
-                input: input
-            )
-            input = normalized ?? ""
-            preview = config.effectiveBlockExplorerPreview(network: selectedNetwork)
-            selectedOption = .custom
-            if normalized == nil {
-                selectedOption = config.selectedBlockExplorerOption(network: selectedNetwork)
+        guard !isSaving else { return }
+
+        let inputToSave = input
+        let networkToSave = selectedNetwork
+        Task { @MainActor in
+            isSaving = true
+            await MiddlePopup(state: .loading).present()
+
+            do {
+                let normalized = try config.setCustomBlockExplorer(
+                    network: networkToSave,
+                    input: inputToSave
+                )
+                input = normalized ?? ""
+                preview = config.effectiveBlockExplorerPreview(network: networkToSave)
+                selectedOption = .custom
+                if normalized == nil {
+                    selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
+                }
+                validationError = nil
+                isInputFocused = false
+
+                await dismissAllPopups()
+                try? await Task.sleep(for: .milliseconds(250))
+                await MiddlePopup(state: .success("Block explorer saved successfully"))
+                    .dismissAfter(2)
+                    .present()
+            } catch {
+                validationError = error.localizedDescription
+                await dismissAllPopups()
             }
-            validationError = nil
-        } catch {
-            validationError = error.localizedDescription
+
+            isSaving = false
         }
     }
 

--- a/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
+++ b/ios/Cove/Flows/SettingsFlow/BlockExplorerSettingsView.swift
@@ -10,7 +10,6 @@ struct BlockExplorerSettingsView: View {
     @State private var selectedOption: BlockExplorerOption
     @State private var validationError: String?
     @State private var isSaving = false
-    @State private var saveTask: Task<Void, Never>?
     @State private var showInvalidUrlAlert = false
     @FocusState private var isInputFocused: Bool
 
@@ -96,9 +95,6 @@ struct BlockExplorerSettingsView: View {
         .onChange(of: selectedNetwork) { _, _ in
             reload()
         }
-        .onDisappear {
-            saveTask?.cancel()
-        }
         .alert("Invalid URL", isPresented: $showInvalidUrlAlert) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -164,11 +160,11 @@ struct BlockExplorerSettingsView: View {
                 network: selectedNetwork,
                 input: value
             )
+            validationError = nil
         } catch {
-            // keep save as the validation point while the user is still typing
+            preview = ""
+            validationError = error.localizedDescription
         }
-
-        validationError = nil
     }
 
     private func save() {
@@ -176,87 +172,33 @@ struct BlockExplorerSettingsView: View {
 
         let inputToSave = input
         let networkToSave = selectedNetwork
-        let checkUrl: URL
-
-        do {
-            checkUrl = try blockExplorerCheckUrl(
-                network: networkToSave,
-                input: inputToSave
-            )
-        } catch {
-            validationError = error.localizedDescription
-            showInvalidUrlAlert = true
-            return
-        }
 
         isSaving = true
         isInputFocused = false
 
-        saveTask = Task { @MainActor in
-            await MiddlePopup(state: .loading, message: "Checking URL").present()
+        do {
+            let normalized = try config.setCustomBlockExplorer(
+                network: networkToSave,
+                input: inputToSave
+            )
+            input = normalized ?? ""
+            preview = config.effectiveBlockExplorerPreview(network: networkToSave)
+            selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
+            validationError = nil
 
-            do {
-                try await checkBlockExplorerUrl(checkUrl)
-
-                let normalized = try config.setCustomBlockExplorer(
-                    network: networkToSave,
-                    input: inputToSave
-                )
-                input = normalized ?? ""
-                preview = config.effectiveBlockExplorerPreview(network: networkToSave)
-                selectedOption = .custom
-                if normalized == nil {
-                    selectedOption = config.selectedBlockExplorerOption(network: networkToSave)
-                }
-                validationError = nil
-
+            Task { @MainActor in
                 await dismissAllPopups()
                 try? await Task.sleep(for: .milliseconds(250))
                 await MiddlePopup(state: .success("Block explorer saved successfully"))
                     .dismissAfter(2)
                     .present()
-            } catch is CancellationError {
-                await dismissAllPopups()
-            } catch {
-                let message = error.localizedDescription
-                validationError = message
-
-                await dismissAllPopups()
-                try? await Task.sleep(for: .milliseconds(250))
-                await MiddlePopup(state: .failure(message))
-                    .dismissAfter(7)
-                    .present()
             }
-
-            isSaving = false
-            saveTask = nil
-        }
-    }
-
-    private func blockExplorerCheckUrl(network: Network, input: String) throws -> URL {
-        let previewUrl = try config.previewCustomBlockExplorer(network: network, input: input)
-
-        guard let url = URL(string: previewUrl) else {
-            throw BlockExplorerCheckError.invalidUrl
+        } catch {
+            validationError = error.localizedDescription
+            showInvalidUrlAlert = true
         }
 
-        return url
-    }
-
-    private func checkBlockExplorerUrl(_ url: URL) async throws {
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        request.timeoutInterval = 10
-
-        let (_, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw BlockExplorerCheckError.invalidResponse
-        }
-
-        guard 200 ..< 300 ~= httpResponse.statusCode else {
-            throw BlockExplorerCheckError.unsuccessfulStatus(httpResponse.statusCode)
-        }
+        isSaving = false
     }
 
     private func reset() {
@@ -265,23 +207,6 @@ struct BlockExplorerSettingsView: View {
             reload()
         } catch {
             validationError = error.localizedDescription
-        }
-    }
-}
-
-private enum BlockExplorerCheckError: LocalizedError {
-    case invalidUrl
-    case invalidResponse
-    case unsuccessfulStatus(Int)
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidUrl:
-            "Invalid URL"
-        case .invalidResponse:
-            "Block explorer check did not return an HTTP response"
-        case let .unsuccessfulStatus(statusCode):
-            "Block explorer returned HTTP \(statusCode) for the test transaction"
         }
     }
 }

--- a/ios/Cove/Flows/SettingsFlow/MainSettingsScreen.swift
+++ b/ios/Cove/Flows/SettingsFlow/MainSettingsScreen.swift
@@ -194,10 +194,7 @@ struct MainSettingsScreen: View {
                 title: "Node", route: .node, symbol: "point.3.filled.connected.trianglepath.dotted"
             )
             SettingsRow(
-                title: "Block Explorer",
-                subtitle: Database().globalConfig().effectiveBlockExplorerHost(network: .bitcoin),
-                route: .blockExplorer,
-                symbol: "safari"
+                title: "Block Explorer", route: .blockExplorer, symbol: "safari"
             )
             SettingsRow(title: "Currency", route: .fiatCurrency, symbol: "dollarsign.circle")
         }

--- a/ios/Cove/Info.plist
+++ b/ios/Cove/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Cove checks and connects to block explorers and nodes on your local network.</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/ios/Cove/Views/MiddlePopupView.swift
+++ b/ios/Cove/Views/MiddlePopupView.swift
@@ -118,7 +118,7 @@ struct MiddlePopupView: View {
 
             } else {
                 ProgressView(label: {
-                    Text("Working on it...")
+                    Text(popupMessage.isEmpty ? "Working on it..." : popupMessage)
                         .font(.caption)
                         .padding(.top, 6)
                 })

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -4132,6 +4132,8 @@ public protocol GlobalConfigTableProtocol: AnyObject, Sendable {
 
     func selectedFiatCurrency()  -> FiatCurrency
 
+    func selectedBlockExplorerOption(network: Network)  -> BlockExplorerOption
+
     func selectedNetwork()  -> Network
 
     func selectedNode()  -> Node
@@ -4141,6 +4143,8 @@ public protocol GlobalConfigTableProtocol: AnyObject, Sendable {
     func set(key: GlobalConfigKey, value: String) throws
 
     func setColorScheme(colorScheme: ColorSchemeSelection) throws
+
+    func setBlockExplorerOption(network: Network, option: BlockExplorerOption) throws  -> String?
 
     func setCustomBlockExplorer(network: Network, input: String) throws  -> String?
 
@@ -4354,6 +4358,16 @@ open func selectedFiatCurrency() -> FiatCurrency  {
 })
 }
 
+open func selectedBlockExplorerOption(network: Network) -> BlockExplorerOption  {
+    return try!  FfiConverterTypeBlockExplorerOption_lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_globalconfigtable_selected_block_explorer_option(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeNetwork_lower(network),uniffiCallStatus
+    )
+})
+}
+
 open func selectedNetwork() -> Network  {
     return try!  FfiConverterTypeNetwork_lift(try! rustCall() {
         uniffiCallStatus in
@@ -4398,6 +4412,17 @@ open func setColorScheme(colorScheme: ColorSchemeSelection)throws   {try rustCal
         FfiConverterTypeColorSchemeSelection_lower(colorScheme),uniffiCallStatus
     )
 }
+}
+
+open func setBlockExplorerOption(network: Network, option: BlockExplorerOption)throws  -> String?  {
+    return try  FfiConverterOptionString.lift(try rustCallWithError(FfiConverterTypeDatabaseError_lift) {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_globalconfigtable_set_block_explorer_option(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeNetwork_lower(network),
+        FfiConverterTypeBlockExplorerOption_lower(option),uniffiCallStatus
+    )
+})
 }
 
 open func setCustomBlockExplorer(network: Network, input: String)throws  -> String?  {
@@ -19218,6 +19243,102 @@ public func FfiConverterTypeBitcoinTransactionError_lift(_ buf: RustBuffer) thro
 public func FfiConverterTypeBitcoinTransactionError_lower(_ value: BitcoinTransactionError) -> RustBuffer {
     return FfiConverterTypeBitcoinTransactionError.lower(value)
 }
+
+
+
+public enum BlockExplorerOption: Equatable, Hashable {
+
+    case mempoolSpace
+    case mempoolGuide
+    case bullBitcoin
+    case blockstream
+    case custom
+
+
+
+public func displayName() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_blockexploreroption_display_name(
+            FfiConverterTypeBlockExplorerOption_lower(self),uniffiCallStatus
+    )
+})
+}
+
+
+
+}
+
+#if compiler(>=6)
+extension BlockExplorerOption: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeBlockExplorerOption: FfiConverterRustBuffer {
+    typealias SwiftType = BlockExplorerOption
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlockExplorerOption {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .mempoolSpace
+
+        case 2: return .mempoolGuide
+
+        case 3: return .bullBitcoin
+
+        case 4: return .blockstream
+
+        case 5: return .custom
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: BlockExplorerOption, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .mempoolSpace:
+            writeInt(&buf, Int32(1))
+
+
+        case .mempoolGuide:
+            writeInt(&buf, Int32(2))
+
+
+        case .bullBitcoin:
+            writeInt(&buf, Int32(3))
+
+
+        case .blockstream:
+            writeInt(&buf, Int32(4))
+
+
+        case .custom:
+            writeInt(&buf, Int32(5))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeBlockExplorerOption_lift(_ buf: RustBuffer) throws -> BlockExplorerOption {
+    return try FfiConverterTypeBlockExplorerOption.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeBlockExplorerOption_lower(_ value: BlockExplorerOption) -> RustBuffer {
+    return FfiConverterTypeBlockExplorerOption.lower(value)
+}
+
 
 
 
@@ -38920,6 +39041,31 @@ fileprivate struct FfiConverterSequenceTypeUtxo: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeBlockExplorerOption: FfiConverterRustBuffer {
+    typealias SwiftType = [BlockExplorerOption]
+
+    public static func write(_ value: [BlockExplorerOption], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeBlockExplorerOption.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [BlockExplorerOption] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [BlockExplorerOption]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeBlockExplorerOption.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeCoinControlManagerReconcileMessage: FfiConverterRustBuffer {
     typealias SwiftType = [CoinControlManagerReconcileMessage]
 
@@ -39530,6 +39676,13 @@ public func activeMigration() -> Migration?  {
     )
 })
 }
+public func allBlockExplorerOptions() -> [BlockExplorerOption]  {
+    return try!  FfiConverterSequenceTypeBlockExplorerOption.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_all_block_explorer_options(uniffiCallStatus
+    )
+})
+}
 public func allFiatCurrencies() -> [FiatCurrency]  {
     return try!  FfiConverterSequenceTypeFiatCurrency.lift(try! rustCall() {
         uniffiCallStatus in
@@ -40012,6 +40165,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_func_active_migration() != 29388) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_func_all_block_explorer_options() != 48219) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_func_all_fiat_currencies() != 53482) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40378,6 +40534,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_globalconfigtable_selectedfiatcurrency() != 11234) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_cove_checksum_method_globalconfigtable_selected_block_explorer_option() != 31659) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_cove_checksum_method_globalconfigtable_selected_network() != 17475) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -40391,6 +40550,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_globalconfigtable_setcolorscheme() != 42967) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_globalconfigtable_set_block_explorer_option() != 32847) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_globalconfigtable_set_custom_block_explorer() != 26335) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -19256,6 +19256,9 @@ public enum BlockExplorerOption: Equatable, Hashable {
 
 
 
+    /**
+     * Returns the user-visible label for this explorer option.
+     */
 public func displayName() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
         uniffiCallStatus in
@@ -39676,6 +39679,9 @@ public func activeMigration() -> Migration?  {
     )
 })
 }
+/**
+ * Returns every block explorer option exposed to mobile clients.
+ */
 public func allBlockExplorerOptions() -> [BlockExplorerOption]  {
     return try!  FfiConverterSequenceTypeBlockExplorerOption.lift(try! rustCall() {
         uniffiCallStatus in
@@ -40165,7 +40171,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_func_active_migration() != 29388) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_func_all_block_explorer_options() != 48219) {
+    if (uniffi_cove_checksum_func_all_block_explorer_options() != 60996) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_all_fiat_currencies() != 53482) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -4114,8 +4114,6 @@ public protocol GlobalConfigTableProtocol: AnyObject, Sendable {
 
     func deleteHashedPinCode() throws
 
-    func effectiveBlockExplorerHost(network: Network)  -> String
-
     func effectiveBlockExplorerPreview(network: Network)  -> String
 
     func get(key: GlobalConfigKey) throws  -> String?
@@ -4270,16 +4268,6 @@ open func deleteHashedPinCode()throws   {try rustCallWithError(FfiConverterTypeD
             self.uniffiCloneHandle(),uniffiCallStatus
     )
 }
-}
-
-open func effectiveBlockExplorerHost(network: Network) -> String  {
-    return try!  FfiConverterString.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_method_globalconfigtable_effective_block_explorer_host(
-            self.uniffiCloneHandle(),
-        FfiConverterTypeNetwork_lower(network),uniffiCallStatus
-    )
-})
 }
 
 open func effectiveBlockExplorerPreview(network: Network) -> String  {
@@ -19257,7 +19245,7 @@ public enum BlockExplorerOption: Equatable, Hashable {
 
 
     /**
-     * Returns the user-visible label for this explorer option.
+     * Returns the user-visible label for this explorer option
      */
 public func displayName() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
@@ -39680,7 +39668,7 @@ public func activeMigration() -> Migration?  {
 })
 }
 /**
- * Returns every block explorer option exposed to mobile clients.
+ * Returns every block explorer option exposed to mobile clients
  */
 public func allBlockExplorerOptions() -> [BlockExplorerOption]  {
     return try!  FfiConverterSequenceTypeBlockExplorerOption.lift(try! rustCall() {
@@ -40171,7 +40159,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_func_active_migration() != 29388) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_func_all_block_explorer_options() != 60996) {
+    if (uniffi_cove_checksum_func_all_block_explorer_options() != 40123) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_all_fiat_currencies() != 53482) {
@@ -40511,9 +40499,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_globalconfigtable_delete_hashed_pin_code() != 24897) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_method_globalconfigtable_effective_block_explorer_host() != 22806) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_globalconfigtable_effective_block_explorer_preview() != 21192) {

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -9,6 +9,87 @@ const SUPPORTED_PLACEHOLDERS: [&str; 3] = ["{0}", "{txid}", "{tx_id}"];
 
 pub const PREVIEW_TXID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, uniffi::Enum)]
+pub enum BlockExplorerOption {
+    MempoolSpace,
+    MempoolGuide,
+    BullBitcoin,
+    Blockstream,
+    Custom,
+}
+
+#[uniffi::export]
+impl BlockExplorerOption {
+    pub fn display_name(&self) -> String {
+        self.as_display_name().to_string()
+    }
+}
+
+impl BlockExplorerOption {
+    const PRESETS: [Self; 5] = [
+        Self::MempoolSpace,
+        Self::MempoolGuide,
+        Self::BullBitcoin,
+        Self::Blockstream,
+        Self::Custom,
+    ];
+
+    pub(crate) const fn all() -> [Self; 5] {
+        Self::PRESETS
+    }
+
+    pub(crate) const fn base_url(&self) -> Option<&'static str> {
+        match self {
+            Self::MempoolSpace | Self::Custom => None,
+            Self::MempoolGuide => Some("https://mempool.guide/"),
+            Self::BullBitcoin => Some("https://mempool.bullbitcoin.com/"),
+            Self::Blockstream => Some("https://blockstream.info/"),
+        }
+    }
+
+    pub(crate) fn matching_stored_template(stored_template: Option<&str>) -> Self {
+        let Some(stored_template) = stored_template else {
+            return Self::MempoolSpace;
+        };
+
+        let Ok(template) = CustomBlockExplorerTemplate::parse_stored(stored_template) else {
+            return Self::MempoolSpace;
+        };
+
+        Self::all()
+            .into_iter()
+            .find(|option| option.matches_template(&template))
+            .unwrap_or(Self::Custom)
+    }
+
+    fn as_display_name(&self) -> &'static str {
+        match self {
+            Self::MempoolSpace => "Default (mempool.space)",
+            Self::MempoolGuide => "mempool.guide",
+            Self::BullBitcoin => "mempool.bullbitcoin.com",
+            Self::Blockstream => "blockstream.info",
+            Self::Custom => "Custom",
+        }
+    }
+
+    fn matches_template(&self, template: &CustomBlockExplorerTemplate) -> bool {
+        let preset_template = match self {
+            Self::MempoolSpace => Some(CustomBlockExplorerTemplate::default_for(Network::Bitcoin)),
+            Self::Custom => None,
+            _ => self.base_url().and_then(|base_url| {
+                CustomBlockExplorerTemplate::parse(Network::Bitcoin, base_url).ok()
+            }),
+        };
+
+        preset_template.is_some_and(|preset_template| preset_template.as_str() == template.as_str())
+    }
+}
+
+#[uniffi::export]
+pub fn all_block_explorer_options() -> Vec<BlockExplorerOption> {
+    BlockExplorerOption::all().to_vec()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CustomBlockExplorerError {
     #[error("Block explorer URL cannot be empty")]
@@ -246,10 +327,28 @@ fn replace_supported_placeholders(input: &str, replacement: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{CustomBlockExplorerError, CustomBlockExplorerTemplate};
+    use super::{BlockExplorerOption, CustomBlockExplorerError, CustomBlockExplorerTemplate};
     use crate::network::Network;
 
     const TXID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn block_explorer_options_expose_expected_order_and_labels() {
+        let options = super::all_block_explorer_options();
+
+        assert_eq!(
+            options.as_slice(),
+            &[
+                BlockExplorerOption::MempoolSpace,
+                BlockExplorerOption::MempoolGuide,
+                BlockExplorerOption::BullBitcoin,
+                BlockExplorerOption::Blockstream,
+                BlockExplorerOption::Custom,
+            ]
+        );
+        assert_eq!(BlockExplorerOption::MempoolSpace.display_name(), "Default (mempool.space)");
+        assert_eq!(BlockExplorerOption::Blockstream.display_name(), "blockstream.info");
+    }
 
     #[test]
     fn defaults_match_existing_transaction_urls() {
@@ -302,10 +401,18 @@ mod tests {
 
     #[test]
     fn plain_base_url_normalizes_to_transaction_template() {
-        let template =
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, " https://example.com ").unwrap();
+        let cases = [
+            (" https://example.com ", "https://example.com/tx/{txid}"),
+            ("https://mempool.guide/", "https://mempool.guide/tx/{txid}"),
+            ("https://mempool.bullbitcoin.com/", "https://mempool.bullbitcoin.com/tx/{txid}"),
+            ("https://blockstream.info/", "https://blockstream.info/tx/{txid}"),
+        ];
 
-        assert_eq!(template.as_str(), "https://example.com/tx/{txid}");
+        for (input, expected) in cases {
+            let template = CustomBlockExplorerTemplate::parse(Network::Bitcoin, input).unwrap();
+
+            assert_eq!(template.as_str(), expected);
+        }
     }
 
     #[test]

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -19,7 +19,7 @@ pub enum BlockExplorerOption {
 
 #[uniffi::export]
 impl BlockExplorerOption {
-    /// Returns the user-visible label for this explorer option.
+    /// Returns the user-visible label for this explorer option
     pub fn display_name(&self) -> String {
         self.as_display_name().to_string()
     }
@@ -34,12 +34,12 @@ impl BlockExplorerOption {
         Self::Custom,
     ];
 
-    /// Returns all options in the order shown by the settings UI.
+    /// Returns all options in the order shown by the settings UI
     pub(crate) const fn all() -> [Self; 5] {
         Self::PRESETS
     }
 
-    /// Returns the base URL for preset options that are backed by stored custom templates.
+    /// Returns the base URL for preset options that are backed by stored custom templates
     pub(crate) const fn base_url(&self) -> Option<&'static str> {
         match self {
             Self::MempoolSpace | Self::Custom => None,
@@ -49,7 +49,8 @@ impl BlockExplorerOption {
         }
     }
 
-    /// Returns the option represented by a stored template, falling back to the default option.
+    /// Returns the matching preset, Custom for non-preset templates,
+    /// or the default for empty or invalid values
     pub(crate) fn matching_stored_template(
         network: Network,
         stored_template: Option<&str>,
@@ -68,7 +69,7 @@ impl BlockExplorerOption {
             .unwrap_or(Self::Custom)
     }
 
-    /// Returns the static display name for this option.
+    /// Returns the static display name for this option
     fn as_display_name(&self) -> &'static str {
         match self {
             Self::MempoolSpace => "Default (mempool.space)",
@@ -79,7 +80,7 @@ impl BlockExplorerOption {
         }
     }
 
-    /// Builds the canonical transaction template for this option on the given network.
+    /// Builds the canonical transaction template for this option on the given network
     fn template_for_network(&self, network: Network) -> Option<CustomBlockExplorerTemplate> {
         match self {
             Self::MempoolSpace => Some(CustomBlockExplorerTemplate::default_for(network)),
@@ -90,7 +91,7 @@ impl BlockExplorerOption {
         }
     }
 
-    /// Returns whether a stored template exactly matches this preset option.
+    /// Returns whether a stored template exactly matches this preset option
     fn matches_template(&self, network: Network, template: &CustomBlockExplorerTemplate) -> bool {
         self.template_for_network(network)
             .is_some_and(|preset_template| preset_template.as_str() == template.as_str())
@@ -98,12 +99,12 @@ impl BlockExplorerOption {
 }
 
 #[uniffi::export]
-/// Returns every block explorer option exposed to mobile clients.
+/// Returns every block explorer option exposed to mobile clients
 pub fn all_block_explorer_options() -> Vec<BlockExplorerOption> {
     BlockExplorerOption::all().to_vec()
 }
 
-/// Returns the transaction URL for a stored template or the network default.
+/// Returns the transaction URL for a stored template or the network default
 pub fn effective_transaction_url(
     network: Network,
     stored_template: Option<&str>,

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -72,7 +72,7 @@ impl BlockExplorerOption {
     /// Returns the static display name for this option
     fn as_display_name(&self) -> &'static str {
         match self {
-            Self::MempoolSpace => "Default (mempool.space)",
+            Self::MempoolSpace => "Default explorer",
             Self::MempoolGuide => "mempool.guide",
             Self::BullBitcoin => "mempool.bullbitcoin.com",
             Self::Blockstream => "blockstream.info",
@@ -81,10 +81,14 @@ impl BlockExplorerOption {
     }
 
     /// Builds the canonical transaction template for this option on the given network
-    fn template_for_network(&self, network: Network) -> Option<CustomBlockExplorerTemplate> {
+    pub(crate) fn template_for_network(
+        &self,
+        network: Network,
+    ) -> Option<CustomBlockExplorerTemplate> {
         match self {
             Self::MempoolSpace => Some(CustomBlockExplorerTemplate::default_for(network)),
             Self::Custom => None,
+            Self::Blockstream if network == Network::Testnet4 => None,
             _ => self.base_url().and_then(|base_url| {
                 CustomBlockExplorerTemplate::from_preset_base_url(network, base_url)
             }),
@@ -138,7 +142,7 @@ mod tests {
                 BlockExplorerOption::Custom,
             ]
         );
-        assert_eq!(BlockExplorerOption::MempoolSpace.display_name(), "Default (mempool.space)");
+        assert_eq!(BlockExplorerOption::MempoolSpace.display_name(), "Default explorer");
         assert_eq!(BlockExplorerOption::Blockstream.display_name(), "blockstream.info");
     }
 }

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -47,7 +47,10 @@ impl BlockExplorerOption {
         }
     }
 
-    pub(crate) fn matching_stored_template(stored_template: Option<&str>) -> Self {
+    pub(crate) fn matching_stored_template(
+        network: Network,
+        stored_template: Option<&str>,
+    ) -> Self {
         let Some(stored_template) = stored_template else {
             return Self::MempoolSpace;
         };
@@ -58,7 +61,7 @@ impl BlockExplorerOption {
 
         Self::all()
             .into_iter()
-            .find(|option| option.matches_template(&template))
+            .find(|option| option.matches_template(network, &template))
             .unwrap_or(Self::Custom)
     }
 
@@ -72,16 +75,21 @@ impl BlockExplorerOption {
         }
     }
 
-    fn matches_template(&self, template: &CustomBlockExplorerTemplate) -> bool {
-        let preset_template = match self {
-            Self::MempoolSpace => Some(CustomBlockExplorerTemplate::default_for(Network::Bitcoin)),
+    fn template_for_network(&self, network: Network) -> Option<CustomBlockExplorerTemplate> {
+        match self {
+            Self::MempoolSpace => Some(CustomBlockExplorerTemplate::default_for(network)),
             Self::Custom => None,
             _ => self.base_url().and_then(|base_url| {
-                CustomBlockExplorerTemplate::parse(Network::Bitcoin, base_url).ok()
+                parse_http_url(base_url)
+                    .ok()
+                    .map(|url| CustomBlockExplorerTemplate::from_base_url(network, url))
             }),
-        };
+        }
+    }
 
-        preset_template.is_some_and(|preset_template| preset_template.as_str() == template.as_str())
+    fn matches_template(&self, network: Network, template: &CustomBlockExplorerTemplate) -> bool {
+        self.template_for_network(network)
+            .is_some_and(|preset_template| preset_template.as_str() == template.as_str())
     }
 }
 
@@ -182,17 +190,25 @@ impl CustomBlockExplorerTemplate {
     }
 
     fn parse_base_url(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
-        let mut url = parse_http_url_with_optional_scheme(input)?;
+        let url = parse_http_url_with_optional_scheme(input)?;
         if url.fragment().is_some() {
             return Err(CustomBlockExplorerError::Fragment);
         }
 
+        if let Some(template) = known_template_for_input_url(network, &url) {
+            return Ok(template);
+        }
+
+        Ok(Self::from_base_url(network, url))
+    }
+
+    fn from_base_url(network: Network, mut url: Url) -> Self {
         let placeholder_marker = placeholder_marker_absent_from(url.as_str());
         let path = canonical_base_path(&url, network, &placeholder_marker);
         url.set_path(&path);
 
         let canonical = url.to_string().replace(&placeholder_marker, PLACEHOLDER);
-        Ok(Self(canonical))
+        Self(canonical)
     }
 }
 
@@ -236,12 +252,69 @@ fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockEx
     }
 }
 
+fn known_template_for_input_url(
+    network: Network,
+    url: &Url,
+) -> Option<CustomBlockExplorerTemplate> {
+    BlockExplorerOption::all()
+        .into_iter()
+        .filter_map(|option| option.template_for_network(network))
+        .find(|template| known_template_matches_input_url(template, url))
+}
+
+fn known_template_matches_input_url(
+    template: &CustomBlockExplorerTemplate,
+    input_url: &Url,
+) -> bool {
+    if input_url.query().is_some() {
+        return false;
+    }
+
+    let placeholder_marker = placeholder_marker_absent_from(template.as_str());
+    let probe = template.as_str().replace(PLACEHOLDER, &placeholder_marker);
+    let Ok(template_url) = parse_http_url(&probe) else {
+        return false;
+    };
+
+    if input_url.scheme() != template_url.scheme()
+        || input_url.host_str() != template_url.host_str()
+        || input_url.port_or_known_default() != template_url.port_or_known_default()
+    {
+        return false;
+    }
+
+    let Some(transaction_path) =
+        normalized_template_transaction_path(&template_url, &placeholder_marker)
+    else {
+        return false;
+    };
+    let base_path = transaction_path
+        .strip_suffix("/tx")
+        .unwrap_or_else(|| if transaction_path == "tx" { "" } else { transaction_path });
+    let input_path = normalized_path(input_url.path());
+
+    input_path.is_empty() || input_path == base_path || input_path == transaction_path
+}
+
+fn normalized_template_transaction_path<'a>(url: &'a Url, marker: &str) -> Option<&'a str> {
+    let path = normalized_path(url.path());
+    let path = path.strip_suffix(marker)?;
+
+    Some(path.trim_end_matches('/'))
+}
+
+fn normalized_path(path: &str) -> &str {
+    path.trim_end_matches('/').trim_start_matches('/')
+}
+
 fn canonical_base_path(url: &Url, network: Network, placeholder_marker: &str) -> String {
-    let path = url.path().trim_end_matches('/').trim_start_matches('/');
+    let path = normalized_path(url.path());
     let path = canonicalize_known_host_path(url.host_str(), network, path);
 
     if path.is_empty() {
         format!("/tx/{placeholder_marker}")
+    } else if path.rsplit('/').next() == Some("tx") {
+        format!("/{path}/{placeholder_marker}")
     } else {
         format!("/{path}/tx/{placeholder_marker}")
     }
@@ -421,12 +494,16 @@ mod tests {
         let cases = [
             (" https://example.com ", "https://example.com/tx/{txid}"),
             ("example.com", "https://example.com/tx/{txid}"),
+            ("example.com/tx", "https://example.com/tx/{txid}"),
             ("mempool.space", "https://mempool.space/tx/{txid}"),
+            ("mempool.space/tx", "https://mempool.space/tx/{txid}"),
             ("https://mempool.guide/", "https://mempool.guide/tx/{txid}"),
             ("mempool.guide", "https://mempool.guide/tx/{txid}"),
+            ("mempool.guide/tx", "https://mempool.guide/tx/{txid}"),
             ("https://mempool.bullbitcoin.com/", "https://mempool.bullbitcoin.com/tx/{txid}"),
             ("https://blockstream.info/", "https://blockstream.info/tx/{txid}"),
             ("blockstream.info", "https://blockstream.info/tx/{txid}"),
+            ("blockstream.info/tx", "https://blockstream.info/tx/{txid}"),
         ];
 
         for (input, expected) in cases {
@@ -486,10 +563,17 @@ mod tests {
                 .unwrap();
         let signet =
             CustomBlockExplorerTemplate::parse(Network::Signet, "https://mutinynet.com").unwrap();
+        let testnet_tx =
+            CustomBlockExplorerTemplate::parse(Network::Testnet, "mempool.space/testnet/tx")
+                .unwrap();
+        let signet_tx =
+            CustomBlockExplorerTemplate::parse(Network::Signet, "mutinynet.com/tx").unwrap();
 
         assert_eq!(testnet.as_str(), "https://mempool.space/testnet/tx/{txid}");
         assert_eq!(testnet4.as_str(), "https://mempool.space/testnet4/tx/{txid}");
         assert_eq!(signet.as_str(), "https://mutinynet.com/tx/{txid}");
+        assert_eq!(testnet_tx.as_str(), "https://mempool.space/testnet/tx/{txid}");
+        assert_eq!(signet_tx.as_str(), "https://mutinynet.com/tx/{txid}");
     }
 
     #[test]

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -6,7 +6,7 @@ mod template;
 
 pub use template::{CustomBlockExplorerError, CustomBlockExplorerTemplate};
 
-pub const PREVIEW_TXID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+pub const PREVIEW_TXID: &str = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, uniffi::Enum)]
 pub enum BlockExplorerOption {

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -1,11 +1,10 @@
-use std::{fmt, net::IpAddr};
+use std::fmt;
 
 use cove_types::Network;
-use url::Url;
 
-const PLACEHOLDER: &str = "{txid}";
-const PLACEHOLDER_MARKER_SEED: &str = "coveplaceholdertxid";
-const SUPPORTED_PLACEHOLDERS: [&str; 3] = ["{0}", "{txid}", "{tx_id}"];
+mod template;
+
+pub use template::{CustomBlockExplorerError, CustomBlockExplorerTemplate};
 
 pub const PREVIEW_TXID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
@@ -20,6 +19,7 @@ pub enum BlockExplorerOption {
 
 #[uniffi::export]
 impl BlockExplorerOption {
+    /// Returns the user-visible label for this explorer option.
     pub fn display_name(&self) -> String {
         self.as_display_name().to_string()
     }
@@ -34,10 +34,12 @@ impl BlockExplorerOption {
         Self::Custom,
     ];
 
+    /// Returns all options in the order shown by the settings UI.
     pub(crate) const fn all() -> [Self; 5] {
         Self::PRESETS
     }
 
+    /// Returns the base URL for preset options that are backed by stored custom templates.
     pub(crate) const fn base_url(&self) -> Option<&'static str> {
         match self {
             Self::MempoolSpace | Self::Custom => None,
@@ -47,6 +49,7 @@ impl BlockExplorerOption {
         }
     }
 
+    /// Returns the option represented by a stored template, falling back to the default option.
     pub(crate) fn matching_stored_template(
         network: Network,
         stored_template: Option<&str>,
@@ -65,6 +68,7 @@ impl BlockExplorerOption {
             .unwrap_or(Self::Custom)
     }
 
+    /// Returns the static display name for this option.
     fn as_display_name(&self) -> &'static str {
         match self {
             Self::MempoolSpace => "Default (mempool.space)",
@@ -75,18 +79,18 @@ impl BlockExplorerOption {
         }
     }
 
+    /// Builds the canonical transaction template for this option on the given network.
     fn template_for_network(&self, network: Network) -> Option<CustomBlockExplorerTemplate> {
         match self {
             Self::MempoolSpace => Some(CustomBlockExplorerTemplate::default_for(network)),
             Self::Custom => None,
             _ => self.base_url().and_then(|base_url| {
-                parse_http_url(base_url)
-                    .ok()
-                    .map(|url| CustomBlockExplorerTemplate::from_base_url(network, url))
+                CustomBlockExplorerTemplate::from_preset_base_url(network, base_url)
             }),
         }
     }
 
+    /// Returns whether a stored template exactly matches this preset option.
     fn matches_template(&self, network: Network, template: &CustomBlockExplorerTemplate) -> bool {
         self.template_for_network(network)
             .is_some_and(|preset_template| preset_template.as_str() == template.as_str())
@@ -94,347 +98,30 @@ impl BlockExplorerOption {
 }
 
 #[uniffi::export]
+/// Returns every block explorer option exposed to mobile clients.
 pub fn all_block_explorer_options() -> Vec<BlockExplorerOption> {
     BlockExplorerOption::all().to_vec()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum CustomBlockExplorerError {
-    #[error("Block explorer URL cannot be empty")]
-    Empty,
-
-    #[error("Block explorer URL must use http or https")]
-    InvalidScheme,
-
-    #[error("Block explorer URL must include a host")]
-    MissingHost,
-
-    #[error("Block explorer URL cannot include a fragment")]
-    Fragment,
-
-    #[error("Unsupported block explorer template placeholder")]
-    UnsupportedPlaceholder,
-
-    #[error("Invalid block explorer URL")]
-    InvalidUrl,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CustomBlockExplorerTemplate(String);
-
-impl CustomBlockExplorerTemplate {
-    pub fn parse(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
-        let trimmed = input.trim();
-        if trimmed.is_empty() {
-            return Err(CustomBlockExplorerError::Empty);
-        }
-
-        validate_placeholders(trimmed)?;
-
-        if contains_supported_placeholder(trimmed) {
-            return Self::parse_template(trimmed);
-        }
-
-        Self::parse_base_url(network, trimmed)
-    }
-
-    pub fn default_for(network: Network) -> Self {
-        let template = match network {
-            Network::Bitcoin => "https://mempool.space/tx/{txid}",
-            Network::Testnet => "https://mempool.space/testnet/tx/{txid}",
-            Network::Testnet4 => "https://mempool.space/testnet4/tx/{txid}",
-            Network::Signet => "https://mutinynet.com/tx/{txid}",
-        };
-
-        Self(template.to_string())
-    }
-
-    pub fn parse_stored(input: &str) -> Result<Self, CustomBlockExplorerError> {
-        let trimmed = input.trim();
-        if trimmed.is_empty() {
-            return Err(CustomBlockExplorerError::Empty);
-        }
-
-        validate_placeholders(trimmed)?;
-
-        if !contains_supported_placeholder(trimmed) {
-            return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
-        }
-
-        Self::parse_template(trimmed)
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    pub fn render(&self, txid: impl fmt::Display) -> String {
-        let txid = txid.to_string();
-        SUPPORTED_PLACEHOLDERS
-            .iter()
-            .fold(self.0.clone(), |rendered, placeholder| rendered.replace(placeholder, &txid))
-    }
-
-    fn parse_template(input: &str) -> Result<Self, CustomBlockExplorerError> {
-        let placeholder_marker = placeholder_marker_absent_from(input);
-        let probe = replace_supported_placeholders(input, &placeholder_marker);
-        let url = parse_http_url_with_optional_scheme(&probe)?;
-        if url.fragment().is_some() {
-            return Err(CustomBlockExplorerError::Fragment);
-        }
-
-        validate_placeholder_location(&url, &placeholder_marker)?;
-
-        let canonical = url.to_string().replace(&placeholder_marker, PLACEHOLDER);
-        Ok(Self(canonical))
-    }
-
-    fn parse_base_url(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
-        let url = parse_http_url_with_optional_scheme(input)?;
-        if url.fragment().is_some() {
-            return Err(CustomBlockExplorerError::Fragment);
-        }
-
-        if let Some(template) = known_template_for_input_url(network, &url) {
-            return Ok(template);
-        }
-
-        Ok(Self::from_base_url(network, url))
-    }
-
-    fn from_base_url(network: Network, mut url: Url) -> Self {
-        let placeholder_marker = placeholder_marker_absent_from(url.as_str());
-        let path = canonical_base_path(&url, network, &placeholder_marker);
-        url.set_path(&path);
-
-        let canonical = url.to_string().replace(&placeholder_marker, PLACEHOLDER);
-        Self(canonical)
-    }
-}
-
+/// Returns the transaction URL for a stored template or the network default.
 pub fn effective_transaction_url(
     network: Network,
     stored_template: Option<&str>,
     txid: impl fmt::Display,
 ) -> String {
-    if let Some(template) = stored_template
-        .and_then(|stored_template| CustomBlockExplorerTemplate::parse_stored(stored_template).ok())
-    {
-        return template.render(txid);
-    }
-
-    CustomBlockExplorerTemplate::default_for(network).render(txid)
-}
-
-fn parse_http_url(input: &str) -> Result<Url, CustomBlockExplorerError> {
-    let url = Url::parse(input).map_err(|_| CustomBlockExplorerError::InvalidUrl)?;
-
-    match url.scheme() {
-        "http" | "https" => {}
-        _ => return Err(CustomBlockExplorerError::InvalidScheme),
-    }
-
-    if url.host_str().is_none() {
-        return Err(CustomBlockExplorerError::MissingHost);
-    }
-
-    Ok(url)
-}
-
-fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockExplorerError> {
-    match parse_http_url(input) {
-        Ok(url) => Ok(url),
-        Err(error) if !input.contains("://") => {
-            let scheme = default_scheme_for_scheme_less_input(input);
-            let input_with_scheme = format!("{scheme}://{input}");
-            parse_http_url(&input_with_scheme).map_err(|_| error)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-fn default_scheme_for_scheme_less_input(input: &str) -> &'static str {
-    if scheme_less_input_prefers_http(input) { "http" } else { "https" }
-}
-
-fn scheme_less_input_prefers_http(input: &str) -> bool {
-    let probe = format!("https://{input}");
-    let Ok(url) = Url::parse(&probe) else {
-        return false;
-    };
-    let Some(host) = url.host_str() else {
-        return false;
+    let Some(stored_template) = stored_template else {
+        return CustomBlockExplorerTemplate::default_for(network).render(txid);
     };
 
-    let host = host.trim_end_matches('.');
-    let host_for_ip = host.trim_matches(&['[', ']'][..]);
-
-    host_for_ip.parse::<IpAddr>().is_ok() || host.to_ascii_lowercase().ends_with(".local")
-}
-
-fn known_template_for_input_url(
-    network: Network,
-    url: &Url,
-) -> Option<CustomBlockExplorerTemplate> {
-    BlockExplorerOption::all()
-        .into_iter()
-        .filter_map(|option| option.template_for_network(network))
-        .find(|template| known_template_matches_input_url(template, url))
-}
-
-fn known_template_matches_input_url(
-    template: &CustomBlockExplorerTemplate,
-    input_url: &Url,
-) -> bool {
-    if input_url.query().is_some() {
-        return false;
+    match CustomBlockExplorerTemplate::parse_stored(stored_template) {
+        Ok(template) => template.render(txid),
+        Err(_) => CustomBlockExplorerTemplate::default_for(network).render(txid),
     }
-
-    let placeholder_marker = placeholder_marker_absent_from(template.as_str());
-    let probe = template.as_str().replace(PLACEHOLDER, &placeholder_marker);
-    let Ok(template_url) = parse_http_url(&probe) else {
-        return false;
-    };
-
-    if input_url.scheme() != template_url.scheme()
-        || input_url.host_str() != template_url.host_str()
-        || input_url.port_or_known_default() != template_url.port_or_known_default()
-    {
-        return false;
-    }
-
-    let Some(transaction_path) =
-        normalized_template_transaction_path(&template_url, &placeholder_marker)
-    else {
-        return false;
-    };
-    let base_path = transaction_path
-        .strip_suffix("/tx")
-        .unwrap_or_else(|| if transaction_path == "tx" { "" } else { transaction_path });
-    let input_path = normalized_path(input_url.path());
-
-    input_path.is_empty() || input_path == base_path || input_path == transaction_path
-}
-
-fn normalized_template_transaction_path<'a>(url: &'a Url, marker: &str) -> Option<&'a str> {
-    let path = normalized_path(url.path());
-    let path = path.strip_suffix(marker)?;
-
-    Some(path.trim_end_matches('/'))
-}
-
-fn normalized_path(path: &str) -> &str {
-    path.trim_end_matches('/').trim_start_matches('/')
-}
-
-fn canonical_base_path(url: &Url, network: Network, placeholder_marker: &str) -> String {
-    let path = normalized_path(url.path());
-    let path = canonicalize_known_host_path(url.host_str(), network, path);
-
-    if path.is_empty() {
-        format!("/tx/{placeholder_marker}")
-    } else if path.rsplit('/').next() == Some("tx") {
-        format!("/{path}/{placeholder_marker}")
-    } else {
-        format!("/{path}/tx/{placeholder_marker}")
-    }
-}
-
-fn canonicalize_known_host_path(host: Option<&str>, network: Network, path: &str) -> String {
-    let Some(host) = host else {
-        return path.to_string();
-    };
-
-    let Some(prefix) = known_host_network_prefix(host, network) else {
-        return path.to_string();
-    };
-
-    if prefix.is_empty() || path == prefix || path.starts_with(&format!("{prefix}/")) {
-        return path.to_string();
-    }
-
-    if path.is_empty() { prefix.to_string() } else { format!("{prefix}/{path}") }
-}
-
-fn known_host_network_prefix(host: &str, network: Network) -> Option<&'static str> {
-    match (host, network) {
-        ("mempool.space", Network::Bitcoin) => Some(""),
-        ("mempool.space", Network::Testnet) => Some("testnet"),
-        ("mempool.space", Network::Testnet4) => Some("testnet4"),
-        ("mutinynet.com", Network::Signet) => Some(""),
-        _ => None,
-    }
-}
-
-fn validate_placeholder_location(
-    url: &Url,
-    placeholder_marker: &str,
-) -> Result<(), CustomBlockExplorerError> {
-    let placeholder_in_path = url.path().contains(placeholder_marker);
-    let placeholder_in_query = url.query().is_some_and(|query| query.contains(placeholder_marker));
-    let placeholder_in_user_info = url.username().contains(placeholder_marker)
-        || url.password().is_some_and(|password| password.contains(placeholder_marker));
-    let placeholder_in_host = url.host_str().is_some_and(|host| host.contains(placeholder_marker));
-
-    if placeholder_in_user_info || placeholder_in_host {
-        return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
-    }
-
-    if placeholder_in_path || placeholder_in_query {
-        return Ok(());
-    }
-
-    Err(CustomBlockExplorerError::UnsupportedPlaceholder)
-}
-
-fn placeholder_marker_absent_from(input: &str) -> String {
-    let mut marker = PLACEHOLDER_MARKER_SEED.to_string();
-    while input.contains(&marker) {
-        marker.push('_');
-    }
-
-    marker
-}
-
-fn validate_placeholders(input: &str) -> Result<(), CustomBlockExplorerError> {
-    let mut chars = input.char_indices().peekable();
-
-    while let Some((index, character)) = chars.next() {
-        match character {
-            '{' => {
-                let Some((end_index, _)) = chars.find(|(_, character)| *character == '}') else {
-                    return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
-                };
-
-                let token = &input[index..=end_index];
-                if !SUPPORTED_PLACEHOLDERS.contains(&token) {
-                    return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
-                }
-            }
-            '}' => return Err(CustomBlockExplorerError::UnsupportedPlaceholder),
-            _ => {}
-        }
-    }
-
-    Ok(())
-}
-
-fn contains_supported_placeholder(input: &str) -> bool {
-    SUPPORTED_PLACEHOLDERS.iter().any(|placeholder| input.contains(placeholder))
-}
-
-fn replace_supported_placeholders(input: &str, replacement: &str) -> String {
-    SUPPORTED_PLACEHOLDERS
-        .iter()
-        .fold(input.to_string(), |value, placeholder| value.replace(placeholder, replacement))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BlockExplorerOption, CustomBlockExplorerError, CustomBlockExplorerTemplate};
-    use crate::network::Network;
-
-    const TXID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    use super::BlockExplorerOption;
 
     #[test]
     fn block_explorer_options_expose_expected_order_and_labels() {
@@ -452,205 +139,5 @@ mod tests {
         );
         assert_eq!(BlockExplorerOption::MempoolSpace.display_name(), "Default (mempool.space)");
         assert_eq!(BlockExplorerOption::Blockstream.display_name(), "blockstream.info");
-    }
-
-    #[test]
-    fn defaults_match_existing_transaction_urls() {
-        assert_eq!(
-            CustomBlockExplorerTemplate::default_for(Network::Bitcoin).render(TXID),
-            "https://mempool.space/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::default_for(Network::Testnet).render(TXID),
-            "https://mempool.space/testnet/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::default_for(Network::Testnet4).render(TXID),
-            "https://mempool.space/testnet4/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::default_for(Network::Signet).render(TXID),
-            "https://mutinynet.com/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-    }
-
-    #[test]
-    fn placeholders_are_normalized_and_all_occurrences_render() {
-        let template = CustomBlockExplorerTemplate::parse(
-            Network::Bitcoin,
-            "https://example.com/tx/{0}/again/{txid}?id={tx_id}",
-        )
-        .unwrap();
-
-        assert_eq!(template.as_str(), "https://example.com/tx/{txid}/again/{txid}?id={txid}");
-        assert_eq!(
-            template.render(TXID),
-            "https://example.com/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/again/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-    }
-
-    #[test]
-    fn query_placeholder_renders() {
-        let template = CustomBlockExplorerTemplate::parse(
-            Network::Bitcoin,
-            "https://example.com/search?q={txid}",
-        )
-        .unwrap();
-
-        assert_eq!(
-            template.render(TXID),
-            "https://example.com/search?q=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-
-        let template =
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "example.com/search?q={txid}")
-                .unwrap();
-
-        assert_eq!(template.as_str(), "https://example.com/search?q={txid}");
-
-        let template =
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "node.local/search?q={txid}")
-                .unwrap();
-
-        assert_eq!(template.as_str(), "http://node.local/search?q={txid}");
-    }
-
-    #[test]
-    fn plain_base_url_normalizes_to_transaction_template() {
-        let cases = [
-            (" https://example.com ", "https://example.com/tx/{txid}"),
-            ("example.com", "https://example.com/tx/{txid}"),
-            ("example.com/tx", "https://example.com/tx/{txid}"),
-            ("node.local", "http://node.local/tx/{txid}"),
-            ("node.local:3000/explorer", "http://node.local:3000/explorer/tx/{txid}"),
-            ("192.168.1.10:3000/explorer", "http://192.168.1.10:3000/explorer/tx/{txid}"),
-            ("[::1]:3000/explorer", "http://[::1]:3000/explorer/tx/{txid}"),
-            ("mempool.space", "https://mempool.space/tx/{txid}"),
-            ("mempool.space/tx", "https://mempool.space/tx/{txid}"),
-            ("https://mempool.guide/", "https://mempool.guide/tx/{txid}"),
-            ("mempool.guide", "https://mempool.guide/tx/{txid}"),
-            ("mempool.guide/tx", "https://mempool.guide/tx/{txid}"),
-            ("https://mempool.bullbitcoin.com/", "https://mempool.bullbitcoin.com/tx/{txid}"),
-            ("https://blockstream.info/", "https://blockstream.info/tx/{txid}"),
-            ("blockstream.info", "https://blockstream.info/tx/{txid}"),
-            ("blockstream.info/tx", "https://blockstream.info/tx/{txid}"),
-        ];
-
-        for (input, expected) in cases {
-            let template = CustomBlockExplorerTemplate::parse(Network::Bitcoin, input).unwrap();
-
-            assert_eq!(template.as_str(), expected);
-        }
-    }
-
-    #[test]
-    fn plain_base_path_preserves_path_port_and_query() {
-        let template = CustomBlockExplorerTemplate::parse(
-            Network::Bitcoin,
-            "http://192.168.1.10:3000/explorer/?source=cove",
-        )
-        .unwrap();
-
-        assert_eq!(template.as_str(), "http://192.168.1.10:3000/explorer/tx/{txid}?source=cove");
-
-        let template =
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "example.com/explorer").unwrap();
-
-        assert_eq!(template.as_str(), "https://example.com/explorer/tx/{txid}");
-    }
-
-    #[test]
-    fn literal_marker_text_is_not_rewritten_to_placeholder() {
-        let template = CustomBlockExplorerTemplate::parse(
-            Network::Bitcoin,
-            "https://example.com/coveplaceholdertxid?q=coveplaceholdertxid",
-        )
-        .unwrap();
-
-        assert_eq!(
-            template.as_str(),
-            "https://example.com/coveplaceholdertxid/tx/{txid}?q=coveplaceholdertxid"
-        );
-
-        let template = CustomBlockExplorerTemplate::parse(
-            Network::Bitcoin,
-            "https://example.com/coveplaceholdertxid/{txid}?q=coveplaceholdertxid",
-        )
-        .unwrap();
-
-        assert_eq!(
-            template.as_str(),
-            "https://example.com/coveplaceholdertxid/{txid}?q=coveplaceholdertxid"
-        );
-    }
-
-    #[test]
-    fn known_hosts_canonicalize_network_path_before_transaction_path() {
-        let testnet =
-            CustomBlockExplorerTemplate::parse(Network::Testnet, "https://mempool.space").unwrap();
-        let testnet4 =
-            CustomBlockExplorerTemplate::parse(Network::Testnet4, "https://mempool.space/")
-                .unwrap();
-        let signet =
-            CustomBlockExplorerTemplate::parse(Network::Signet, "https://mutinynet.com").unwrap();
-        let testnet_tx =
-            CustomBlockExplorerTemplate::parse(Network::Testnet, "mempool.space/testnet/tx")
-                .unwrap();
-        let signet_tx =
-            CustomBlockExplorerTemplate::parse(Network::Signet, "mutinynet.com/tx").unwrap();
-
-        assert_eq!(testnet.as_str(), "https://mempool.space/testnet/tx/{txid}");
-        assert_eq!(testnet4.as_str(), "https://mempool.space/testnet4/tx/{txid}");
-        assert_eq!(signet.as_str(), "https://mutinynet.com/tx/{txid}");
-        assert_eq!(testnet_tx.as_str(), "https://mempool.space/testnet/tx/{txid}");
-        assert_eq!(signet_tx.as_str(), "https://mutinynet.com/tx/{txid}");
-    }
-
-    #[test]
-    fn invalid_values_are_rejected() {
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "").unwrap_err(),
-            CustomBlockExplorerError::Empty
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "ftp://example.com").unwrap_err(),
-            CustomBlockExplorerError::InvalidScheme
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://").unwrap_err(),
-            CustomBlockExplorerError::InvalidUrl
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://example.com/#frag")
-                .unwrap_err(),
-            CustomBlockExplorerError::Fragment
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://example.com/{hash}")
-                .unwrap_err(),
-            CustomBlockExplorerError::UnsupportedPlaceholder
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://{txid}.example.com")
-                .unwrap_err(),
-            CustomBlockExplorerError::UnsupportedPlaceholder
-        );
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://user{txid}@example.com")
-                .unwrap_err(),
-            CustomBlockExplorerError::UnsupportedPlaceholder
-        );
-    }
-
-    #[test]
-    fn stored_values_must_be_valid_templates() {
-        assert_eq!(
-            CustomBlockExplorerTemplate::parse_stored("https://example.com").unwrap_err(),
-            CustomBlockExplorerError::UnsupportedPlaceholder
-        );
-
-        let template =
-            CustomBlockExplorerTemplate::parse_stored("https://example.com/tx/{0}").unwrap();
-        assert_eq!(template.as_str(), "https://example.com/tx/{txid}");
     }
 }

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, net::IpAddr};
 
 use cove_types::Network;
 use url::Url;
@@ -245,11 +245,31 @@ fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockEx
     match parse_http_url(input) {
         Ok(url) => Ok(url),
         Err(error) if !input.contains("://") => {
-            let input_with_scheme = format!("https://{input}");
+            let scheme = default_scheme_for_scheme_less_input(input);
+            let input_with_scheme = format!("{scheme}://{input}");
             parse_http_url(&input_with_scheme).map_err(|_| error)
         }
         Err(error) => Err(error),
     }
+}
+
+fn default_scheme_for_scheme_less_input(input: &str) -> &'static str {
+    if scheme_less_input_prefers_http(input) { "http" } else { "https" }
+}
+
+fn scheme_less_input_prefers_http(input: &str) -> bool {
+    let probe = format!("https://{input}");
+    let Ok(url) = Url::parse(&probe) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+
+    let host = host.trim_end_matches('.');
+    let host_for_ip = host.trim_matches(&['[', ']'][..]);
+
+    host_for_ip.parse::<IpAddr>().is_ok() || host.to_ascii_lowercase().ends_with(".local")
 }
 
 fn known_template_for_input_url(
@@ -487,6 +507,12 @@ mod tests {
                 .unwrap();
 
         assert_eq!(template.as_str(), "https://example.com/search?q={txid}");
+
+        let template =
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "node.local/search?q={txid}")
+                .unwrap();
+
+        assert_eq!(template.as_str(), "http://node.local/search?q={txid}");
     }
 
     #[test]
@@ -495,6 +521,10 @@ mod tests {
             (" https://example.com ", "https://example.com/tx/{txid}"),
             ("example.com", "https://example.com/tx/{txid}"),
             ("example.com/tx", "https://example.com/tx/{txid}"),
+            ("node.local", "http://node.local/tx/{txid}"),
+            ("node.local:3000/explorer", "http://node.local:3000/explorer/tx/{txid}"),
+            ("192.168.1.10:3000/explorer", "http://192.168.1.10:3000/explorer/tx/{txid}"),
+            ("[::1]:3000/explorer", "http://[::1]:3000/explorer/tx/{txid}"),
             ("mempool.space", "https://mempool.space/tx/{txid}"),
             ("mempool.space/tx", "https://mempool.space/tx/{txid}"),
             ("https://mempool.guide/", "https://mempool.guide/tx/{txid}"),

--- a/rust/src/custom_block_explorer.rs
+++ b/rust/src/custom_block_explorer.rs
@@ -170,7 +170,7 @@ impl CustomBlockExplorerTemplate {
     fn parse_template(input: &str) -> Result<Self, CustomBlockExplorerError> {
         let placeholder_marker = placeholder_marker_absent_from(input);
         let probe = replace_supported_placeholders(input, &placeholder_marker);
-        let url = parse_http_url(&probe)?;
+        let url = parse_http_url_with_optional_scheme(&probe)?;
         if url.fragment().is_some() {
             return Err(CustomBlockExplorerError::Fragment);
         }
@@ -182,7 +182,7 @@ impl CustomBlockExplorerTemplate {
     }
 
     fn parse_base_url(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
-        let mut url = parse_http_url(input)?;
+        let mut url = parse_http_url_with_optional_scheme(input)?;
         if url.fragment().is_some() {
             return Err(CustomBlockExplorerError::Fragment);
         }
@@ -223,6 +223,17 @@ fn parse_http_url(input: &str) -> Result<Url, CustomBlockExplorerError> {
     }
 
     Ok(url)
+}
+
+fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockExplorerError> {
+    match parse_http_url(input) {
+        Ok(url) => Ok(url),
+        Err(error) if !input.contains("://") => {
+            let input_with_scheme = format!("https://{input}");
+            parse_http_url(&input_with_scheme).map_err(|_| error)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn canonical_base_path(url: &Url, network: Network, placeholder_marker: &str) -> String {
@@ -397,15 +408,25 @@ mod tests {
             template.render(TXID),
             "https://example.com/search?q=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
+
+        let template =
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "example.com/search?q={txid}")
+                .unwrap();
+
+        assert_eq!(template.as_str(), "https://example.com/search?q={txid}");
     }
 
     #[test]
     fn plain_base_url_normalizes_to_transaction_template() {
         let cases = [
             (" https://example.com ", "https://example.com/tx/{txid}"),
+            ("example.com", "https://example.com/tx/{txid}"),
+            ("mempool.space", "https://mempool.space/tx/{txid}"),
             ("https://mempool.guide/", "https://mempool.guide/tx/{txid}"),
+            ("mempool.guide", "https://mempool.guide/tx/{txid}"),
             ("https://mempool.bullbitcoin.com/", "https://mempool.bullbitcoin.com/tx/{txid}"),
             ("https://blockstream.info/", "https://blockstream.info/tx/{txid}"),
+            ("blockstream.info", "https://blockstream.info/tx/{txid}"),
         ];
 
         for (input, expected) in cases {
@@ -424,6 +445,11 @@ mod tests {
         .unwrap();
 
         assert_eq!(template.as_str(), "http://192.168.1.10:3000/explorer/tx/{txid}?source=cove");
+
+        let template =
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "example.com/explorer").unwrap();
+
+        assert_eq!(template.as_str(), "https://example.com/explorer/tx/{txid}");
     }
 
     #[test]

--- a/rust/src/custom_block_explorer/template.rs
+++ b/rust/src/custom_block_explorer/template.rs
@@ -34,7 +34,7 @@ pub enum CustomBlockExplorerError {
 pub struct CustomBlockExplorerTemplate(String);
 
 impl CustomBlockExplorerTemplate {
-    /// Parses user input into a canonical transaction URL template.
+    /// Parses user input into a canonical transaction URL template
     pub fn parse(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
         let trimmed = input.trim();
         if trimmed.is_empty() {
@@ -50,7 +50,7 @@ impl CustomBlockExplorerTemplate {
         Self::parse_base_url(network, trimmed)
     }
 
-    /// Returns the built-in transaction URL template for a network.
+    /// Returns the built-in transaction URL template for a network
     pub fn default_for(network: Network) -> Self {
         let template = match network {
             Network::Bitcoin => "https://mempool.space/tx/{txid}",
@@ -62,7 +62,7 @@ impl CustomBlockExplorerTemplate {
         Self(template.to_string())
     }
 
-    /// Parses an already stored template and rejects values that are not complete templates.
+    /// Parses an already stored template and rejects values that are not complete templates
     pub fn parse_stored(input: &str) -> Result<Self, CustomBlockExplorerError> {
         let trimmed = input.trim();
         if trimmed.is_empty() {
@@ -78,12 +78,12 @@ impl CustomBlockExplorerTemplate {
         Self::parse_template(trimmed)
     }
 
-    /// Returns the canonical template string.
+    /// Returns the canonical template string
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
-    /// Renders this template with a transaction id.
+    /// Renders this template with a transaction id
     pub fn render(&self, txid: impl fmt::Display) -> String {
         let txid = txid.to_string();
         SUPPORTED_PLACEHOLDERS
@@ -95,7 +95,7 @@ impl CustomBlockExplorerTemplate {
         parse_http_url(input).ok().map(|url| Self::from_base_url(network, url))
     }
 
-    /// Parses input that already includes a supported transaction placeholder.
+    /// Parses input that already includes a supported transaction placeholder
     fn parse_template(input: &str) -> Result<Self, CustomBlockExplorerError> {
         let placeholder_marker = placeholder_marker_absent_from(input);
         let probe = replace_supported_placeholders(input, &placeholder_marker);
@@ -110,7 +110,7 @@ impl CustomBlockExplorerTemplate {
         Ok(Self(canonical))
     }
 
-    /// Parses a bare explorer URL and expands it into a transaction template.
+    /// Parses a bare explorer URL and expands it into a transaction template
     fn parse_base_url(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
         let url = parse_http_url_with_optional_scheme(input)?;
         if url.fragment().is_some() {
@@ -124,7 +124,7 @@ impl CustomBlockExplorerTemplate {
         Ok(Self::from_base_url(network, url))
     }
 
-    /// Builds a transaction template from a validated base URL.
+    /// Builds a transaction template from a validated base URL
     fn from_base_url(network: Network, mut url: Url) -> Self {
         let placeholder_marker = placeholder_marker_absent_from(url.as_str());
         let path = canonical_base_path(&url, network, &placeholder_marker);
@@ -180,7 +180,7 @@ impl CustomBlockExplorerTemplate {
     }
 }
 
-/// Parses a URL and accepts only HTTP(S) URLs with a host.
+/// Parses a URL and accepts only HTTP(S) URLs with a host
 fn parse_http_url(input: &str) -> Result<Url, CustomBlockExplorerError> {
     let url = Url::parse(input).map_err(|_| CustomBlockExplorerError::InvalidUrl)?;
 
@@ -250,7 +250,7 @@ fn is_valid_domain_label(label: &str) -> bool {
     label.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
-/// Parses a URL, inferring a scheme when the user omitted one.
+/// Parses a URL, inferring a scheme when the user omitted one
 fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockExplorerError> {
     match parse_http_url(input) {
         Ok(url) => Ok(url),
@@ -263,12 +263,12 @@ fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockEx
     }
 }
 
-/// Returns the scheme to use for input that did not include one.
+/// Returns the scheme to use for input that did not include one
 fn default_scheme_for_scheme_less_input(input: &str) -> &'static str {
     if scheme_less_input_prefers_http(input) { "http" } else { "https" }
 }
 
-/// Returns whether scheme-less input should default to HTTP.
+/// Returns whether scheme-less input should default to HTTP
 fn scheme_less_input_prefers_http(input: &str) -> bool {
     let probe = format!("https://{input}");
 
@@ -286,12 +286,12 @@ fn scheme_less_input_prefers_http(input: &str) -> bool {
     }
 }
 
-/// Normalizes a URL path for path comparison and composition.
+/// Normalizes a URL path for path comparison and composition
 fn normalized_path(path: &str) -> &str {
     path.trim_end_matches('/').trim_start_matches('/')
 }
 
-/// Returns the canonical path for a base URL plus transaction placeholder.
+/// Returns the canonical path for a base URL plus transaction placeholder
 fn canonical_base_path(url: &Url, network: Network, placeholder_marker: &str) -> String {
     let path = normalized_path(url.path());
     let path = canonicalize_known_host_path(url.host_str(), network, path);
@@ -305,7 +305,7 @@ fn canonical_base_path(url: &Url, network: Network, placeholder_marker: &str) ->
     }
 }
 
-/// Inserts the network path prefix required by known multi-network hosts.
+/// Inserts the network path prefix required by known multi-network hosts
 fn canonicalize_known_host_path(host: Option<&str>, network: Network, path: &str) -> String {
     let Some(host) = host else {
         return path.to_string();
@@ -322,7 +322,7 @@ fn canonicalize_known_host_path(host: Option<&str>, network: Network, path: &str
     if path.is_empty() { prefix.to_string() } else { format!("{prefix}/{path}") }
 }
 
-/// Returns the network path prefix for hosts whose URL paths encode network selection.
+/// Returns the network path prefix for hosts whose URL paths encode network selection
 fn known_host_network_prefix(host: &str, network: Network) -> Option<&'static str> {
     match (host, network) {
         ("mempool.space", Network::Bitcoin) => Some(""),
@@ -333,7 +333,7 @@ fn known_host_network_prefix(host: &str, network: Network) -> Option<&'static st
     }
 }
 
-/// Validates that the transaction placeholder appears only where URL rendering can replace it.
+/// Validates that the transaction placeholder appears only where URL rendering can replace it
 fn validate_placeholder_location(
     url: &Url,
     placeholder_marker: &str,
@@ -355,7 +355,7 @@ fn validate_placeholder_location(
     Err(CustomBlockExplorerError::UnsupportedPlaceholder)
 }
 
-/// Creates a temporary marker that is not already present in the input.
+/// Creates a temporary marker that is not already present in the input
 fn placeholder_marker_absent_from(input: &str) -> String {
     let mut marker = PLACEHOLDER_MARKER_SEED.to_string();
     while input.contains(&marker) {
@@ -365,7 +365,7 @@ fn placeholder_marker_absent_from(input: &str) -> String {
     marker
 }
 
-/// Validates that every brace-delimited placeholder is supported.
+/// Validates that every brace-delimited placeholder is supported
 fn validate_placeholders(input: &str) -> Result<(), CustomBlockExplorerError> {
     let mut chars = input.char_indices().peekable();
 
@@ -389,12 +389,12 @@ fn validate_placeholders(input: &str) -> Result<(), CustomBlockExplorerError> {
     Ok(())
 }
 
-/// Returns whether the input includes a supported transaction placeholder.
+/// Returns whether the input includes a supported transaction placeholder
 fn contains_supported_placeholder(input: &str) -> bool {
     SUPPORTED_PLACEHOLDERS.iter().any(|placeholder| input.contains(placeholder))
 }
 
-/// Replaces every supported transaction placeholder with a temporary marker.
+/// Replaces every supported transaction placeholder with a temporary marker
 fn replace_supported_placeholders(input: &str, replacement: &str) -> String {
     SUPPORTED_PLACEHOLDERS
         .iter()

--- a/rust/src/custom_block_explorer/template.rs
+++ b/rust/src/custom_block_explorer/template.rs
@@ -1,0 +1,580 @@
+use std::fmt;
+
+use cove_types::Network;
+use url::{Host, Url};
+
+use super::BlockExplorerOption;
+
+const PLACEHOLDER: &str = "{txid}";
+const PLACEHOLDER_MARKER_SEED: &str = "coveplaceholdertxid";
+const SUPPORTED_PLACEHOLDERS: [&str; 3] = ["{0}", "{txid}", "{tx_id}"];
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CustomBlockExplorerError {
+    #[error("Block explorer URL cannot be empty")]
+    Empty,
+
+    #[error("Block explorer URL must use http or https")]
+    InvalidScheme,
+
+    #[error("Block explorer URL must include a host")]
+    MissingHost,
+
+    #[error("Block explorer URL cannot include a fragment")]
+    Fragment,
+
+    #[error("Unsupported block explorer template placeholder")]
+    UnsupportedPlaceholder,
+
+    #[error("Invalid block explorer URL")]
+    InvalidUrl,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomBlockExplorerTemplate(String);
+
+impl CustomBlockExplorerTemplate {
+    /// Parses user input into a canonical transaction URL template.
+    pub fn parse(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(CustomBlockExplorerError::Empty);
+        }
+
+        validate_placeholders(trimmed)?;
+
+        if contains_supported_placeholder(trimmed) {
+            return Self::parse_template(trimmed);
+        }
+
+        Self::parse_base_url(network, trimmed)
+    }
+
+    /// Returns the built-in transaction URL template for a network.
+    pub fn default_for(network: Network) -> Self {
+        let template = match network {
+            Network::Bitcoin => "https://mempool.space/tx/{txid}",
+            Network::Testnet => "https://mempool.space/testnet/tx/{txid}",
+            Network::Testnet4 => "https://mempool.space/testnet4/tx/{txid}",
+            Network::Signet => "https://mutinynet.com/tx/{txid}",
+        };
+
+        Self(template.to_string())
+    }
+
+    /// Parses an already stored template and rejects values that are not complete templates.
+    pub fn parse_stored(input: &str) -> Result<Self, CustomBlockExplorerError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(CustomBlockExplorerError::Empty);
+        }
+
+        validate_placeholders(trimmed)?;
+
+        if !contains_supported_placeholder(trimmed) {
+            return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
+        }
+
+        Self::parse_template(trimmed)
+    }
+
+    /// Returns the canonical template string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Renders this template with a transaction id.
+    pub fn render(&self, txid: impl fmt::Display) -> String {
+        let txid = txid.to_string();
+        SUPPORTED_PLACEHOLDERS
+            .iter()
+            .fold(self.0.clone(), |rendered, placeholder| rendered.replace(placeholder, &txid))
+    }
+
+    pub(crate) fn from_preset_base_url(network: Network, input: &str) -> Option<Self> {
+        parse_http_url(input).ok().map(|url| Self::from_base_url(network, url))
+    }
+
+    /// Parses input that already includes a supported transaction placeholder.
+    fn parse_template(input: &str) -> Result<Self, CustomBlockExplorerError> {
+        let placeholder_marker = placeholder_marker_absent_from(input);
+        let probe = replace_supported_placeholders(input, &placeholder_marker);
+        let url = parse_http_url_with_optional_scheme(&probe)?;
+        if url.fragment().is_some() {
+            return Err(CustomBlockExplorerError::Fragment);
+        }
+
+        validate_placeholder_location(&url, &placeholder_marker)?;
+
+        let canonical = url.to_string().replace(&placeholder_marker, PLACEHOLDER);
+        Ok(Self(canonical))
+    }
+
+    /// Parses a bare explorer URL and expands it into a transaction template.
+    fn parse_base_url(network: Network, input: &str) -> Result<Self, CustomBlockExplorerError> {
+        let url = parse_http_url_with_optional_scheme(input)?;
+        if url.fragment().is_some() {
+            return Err(CustomBlockExplorerError::Fragment);
+        }
+
+        if let Some(template) = Self::known_for_input_url(network, &url) {
+            return Ok(template);
+        }
+
+        Ok(Self::from_base_url(network, url))
+    }
+
+    /// Builds a transaction template from a validated base URL.
+    fn from_base_url(network: Network, mut url: Url) -> Self {
+        let placeholder_marker = placeholder_marker_absent_from(url.as_str());
+        let path = canonical_base_path(&url, network, &placeholder_marker);
+        url.set_path(&path);
+
+        let canonical = url.to_string().replace(&placeholder_marker, PLACEHOLDER);
+        Self(canonical)
+    }
+
+    fn known_for_input_url(network: Network, url: &Url) -> Option<Self> {
+        BlockExplorerOption::all()
+            .into_iter()
+            .filter_map(|option| option.template_for_network(network))
+            .find(|template| template.matches_input_url(url))
+    }
+
+    fn matches_input_url(&self, input_url: &Url) -> bool {
+        if input_url.query().is_some() {
+            return false;
+        }
+
+        let placeholder_marker = placeholder_marker_absent_from(self.as_str());
+        let probe = self.as_str().replace(PLACEHOLDER, &placeholder_marker);
+        let Ok(template_url) = parse_http_url(&probe) else {
+            return false;
+        };
+
+        if input_url.scheme() != template_url.scheme()
+            || input_url.host_str() != template_url.host_str()
+            || input_url.port_or_known_default() != template_url.port_or_known_default()
+        {
+            return false;
+        }
+
+        let Some(transaction_path) =
+            Self::normalized_transaction_path(&template_url, &placeholder_marker)
+        else {
+            return false;
+        };
+        let base_path = transaction_path
+            .strip_suffix("/tx")
+            .unwrap_or_else(|| if transaction_path == "tx" { "" } else { transaction_path });
+        let input_path = normalized_path(input_url.path());
+
+        input_path.is_empty() || input_path == base_path || input_path == transaction_path
+    }
+
+    fn normalized_transaction_path<'a>(url: &'a Url, marker: &str) -> Option<&'a str> {
+        let path = normalized_path(url.path());
+        let path = path.strip_suffix(marker)?;
+
+        Some(path.trim_end_matches('/'))
+    }
+}
+
+/// Parses a URL and accepts only HTTP(S) URLs with a host.
+fn parse_http_url(input: &str) -> Result<Url, CustomBlockExplorerError> {
+    let url = Url::parse(input).map_err(|_| CustomBlockExplorerError::InvalidUrl)?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return Err(CustomBlockExplorerError::InvalidScheme),
+    }
+
+    if url.host_str().is_none() {
+        return Err(CustomBlockExplorerError::MissingHost);
+    }
+
+    Ok(url)
+}
+
+/// Parses a URL, inferring a scheme when the user omitted one.
+fn parse_http_url_with_optional_scheme(input: &str) -> Result<Url, CustomBlockExplorerError> {
+    match parse_http_url(input) {
+        Ok(url) => Ok(url),
+        Err(error) if !input.contains("://") => {
+            let scheme = default_scheme_for_scheme_less_input(input);
+            let input_with_scheme = format!("{scheme}://{input}");
+            parse_http_url(&input_with_scheme).map_err(|_| error)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Returns the scheme to use for input that did not include one.
+fn default_scheme_for_scheme_less_input(input: &str) -> &'static str {
+    if scheme_less_input_prefers_http(input) { "http" } else { "https" }
+}
+
+/// Returns whether scheme-less input should default to HTTP.
+fn scheme_less_input_prefers_http(input: &str) -> bool {
+    let probe = format!("https://{input}");
+
+    let Ok(url) = Url::parse(&probe) else {
+        return false;
+    };
+
+    match url.host() {
+        Some(Host::Ipv4(_) | Host::Ipv6(_)) => true,
+        Some(Host::Domain(host)) => {
+            host.trim_end_matches('.').to_ascii_lowercase().ends_with(".local")
+        }
+        None => false,
+    }
+}
+
+/// Normalizes a URL path for path comparison and composition.
+fn normalized_path(path: &str) -> &str {
+    path.trim_end_matches('/').trim_start_matches('/')
+}
+
+/// Returns the canonical path for a base URL plus transaction placeholder.
+fn canonical_base_path(url: &Url, network: Network, placeholder_marker: &str) -> String {
+    let path = normalized_path(url.path());
+    let path = canonicalize_known_host_path(url.host_str(), network, path);
+
+    if path.is_empty() {
+        format!("/tx/{placeholder_marker}")
+    } else if path.rsplit('/').next() == Some("tx") {
+        format!("/{path}/{placeholder_marker}")
+    } else {
+        format!("/{path}/tx/{placeholder_marker}")
+    }
+}
+
+/// Inserts the network path prefix required by known multi-network hosts.
+fn canonicalize_known_host_path(host: Option<&str>, network: Network, path: &str) -> String {
+    let Some(host) = host else {
+        return path.to_string();
+    };
+
+    let Some(prefix) = known_host_network_prefix(host, network) else {
+        return path.to_string();
+    };
+
+    if prefix.is_empty() || path == prefix || path.starts_with(&format!("{prefix}/")) {
+        return path.to_string();
+    }
+
+    if path.is_empty() { prefix.to_string() } else { format!("{prefix}/{path}") }
+}
+
+/// Returns the network path prefix for hosts whose URL paths encode network selection.
+fn known_host_network_prefix(host: &str, network: Network) -> Option<&'static str> {
+    match (host, network) {
+        ("mempool.space", Network::Bitcoin) => Some(""),
+        ("mempool.space", Network::Testnet) => Some("testnet"),
+        ("mempool.space", Network::Testnet4) => Some("testnet4"),
+        ("mutinynet.com", Network::Signet) => Some(""),
+        _ => None,
+    }
+}
+
+/// Validates that the transaction placeholder appears only where URL rendering can replace it.
+fn validate_placeholder_location(
+    url: &Url,
+    placeholder_marker: &str,
+) -> Result<(), CustomBlockExplorerError> {
+    let placeholder_in_path = url.path().contains(placeholder_marker);
+    let placeholder_in_query = url.query().is_some_and(|query| query.contains(placeholder_marker));
+    let placeholder_in_user_info = url.username().contains(placeholder_marker)
+        || url.password().is_some_and(|password| password.contains(placeholder_marker));
+    let placeholder_in_host = url.host_str().is_some_and(|host| host.contains(placeholder_marker));
+
+    if placeholder_in_user_info || placeholder_in_host {
+        return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
+    }
+
+    if placeholder_in_path || placeholder_in_query {
+        return Ok(());
+    }
+
+    Err(CustomBlockExplorerError::UnsupportedPlaceholder)
+}
+
+/// Creates a temporary marker that is not already present in the input.
+fn placeholder_marker_absent_from(input: &str) -> String {
+    let mut marker = PLACEHOLDER_MARKER_SEED.to_string();
+    while input.contains(&marker) {
+        marker.push('_');
+    }
+
+    marker
+}
+
+/// Validates that every brace-delimited placeholder is supported.
+fn validate_placeholders(input: &str) -> Result<(), CustomBlockExplorerError> {
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((index, character)) = chars.next() {
+        match character {
+            '{' => {
+                let Some((end_index, _)) = chars.find(|(_, character)| *character == '}') else {
+                    return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
+                };
+
+                let token = &input[index..=end_index];
+                if !SUPPORTED_PLACEHOLDERS.contains(&token) {
+                    return Err(CustomBlockExplorerError::UnsupportedPlaceholder);
+                }
+            }
+            '}' => return Err(CustomBlockExplorerError::UnsupportedPlaceholder),
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns whether the input includes a supported transaction placeholder.
+fn contains_supported_placeholder(input: &str) -> bool {
+    SUPPORTED_PLACEHOLDERS.iter().any(|placeholder| input.contains(placeholder))
+}
+
+/// Replaces every supported transaction placeholder with a temporary marker.
+fn replace_supported_placeholders(input: &str, replacement: &str) -> String {
+    SUPPORTED_PLACEHOLDERS
+        .iter()
+        .fold(input.to_string(), |value, placeholder| value.replace(placeholder, replacement))
+}
+
+#[cfg(test)]
+mod tests {
+    use cove_types::Network;
+
+    use super::{CustomBlockExplorerError, CustomBlockExplorerTemplate};
+    use crate::custom_block_explorer::effective_transaction_url;
+
+    const TXID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn defaults_match_existing_transaction_urls() {
+        assert_eq!(
+            CustomBlockExplorerTemplate::default_for(Network::Bitcoin).render(TXID),
+            "https://mempool.space/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::default_for(Network::Testnet).render(TXID),
+            "https://mempool.space/testnet/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::default_for(Network::Testnet4).render(TXID),
+            "https://mempool.space/testnet4/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::default_for(Network::Signet).render(TXID),
+            "https://mutinynet.com/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn placeholders_are_normalized_and_all_occurrences_render() {
+        let template = CustomBlockExplorerTemplate::parse(
+            Network::Bitcoin,
+            "https://example.com/tx/{0}/again/{txid}?id={tx_id}",
+        )
+        .unwrap();
+
+        assert_eq!(template.as_str(), "https://example.com/tx/{txid}/again/{txid}?id={txid}");
+        assert_eq!(
+            template.render(TXID),
+            "https://example.com/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/again/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn query_placeholder_renders() {
+        let template = CustomBlockExplorerTemplate::parse(
+            Network::Bitcoin,
+            "https://example.com/search?q={txid}",
+        )
+        .unwrap();
+
+        assert_eq!(
+            template.render(TXID),
+            "https://example.com/search?q=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        let template =
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "example.com/search?q={txid}")
+                .unwrap();
+
+        assert_eq!(template.as_str(), "https://example.com/search?q={txid}");
+
+        let template =
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "node.local/search?q={txid}")
+                .unwrap();
+
+        assert_eq!(template.as_str(), "http://node.local/search?q={txid}");
+    }
+
+    #[test]
+    fn plain_base_url_normalizes_to_transaction_template() {
+        let cases = [
+            (" https://example.com ", "https://example.com/tx/{txid}"),
+            ("example.com", "https://example.com/tx/{txid}"),
+            ("example.com/tx", "https://example.com/tx/{txid}"),
+            ("https://node.local", "https://node.local/tx/{txid}"),
+            ("https://192.168.1.10:3000/explorer", "https://192.168.1.10:3000/explorer/tx/{txid}"),
+            ("node.local", "http://node.local/tx/{txid}"),
+            ("node.local:3000/explorer", "http://node.local:3000/explorer/tx/{txid}"),
+            ("192.168.1.10:3000/explorer", "http://192.168.1.10:3000/explorer/tx/{txid}"),
+            ("[::1]:3000/explorer", "http://[::1]:3000/explorer/tx/{txid}"),
+            ("mempool.space", "https://mempool.space/tx/{txid}"),
+            ("mempool.space/tx", "https://mempool.space/tx/{txid}"),
+            ("https://mempool.guide/", "https://mempool.guide/tx/{txid}"),
+            ("mempool.guide", "https://mempool.guide/tx/{txid}"),
+            ("mempool.guide/tx", "https://mempool.guide/tx/{txid}"),
+            ("https://mempool.bullbitcoin.com/", "https://mempool.bullbitcoin.com/tx/{txid}"),
+            ("https://blockstream.info/", "https://blockstream.info/tx/{txid}"),
+            ("blockstream.info", "https://blockstream.info/tx/{txid}"),
+            ("blockstream.info/tx", "https://blockstream.info/tx/{txid}"),
+        ];
+
+        for (input, expected) in cases {
+            let template = CustomBlockExplorerTemplate::parse(Network::Bitcoin, input).unwrap();
+
+            assert_eq!(template.as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn plain_base_path_preserves_path_port_and_query() {
+        let template = CustomBlockExplorerTemplate::parse(
+            Network::Bitcoin,
+            "http://192.168.1.10:3000/explorer/?source=cove",
+        )
+        .unwrap();
+
+        assert_eq!(template.as_str(), "http://192.168.1.10:3000/explorer/tx/{txid}?source=cove");
+
+        let template =
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "example.com/explorer").unwrap();
+
+        assert_eq!(template.as_str(), "https://example.com/explorer/tx/{txid}");
+    }
+
+    #[test]
+    fn literal_marker_text_is_not_rewritten_to_placeholder() {
+        let template = CustomBlockExplorerTemplate::parse(
+            Network::Bitcoin,
+            "https://example.com/coveplaceholdertxid?q=coveplaceholdertxid",
+        )
+        .unwrap();
+
+        assert_eq!(
+            template.as_str(),
+            "https://example.com/coveplaceholdertxid/tx/{txid}?q=coveplaceholdertxid"
+        );
+
+        let template = CustomBlockExplorerTemplate::parse(
+            Network::Bitcoin,
+            "https://example.com/coveplaceholdertxid/{txid}?q=coveplaceholdertxid",
+        )
+        .unwrap();
+
+        assert_eq!(
+            template.as_str(),
+            "https://example.com/coveplaceholdertxid/{txid}?q=coveplaceholdertxid"
+        );
+    }
+
+    #[test]
+    fn known_hosts_canonicalize_network_path_before_transaction_path() {
+        let testnet =
+            CustomBlockExplorerTemplate::parse(Network::Testnet, "https://mempool.space").unwrap();
+        let testnet4 =
+            CustomBlockExplorerTemplate::parse(Network::Testnet4, "https://mempool.space/")
+                .unwrap();
+        let signet =
+            CustomBlockExplorerTemplate::parse(Network::Signet, "https://mutinynet.com").unwrap();
+        let testnet_tx =
+            CustomBlockExplorerTemplate::parse(Network::Testnet, "mempool.space/testnet/tx")
+                .unwrap();
+        let signet_tx =
+            CustomBlockExplorerTemplate::parse(Network::Signet, "mutinynet.com/tx").unwrap();
+
+        assert_eq!(testnet.as_str(), "https://mempool.space/testnet/tx/{txid}");
+        assert_eq!(testnet4.as_str(), "https://mempool.space/testnet4/tx/{txid}");
+        assert_eq!(signet.as_str(), "https://mutinynet.com/tx/{txid}");
+        assert_eq!(testnet_tx.as_str(), "https://mempool.space/testnet/tx/{txid}");
+        assert_eq!(signet_tx.as_str(), "https://mutinynet.com/tx/{txid}");
+    }
+
+    #[test]
+    fn invalid_values_are_rejected() {
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "").unwrap_err(),
+            CustomBlockExplorerError::Empty
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "ftp://example.com").unwrap_err(),
+            CustomBlockExplorerError::InvalidScheme
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://").unwrap_err(),
+            CustomBlockExplorerError::InvalidUrl
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://example.com/#frag")
+                .unwrap_err(),
+            CustomBlockExplorerError::Fragment
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://example.com/{hash}")
+                .unwrap_err(),
+            CustomBlockExplorerError::UnsupportedPlaceholder
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://{txid}.example.com")
+                .unwrap_err(),
+            CustomBlockExplorerError::UnsupportedPlaceholder
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://user{txid}@example.com")
+                .unwrap_err(),
+            CustomBlockExplorerError::UnsupportedPlaceholder
+        );
+    }
+
+    #[test]
+    fn stored_values_must_be_valid_templates() {
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse_stored("https://example.com").unwrap_err(),
+            CustomBlockExplorerError::UnsupportedPlaceholder
+        );
+
+        let template =
+            CustomBlockExplorerTemplate::parse_stored("https://example.com/tx/{0}").unwrap();
+        assert_eq!(template.as_str(), "https://example.com/tx/{txid}");
+
+        let template =
+            CustomBlockExplorerTemplate::parse_stored("https://node.local/tx/{txid}").unwrap();
+        assert_eq!(template.as_str(), "https://node.local/tx/{txid}");
+    }
+
+    #[test]
+    fn effective_transaction_url_preserves_explicit_local_and_ip_schemes() {
+        assert_eq!(
+            effective_transaction_url(Network::Bitcoin, Some("https://node.local/tx/{txid}"), TXID),
+            "https://node.local/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        assert_eq!(
+            effective_transaction_url(
+                Network::Bitcoin,
+                Some("https://192.168.1.10:3000/explorer/tx/{txid}"),
+                TXID
+            ),
+            "https://192.168.1.10:3000/explorer/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+}

--- a/rust/src/custom_block_explorer/template.rs
+++ b/rust/src/custom_block_explorer/template.rs
@@ -189,11 +189,65 @@ fn parse_http_url(input: &str) -> Result<Url, CustomBlockExplorerError> {
         _ => return Err(CustomBlockExplorerError::InvalidScheme),
     }
 
-    if url.host_str().is_none() {
+    let Some(host) = url.host() else {
         return Err(CustomBlockExplorerError::MissingHost);
-    }
+    };
+
+    validate_host(host)?;
 
     Ok(url)
+}
+
+fn validate_host(host: Host<&str>) -> Result<(), CustomBlockExplorerError> {
+    match host {
+        Host::Ipv4(_) | Host::Ipv6(_) => Ok(()),
+        Host::Domain(host) => validate_domain_host(host),
+    }
+}
+
+fn validate_domain_host(host: &str) -> Result<(), CustomBlockExplorerError> {
+    let host = host.trim_end_matches('.');
+    if host.eq_ignore_ascii_case("localhost") {
+        return Ok(());
+    }
+
+    if host.is_empty() || host.len() > 253 || !host.contains('.') {
+        return Err(CustomBlockExplorerError::InvalidUrl);
+    }
+
+    let labels = host.split('.');
+    for label in labels {
+        if !is_valid_domain_label(label) {
+            return Err(CustomBlockExplorerError::InvalidUrl);
+        }
+    }
+
+    let Some(top_level_domain) = host.rsplit('.').next() else {
+        return Err(CustomBlockExplorerError::InvalidUrl);
+    };
+    if top_level_domain.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(CustomBlockExplorerError::InvalidUrl);
+    }
+
+    Ok(())
+}
+
+fn is_valid_domain_label(label: &str) -> bool {
+    if label.is_empty() || label.len() > 63 {
+        return false;
+    }
+
+    let Some(first) = label.as_bytes().first() else {
+        return false;
+    };
+    let Some(last) = label.as_bytes().last() else {
+        return false;
+    };
+    if *first == b'-' || *last == b'-' {
+        return false;
+    }
+
+    label.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
 /// Parses a URL, inferring a scheme when the user omitted one.
@@ -225,7 +279,8 @@ fn scheme_less_input_prefers_http(input: &str) -> bool {
     match url.host() {
         Some(Host::Ipv4(_) | Host::Ipv6(_)) => true,
         Some(Host::Domain(host)) => {
-            host.trim_end_matches('.').to_ascii_lowercase().ends_with(".local")
+            let host = host.trim_end_matches('.').to_ascii_lowercase();
+            host == "localhost" || host.ends_with(".local")
         }
         None => false,
     }
@@ -422,10 +477,12 @@ mod tests {
             (" https://example.com ", "https://example.com/tx/{txid}"),
             ("example.com", "https://example.com/tx/{txid}"),
             ("example.com/tx", "https://example.com/tx/{txid}"),
+            ("bitcoin.local", "http://bitcoin.local/tx/{txid}"),
             ("https://node.local", "https://node.local/tx/{txid}"),
             ("https://192.168.1.10:3000/explorer", "https://192.168.1.10:3000/explorer/tx/{txid}"),
             ("node.local", "http://node.local/tx/{txid}"),
             ("node.local:3000/explorer", "http://node.local:3000/explorer/tx/{txid}"),
+            ("localhost:3000/explorer", "http://localhost:3000/explorer/tx/{txid}"),
             ("192.168.1.10:3000/explorer", "http://192.168.1.10:3000/explorer/tx/{txid}"),
             ("[::1]:3000/explorer", "http://[::1]:3000/explorer/tx/{txid}"),
             ("mempool.space", "https://mempool.space/tx/{txid}"),
@@ -521,6 +578,24 @@ mod tests {
         );
         assert_eq!(
             CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://").unwrap_err(),
+            CustomBlockExplorerError::InvalidUrl
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "bitcoin").unwrap_err(),
+            CustomBlockExplorerError::InvalidUrl
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://bitcoin").unwrap_err(),
+            CustomBlockExplorerError::InvalidUrl
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://not_valid.example.com")
+                .unwrap_err(),
+            CustomBlockExplorerError::InvalidUrl
+        );
+        assert_eq!(
+            CustomBlockExplorerTemplate::parse(Network::Bitcoin, "https://example.123")
+                .unwrap_err(),
             CustomBlockExplorerError::InvalidUrl
         );
         assert_eq!(

--- a/rust/src/custom_block_explorer/template.rs
+++ b/rust/src/custom_block_explorer/template.rs
@@ -328,6 +328,9 @@ fn known_host_network_prefix(host: &str, network: Network) -> Option<&'static st
         ("mempool.space", Network::Bitcoin) => Some(""),
         ("mempool.space", Network::Testnet) => Some("testnet"),
         ("mempool.space", Network::Testnet4) => Some("testnet4"),
+        ("blockstream.info", Network::Bitcoin) => Some(""),
+        ("blockstream.info", Network::Testnet) => Some("testnet"),
+        ("blockstream.info", Network::Signet) => Some("signet"),
         ("mutinynet.com", Network::Signet) => Some(""),
         _ => None,
     }
@@ -564,6 +567,23 @@ mod tests {
         assert_eq!(signet.as_str(), "https://mutinynet.com/tx/{txid}");
         assert_eq!(testnet_tx.as_str(), "https://mempool.space/testnet/tx/{txid}");
         assert_eq!(signet_tx.as_str(), "https://mutinynet.com/tx/{txid}");
+    }
+
+    #[test]
+    fn blockstream_preset_canonicalizes_supported_non_bitcoin_network_paths() {
+        let testnet = CustomBlockExplorerTemplate::from_preset_base_url(
+            Network::Testnet,
+            "https://blockstream.info/",
+        )
+        .unwrap();
+        let signet = CustomBlockExplorerTemplate::from_preset_base_url(
+            Network::Signet,
+            "https://blockstream.info/",
+        )
+        .unwrap();
+
+        assert_eq!(testnet.as_str(), "https://blockstream.info/testnet/tx/{txid}");
+        assert_eq!(signet.as_str(), "https://blockstream.info/signet/tx/{txid}");
     }
 
     #[test]

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -566,6 +566,26 @@ mod tests {
     }
 
     #[test]
+    fn custom_block_explorer_setter_expands_bare_domain_to_known_preset_template() {
+        crate::app::reconcile::test_support::init_noop_updater();
+        let (_tmp, table) = test_table();
+
+        let saved = table
+            .set_custom_block_explorer(Network::Bitcoin, "blockstream.info".to_string())
+            .unwrap();
+
+        assert_eq!(saved.as_deref(), Some("https://blockstream.info/tx/{txid}"));
+        assert_eq!(
+            table.custom_block_explorer(Network::Bitcoin).as_deref(),
+            Some("https://blockstream.info/tx/{txid}")
+        );
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Bitcoin),
+            BlockExplorerOption::Blockstream
+        );
+    }
+
+    #[test]
     fn custom_block_explorer_input_preview_validates_without_saving() {
         let (_tmp, table) = test_table();
 

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -309,7 +309,7 @@ impl GlobalConfigTable {
         let stored_template =
             self.get(GlobalConfigKey::CustomBlockExplorer(network)).ok().flatten();
 
-        BlockExplorerOption::matching_stored_template(stored_template.as_deref())
+        BlockExplorerOption::matching_stored_template(network, stored_template.as_deref())
     }
 
     pub fn effective_block_explorer_preview(&self, network: Network) -> String {
@@ -571,7 +571,7 @@ mod tests {
         let (_tmp, table) = test_table();
 
         let saved = table
-            .set_custom_block_explorer(Network::Bitcoin, "blockstream.info".to_string())
+            .set_custom_block_explorer(Network::Bitcoin, "blockstream.info/tx".to_string())
             .unwrap();
 
         assert_eq!(saved.as_deref(), Some("https://blockstream.info/tx/{txid}"));

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -327,15 +327,6 @@ impl GlobalConfigTable {
         Ok(template.render(PREVIEW_TXID))
     }
 
-    pub fn effective_block_explorer_host(&self, network: Network) -> String {
-        let preview = self.effective_block_explorer_preview(network);
-
-        url::Url::parse(&preview)
-            .ok()
-            .and_then(|url| url.host_str().map(ToString::to_string))
-            .unwrap_or_default()
-    }
-
     pub fn set_custom_block_explorer(
         &self,
         network: Network,

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -356,7 +356,9 @@ impl GlobalConfigTable {
                 Ok(None)
             }
             BlockExplorerOption::Custom => Ok(self.custom_block_explorer(network)),
-            _ => {
+            BlockExplorerOption::MempoolGuide
+            | BlockExplorerOption::BullBitcoin
+            | BlockExplorerOption::Blockstream => {
                 let base_url = option.base_url().expect("preset block explorer has a base URL");
                 self.set_custom_block_explorer(network, base_url.to_string())
             }

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -9,7 +9,7 @@ use crate::{
     auth::AuthType,
     color_scheme::ColorSchemeSelection,
     custom_block_explorer::{
-        CustomBlockExplorerError, CustomBlockExplorerTemplate, PREVIEW_TXID,
+        BlockExplorerOption, CustomBlockExplorerError, CustomBlockExplorerTemplate, PREVIEW_TXID,
         effective_transaction_url,
     },
     fiat::FiatCurrency,
@@ -305,6 +305,13 @@ impl GlobalConfigTable {
         )
     }
 
+    pub fn selected_block_explorer_option(&self, network: Network) -> BlockExplorerOption {
+        let stored_template =
+            self.get(GlobalConfigKey::CustomBlockExplorer(network)).ok().flatten();
+
+        BlockExplorerOption::matching_stored_template(stored_template.as_deref())
+    }
+
     pub fn effective_block_explorer_preview(&self, network: Network) -> String {
         self.custom_block_explorer_transaction_url(network, PREVIEW_TXID.to_string())
     }
@@ -345,6 +352,24 @@ impl GlobalConfigTable {
         self.set(GlobalConfigKey::CustomBlockExplorer(network), canonical.clone())?;
 
         Ok(Some(canonical))
+    }
+
+    pub fn set_block_explorer_option(
+        &self,
+        network: Network,
+        option: BlockExplorerOption,
+    ) -> Result<Option<String>> {
+        match option {
+            BlockExplorerOption::MempoolSpace => {
+                self.clear_custom_block_explorer(network)?;
+                Ok(None)
+            }
+            BlockExplorerOption::Custom => Ok(self.custom_block_explorer(network)),
+            _ => {
+                let base_url = option.base_url().expect("preset block explorer has a base URL");
+                self.set_custom_block_explorer(network, base_url.to_string())
+            }
+        }
     }
 
     pub fn clear_custom_block_explorer(&self, network: Network) -> Result<()> {
@@ -452,6 +477,7 @@ impl GlobalConfigTable {
 
 #[cfg(test)]
 mod tests {
+    use crate::custom_block_explorer::BlockExplorerOption;
     use cove_types::Network;
 
     #[test]
@@ -499,6 +525,44 @@ mod tests {
         let cleared = table.set_custom_block_explorer(Network::Bitcoin, "   ".to_string()).unwrap();
         assert_eq!(cleared, None);
         assert_eq!(table.custom_block_explorer(Network::Bitcoin), None);
+    }
+
+    #[test]
+    fn block_explorer_option_setter_selects_presets_and_clears_default() {
+        crate::app::reconcile::test_support::init_noop_updater();
+        let (_tmp, table) = test_table();
+
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Bitcoin),
+            BlockExplorerOption::MempoolSpace
+        );
+
+        let saved = table
+            .set_block_explorer_option(Network::Bitcoin, BlockExplorerOption::Blockstream)
+            .unwrap();
+        assert_eq!(saved.as_deref(), Some("https://blockstream.info/tx/{txid}"));
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Bitcoin),
+            BlockExplorerOption::Blockstream
+        );
+
+        table
+            .set_custom_block_explorer(Network::Bitcoin, "https://example.com".to_string())
+            .unwrap();
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Bitcoin),
+            BlockExplorerOption::Custom
+        );
+
+        let cleared = table
+            .set_block_explorer_option(Network::Bitcoin, BlockExplorerOption::MempoolSpace)
+            .unwrap();
+        assert_eq!(cleared, None);
+        assert_eq!(table.custom_block_explorer(Network::Bitcoin), None);
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Bitcoin),
+            BlockExplorerOption::MempoolSpace
+        );
     }
 
     #[test]
@@ -556,6 +620,10 @@ mod tests {
             "https://mempool.space/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
         assert_eq!(table.custom_block_explorer(Network::Bitcoin), None);
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Bitcoin),
+            BlockExplorerOption::MempoolSpace
+        );
     }
 
     fn test_table() -> (tempfile::TempDir, super::GlobalConfigTable) {

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -359,8 +359,17 @@ impl GlobalConfigTable {
             BlockExplorerOption::MempoolGuide
             | BlockExplorerOption::BullBitcoin
             | BlockExplorerOption::Blockstream => {
-                let base_url = option.base_url().expect("preset block explorer has a base URL");
-                self.set_custom_block_explorer(network, base_url.to_string())
+                let template = option.template_for_network(network).ok_or_else(|| {
+                    GlobalConfigTableError::InvalidCustomBlockExplorer(format!(
+                        "{} is not supported on {}",
+                        option.display_name(),
+                        network.display_name()
+                    ))
+                })?;
+                let canonical = template.as_str().to_string();
+                self.set(GlobalConfigKey::CustomBlockExplorer(network), canonical.clone())?;
+
+                Ok(Some(canonical))
             }
         }
     }
@@ -576,6 +585,46 @@ mod tests {
             table.selected_block_explorer_option(Network::Bitcoin),
             BlockExplorerOption::Blockstream
         );
+    }
+
+    #[test]
+    fn block_explorer_option_setter_preserves_preset_network_paths() {
+        crate::app::reconcile::test_support::init_noop_updater();
+        let (_tmp, table) = test_table();
+
+        let testnet = table
+            .set_block_explorer_option(Network::Testnet, BlockExplorerOption::Blockstream)
+            .unwrap();
+        let signet = table
+            .set_block_explorer_option(Network::Signet, BlockExplorerOption::Blockstream)
+            .unwrap();
+
+        assert_eq!(testnet.as_deref(), Some("https://blockstream.info/testnet/tx/{txid}"));
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Testnet),
+            BlockExplorerOption::Blockstream
+        );
+        assert_eq!(signet.as_deref(), Some("https://blockstream.info/signet/tx/{txid}"));
+        assert_eq!(
+            table.selected_block_explorer_option(Network::Signet),
+            BlockExplorerOption::Blockstream
+        );
+    }
+
+    #[test]
+    fn block_explorer_option_setter_rejects_unsupported_preset_networks() {
+        crate::app::reconcile::test_support::init_noop_updater();
+        let (_tmp, table) = test_table();
+
+        assert_eq!(
+            table
+                .set_block_explorer_option(Network::Testnet4, BlockExplorerOption::Blockstream)
+                .unwrap_err(),
+            super::Error::GlobalConfig(super::GlobalConfigTableError::InvalidCustomBlockExplorer(
+                "blockstream.info is not supported on Testnet4".to_string(),
+            ))
+        );
+        assert_eq!(table.custom_block_explorer(Network::Testnet4), None);
     }
 
     #[test]

--- a/rust/src/database/global_config.rs
+++ b/rust/src/database/global_config.rs
@@ -593,7 +593,7 @@ mod tests {
             table
                 .preview_custom_block_explorer(Network::Bitcoin, "https://example.com".to_string())
                 .unwrap(),
-            "https://example.com/tx/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "https://example.com/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
         );
         assert!(table.custom_block_explorer(Network::Bitcoin).is_none());
 
@@ -616,7 +616,7 @@ mod tests {
 
         assert_eq!(
             table.preview_custom_block_explorer(Network::Signet, "   ".to_string()).unwrap(),
-            "https://mutinynet.com/tx/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "https://mutinynet.com/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add Rust-owned block explorer preset options for mempool.guide, Bull Bitcoin mempool, Blockstream, Custom, and the default mempool.space explorer
- Expose the preset list and selected option through UniFFI so iOS and Android share the same explorer catalog and selection behavior
- Add settings UI copy explaining block explorers and show preset options before the custom URL/template editor

## Validation

- just fmt
- cargo test block_explorer --lib
- just clippy
- just build-ios
- just build-android
- just compile-ios
- just compile-android
- just lint-android
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable block explorer options, including custom URL/template support, with clearer save/reset flows and success feedback.
  * Improved block explorer URL handling across the app for more reliable previews and matching.
  * Enabled local network access on iOS for connecting to explorers and nodes.

* **Bug Fixes**
  * Prevented duplicate updates when reselecting the same node preset.
  * Improved network request reliability in CI by reducing Cargo transport issues.

* **UI Improvements**
  * Updated settings screens to better separate preset options from custom explorer input.
  * Simplified the block explorer entry in General settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->