### PR TITLE
Wait for backup restart recovery to settle

### DIFF
--- a/rust/src/manager/cloud_backup_manager/ops/tests.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/tests.rs
@@ -3203,15 +3203,14 @@ async fn persisted_disabling_on_restart_resumes_to_disabled() {
         .unwrap();
 
     let restarted_manager = init_manager();
-    for _ in 0..20 {
-        if Database::global().cloud_backup_state.get().unwrap().status()
-            == PersistedCloudBackupStatus::Disabled
-        {
-            break;
-        }
-
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+    wait_for_test_condition(Duration::from_secs(2), "restart disable recovery finishes", || {
+        !globals.cloud.has_namespace(&namespace)
+            && Database::global().cloud_backup_state.get().unwrap().status()
+                == PersistedCloudBackupStatus::Disabled
+            && CloudBackupKeychain::global().namespace_id().is_none()
+            && restarted_manager.model_snapshot().status == CloudBackupStatus::Disabled
+    })
+    .await;
 
     assert!(!globals.cloud.has_namespace(&namespace));
     assert_eq!(


### PR DESCRIPTION
## Summary

- Replace the short fixed sleep loop in the cloud backup restart test with the existing bounded test-condition helper.
- Wait for all restart recovery outcomes together: namespace deleted, persisted state disabled, keychain cleared, and restarted model disabled.

## Root cause

The restart path resumes persisted disable recovery through a fire-and-forget supervisor operation. On slower scheduling, the test could observe the persisted state while recovery was still legitimately `Disabling`.

## Validation

- `cargo test -p cove --lib manager::cloud_backup_manager::ops::tests::persisted_disabling_on_restart_resumes_to_disabled`
- `just fmt`
- `just clippy`