### PR TITLE
Move transaction detail loading after navigation

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -641,14 +641,6 @@ class AppManager private constructor() : FfiReconcile {
     }
 }
 
-private fun Route.isSameNavigationDestination(other: Route): Boolean =
-    when {
-        this is Route.TransactionDetails && other is Route.TransactionDetails ->
-            id == other.id &&
-                details.txId().asHashString() == other.details.txId().asHashString()
-        else -> this == other
-    }
-
 // global accessor for convenience
 val App: AppManager
     get() = AppManager.getInstance()

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -241,6 +241,9 @@ class AppManager private constructor() : FfiReconcile {
     val currentRoute: Route
         get() = router.currentRoute
 
+    private fun isDuplicateTopRoute(route: Route): Boolean =
+        currentRoute.isSameNavigationDestination(route)
+
     val hasWallets: Boolean
         get() = rust.hasWallets()
 
@@ -337,6 +340,11 @@ class AppManager private constructor() : FfiReconcile {
     }
 
     fun pushRoute(route: Route) {
+        if (isDuplicateTopRoute(route)) {
+            isSidebarVisible = false
+            return
+        }
+
         advanceNavigationGeneration()
         pushRouteWithoutNavigationGeneration(route)
     }
@@ -344,6 +352,8 @@ class AppManager private constructor() : FfiReconcile {
     private fun pushRouteWithoutNavigationGeneration(route: Route) {
         Log.d(tag, "pushRoute: $route")
         isSidebarVisible = false
+        if (isDuplicateTopRoute(route)) return
+
         val newRoutes = router.routes.toMutableList().apply { add(route) }
 
         // only dispatch if routes actually changed
@@ -499,6 +509,11 @@ class AppManager private constructor() : FfiReconcile {
                 }
 
                 is AppStateReconcileMessage.PushedRoute -> {
+                    if (isDuplicateTopRoute(message.v1)) {
+                        isSidebarVisible = false
+                        return@launch
+                    }
+
                     val newRoutes = (router.routes + message.v1).toList()
                     updateRoutesAndClearInactiveSendFlowManager(newRoutes)
                     scheduleNavigationSettledForCurrentGeneration()
@@ -625,6 +640,14 @@ class AppManager private constructor() : FfiReconcile {
             }
     }
 }
+
+private fun Route.isSameNavigationDestination(other: Route): Boolean =
+    when {
+        this is Route.TransactionDetails && other is Route.TransactionDetails ->
+            id == other.id &&
+                details.txId().asHashString() == other.details.txId().asHashString()
+        else -> this == other
+    }
 
 // global accessor for convenience
 val App: AppManager

--- a/android/app/src/main/java/org/bitcoinppl/cove/RouteView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/RouteView.kt
@@ -56,7 +56,7 @@ fun RouteView(app: AppManager, route: Route) {
                 TransactionDetailsContainer(
                     app = app,
                     walletId = route.id,
-                    details = route.details,
+                    txId = route.txId,
                 )
             }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -1,6 +1,8 @@
 package org.bitcoinppl.cove.flows.SelectedWalletFlow.TransactionDetails
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -9,10 +11,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove.components.FullPageLoadingView
-import org.bitcoinppl.cove_core.TransactionDetails
+import org.bitcoinppl.cove_core.types.TxId
 import org.bitcoinppl.cove_core.types.WalletId
 
 /**
@@ -23,13 +26,17 @@ import org.bitcoinppl.cove_core.types.WalletId
 fun TransactionDetailsContainer(
     app: AppManager,
     walletId: WalletId,
-    details: TransactionDetails,
+    txId: TxId,
 ) {
     var manager by remember { mutableStateOf<WalletManager?>(null) }
     var loading by remember { mutableStateOf(true) }
     var error by remember { mutableStateOf<String?>(null) }
+    var detailsError by remember(txId) { mutableStateOf<String?>(null) }
+    var didLoadInitialDetails by remember(txId) { mutableStateOf(false) }
+    var retryAttempt by remember(txId) { mutableStateOf(0) }
+    var managerRetryAttempt by remember(walletId) { mutableStateOf(0) }
 
-    LaunchedEffect(walletId) {
+    LaunchedEffect(walletId, managerRetryAttempt) {
         loading = true
         error = null
         manager = null
@@ -43,23 +50,75 @@ fun TransactionDetailsContainer(
         }
     }
 
+    val details = manager?.transactionDetailsCache?.get(txId)
+
+    LaunchedEffect(manager, txId, retryAttempt) {
+        val currentManager = manager ?: return@LaunchedEffect
+        if (currentManager.transactionDetailsCache[txId] != null) return@LaunchedEffect
+
+        detailsError = null
+
+        try {
+            currentManager.transactionDetails(txId)
+            didLoadInitialDetails = true
+        } catch (e: Exception) {
+            detailsError = e.message ?: "failed to load transaction"
+            android.util.Log.e("TransactionDetails", "Failed to load transaction details", e)
+        }
+    }
+
     when {
         loading -> FullPageLoadingView()
         error != null -> {
-            // show error - TODO: better error UI
-            androidx.compose.foundation.layout.Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                androidx.compose.material3.Text("Error: $error")
-            }
+            TransactionDetailsLoadError(
+                message = error!!,
+                onRetry = {
+                    error = null
+                    managerRetryAttempt++
+                },
+            )
         }
-        manager != null -> {
+        manager != null && details != null -> {
             TransactionDetailsScreen(
                 app = app,
                 manager = manager!!,
                 details = details,
+                txId = txId,
+                refreshOnAppear = !didLoadInitialDetails,
             )
+        }
+        detailsError != null -> {
+            TransactionDetailsLoadError(
+                message = detailsError!!,
+                onRetry = {
+                    detailsError = null
+                    didLoadInitialDetails = false
+                    retryAttempt++
+                },
+            )
+        }
+        else -> FullPageLoadingView()
+    }
+}
+
+@Composable
+private fun TransactionDetailsLoadError(
+    message: String,
+    onRetry: () -> Unit,
+) {
+    androidx.compose.foundation.layout.Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            androidx.compose.material3.Text("Unable to load transaction")
+            androidx.compose.material3.Text(message)
+            androidx.compose.material3.Button(onClick = onRetry) {
+                androidx.compose.material3.Text("Try again")
+            }
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -78,6 +78,7 @@ fun TransactionDetailsContainer(
                 },
             )
         }
+
         manager != null && details != null -> {
             TransactionDetailsScreen(
                 app = app,
@@ -87,6 +88,7 @@ fun TransactionDetailsContainer(
                 refreshOnAppear = !didLoadInitialDetails,
             )
         }
+
         detailsError != null -> {
             TransactionDetailsLoadError(
                 message = detailsError!!,
@@ -97,6 +99,7 @@ fun TransactionDetailsContainer(
                 },
             )
         }
+
         else -> FullPageLoadingView()
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
@@ -81,6 +81,7 @@ import org.bitcoinppl.cove_core.TransactionDetails
 import org.bitcoinppl.cove_core.TransactionState
 import org.bitcoinppl.cove_core.WalletManagerAction
 import org.bitcoinppl.cove_core.types.FfiColorScheme
+import org.bitcoinppl.cove_core.types.TxId
 import org.bitcoinppl.cove_core.types.TransactionDirection
 
 private const val INITIAL_DELAY_MS = 2000L
@@ -99,6 +100,8 @@ fun TransactionDetailsScreen(
     app: AppManager,
     manager: WalletManager,
     details: TransactionDetails,
+    txId: TxId,
+    refreshOnAppear: Boolean = true,
 ) {
     // reset status bar icons to match theme (needed after navigating from SelectedWalletScreen
     // which forces white icons for its dark header)
@@ -107,7 +110,6 @@ fun TransactionDetailsScreen(
     val context = LocalContext.current
     val metadata = manager.walletMetadata ?: return
     val scope = rememberCoroutineScope()
-    val txId = details.txId()
 
     // read transaction details from cache (observable), fallback to passed-in details
     val transactionDetails = manager.transactionDetailsCache[txId] ?: details
@@ -126,7 +128,9 @@ fun TransactionDetailsScreen(
     val isDark = !MaterialTheme.colorScheme.isLight
 
     // immediately fetch fresh transaction details on screen load
-    LaunchedEffect(manager, txId) {
+    LaunchedEffect(manager, txId, refreshOnAppear) {
+        if (!refreshOnAppear) return@LaunchedEffect
+
         try {
             val freshDetails = manager.rust.transactionDetails(txId = txId)
             manager.updateTransactionDetailsCache(txId, freshDetails)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionsCardView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionsCardView.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,7 +52,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.launch
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.R
 import org.bitcoinppl.cove.TaggedItem
@@ -562,10 +560,7 @@ internal fun ConfirmedTransactionWidget(
     manager: WalletManager,
     sensitiveVisible: Boolean,
 ) {
-    val scope = rememberCoroutineScope()
     val txId = transaction.v1.id()
-    val txIdHash = txId.asHashString()
-    var isOpeningDetails by remember(txIdHash) { mutableStateOf(false) }
 
     fun privateShow(text: String, placeholder: String = "••••••"): String =
         if (sensitiveVisible) text else placeholder
@@ -579,26 +574,14 @@ internal fun ConfirmedTransactionWidget(
             Modifier
                 .fillMaxWidth()
                 .padding(vertical = 6.dp)
-                .graphicsLayer { alpha = if (isOpeningDetails) 0.65f else 1f }
-                .clickable(enabled = !isOpeningDetails) {
-                    isOpeningDetails = true
-                    scope.launch {
-                        try {
-                            val details = manager.transactionDetails(txId)
-                            val walletId = manager.walletMetadata?.id
-                            if (walletId != null) {
-                                if (index > SCROLL_THRESHOLD_INDEX) {
-                                    manager.pendingScrollTransactionId = txId.toString()
-                                }
-                                app.pushRoute(Route.TransactionDetails(walletId, details))
-                                isOpeningDetails = false
-                            } else {
-                                isOpeningDetails = false
-                            }
-                        } catch (e: Exception) {
-                            isOpeningDetails = false
-                            android.util.Log.e("ConfirmedTxWidget", "Failed to load transaction details", e)
+                .clickable {
+                    val walletId = manager.walletMetadata?.id
+                    if (walletId != null) {
+                        if (index > SCROLL_THRESHOLD_INDEX) {
+                            manager.pendingScrollTransactionId = txId.toString()
                         }
+
+                        app.pushRoute(Route.TransactionDetails(walletId, txId))
                     }
                 },
         verticalAlignment = Alignment.CenterVertically,
@@ -611,20 +594,12 @@ internal fun ConfirmedTransactionWidget(
                     .background(iconBackground),
             contentAlignment = Alignment.Center,
         ) {
-            if (isOpeningDetails) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(20.dp),
-                    color = iconForeground,
-                    strokeWidth = 2.dp,
-                )
-            } else {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = label,
-                    tint = iconForeground,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = iconForeground,
+                modifier = Modifier.size(24.dp),
+            )
         }
 
         Spacer(modifier = Modifier.size(12.dp))
@@ -685,10 +660,7 @@ internal fun UnconfirmedTransactionWidget(
     manager: WalletManager,
     sensitiveVisible: Boolean,
 ) {
-    val scope = rememberCoroutineScope()
     val txId = transaction.v1.id()
-    val txIdHash = txId.asHashString()
-    var isOpeningDetails by remember(txIdHash) { mutableStateOf(false) }
 
     fun privateShow(text: String, placeholder: String = "••••••"): String =
         if (sensitiveVisible) text else placeholder
@@ -701,26 +673,14 @@ internal fun UnconfirmedTransactionWidget(
             Modifier
                 .fillMaxWidth()
                 .padding(vertical = 6.dp)
-                .graphicsLayer { alpha = if (isOpeningDetails) 0.65f else 1f }
-                .clickable(enabled = !isOpeningDetails) {
-                    isOpeningDetails = true
-                    scope.launch {
-                        try {
-                            val details = manager.transactionDetails(txId)
-                            val walletId = manager.walletMetadata?.id
-                            if (walletId != null) {
-                                if (index > SCROLL_THRESHOLD_INDEX) {
-                                    manager.pendingScrollTransactionId = txId.toString()
-                                }
-                                app.pushRoute(Route.TransactionDetails(walletId, details))
-                                isOpeningDetails = false
-                            } else {
-                                isOpeningDetails = false
-                            }
-                        } catch (e: Exception) {
-                            isOpeningDetails = false
-                            android.util.Log.e("UnconfirmedTxWidget", "Failed to load transaction details", e)
+                .clickable {
+                    val walletId = manager.walletMetadata?.id
+                    if (walletId != null) {
+                        if (index > SCROLL_THRESHOLD_INDEX) {
+                            manager.pendingScrollTransactionId = txId.toString()
                         }
+
+                        app.pushRoute(Route.TransactionDetails(walletId, txId))
                     }
                 },
         verticalAlignment = Alignment.CenterVertically,
@@ -734,20 +694,12 @@ internal fun UnconfirmedTransactionWidget(
                         .background(iconBackground),
                 contentAlignment = Alignment.Center,
             ) {
-                if (isOpeningDetails) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        color = iconForeground,
-                        strokeWidth = 2.dp,
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Filled.Schedule,
-                        contentDescription = label,
-                        tint = iconForeground,
-                        modifier = Modifier.size(24.dp),
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Filled.Schedule,
+                    contentDescription = label,
+                    tint = iconForeground,
+                    modifier = Modifier.size(24.dp),
+                )
             }
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionsCardView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionsCardView.kt
@@ -563,6 +563,9 @@ internal fun ConfirmedTransactionWidget(
     sensitiveVisible: Boolean,
 ) {
     val scope = rememberCoroutineScope()
+    val txId = transaction.v1.id()
+    val txIdHash = txId.asHashString()
+    var isOpeningDetails by remember(txIdHash) { mutableStateOf(false) }
 
     fun privateShow(text: String, placeholder: String = "••••••"): String =
         if (sensitiveVisible) text else placeholder
@@ -576,18 +579,24 @@ internal fun ConfirmedTransactionWidget(
             Modifier
                 .fillMaxWidth()
                 .padding(vertical = 6.dp)
-                .clickable {
+                .graphicsLayer { alpha = if (isOpeningDetails) 0.65f else 1f }
+                .clickable(enabled = !isOpeningDetails) {
+                    isOpeningDetails = true
                     scope.launch {
                         try {
-                            val details = manager.transactionDetails(transaction.v1.id())
+                            val details = manager.transactionDetails(txId)
                             val walletId = manager.walletMetadata?.id
                             if (walletId != null) {
                                 if (index > SCROLL_THRESHOLD_INDEX) {
-                                    manager.pendingScrollTransactionId = transaction.v1.id().toString()
+                                    manager.pendingScrollTransactionId = txId.toString()
                                 }
                                 app.pushRoute(Route.TransactionDetails(walletId, details))
+                                isOpeningDetails = false
+                            } else {
+                                isOpeningDetails = false
                             }
                         } catch (e: Exception) {
+                            isOpeningDetails = false
                             android.util.Log.e("ConfirmedTxWidget", "Failed to load transaction details", e)
                         }
                     }
@@ -602,12 +611,20 @@ internal fun ConfirmedTransactionWidget(
                     .background(iconBackground),
             contentAlignment = Alignment.Center,
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = label,
-                tint = iconForeground,
-                modifier = Modifier.size(24.dp),
-            )
+            if (isOpeningDetails) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    color = iconForeground,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = label,
+                    tint = iconForeground,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
         }
 
         Spacer(modifier = Modifier.size(12.dp))
@@ -669,6 +686,9 @@ internal fun UnconfirmedTransactionWidget(
     sensitiveVisible: Boolean,
 ) {
     val scope = rememberCoroutineScope()
+    val txId = transaction.v1.id()
+    val txIdHash = txId.asHashString()
+    var isOpeningDetails by remember(txIdHash) { mutableStateOf(false) }
 
     fun privateShow(text: String, placeholder: String = "••••••"): String =
         if (sensitiveVisible) text else placeholder
@@ -681,18 +701,24 @@ internal fun UnconfirmedTransactionWidget(
             Modifier
                 .fillMaxWidth()
                 .padding(vertical = 6.dp)
-                .clickable {
+                .graphicsLayer { alpha = if (isOpeningDetails) 0.65f else 1f }
+                .clickable(enabled = !isOpeningDetails) {
+                    isOpeningDetails = true
                     scope.launch {
                         try {
-                            val details = manager.transactionDetails(transaction.v1.id())
+                            val details = manager.transactionDetails(txId)
                             val walletId = manager.walletMetadata?.id
                             if (walletId != null) {
                                 if (index > SCROLL_THRESHOLD_INDEX) {
-                                    manager.pendingScrollTransactionId = transaction.v1.id().toString()
+                                    manager.pendingScrollTransactionId = txId.toString()
                                 }
                                 app.pushRoute(Route.TransactionDetails(walletId, details))
+                                isOpeningDetails = false
+                            } else {
+                                isOpeningDetails = false
                             }
                         } catch (e: Exception) {
+                            isOpeningDetails = false
                             android.util.Log.e("UnconfirmedTxWidget", "Failed to load transaction details", e)
                         }
                     }
@@ -708,12 +734,20 @@ internal fun UnconfirmedTransactionWidget(
                         .background(iconBackground),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Schedule,
-                    contentDescription = label,
-                    tint = iconForeground,
-                    modifier = Modifier.size(24.dp),
-                )
+                if (isOpeningDetails) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        color = iconForeground,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Schedule,
+                        contentDescription = label,
+                        tint = iconForeground,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/navigation/CoveNavDisplay.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/navigation/CoveNavDisplay.kt
@@ -156,7 +156,7 @@ private fun RouteContent(app: AppManager, route: Route) {
             TransactionDetailsContainer(
                 app = app,
                 walletId = route.id,
-                details = route.details,
+                txId = route.txId,
             )
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -45663,7 +45663,7 @@ sealed class Route: Disposable  {
 
     data class TransactionDetails(
         val `id`: org.bitcoinppl.cove_core.types.WalletId,
-        val `details`: org.bitcoinppl.cove_core.TransactionDetails) : Route()
+        val `txId`: org.bitcoinppl.cove_core.types.TxId) : Route()
 
     {
 
@@ -45734,7 +45734,7 @@ sealed class Route: Disposable  {
 
     Disposable.destroy(
         this.`id`,
-        this.`details`
+        this.`txId`
     )
 
             }
@@ -45819,7 +45819,7 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
                 )
             6 -> Route.TransactionDetails(
                 FfiConverterTypeWalletId.read(buf),
-                FfiConverterTypeTransactionDetails.read(buf),
+                FfiConverterTypeTxId.read(buf),
                 )
             7 -> Route.Send(
                 FfiConverterTypeSendRoute.read(buf),
@@ -45873,7 +45873,7 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
             (
                 4UL
                 + FfiConverterTypeWalletId.allocationSize(value.`id`)
-                + FfiConverterTypeTransactionDetails.allocationSize(value.`details`)
+                + FfiConverterTypeTxId.allocationSize(value.`txId`)
             )
         }
         is Route.Send -> {
@@ -45923,7 +45923,7 @@ public object FfiConverterTypeRoute : FfiConverterRustBuffer<Route>{
             is Route.TransactionDetails -> {
                 buf.putInt(6)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
-                FfiConverterTypeTransactionDetails.write(value.`details`, buf)
+                FfiConverterTypeTxId.write(value.`txId`, buf)
                 Unit
             }
             is Route.Send -> {

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -3337,6 +3337,8 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_afterpinaction_usermessage(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_fn_method_route_issamenavigationdestination(`ptr`: RustBuffer.ByValue,`routeToCheck`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): Byte
     external fun uniffi_cove_fn_method_route_is_equal(`ptr`: RustBuffer.ByValue,`routeToCheck`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): Byte
     external fun uniffi_cove_fn_method_route_stablehash(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
@@ -45753,6 +45755,17 @@ sealed class Route: Disposable  {
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
+
+
+     fun `isSameNavigationDestination`(`routeToCheck`: Route): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_method_route_issamenavigationdestination(FfiConverterTypeRoute.lower(this),
+
+        FfiConverterTypeRoute.lower(`routeToCheck`),_status)
+}
+    )
+    }
 
 
      fun `isEqual`(`routeToCheck`: Route): kotlin.Boolean {

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -312,7 +312,7 @@ private let navigationSettleDelayMs = 800
     }
 
     private func isDuplicateTopRoute(_ route: Route) -> Bool {
-        currentRoute.isSameNavigationDestination(as: route)
+        currentRoute.isSameNavigationDestination(routeToCheck: route)
     }
 
     var hasWallets: Bool {
@@ -650,20 +650,6 @@ private let navigationSettleDelayMs = 800
             try rust.dispatch(action: action)
         } catch {
             logger.error("Unable to dispatch app action \(action), error: \(error)")
-        }
-    }
-}
-
-private extension Route {
-    func isSameNavigationDestination(as other: Route) -> Bool {
-        switch (self, other) {
-        case let (
-            .transactionDetails(id: currentId, details: currentDetails),
-            .transactionDetails(id: nextId, details: nextDetails)
-        ):
-            currentId == nextId && currentDetails.txId() == nextDetails.txId()
-        default:
-            self == other
         }
     }
 }

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -311,6 +311,10 @@ private let navigationSettleDelayMs = 800
         router.routes.last ?? router.default
     }
 
+    private func isDuplicateTopRoute(_ route: Route) -> Bool {
+        currentRoute.isSameNavigationDestination(as: route)
+    }
+
     var hasWallets: Bool {
         rust.hasWallets()
     }
@@ -364,12 +368,19 @@ private let navigationSettleDelayMs = 800
     }
 
     func pushRoute(_ route: Route) {
+        guard !isDuplicateTopRoute(route) else {
+            isSidebarVisible = false
+            return
+        }
+
         advanceNavigationGeneration()
         pushRouteWithoutNavigationGeneration(route)
     }
 
     private func pushRouteWithoutNavigationGeneration(_ route: Route) {
         isSidebarVisible = false
+        guard !isDuplicateTopRoute(route) else { return }
+
         router.routes.append(route)
     }
 
@@ -563,6 +574,8 @@ private let navigationSettleDelayMs = 800
                 }
 
             case let .pushedRoute(route):
+                guard !isDuplicateTopRoute(route) else { return }
+
                 router.routes.append(route)
                 scheduleNavigationSettledForCurrentGeneration()
 
@@ -637,6 +650,20 @@ private let navigationSettleDelayMs = 800
             try rust.dispatch(action: action)
         } catch {
             logger.error("Unable to dispatch app action \(action), error: \(error)")
+        }
+    }
+}
+
+private extension Route {
+    func isSameNavigationDestination(as other: Route) -> Bool {
+        switch (self, other) {
+        case let (
+            .transactionDetails(id: currentId, details: currentDetails),
+            .transactionDetails(id: nextId, details: nextDetails)
+        ):
+            currentId == nextId && currentDetails.txId() == nextDetails.txId()
+        default:
+            self == other
         }
     }
 }

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -574,7 +574,10 @@ private let navigationSettleDelayMs = 800
                 }
 
             case let .pushedRoute(route):
-                guard !isDuplicateTopRoute(route) else { return }
+                guard !isDuplicateTopRoute(route) else {
+                    isSidebarVisible = false
+                    return
+                }
 
                 router.routes.append(route)
                 scheduleNavigationSettledForCurrentGeneration()

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -5,7 +5,6 @@
 //  Created by Praveen Perera on 5/19/25.
 //
 
-import MijickPopups
 import SwiftUI
 
 // MARK: - View
@@ -24,24 +23,7 @@ struct UtxoListScreen: View {
         let txId = utxo.id.txid()
         let walletId = walletManager.walletMetadata.id
 
-        if let details = walletManager.transactionDetails[txId] {
-            return navigate(Route.transactionDetails(id: walletId, details: details))
-        }
-
-        Task {
-            await MiddlePopup(state: .loading).present()
-            do {
-                let details = try await walletManager.transactionDetails(for: txId)
-                await MainActor.run {
-                    Task { await dismissAllPopups() }
-                    navigate(Route.transactionDetails(id: walletId, details: details))
-                }
-            } catch {
-                Log.error(
-                    "Unable to get transaction details: \(error.localizedDescription), for txn: \(txId)"
-                )
-            }
-        }
+        navigate(Route.transactionDetails(id: walletId, txId: txId))
     }
 
     func UtxoList() -> some View {

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -9,12 +9,8 @@ import SwiftUI
 
 struct TransactionDetailsView: View {
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(AppManager.self) private var app
     @Environment(\.openURL) private var openURL
     @Environment(\.sizeCategory) var sizeCategory
-
-    private let screenWidth = UIScreen.main.bounds.width
-    private let screenHeight = UIScreen.main.bounds.height
 
     @State private var numberOfConfirmations: Int? = nil
     @State private var scrollPosition = ScrollPosition()
@@ -24,17 +20,27 @@ struct TransactionDetailsView: View {
 
     // public
     let id: WalletId
+    let txId: TxId
     private let initialDetails: TransactionDetails
+    let refreshOnAppear: Bool
     var manager: WalletManager
 
     /// read from cache (observable), fallback to initial details
     var transactionDetails: TransactionDetails {
-        manager.transactionDetails[initialDetails.txId()] ?? initialDetails
+        manager.transactionDetails[txId] ?? initialDetails
     }
 
-    init(id: WalletId, transactionDetails: TransactionDetails, manager: WalletManager) {
+    init(
+        id: WalletId,
+        txId: TxId,
+        transactionDetails: TransactionDetails,
+        refreshOnAppear: Bool = true,
+        manager: WalletManager
+    ) {
         self.id = id
+        self.txId = txId
         self.initialDetails = transactionDetails
+        self.refreshOnAppear = refreshOnAppear
         self.manager = manager
     }
 
@@ -304,7 +310,9 @@ struct TransactionDetailsView: View {
         }
         .task {
             // fetch fresh details on load
-            await refreshTransactionDetails()
+            if refreshOnAppear {
+                await refreshTransactionDetails()
+            }
 
             // start watcher after a delay to avoid race condition with onDisappear
             if !transactionDetails.isConfirmed() {
@@ -339,7 +347,6 @@ struct TransactionDetailsView: View {
     }
 
     func refreshTransactionDetails() async {
-        let txId = initialDetails.txId()
         do {
             let details = try await manager.rust.transactionDetails(txId: txId)
             await MainActor.run {
@@ -382,7 +389,6 @@ struct TransactionDetailsView: View {
     }
 
     func updateNumberOfConfirmations() async {
-        let txId = initialDetails.txId()
         var needsFrequentCheck = true
         var errors = 0
 
@@ -433,9 +439,12 @@ struct TransactionDetailsView: View {
 
 #Preview("confirmed received") {
     AsyncPreview {
+        let details = TransactionDetails.previewConfirmedReceived()
+
         TransactionDetailsView(
             id: WalletId(),
-            transactionDetails: TransactionDetails.previewConfirmedReceived(),
+            txId: details.txId(),
+            transactionDetails: details,
             manager: WalletManager(preview: "preview_only")
         )
         .environment(AppManager.shared)
@@ -444,9 +453,12 @@ struct TransactionDetailsView: View {
 
 #Preview("confirmed sent") {
     AsyncPreview {
+        let details = TransactionDetails.previewConfirmedSent()
+
         TransactionDetailsView(
             id: WalletId(),
-            transactionDetails: TransactionDetails.previewConfirmedSent(),
+            txId: details.txId(),
+            transactionDetails: details,
             manager: WalletManager(preview: "preview_only")
         )
         .environment(AppManager.shared)
@@ -455,9 +467,12 @@ struct TransactionDetailsView: View {
 
 #Preview("pending received") {
     AsyncPreview {
+        let details = TransactionDetails.previewPendingReceived()
+
         TransactionDetailsView(
             id: WalletId(),
-            transactionDetails: TransactionDetails.previewPendingReceived(),
+            txId: details.txId(),
+            transactionDetails: details,
             manager: WalletManager(preview: "preview_only")
         )
         .environment(AppManager.shared)
@@ -466,9 +481,12 @@ struct TransactionDetailsView: View {
 
 #Preview("pending sent") {
     AsyncPreview {
+        let details = TransactionDetails.previewPendingSent()
+
         TransactionDetailsView(
             id: WalletId(),
-            transactionDetails: TransactionDetails.previewPendingSent(),
+            txId: details.txId(),
+            transactionDetails: details,
             manager: WalletManager(preview: "preview_only")
         )
         .environment(AppManager.shared)

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsView.swift
@@ -308,7 +308,7 @@ struct TransactionDetailsView: View {
         .refreshable {
             await refreshTransactionDetails()
         }
-        .task {
+        .task(id: txId) {
             // fetch fresh details on load
             if refreshOnAppear {
                 await refreshTransactionDetails()

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionsDetailScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionsDetailScreen.swift
@@ -80,7 +80,7 @@ private struct TransactionDetailsLoader: View {
                 self.error = error
             }
 
-            Log.error("Unable to get transaction details: \(error.localizedDescription), for txn: \(txId)")
+            Log.error("Unable to get transaction details: \(error.localizedDescription)")
         }
     }
 }

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionsDetailScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionDetails/TransactionsDetailScreen.swift
@@ -14,18 +14,89 @@ struct TransactionsDetailScreen: View {
 
     // public
     let id: WalletId
-    let transactionDetails: TransactionDetails
+    let txId: TxId
 
     var body: some View {
         WalletManagerHost(walletId: id, loading: {
-            Text("Loading...")
+            FullPageLoadingView(backgroundColor: .background)
         }, onError: { error in
             Log.error("Something went very wrong: \(error)")
             app.trySelectLatestOrNewWallet()
         }) { manager in
-            TransactionDetailsView(
-                id: id, transactionDetails: transactionDetails, manager: manager
-            )
+            TransactionDetailsLoader(id: id, txId: txId, manager: manager)
+        }
+    }
+}
+
+private struct TransactionDetailsLoader: View {
+    let id: WalletId
+    let txId: TxId
+    var manager: WalletManager
+
+    @State private var error: Error?
+    @State private var didLoadInitialDetails = false
+
+    private var transactionDetails: TransactionDetails? {
+        manager.transactionDetails[txId]
+    }
+
+    var body: some View {
+        Group {
+            if let transactionDetails {
+                TransactionDetailsView(
+                    id: id,
+                    txId: txId,
+                    transactionDetails: transactionDetails,
+                    refreshOnAppear: !didLoadInitialDetails,
+                    manager: manager
+                )
+            } else if let error {
+                TransactionDetailsLoadErrorView(error: error) {
+                    Task { await loadTransactionDetails() }
+                }
+            } else {
+                FullPageLoadingView(backgroundColor: .background)
+            }
+        }
+        .task(id: txId) {
+            await loadTransactionDetails()
+        }
+    }
+
+    private func loadTransactionDetails() async {
+        if transactionDetails != nil { return }
+
+        await MainActor.run {
+            error = nil
+        }
+
+        do {
+            _ = try await manager.transactionDetails(for: txId)
+            await MainActor.run {
+                didLoadInitialDetails = true
+            }
+        } catch {
+            await MainActor.run {
+                self.error = error
+            }
+
+            Log.error("Unable to get transaction details: \(error.localizedDescription), for txn: \(txId)")
+        }
+    }
+}
+
+private struct TransactionDetailsLoadErrorView: View {
+    let error: Error
+    let retry: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Unable to Load Transaction", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(error.localizedDescription)
+        } actions: {
+            Button("Try Again", action: retry)
+                .buttonStyle(.borderedProminent)
         }
     }
 }

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionsCardView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionsCardView.swift
@@ -266,9 +266,7 @@ struct ConfirmedTransactionView: View {
     let metadata: WalletMetadata
     let index: Int
 
-    // private
-    @State private var transactionDetails: TransactionDetails? = nil
-    @State private var loading: Bool = false
+    @State private var isOpeningDetails = false
 
     private var amount: String {
         if case .btc = metadata.fiatOrBtc {
@@ -314,26 +312,39 @@ struct ConfirmedTransactionView: View {
     }
 
     private func goToTransactionDetails() {
+        guard !isOpeningDetails else { return }
+
         let txId = txn.id()
+        isOpeningDetails = true
 
         if let details = manager.transactionDetails[txId] {
-            if index > scrollThresholdIndex { manager.scrolledTransactionId = txId.description }
-            return navigate(Route.transactionDetails(id: metadata.id, details: details))
+            navigateToTransactionDetails(txId: txId, details: details)
+            return
         }
 
         Task {
             do {
                 let details = try await manager.transactionDetails(for: txId)
                 await MainActor.run {
-                    if index > scrollThresholdIndex { manager.scrolledTransactionId = txId.description }
-                    navigate(Route.transactionDetails(id: metadata.id, details: details))
+                    navigateToTransactionDetails(txId: txId, details: details)
                 }
             } catch {
+                await MainActor.run {
+                    isOpeningDetails = false
+                }
+
                 Log.error(
                     "Unable to get transaction details: \(error.localizedDescription), for txn: \(txn.id())"
                 )
             }
         }
+    }
+
+    @MainActor
+    private func navigateToTransactionDetails(txId: TxId, details: TransactionDetails) {
+        if index > scrollThresholdIndex { manager.scrolledTransactionId = txId.description }
+        navigate(Route.transactionDetails(id: metadata.id, details: details))
+        isOpeningDetails = false
     }
 
     var label: String {
@@ -343,7 +354,7 @@ struct ConfirmedTransactionView: View {
 
     var body: some View {
         HStack {
-            TxnIcon(direction: txn.sentAndReceived().direction())
+            TxnIcon(direction: txn.sentAndReceived().direction(), isLoading: isOpeningDetails)
 
             VStack(alignment: .leading, spacing: 5) {
                 Text(label)
@@ -372,6 +383,8 @@ struct ConfirmedTransactionView: View {
                     .foregroundColor(.secondary)
             }
         }
+        .opacity(isOpeningDetails ? 0.65 : 1)
+        .animation(.easeInOut(duration: 0.12), value: isOpeningDetails)
         .contentShape(Rectangle())
         .onTapGesture {
             goToTransactionDetails()
@@ -386,6 +399,8 @@ struct UnconfirmedTransactionView: View {
     let txn: UnconfirmedTransaction
     let metadata: WalletMetadata
     let index: Int
+
+    @State private var isOpeningDetails = false
 
     func privateShow(_ text: String, placeholder: String = "••••••") -> String {
         if !metadata.sensitiveVisible {
@@ -436,10 +451,45 @@ struct UnconfirmedTransactionView: View {
         )
     }
 
+    private func goToTransactionDetails() {
+        guard !isOpeningDetails else { return }
+
+        let txId = txn.id()
+        isOpeningDetails = true
+
+        Task {
+            do {
+                let details = try await manager.transactionDetails(for: txId)
+                await MainActor.run {
+                    navigateToTransactionDetails(txId: txId, details: details)
+                }
+            } catch {
+                await MainActor.run {
+                    isOpeningDetails = false
+                }
+
+                Log.error(
+                    "Unable to get transaction details: \(error.localizedDescription), for txn: \(txn.id())"
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func navigateToTransactionDetails(txId: TxId, details: TransactionDetails) {
+        if index > scrollThresholdIndex { manager.scrolledTransactionId = txId.description }
+        navigate(Route.transactionDetails(id: metadata.id, details: details))
+        isOpeningDetails = false
+    }
+
     var body: some View {
         HStack {
-            TxnIcon(direction: txn.sentAndReceived().direction(), confirmed: false)
-                .opacity(0.6)
+            TxnIcon(
+                direction: txn.sentAndReceived().direction(),
+                confirmed: false,
+                isLoading: isOpeningDetails
+            )
+            .opacity(0.6)
 
             VStack(alignment: .leading, spacing: 5) {
                 Text(txn.label())
@@ -457,21 +507,11 @@ struct UnconfirmedTransactionView: View {
                     .foregroundColor(.secondary)
             }
         }
+        .opacity(isOpeningDetails ? 0.65 : 1)
+        .animation(.easeInOut(duration: 0.12), value: isOpeningDetails)
         .contentShape(Rectangle())
         .onTapGesture {
-            Task {
-                do {
-                    let details = try await manager.rust.transactionDetails(txId: txn.id())
-                    await MainActor.run {
-                        if index > scrollThresholdIndex { manager.scrolledTransactionId = txn.id().description }
-                        navigate(Route.transactionDetails(id: metadata.id, details: details))
-                    }
-                } catch {
-                    Log.error(
-                        "Unable to get transaction details: \(error.localizedDescription), for txn: \(txn.id())"
-                    )
-                }
-            }
+            goToTransactionDetails()
         }
     }
 }
@@ -585,6 +625,7 @@ private struct TxnIcon: View {
 
     let direction: TransactionDirection
     var confirmed: Bool = true
+    var isLoading: Bool = false
 
     var iconColor: Color {
         colorScheme == .dark ? .gray.opacity(0.35) : .primary.opacity(0.75)
@@ -604,13 +645,22 @@ private struct TxnIcon: View {
     }
 
     var body: some View {
-        Image(systemName: arrow)
-            .foregroundColor(.white)
-            .padding()
-            .frame(width: 50, height: 50)
-            .background(iconColor)
-            .cornerRadius(6)
-            .padding(.trailing, 5)
+        ZStack {
+            if isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(.white)
+                    .scaleEffect(0.75)
+            } else {
+                Image(systemName: arrow)
+                    .foregroundColor(.white)
+                    .padding()
+            }
+        }
+        .frame(width: 50, height: 50)
+        .background(iconColor)
+        .cornerRadius(6)
+        .padding(.trailing, 5)
     }
 }
 

--- a/ios/Cove/Flows/SelectedWalletFlow/TransactionsCardView.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/TransactionsCardView.swift
@@ -266,8 +266,6 @@ struct ConfirmedTransactionView: View {
     let metadata: WalletMetadata
     let index: Int
 
-    @State private var isOpeningDetails = false
-
     private var amount: String {
         if case .btc = metadata.fiatOrBtc {
             return privateShow(
@@ -312,39 +310,9 @@ struct ConfirmedTransactionView: View {
     }
 
     private func goToTransactionDetails() {
-        guard !isOpeningDetails else { return }
-
         let txId = txn.id()
-        isOpeningDetails = true
-
-        if let details = manager.transactionDetails[txId] {
-            navigateToTransactionDetails(txId: txId, details: details)
-            return
-        }
-
-        Task {
-            do {
-                let details = try await manager.transactionDetails(for: txId)
-                await MainActor.run {
-                    navigateToTransactionDetails(txId: txId, details: details)
-                }
-            } catch {
-                await MainActor.run {
-                    isOpeningDetails = false
-                }
-
-                Log.error(
-                    "Unable to get transaction details: \(error.localizedDescription), for txn: \(txn.id())"
-                )
-            }
-        }
-    }
-
-    @MainActor
-    private func navigateToTransactionDetails(txId: TxId, details: TransactionDetails) {
         if index > scrollThresholdIndex { manager.scrolledTransactionId = txId.description }
-        navigate(Route.transactionDetails(id: metadata.id, details: details))
-        isOpeningDetails = false
+        navigate(Route.transactionDetails(id: metadata.id, txId: txId))
     }
 
     var label: String {
@@ -354,7 +322,7 @@ struct ConfirmedTransactionView: View {
 
     var body: some View {
         HStack {
-            TxnIcon(direction: txn.sentAndReceived().direction(), isLoading: isOpeningDetails)
+            TxnIcon(direction: txn.sentAndReceived().direction())
 
             VStack(alignment: .leading, spacing: 5) {
                 Text(label)
@@ -383,8 +351,6 @@ struct ConfirmedTransactionView: View {
                     .foregroundColor(.secondary)
             }
         }
-        .opacity(isOpeningDetails ? 0.65 : 1)
-        .animation(.easeInOut(duration: 0.12), value: isOpeningDetails)
         .contentShape(Rectangle())
         .onTapGesture {
             goToTransactionDetails()
@@ -399,8 +365,6 @@ struct UnconfirmedTransactionView: View {
     let txn: UnconfirmedTransaction
     let metadata: WalletMetadata
     let index: Int
-
-    @State private var isOpeningDetails = false
 
     func privateShow(_ text: String, placeholder: String = "••••••") -> String {
         if !metadata.sensitiveVisible {
@@ -452,42 +416,16 @@ struct UnconfirmedTransactionView: View {
     }
 
     private func goToTransactionDetails() {
-        guard !isOpeningDetails else { return }
-
         let txId = txn.id()
-        isOpeningDetails = true
-
-        Task {
-            do {
-                let details = try await manager.transactionDetails(for: txId)
-                await MainActor.run {
-                    navigateToTransactionDetails(txId: txId, details: details)
-                }
-            } catch {
-                await MainActor.run {
-                    isOpeningDetails = false
-                }
-
-                Log.error(
-                    "Unable to get transaction details: \(error.localizedDescription), for txn: \(txn.id())"
-                )
-            }
-        }
-    }
-
-    @MainActor
-    private func navigateToTransactionDetails(txId: TxId, details: TransactionDetails) {
         if index > scrollThresholdIndex { manager.scrolledTransactionId = txId.description }
-        navigate(Route.transactionDetails(id: metadata.id, details: details))
-        isOpeningDetails = false
+        navigate(Route.transactionDetails(id: metadata.id, txId: txId))
     }
 
     var body: some View {
         HStack {
             TxnIcon(
                 direction: txn.sentAndReceived().direction(),
-                confirmed: false,
-                isLoading: isOpeningDetails
+                confirmed: false
             )
             .opacity(0.6)
 
@@ -507,8 +445,6 @@ struct UnconfirmedTransactionView: View {
                     .foregroundColor(.secondary)
             }
         }
-        .opacity(isOpeningDetails ? 0.65 : 1)
-        .animation(.easeInOut(duration: 0.12), value: isOpeningDetails)
         .contentShape(Rectangle())
         .onTapGesture {
             goToTransactionDetails()
@@ -625,7 +561,6 @@ private struct TxnIcon: View {
 
     let direction: TransactionDirection
     var confirmed: Bool = true
-    var isLoading: Bool = false
 
     var iconColor: Color {
         colorScheme == .dark ? .gray.opacity(0.35) : .primary.opacity(0.75)
@@ -646,16 +581,9 @@ private struct TxnIcon: View {
 
     var body: some View {
         ZStack {
-            if isLoading {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .tint(.white)
-                    .scaleEffect(0.75)
-            } else {
-                Image(systemName: arrow)
-                    .foregroundColor(.white)
-                    .padding()
-            }
+            Image(systemName: arrow)
+                .foregroundColor(.white)
+                .padding()
         }
         .frame(width: 50, height: 50)
         .background(iconColor)

--- a/ios/Cove/RouteView.swift
+++ b/ios/Cove/RouteView.swift
@@ -44,8 +44,8 @@ struct RouteView: View {
             SelectedWalletContainer(id: walletId)
         case let .secretWords(id: walletId):
             SecretWordsScreen(id: walletId)
-        case let .transactionDetails(id: id, details: details):
-            TransactionsDetailScreen(id: id, transactionDetails: details)
+        case let .transactionDetails(id: id, txId: txId):
+            TransactionsDetailScreen(id: id, txId: txId)
         case let .send(sendRoute):
             SendFlowContainer(sendRoute: sendRoute)
         case let .coinControl(route):

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -28697,6 +28697,16 @@ public enum Route {
 
 
 
+public func isSameNavigationDestination(routeToCheck: Route) -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_method_route_issamenavigationdestination(
+            FfiConverterTypeRoute_lower(self),
+        FfiConverterTypeRoute_lower(routeToCheck),uniffiCallStatus
+    )
+})
+}
+
 public func isEqual(routeToCheck: Route) -> Bool  {
     return try!  FfiConverterBool.lift(try! rustCall() {
         uniffiCallStatus in

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -28688,7 +28688,7 @@ public enum Route {
     )
     case secretWords(WalletId
     )
-    case transactionDetails(id: WalletId, details: TransactionDetails
+    case transactionDetails(id: WalletId, txId: TxId
     )
     case send(SendRoute
     )
@@ -28759,7 +28759,7 @@ public struct FfiConverterTypeRoute: FfiConverterRustBuffer {
         case 5: return .secretWords(try FfiConverterTypeWalletId.read(from: &buf)
         )
 
-        case 6: return .transactionDetails(id: try FfiConverterTypeWalletId.read(from: &buf), details: try FfiConverterTypeTransactionDetails.read(from: &buf)
+        case 6: return .transactionDetails(id: try FfiConverterTypeWalletId.read(from: &buf), txId: try FfiConverterTypeTxId.read(from: &buf)
         )
 
         case 7: return .send(try FfiConverterTypeSendRoute.read(from: &buf)
@@ -28802,10 +28802,10 @@ public struct FfiConverterTypeRoute: FfiConverterRustBuffer {
             FfiConverterTypeWalletId.write(v1, into: &buf)
 
 
-        case let .transactionDetails(id,details):
+        case let .transactionDetails(id,txId):
             writeInt(&buf, Int32(6))
             FfiConverterTypeWalletId.write(id, into: &buf)
-            FfiConverterTypeTransactionDetails.write(details, into: &buf)
+            FfiConverterTypeTxId.write(txId, into: &buf)
 
 
         case let .send(v1):

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -952,24 +952,21 @@ impl RustWalletManager {
         let tx_id = Arc::unwrap_or_clone(tx_id);
         let actor = self.actor.clone();
 
-        crate::loading_popup::with_loading_popup(async move {
-            let details = task::spawn(async move {
-                call!(actor.transaction_details(tx_id))
-                    .await
-                    .map_err_str(Error::TransactionDetailsError)
-            })
-            .await
-            .map_err_str(Error::TransactionDetailsError)??;
-
-            // for unconfirmed transactions, trigger a background sync to update status
-            // this uses SyncRequest with just this txid so it's fast
-            if !details.is_confirmed() {
-                send!(self.actor.perform_scan_for_single_tx_id(details.tx_id().0));
-            }
-
-            Ok(details)
+        let details = task::spawn(async move {
+            call!(actor.transaction_details(tx_id))
+                .await
+                .map_err_str(Error::TransactionDetailsError)
         })
         .await
+        .map_err_str(Error::TransactionDetailsError)??;
+
+        // for unconfirmed transactions, trigger a background sync to update status
+        // this uses SyncRequest with just this txid so it's fast
+        if !details.is_confirmed() {
+            send!(self.actor.perform_scan_for_single_tx_id(details.tx_id().0));
+        }
+
+        Ok(details)
     }
 
     #[uniffi::method]

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -445,6 +445,17 @@ impl Route {
         self == &route_to_check
     }
 
+    #[uniffi::method(name = "isSameNavigationDestination")]
+    fn is_same_navigation_destination(&self, route_to_check: Route) -> bool {
+        match (self, route_to_check) {
+            (
+                Self::TransactionDetails { id: current_id, details: current_details },
+                Self::TransactionDetails { id: next_id, details: next_details },
+            ) => current_id == &next_id && current_details.tx_id() == next_details.tx_id(),
+            (current, next) => current == &next,
+        }
+    }
+
     #[uniffi::method(name = "stableHash")]
     fn stable_hash(&self) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -456,6 +467,49 @@ impl Route {
 impl From<SettingsRoute> for Route {
     fn from(settings_route: SettingsRoute) -> Self {
         Self::Settings(settings_route)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_details_with_same_wallet_and_txid_are_same_navigation_destination() {
+        let wallet_id = WalletId::from("wallet-id".to_string());
+        let current_details = TransactionDetails::preview_new_with_label("current".into());
+        let mut next_details = TransactionDetails::preview_new_with_label("next".into());
+        next_details.tx_id = current_details.tx_id;
+
+        let current =
+            Route::TransactionDetails { id: wallet_id.clone(), details: Arc::new(current_details) };
+        let next = Route::TransactionDetails { id: wallet_id, details: Arc::new(next_details) };
+
+        assert!(!current.is_equal(next.clone()));
+        assert!(current.is_same_navigation_destination(next));
+    }
+
+    #[test]
+    fn transaction_details_for_different_wallets_are_different_navigation_destinations() {
+        let details = Arc::new(TransactionDetails::preview_new_confirmed());
+        let current = Route::TransactionDetails {
+            id: WalletId::from("wallet-one".to_string()),
+            details: details.clone(),
+        };
+        let next =
+            Route::TransactionDetails { id: WalletId::from("wallet-two".to_string()), details };
+
+        assert!(!current.is_same_navigation_destination(next));
+    }
+
+    #[test]
+    fn non_transaction_routes_use_full_route_equality_for_navigation_destination() {
+        let current = Route::SelectedWallet(WalletId::from("wallet-one".to_string()));
+        let matching = Route::SelectedWallet(WalletId::from("wallet-one".to_string()));
+        let different = Route::SelectedWallet(WalletId::from("wallet-two".to_string()));
+
+        assert!(current.is_same_navigation_destination(matching));
+        assert!(!current.is_same_navigation_destination(different));
     }
 }
 

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -9,7 +9,7 @@ use crate::{
     mnemonic::NumberOfBip39Words,
     psbt::Psbt,
     tap_card::tap_signer_reader::{DeriveInfo, SetupCmdResponse, TapSignerSetupComplete},
-    transaction::{Amount, TransactionDetails, ffi::BitcoinTransaction},
+    transaction::{Amount, TxId, ffi::BitcoinTransaction},
     wallet::Address,
 };
 
@@ -24,7 +24,7 @@ pub enum Route {
     NewWallet(NewWalletRoute),
     Settings(SettingsRoute),
     SecretWords(WalletId),
-    TransactionDetails { id: WalletId, details: Arc<TransactionDetails> },
+    TransactionDetails { id: WalletId, tx_id: Arc<TxId> },
     Send(SendRoute),
     CoinControl(CoinControlRoute),
 }
@@ -449,9 +449,9 @@ impl Route {
     fn is_same_navigation_destination(&self, route_to_check: Route) -> bool {
         match (self, route_to_check) {
             (
-                Self::TransactionDetails { id: current_id, details: current_details },
-                Self::TransactionDetails { id: next_id, details: next_details },
-            ) => current_id == &next_id && current_details.tx_id() == next_details.tx_id(),
+                Self::TransactionDetails { id: current_id, tx_id: current_tx_id },
+                Self::TransactionDetails { id: next_id, tx_id: next_tx_id },
+            ) => current_id == &next_id && current_tx_id == &next_tx_id,
             (current, next) => current == &next,
         }
     }
@@ -477,27 +477,37 @@ mod tests {
     #[test]
     fn transaction_details_with_same_wallet_and_txid_are_same_navigation_destination() {
         let wallet_id = WalletId::from("wallet-id".to_string());
-        let current_details = TransactionDetails::preview_new_with_label("current".into());
-        let mut next_details = TransactionDetails::preview_new_with_label("next".into());
-        next_details.tx_id = current_details.tx_id;
+        let tx_id = Arc::new(TxId::preview_new());
 
-        let current =
-            Route::TransactionDetails { id: wallet_id.clone(), details: Arc::new(current_details) };
-        let next = Route::TransactionDetails { id: wallet_id, details: Arc::new(next_details) };
+        let current = Route::TransactionDetails { id: wallet_id.clone(), tx_id: tx_id.clone() };
+        let next = Route::TransactionDetails { id: wallet_id, tx_id };
 
-        assert!(!current.is_equal(next.clone()));
+        assert!(current.is_equal(next.clone()));
         assert!(current.is_same_navigation_destination(next));
     }
 
     #[test]
     fn transaction_details_for_different_wallets_are_different_navigation_destinations() {
-        let details = Arc::new(TransactionDetails::preview_new_confirmed());
+        let tx_id = Arc::new(TxId::preview_new());
         let current = Route::TransactionDetails {
             id: WalletId::from("wallet-one".to_string()),
-            details: details.clone(),
+            tx_id: tx_id.clone(),
         };
         let next =
-            Route::TransactionDetails { id: WalletId::from("wallet-two".to_string()), details };
+            Route::TransactionDetails { id: WalletId::from("wallet-two".to_string()), tx_id };
+
+        assert!(!current.is_same_navigation_destination(next));
+    }
+
+    #[test]
+    fn transaction_details_for_different_txids_are_different_navigation_destinations() {
+        let wallet_id = WalletId::from("wallet-id".to_string());
+        let current = Route::TransactionDetails {
+            id: wallet_id.clone(),
+            tx_id: Arc::new(TxId::preview_new()),
+        };
+        let next =
+            Route::TransactionDetails { id: wallet_id, tx_id: Arc::new(TxId::preview_new()) };
 
         assert!(!current.is_same_navigation_destination(next));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction details now load on-demand when navigating to a transaction.
  * Added error UI with retry option when transaction details fail to load.

* **Bug Fixes**
  * Prevents redundant navigation when viewing the same transaction multiple times.

* **Refactor**
  * Simplified transaction navigation flow to reduce upfront loading requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->