### PR TITLE
Clear cached wallet managers when wallets are deleted

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -235,6 +235,16 @@ class AppManager private constructor() : FfiReconcile {
         walletManager = null
     }
 
+    private fun clearWalletManager(id: WalletId) {
+        if (walletManager?.id == id) {
+            clearWalletManager()
+        }
+
+        if (sendFlowManager?.id == id) {
+            clearSendFlowManager()
+        }
+    }
+
     private fun clearSendFlowManager() {
         try {
             sendFlowManager?.close()
@@ -635,9 +645,7 @@ class AppManager private constructor() : FfiReconcile {
                 }
 
                 is AppStateReconcileMessage.ClearCachedWalletManager -> {
-                    if (walletManager?.id == message.v1) {
-                        clearWalletManager()
-                    }
+                    clearWalletManager(message.v1)
                 }
 
                 is AppStateReconcileMessage.ShowLoadingPopup -> {

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -542,6 +542,8 @@ impl FfiApp {
             error!("Unable to delete wallet persisted data: {error}");
         }
 
+        Updater::send_update(AppMessage::ClearCachedWalletManager(id.clone()));
+
         match database.global_config.selected_wallet() {
             Some(selected_id) if selected_id == id => {
                 let _ = database.global_config.clear_selected_wallet().tap_err(|error| {
@@ -581,6 +583,8 @@ impl FfiApp {
             if let Err(error) = crate::wallet::delete_wallet_specific_data(wallet_id) {
                 error!("Unable to delete wallet persisted bdk data: {error}");
             }
+
+            Updater::send_update(AppMessage::ClearCachedWalletManager(wallet_id.clone()));
         }
 
         if let Err(error) = CloudBackupKeychain::global().clear_local_state() {

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -23,7 +23,10 @@ use cove_tokio::task::{self, spawn_actor};
 use cove_util::{format::NumberFormatter as _, result_ext::ResultExt as _};
 
 use crate::{
-    app::FfiApp,
+    app::{
+        FfiApp,
+        reconcile::{Update, Updater},
+    },
     converter::{Converter, ConverterError},
     database::{Database, error::DatabaseError},
     discovery_scanner::{ScannerResponse, WalletDiscoveryScanner},
@@ -1073,6 +1076,8 @@ impl RustWalletManager {
         if let Err(error) = crate::wallet::delete_wallet_specific_data(&wallet_id) {
             error!("Unable to delete wallet persisted bdk data and wallet data database: {error}");
         }
+
+        Updater::send_update(Update::ClearCachedWalletManager(wallet_id.clone()));
 
         // unselect the wallet in the database
         match database.global_config.selected_wallet() {


### PR DESCRIPTION
## Summary
- Send clear-cache reconciliation updates when wallet deletion completes in Rust wallet/app paths
- Teach the Android `AppManager` to clear both wallet and send-flow managers for the affected wallet id
- Prevent stale manager instances from surviving after a wallet has been removed
