### PR TITLE
[ANDROID] Fix empty wallet state going to onboarding

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -22,6 +22,8 @@ import org.bitcoinppl.cove_core.util.GenerationToken
 import org.bitcoinppl.cove_core.util.GenerationTracker
 import java.util.UUID
 
+private class RouteUpdateDispatchException(cause: Throwable) : Exception("Unable to dispatch route update", cause)
+
 /**
  * central app state manager (singleton)
  * holds the FfiApp instance, router, and global state
@@ -408,39 +410,39 @@ class AppManager private constructor() : FfiReconcile {
             return
         }
 
-        advanceNavigationGeneration()
-        pushRouteWithoutNavigationGeneration(route)
+        if (pushRouteWithoutNavigationGeneration(route)) {
+            advanceNavigationGeneration()
+        }
     }
 
-    private fun pushRouteWithoutNavigationGeneration(route: Route) {
+    private fun pushRouteWithoutNavigationGeneration(route: Route): Boolean {
         Log.d(tag, "pushRoute: $route")
         isSidebarVisible = false
-        if (isDuplicateTopRoute(route)) return
+        if (isDuplicateTopRoute(route)) return false
 
         val newRoutes = router.routes.toMutableList().apply { add(route) }
+        if (dispatchRouteUpdate(newRoutes).isFailure) return false
 
-        // only dispatch if routes actually changed
-        if (newRoutes != router.routes) {
-            dispatch(AppAction.UpdateRoute(newRoutes))
-        }
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)
+
+        return true
     }
 
     fun pushRoutes(routes: List<Route>) {
-        advanceNavigationGeneration()
-        pushRoutesWithoutNavigationGeneration(routes)
+        if (pushRoutesWithoutNavigationGeneration(routes)) {
+            advanceNavigationGeneration()
+        }
     }
 
-    private fun pushRoutesWithoutNavigationGeneration(routes: List<Route>) {
+    private fun pushRoutesWithoutNavigationGeneration(routes: List<Route>): Boolean {
         Log.d(tag, "pushRoutes: ${routes.size} routes")
         isSidebarVisible = false
         val newRoutes = router.routes.toMutableList().apply { addAll(routes) }
+        if (dispatchRouteUpdate(newRoutes).isFailure) return false
 
-        // only dispatch if routes actually changed
-        if (newRoutes != router.routes) {
-            dispatch(AppAction.UpdateRoute(newRoutes))
-        }
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)
+
+        return true
     }
 
     /**
@@ -449,36 +451,45 @@ class AppManager private constructor() : FfiReconcile {
      * @return `true` only when a route was removed
      */
     fun popRoute(): Boolean {
+        return popRouteForRecovery() == RoutePopResult.Popped
+    }
+
+    internal fun popRouteForRecovery(): RoutePopResult {
         Log.d(tag, "popRoute")
         if (!rust.canGoBack()) {
-            return false
+            return RoutePopResult.NoRouteToPop
         }
 
         val currentRoutes = router.routes
         if (currentRoutes.isEmpty()) {
-            return false
+            return RoutePopResult.NoRouteToPop
         }
 
         val newRoutes = currentRoutes.dropLast(1)
-        if (!dispatchSuccessfully(AppAction.UpdateRoute(newRoutes))) {
-            return false
+        val dispatchError = dispatchRouteUpdate(newRoutes).exceptionOrNull()
+        if (dispatchError != null) {
+            return RoutePopResult.Failed(RouteUpdateDispatchException(dispatchError))
         }
 
         advanceNavigationGeneration()
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)
 
-        return true
+        return RoutePopResult.Popped
     }
 
     fun setRoute(routes: List<Route>) {
-        advanceNavigationGeneration()
         Log.d(tag, "setRoute: ${routes.size} routes")
 
-        // only dispatch if routes actually changed
-        if (routes != router.routes) {
-            dispatch(AppAction.UpdateRoute(routes))
-        }
+        if (dispatchRouteUpdate(routes).isFailure) return
+
+        advanceNavigationGeneration()
         updateRoutesAndClearInactiveSendFlowManager(routes)
+    }
+
+    private fun dispatchRouteUpdate(routes: List<Route>): Result<Unit> {
+        if (routes == router.routes) return Result.success(Unit)
+
+        return dispatchResult(AppAction.UpdateRoute(routes))
     }
 
     private fun updateRoutesAndClearInactiveSendFlowManager(routes: List<Route>) {
@@ -568,8 +579,9 @@ class AppManager private constructor() : FfiReconcile {
         navigationGenerations.isCurrent(generation)
 
     fun agreeToTerms() {
-        dispatch(AppAction.AcceptTerms)
-        isTermsAccepted = true
+        if (dispatch(AppAction.AcceptTerms)) {
+            isTermsAccepted = true
+        }
     }
 
     override fun reconcile(message: AppStateReconcileMessage) {
@@ -672,15 +684,16 @@ class AppManager private constructor() : FfiReconcile {
         }
     }
 
-    fun dispatch(action: AppAction) {
-        dispatchSuccessfully(action)
-    }
+    fun dispatch(action: AppAction): Boolean = dispatchSuccessfully(action)
 
-    private fun dispatchSuccessfully(action: AppAction): Boolean {
+    private fun dispatchSuccessfully(action: AppAction): Boolean =
+        dispatchResult(action).isSuccess
+
+    private fun dispatchResult(action: AppAction): Result<Unit> {
         Log.d(tag, "dispatch $action")
+
         return runCatching { rust.dispatch(action) }
             .onFailure { Log.e(tag, "Unable to dispatch app action $action", it) }
-            .isSuccess
     }
 
     companion object {

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -443,18 +443,22 @@ class AppManager private constructor() : FfiReconcile {
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)
     }
 
-    fun popRoute() {
-        advanceNavigationGeneration()
+    fun popRoute(): Boolean {
         Log.d(tag, "popRoute")
-        if (rust.canGoBack()) {
-            val newRoutes = router.routes.dropLast(1)
-
-            // only dispatch if routes actually changed
-            if (newRoutes != router.routes) {
-                dispatch(AppAction.UpdateRoute(newRoutes))
-            }
-            updateRoutesAndClearInactiveSendFlowManager(newRoutes)
+        if (!rust.canGoBack()) {
+            return false
         }
+
+        val newRoutes = router.routes.dropLast(1)
+        if (newRoutes == router.routes) {
+            return false
+        }
+
+        advanceNavigationGeneration()
+        dispatch(AppAction.UpdateRoute(newRoutes))
+        updateRoutesAndClearInactiveSendFlowManager(newRoutes)
+
+        return true
     }
 
     fun setRoute(routes: List<Route>) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -460,8 +460,11 @@ class AppManager private constructor() : FfiReconcile {
         }
 
         val newRoutes = currentRoutes.dropLast(1)
+        if (!dispatchSuccessfully(AppAction.UpdateRoute(newRoutes))) {
+            return false
+        }
+
         advanceNavigationGeneration()
-        dispatch(AppAction.UpdateRoute(newRoutes))
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)
 
         return true
@@ -670,9 +673,14 @@ class AppManager private constructor() : FfiReconcile {
     }
 
     fun dispatch(action: AppAction) {
+        dispatchSuccessfully(action)
+    }
+
+    private fun dispatchSuccessfully(action: AppAction): Boolean {
         Log.d(tag, "dispatch $action")
-        runCatching { rust.dispatch(action) }
+        return runCatching { rust.dispatch(action) }
             .onFailure { Log.e(tag, "Unable to dispatch app action $action", it) }
+            .isSuccess
     }
 
     companion object {

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -443,17 +443,23 @@ class AppManager private constructor() : FfiReconcile {
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)
     }
 
+    /**
+     * Pops the top route when both Rust and the local route stack can go back
+     *
+     * @return `true` only when a route was removed
+     */
     fun popRoute(): Boolean {
         Log.d(tag, "popRoute")
         if (!rust.canGoBack()) {
             return false
         }
 
-        val newRoutes = router.routes.dropLast(1)
-        if (newRoutes == router.routes) {
+        val currentRoutes = router.routes
+        if (currentRoutes.isEmpty()) {
             return false
         }
 
+        val newRoutes = currentRoutes.dropLast(1)
         advanceNavigationGeneration()
         dispatch(AppAction.UpdateRoute(newRoutes))
         updateRoutesAndClearInactiveSendFlowManager(newRoutes)

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -511,15 +511,17 @@ class MainActivity : FragmentActivity() {
                     ),
                 )
             }
-            LaunchedEffect(app.isTermsAccepted, hasWallets, cloudBackupLifecycle, persistedOnboardingProgress) {
-                persistedOnboardingProgress = readPersistedOnboardingProgress()
+            LaunchedEffect(app.isTermsAccepted, hasWallets, cloudBackupLifecycle) {
+                val freshProgress = readPersistedOnboardingProgress()
+                persistedOnboardingProgress = freshProgress
+
                 startupMode =
                     resolveStartupModeTransition(
                         currentMode = startupMode,
                         termsAccepted = app.isTermsAccepted,
                         hasWallets = hasWallets,
                         cloudBackupLifecycle = cloudBackupLifecycle,
-                        hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(persistedOnboardingProgress),
+                        hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(freshProgress),
                     )
             }
             val onboardingManager =

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -497,7 +497,7 @@ class MainActivity : FragmentActivity() {
                 runCatching {
                     Database().globalConfig().get(GlobalConfigKey.OnboardingProgress)
                 }.onFailure { error ->
-                    Log.w(TAG, "[STARTUP] failed to read persisted onboarding progress before routing", error)
+                    Log.e(TAG, "[STARTUP] failed to read persisted onboarding progress before routing", error)
                 }
             }
             var persistedOnboardingProgress by remember { mutableStateOf(readPersistedOnboardingProgress().getOrNull()) }

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -513,7 +513,11 @@ class MainActivity : FragmentActivity() {
             }
             LaunchedEffect(app.isTermsAccepted, hasWallets, cloudBackupLifecycle) {
                 val freshProgress = readPersistedOnboardingProgress()
-                val effectiveProgress = freshProgress.getOrElse { persistedOnboardingProgress }
+                val effectiveProgress =
+                    resolveEffectiveOnboardingProgress(
+                        freshProgress = freshProgress,
+                        previousProgress = persistedOnboardingProgress,
+                    )
 
                 persistedOnboardingProgress = effectiveProgress
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -493,14 +493,14 @@ class MainActivity : FragmentActivity() {
             val snackbarHostState = remember { SnackbarHostState() }
             val cloudBackupLifecycle = app.cloudBackupManager.lifecycle
             val hasWallets = app.wallets.isNotEmpty() || app.hasWallets
-            val readPersistedOnboardingProgress = {
+            val readPersistedOnboardingProgress: () -> Result<String?> = {
                 runCatching {
                     Database().globalConfig().get(GlobalConfigKey.OnboardingProgress)
                 }.onFailure { error ->
                     Log.w(TAG, "[STARTUP] failed to read persisted onboarding progress before routing", error)
-                }.getOrNull()
+                }
             }
-            var persistedOnboardingProgress by remember { mutableStateOf(readPersistedOnboardingProgress()) }
+            var persistedOnboardingProgress by remember { mutableStateOf(readPersistedOnboardingProgress().getOrNull()) }
             var startupMode by remember {
                 mutableStateOf(
                     resolveStartupMode(
@@ -513,7 +513,9 @@ class MainActivity : FragmentActivity() {
             }
             LaunchedEffect(app.isTermsAccepted, hasWallets, cloudBackupLifecycle) {
                 val freshProgress = readPersistedOnboardingProgress()
-                persistedOnboardingProgress = freshProgress
+                val effectiveProgress = freshProgress.getOrElse { persistedOnboardingProgress }
+
+                persistedOnboardingProgress = effectiveProgress
 
                 startupMode =
                     resolveStartupModeTransition(
@@ -521,7 +523,7 @@ class MainActivity : FragmentActivity() {
                         termsAccepted = app.isTermsAccepted,
                         hasWallets = hasWallets,
                         cloudBackupLifecycle = cloudBackupLifecycle,
-                        hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(freshProgress),
+                        hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(effectiveProgress),
                     )
             }
             val onboardingManager =

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -500,7 +500,13 @@ class MainActivity : FragmentActivity() {
                     Log.e(TAG, "[STARTUP] failed to read persisted onboarding progress before routing", error)
                 }
             }
-            var persistedOnboardingProgress by remember { mutableStateOf(readPersistedOnboardingProgress().getOrNull()) }
+            val initialPersistedOnboardingProgress = remember { readPersistedOnboardingProgress() }
+            var persistedOnboardingProgress by remember {
+                mutableStateOf(initialPersistedOnboardingProgress.getOrNull())
+            }
+            var previousPersistedOnboardingProgressReadFailed by remember {
+                mutableStateOf(initialPersistedOnboardingProgress.isFailure)
+            }
             var startupMode by remember {
                 mutableStateOf(
                     resolveStartupMode(
@@ -513,6 +519,12 @@ class MainActivity : FragmentActivity() {
             }
             LaunchedEffect(app.isTermsAccepted, hasWallets, cloudBackupLifecycle) {
                 val freshProgress = readPersistedOnboardingProgress()
+                val recoveredOnboardingProgressAfterReadFailure =
+                    hasRecoveredOnboardingProgressAfterReadFailure(
+                        freshProgress = freshProgress,
+                        previousProgress = persistedOnboardingProgress,
+                        previousReadFailed = previousPersistedOnboardingProgressReadFailed,
+                    )
                 val effectiveProgress =
                     resolveEffectiveOnboardingProgress(
                         freshProgress = freshProgress,
@@ -528,7 +540,11 @@ class MainActivity : FragmentActivity() {
                         hasWallets = hasWallets,
                         cloudBackupLifecycle = cloudBackupLifecycle,
                         hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(effectiveProgress),
+                        hasRecoveredOnboardingProgressAfterReadFailure =
+                            recoveredOnboardingProgressAfterReadFailure,
                     )
+
+                previousPersistedOnboardingProgressReadFailed = freshProgress.isFailure
             }
             val onboardingManager =
                 remember(startupMode) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/MainActivity.kt
@@ -514,7 +514,8 @@ class MainActivity : FragmentActivity() {
             LaunchedEffect(app.isTermsAccepted, hasWallets, cloudBackupLifecycle, persistedOnboardingProgress) {
                 persistedOnboardingProgress = readPersistedOnboardingProgress()
                 startupMode =
-                    resolveStartupMode(
+                    resolveStartupModeTransition(
+                        currentMode = startupMode,
                         termsAccepted = app.isTermsAccepted,
                         hasWallets = hasWallets,
                         cloudBackupLifecycle = cloudBackupLifecycle,

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -55,7 +55,19 @@ internal fun hasPersistedOnboardingProgress(
 internal fun resolveEffectiveOnboardingProgress(
     freshProgress: Result<String?>,
     previousProgress: String?,
-): String? = freshProgress.getOrElse { previousProgress }
+): String? {
+    // keep last known progress when a transient read failure would otherwise drop onboarding state
+    return freshProgress.getOrElse { previousProgress }
+}
+
+internal fun hasRecoveredOnboardingProgressAfterReadFailure(
+    freshProgress: Result<String?>,
+    previousProgress: String?,
+    previousReadFailed: Boolean,
+): Boolean =
+    previousReadFailed &&
+        !hasPersistedOnboardingProgress(previousProgress) &&
+        hasPersistedOnboardingProgress(freshProgress.getOrNull())
 
 internal fun resolveStartupMode(
     termsAccepted: Boolean,
@@ -78,9 +90,17 @@ internal fun resolveStartupModeTransition(
     hasWallets: Boolean,
     cloudBackupLifecycle: CloudBackupLifecycle,
     hasPersistedOnboardingProgress: Boolean,
+    hasRecoveredOnboardingProgressAfterReadFailure: Boolean = false,
 ): StartupMode {
     // after startup reaches ready, deleting the last wallet should not restart onboarding
-    if (currentMode == StartupMode.READY && termsAccepted) return StartupMode.READY
+    // recovered persisted progress means ready may have been chosen from an earlier failed read
+    if (
+        currentMode == StartupMode.READY &&
+        termsAccepted &&
+        !hasRecoveredOnboardingProgressAfterReadFailure
+    ) {
+        return StartupMode.READY
+    }
 
     return resolveStartupMode(
         termsAccepted = termsAccepted,

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -93,7 +93,7 @@ internal fun resolveStartupModeTransition(
     hasRecoveredOnboardingProgressAfterReadFailure: Boolean,
 ): StartupMode {
     // after startup reaches ready, deleting the last wallet should not restart onboarding
-    // recovered persisted progress means ready may have been chosen from an earlier failed read
+    // skip this shortcut when recovered progress proves an earlier failed read hid onboarding state
     if (
         currentMode == StartupMode.READY &&
         termsAccepted &&

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -74,6 +74,7 @@ internal fun resolveStartupModeTransition(
     cloudBackupLifecycle: CloudBackupLifecycle,
     hasPersistedOnboardingProgress: Boolean,
 ): StartupMode {
+    // after startup reaches ready, deleting the last wallet should not restart onboarding
     if (currentMode == StartupMode.READY && termsAccepted) return StartupMode.READY
 
     return resolveStartupMode(

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -74,7 +74,7 @@ internal fun resolveStartupModeTransition(
     cloudBackupLifecycle: CloudBackupLifecycle,
     hasPersistedOnboardingProgress: Boolean,
 ): StartupMode {
-    if (currentMode == StartupMode.READY) return StartupMode.READY
+    if (currentMode == StartupMode.READY && termsAccepted) return StartupMode.READY
 
     return resolveStartupMode(
         termsAccepted = termsAccepted,

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -66,3 +66,20 @@ internal fun resolveStartupMode(
         StartupMode.READY
     }
 }
+
+internal fun resolveStartupModeTransition(
+    currentMode: StartupMode,
+    termsAccepted: Boolean,
+    hasWallets: Boolean,
+    cloudBackupLifecycle: CloudBackupLifecycle,
+    hasPersistedOnboardingProgress: Boolean,
+): StartupMode {
+    if (currentMode == StartupMode.READY) return StartupMode.READY
+
+    return resolveStartupMode(
+        termsAccepted = termsAccepted,
+        hasWallets = hasWallets,
+        cloudBackupLifecycle = cloudBackupLifecycle,
+        hasPersistedOnboardingProgress = hasPersistedOnboardingProgress,
+    )
+}

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -52,6 +52,11 @@ internal fun hasPersistedOnboardingProgress(
     persistedProgress: String?,
 ): Boolean = !persistedProgress.isNullOrBlank()
 
+internal fun resolveEffectiveOnboardingProgress(
+    freshProgress: Result<String?>,
+    previousProgress: String?,
+): String? = freshProgress.getOrElse { previousProgress }
+
 internal fun resolveStartupMode(
     termsAccepted: Boolean,
     hasWallets: Boolean,

--- a/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/StartupRecovery.kt
@@ -90,7 +90,7 @@ internal fun resolveStartupModeTransition(
     hasWallets: Boolean,
     cloudBackupLifecycle: CloudBackupLifecycle,
     hasPersistedOnboardingProgress: Boolean,
-    hasRecoveredOnboardingProgressAfterReadFailure: Boolean = false,
+    hasRecoveredOnboardingProgressAfterReadFailure: Boolean,
 ): StartupMode {
     // after startup reaches ready, deleting the last wallet should not restart onboarding
     // recovered persisted progress means ready may have been chosen from an earlier failed read

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletSelectionRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletSelectionRecovery.kt
@@ -9,6 +9,10 @@ internal sealed interface WalletSelectionRecoveryResult {
         val recoveryError: Exception,
     ) : WalletSelectionRecoveryResult
 
+    data class NoRouteToPop(
+        val recoveryError: Exception,
+    ) : WalletSelectionRecoveryResult
+
     data class FailedToPopRoute(
         val recoveryError: Exception,
         val navigationError: Exception,
@@ -17,7 +21,7 @@ internal sealed interface WalletSelectionRecoveryResult {
 
 internal fun recoverWalletSelectionOrPopRoute(
     selectLatestOrNewWallet: () -> Unit,
-    popRoute: () -> Unit,
+    popRoute: () -> Boolean,
 ): WalletSelectionRecoveryResult =
     try {
         selectLatestOrNewWallet()
@@ -33,11 +37,14 @@ internal fun recoverWalletSelectionOrPopRoute(
 
 private fun popRouteAfterRecoveryFailure(
     recoveryError: Exception,
-    popRoute: () -> Unit,
+    popRoute: () -> Boolean,
 ): WalletSelectionRecoveryResult =
     try {
-        popRoute()
-        WalletSelectionRecoveryResult.PoppedRoute(recoveryError)
+        if (popRoute()) {
+            WalletSelectionRecoveryResult.PoppedRoute(recoveryError)
+        } else {
+            WalletSelectionRecoveryResult.NoRouteToPop(recoveryError)
+        }
     } catch (e: CancellationException) {
         throw e
     } catch (navigationError: Exception) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletSelectionRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletSelectionRecovery.kt
@@ -1,0 +1,48 @@
+package org.bitcoinppl.cove
+
+import kotlin.coroutines.cancellation.CancellationException
+
+internal sealed interface WalletSelectionRecoveryResult {
+    data object Recovered : WalletSelectionRecoveryResult
+
+    data class PoppedRoute(
+        val recoveryError: Exception,
+    ) : WalletSelectionRecoveryResult
+
+    data class FailedToPopRoute(
+        val recoveryError: Exception,
+        val navigationError: Exception,
+    ) : WalletSelectionRecoveryResult
+}
+
+internal fun recoverWalletSelectionOrPopRoute(
+    selectLatestOrNewWallet: () -> Unit,
+    popRoute: () -> Unit,
+): WalletSelectionRecoveryResult =
+    try {
+        selectLatestOrNewWallet()
+        WalletSelectionRecoveryResult.Recovered
+    } catch (e: CancellationException) {
+        throw e
+    } catch (recoveryError: Exception) {
+        popRouteAfterRecoveryFailure(
+            recoveryError = recoveryError,
+            popRoute = popRoute,
+        )
+    }
+
+private fun popRouteAfterRecoveryFailure(
+    recoveryError: Exception,
+    popRoute: () -> Unit,
+): WalletSelectionRecoveryResult =
+    try {
+        popRoute()
+        WalletSelectionRecoveryResult.PoppedRoute(recoveryError)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (navigationError: Exception) {
+        WalletSelectionRecoveryResult.FailedToPopRoute(
+            recoveryError = recoveryError,
+            navigationError = navigationError,
+        )
+    }

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletSelectionRecovery.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletSelectionRecovery.kt
@@ -19,9 +19,19 @@ internal sealed interface WalletSelectionRecoveryResult {
     ) : WalletSelectionRecoveryResult
 }
 
+internal sealed interface RoutePopResult {
+    data object Popped : RoutePopResult
+
+    data object NoRouteToPop : RoutePopResult
+
+    data class Failed(
+        val error: Exception,
+    ) : RoutePopResult
+}
+
 internal fun recoverWalletSelectionOrPopRoute(
     selectLatestOrNewWallet: () -> Unit,
-    popRoute: () -> Boolean,
+    popRoute: () -> RoutePopResult,
 ): WalletSelectionRecoveryResult =
     try {
         selectLatestOrNewWallet()
@@ -37,13 +47,17 @@ internal fun recoverWalletSelectionOrPopRoute(
 
 private fun popRouteAfterRecoveryFailure(
     recoveryError: Exception,
-    popRoute: () -> Boolean,
+    popRoute: () -> RoutePopResult,
 ): WalletSelectionRecoveryResult =
     try {
-        if (popRoute()) {
-            WalletSelectionRecoveryResult.PoppedRoute(recoveryError)
-        } else {
-            WalletSelectionRecoveryResult.NoRouteToPop(recoveryError)
+        when (val popResult = popRoute()) {
+            RoutePopResult.Popped -> WalletSelectionRecoveryResult.PoppedRoute(recoveryError)
+            RoutePopResult.NoRouteToPop -> WalletSelectionRecoveryResult.NoRouteToPop(recoveryError)
+            is RoutePopResult.Failed ->
+                WalletSelectionRecoveryResult.FailedToPopRoute(
+                    recoveryError = recoveryError,
+                    navigationError = popResult.error,
+                )
         }
     } catch (e: CancellationException) {
         throw e

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -53,7 +53,7 @@ fun TransactionDetailsContainer(
             val result =
                 recoverWalletSelectionOrPopRoute(
                     selectLatestOrNewWallet = app::selectLatestOrNewWallet,
-                    popRoute = app::popRoute,
+                    popRoute = app::popRouteForRecovery,
                 )
         ) {
             WalletSelectionRecoveryResult.Recovered -> Unit
@@ -130,6 +130,7 @@ fun TransactionDetailsContainer(
             BackHandler(onBack = { recoverWalletSelection() })
 
             TransactionDetailsLoadError(
+                title = "Unable to load wallet",
                 message = error!!,
                 onRetry = {
                     error = null
@@ -151,6 +152,7 @@ fun TransactionDetailsContainer(
 
         detailsError != null -> {
             TransactionDetailsLoadError(
+                title = "Unable to load transaction",
                 message = detailsError!!,
                 onRetry = {
                     detailsError = null
@@ -166,6 +168,7 @@ fun TransactionDetailsContainer(
 
 @Composable
 private fun TransactionDetailsLoadError(
+    title: String,
     message: String,
     onRetry: () -> Unit,
     onRecoverWalletSelection: (() -> Unit)? = null,
@@ -178,7 +181,7 @@ private fun TransactionDetailsLoadError(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            androidx.compose.material3.Text("Unable to load transaction")
+            androidx.compose.material3.Text(title)
             androidx.compose.material3.Text(message)
             androidx.compose.material3.Button(onClick = onRetry) {
                 androidx.compose.material3.Text("Try again")

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -70,6 +70,8 @@ fun TransactionDetailsContainer(
     }
 
     val details = manager?.transactionDetailsCache?.get(txId)
+
+    // route recovery may still remove this screen, so avoid flashing a retry button mid-transition
     val suppressWalletLoadRetry = recoveringWalletSelection && !app.isNavigationSettled
 
     LaunchedEffect(manager, txId, retryAttempt) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -100,6 +100,7 @@ fun TransactionDetailsContainer(
                     error = null
                     managerRetryAttempt++
                 },
+                onRecoverWalletSelection = { app.trySelectLatestOrNewWallet() },
             )
         }
 
@@ -132,6 +133,7 @@ fun TransactionDetailsContainer(
 private fun TransactionDetailsLoadError(
     message: String,
     onRetry: () -> Unit,
+    onRecoverWalletSelection: (() -> Unit)? = null,
 ) {
     androidx.compose.foundation.layout.Box(
         modifier = Modifier.fillMaxSize(),
@@ -145,6 +147,11 @@ private fun TransactionDetailsLoadError(
             androidx.compose.material3.Text(message)
             androidx.compose.material3.Button(onClick = onRetry) {
                 androidx.compose.material3.Text("Try again")
+            }
+            if (onRecoverWalletSelection != null) {
+                androidx.compose.material3.TextButton(onClick = onRecoverWalletSelection) {
+                    androidx.compose.material3.Text("Open wallet")
+                }
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -58,11 +58,11 @@ fun TransactionDetailsContainer(
         } catch (e: Exception) {
             android.util.Log.e("TransactionDetails", "Failed to load wallet", e)
             error = e.message ?: "failed to load wallet"
-            recoveringWalletSelection = true
             loading = false
 
             try {
                 app.selectLatestOrNewWallet()
+                recoveringWalletSelection = true
             } catch (recoveryError: Exception) {
                 android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
             }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -15,8 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import org.bitcoinppl.cove.AppManager
+import org.bitcoinppl.cove.WalletSelectionRecoveryResult
 import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove.components.FullPageLoadingView
+import org.bitcoinppl.cove.recoverWalletSelectionOrPopRoute
 import org.bitcoinppl.cove_core.types.TxId
 import org.bitcoinppl.cove_core.types.WalletId
 import kotlin.coroutines.cancellation.CancellationException
@@ -45,15 +47,25 @@ fun TransactionDetailsContainer(
 
         recoveringWalletSelection = true
 
-        try {
-            app.selectLatestOrNewWallet()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (recoveryError: Exception) {
-            android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
-            try {
-                app.popRoute()
-            } finally {
+        when (
+            val result =
+                recoverWalletSelectionOrPopRoute(
+                    selectLatestOrNewWallet = app::selectLatestOrNewWallet,
+                    popRoute = app::popRoute,
+                )
+        ) {
+            WalletSelectionRecoveryResult.Recovered -> Unit
+            is WalletSelectionRecoveryResult.PoppedRoute -> {
+                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
+                recoveringWalletSelection = false
+            }
+            is WalletSelectionRecoveryResult.FailedToPopRoute -> {
+                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e(
+                    "TransactionDetails",
+                    "Failed to leave transaction details after recovery failure",
+                    result.navigationError,
+                )
                 recoveringWalletSelection = false
             }
         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -51,7 +51,11 @@ fun TransactionDetailsContainer(
             throw e
         } catch (recoveryError: Exception) {
             android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
-            app.popRoute()
+            try {
+                app.popRoute()
+            } finally {
+                recoveringWalletSelection = false
+            }
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -38,6 +38,12 @@ fun TransactionDetailsContainer(
     var managerRetryAttempt by remember(walletId) { mutableStateOf(0) }
     var recoveringWalletSelection by remember(walletId) { mutableStateOf(false) }
 
+    LaunchedEffect(recoveringWalletSelection, app.isNavigationSettled) {
+        if (recoveringWalletSelection && app.isNavigationSettled) {
+            recoveringWalletSelection = false
+        }
+    }
+
     LaunchedEffect(walletId, managerRetryAttempt) {
         loading = true
         error = null
@@ -51,19 +57,20 @@ fun TransactionDetailsContainer(
             throw e
         } catch (e: Exception) {
             android.util.Log.e("TransactionDetails", "Failed to load wallet", e)
+            error = e.message ?: "failed to load wallet"
             recoveringWalletSelection = true
             loading = false
+
             try {
                 app.selectLatestOrNewWallet()
             } catch (recoveryError: Exception) {
                 android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
-                recoveringWalletSelection = false
-                error = e.message ?: "failed to load wallet"
             }
         }
     }
 
     val details = manager?.transactionDetailsCache?.get(txId)
+    val suppressWalletLoadRetry = recoveringWalletSelection && !app.isNavigationSettled
 
     LaunchedEffect(manager, txId, retryAttempt) {
         val currentManager = manager ?: return@LaunchedEffect
@@ -83,7 +90,7 @@ fun TransactionDetailsContainer(
     }
 
     when {
-        loading || recoveringWalletSelection -> FullPageLoadingView()
+        loading || suppressWalletLoadRetry -> FullPageLoadingView()
         error != null -> {
             TransactionDetailsLoadError(
                 message = error!!,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import org.bitcoinppl.cove.AppManager
-import org.bitcoinppl.cove.WalletSelectionRecoveryResult
 import org.bitcoinppl.cove.WalletManager
+import org.bitcoinppl.cove.WalletSelectionRecoveryResult
 import org.bitcoinppl.cove.components.FullPageLoadingView
 import org.bitcoinppl.cove.recoverWalletSelectionOrPopRoute
 import org.bitcoinppl.cove_core.types.TxId

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -59,6 +59,11 @@ fun TransactionDetailsContainer(
                 android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
                 recoveringWalletSelection = false
             }
+            is WalletSelectionRecoveryResult.NoRouteToPop -> {
+                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e("TransactionDetails", "No route available to leave transaction details after recovery failure")
+                recoveringWalletSelection = false
+            }
             is WalletSelectionRecoveryResult.FailedToPopRoute -> {
                 android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
                 android.util.Log.e(

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -21,7 +21,7 @@ import org.bitcoinppl.cove.components.FullPageLoadingView
 import org.bitcoinppl.cove.recoverWalletSelectionOrPopRoute
 import org.bitcoinppl.cove_core.types.TxId
 import org.bitcoinppl.cove_core.types.WalletId
-import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.cancellation.CancellationException as KotlinCancellationException
 
 private const val TAG = "TransactionDetailsContainer"
 
@@ -92,7 +92,7 @@ fun TransactionDetailsContainer(
         try {
             manager = app.getWalletManager(walletId)
             loading = false
-        } catch (e: CancellationException) {
+        } catch (e: KotlinCancellationException) {
             throw e
         } catch (e: Exception) {
             android.util.Log.e(TAG, "Failed to load wallet", e)
@@ -116,7 +116,7 @@ fun TransactionDetailsContainer(
         try {
             currentManager.transactionDetails(txId)
             didLoadInitialDetails = true
-        } catch (e: CancellationException) {
+        } catch (e: KotlinCancellationException) {
             throw e
         } catch (e: Exception) {
             detailsError = e.message ?: "failed to load transaction"

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -36,10 +36,12 @@ fun TransactionDetailsContainer(
     var didLoadInitialDetails by remember(txId) { mutableStateOf(false) }
     var retryAttempt by remember(txId) { mutableStateOf(0) }
     var managerRetryAttempt by remember(walletId) { mutableStateOf(0) }
+    var recoveringWalletSelection by remember(walletId) { mutableStateOf(false) }
 
     LaunchedEffect(walletId, managerRetryAttempt) {
         loading = true
         error = null
+        recoveringWalletSelection = false
         manager = null
 
         try {
@@ -49,9 +51,15 @@ fun TransactionDetailsContainer(
             throw e
         } catch (e: Exception) {
             android.util.Log.e("TransactionDetails", "Failed to load wallet", e)
-            error = e.message ?: "failed to load wallet"
+            recoveringWalletSelection = true
             loading = false
-            app.trySelectLatestOrNewWallet()
+            try {
+                app.selectLatestOrNewWallet()
+            } catch (recoveryError: Exception) {
+                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
+                recoveringWalletSelection = false
+                error = e.message ?: "failed to load wallet"
+            }
         }
     }
 
@@ -75,7 +83,7 @@ fun TransactionDetailsContainer(
     }
 
     when {
-        loading -> FullPageLoadingView()
+        loading || recoveringWalletSelection -> FullPageLoadingView()
         error != null -> {
             TransactionDetailsLoadError(
                 message = error!!,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -59,7 +59,6 @@ fun TransactionDetailsContainer(
             WalletSelectionRecoveryResult.Recovered -> Unit
             is WalletSelectionRecoveryResult.PoppedRoute -> {
                 android.util.Log.e(TAG, "Failed to recover wallet selection", result.recoveryError)
-                recoveringWalletSelection = false
             }
             is WalletSelectionRecoveryResult.NoRouteToPop -> {
                 android.util.Log.e(TAG, "Failed to recover wallet selection", result.recoveryError)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -1,8 +1,9 @@
 package org.bitcoinppl.cove.flows.SelectedWalletFlow.TransactionDetails
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -18,6 +19,7 @@ import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove.components.FullPageLoadingView
 import org.bitcoinppl.cove_core.types.TxId
 import org.bitcoinppl.cove_core.types.WalletId
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * lifecycle container for transaction details screen
@@ -37,6 +39,21 @@ fun TransactionDetailsContainer(
     var retryAttempt by remember(txId) { mutableStateOf(0) }
     var managerRetryAttempt by remember(walletId) { mutableStateOf(0) }
     var recoveringWalletSelection by remember(walletId) { mutableStateOf(false) }
+
+    fun recoverWalletSelection() {
+        if (recoveringWalletSelection && !app.isNavigationSettled) return
+
+        recoveringWalletSelection = true
+
+        try {
+            app.selectLatestOrNewWallet()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (recoveryError: Exception) {
+            android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
+            app.popRoute()
+        }
+    }
 
     LaunchedEffect(recoveringWalletSelection, app.isNavigationSettled) {
         if (recoveringWalletSelection && app.isNavigationSettled) {
@@ -59,13 +76,7 @@ fun TransactionDetailsContainer(
             android.util.Log.e("TransactionDetails", "Failed to load wallet", e)
             error = e.message ?: "failed to load wallet"
             loading = false
-
-            try {
-                app.selectLatestOrNewWallet()
-                recoveringWalletSelection = true
-            } catch (recoveryError: Exception) {
-                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", recoveryError)
-            }
+            recoverWalletSelection()
         }
     }
 
@@ -94,13 +105,15 @@ fun TransactionDetailsContainer(
     when {
         loading || suppressWalletLoadRetry -> FullPageLoadingView()
         error != null -> {
+            BackHandler(onBack = { recoverWalletSelection() })
+
             TransactionDetailsLoadError(
                 message = error!!,
                 onRetry = {
                     error = null
                     managerRetryAttempt++
                 },
-                onRecoverWalletSelection = { app.trySelectLatestOrNewWallet() },
+                onRecoverWalletSelection = { recoverWalletSelection() },
             )
         }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -48,8 +48,10 @@ fun TransactionDetailsContainer(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            android.util.Log.e("TransactionDetails", "Failed to load wallet", e)
             error = e.message ?: "failed to load wallet"
             loading = false
+            app.trySelectLatestOrNewWallet()
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -23,6 +23,8 @@ import org.bitcoinppl.cove_core.types.TxId
 import org.bitcoinppl.cove_core.types.WalletId
 import kotlin.coroutines.cancellation.CancellationException
 
+private const val TAG = "TransactionDetailsContainer"
+
 /**
  * lifecycle container for transaction details screen
  * manages WalletManager loading and cleanup
@@ -56,18 +58,18 @@ fun TransactionDetailsContainer(
         ) {
             WalletSelectionRecoveryResult.Recovered -> Unit
             is WalletSelectionRecoveryResult.PoppedRoute -> {
-                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e(TAG, "Failed to recover wallet selection", result.recoveryError)
                 recoveringWalletSelection = false
             }
             is WalletSelectionRecoveryResult.NoRouteToPop -> {
-                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
-                android.util.Log.e("TransactionDetails", "No route available to leave transaction details after recovery failure")
+                android.util.Log.e(TAG, "Failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e(TAG, "No route available to leave transaction details after recovery failure")
                 recoveringWalletSelection = false
             }
             is WalletSelectionRecoveryResult.FailedToPopRoute -> {
-                android.util.Log.e("TransactionDetails", "Failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e(TAG, "Failed to recover wallet selection", result.recoveryError)
                 android.util.Log.e(
-                    "TransactionDetails",
+                    TAG,
                     "Failed to leave transaction details after recovery failure",
                     result.navigationError,
                 )
@@ -94,7 +96,7 @@ fun TransactionDetailsContainer(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            android.util.Log.e("TransactionDetails", "Failed to load wallet", e)
+            android.util.Log.e(TAG, "Failed to load wallet", e)
             error = e.message ?: "failed to load wallet"
             loading = false
             recoverWalletSelection()
@@ -119,7 +121,7 @@ fun TransactionDetailsContainer(
             throw e
         } catch (e: Exception) {
             detailsError = e.message ?: "failed to load transaction"
-            android.util.Log.e("TransactionDetails", "Failed to load transaction details", e)
+            android.util.Log.e(TAG, "Failed to load transaction details", e)
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -29,6 +29,7 @@ import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.AppAlertState
 import org.bitcoinppl.cove_core.types.*
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Wallet settings container - lazy loads WalletManager for wallet settings
@@ -45,7 +46,30 @@ fun WalletSettingsContainer(
         mutableStateOf<WalletSettingsLoadState>(WalletSettingsLoadState.Loading)
     }
     var loadAttempt by remember(id) { mutableStateOf(0) }
+    var didShowLoadFailureAlert by remember(id, route) { mutableStateOf(false) }
     val tag = "WalletSettingsContainer"
+
+    fun startWalletSelectionRecovery(message: String) {
+        if (loadState is WalletSettingsLoadState.Recovering && !app.isNavigationSettled) return
+
+        loadState = WalletSettingsLoadState.Recovering(message)
+
+        try {
+            app.selectLatestOrNewWallet()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (recoveryError: Exception) {
+            android.util.Log.e(tag, "failed to recover wallet selection", recoveryError)
+            loadState = WalletSettingsLoadState.Failed(message)
+        }
+    }
+
+    LaunchedEffect(loadState, app.isNavigationSettled) {
+        val state = loadState
+        if (state is WalletSettingsLoadState.Recovering && app.isNavigationSettled) {
+            loadState = WalletSettingsLoadState.Failed(state.message)
+        }
+    }
 
     // lazy load wallet manager
     LaunchedEffect(id, loadAttempt) {
@@ -54,34 +78,37 @@ fun WalletSettingsContainer(
         try {
             android.util.Log.d(tag, "getting wallet $id")
             loadState = WalletSettingsLoadState.Ready(app.getWalletManager(id))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             val message = e.message ?: "Unknown error"
 
             android.util.Log.e(tag, "failed to load wallet", e)
             loadState = WalletSettingsLoadState.Failed(message)
-            app.alertState =
-                TaggedItem(
-                    AppAlertState.General(
-                        title = "Error!",
-                        message = "Unable to load wallet: $message",
-                    ),
-                )
+
+            if (!didShowLoadFailureAlert) {
+                app.alertState =
+                    TaggedItem(
+                        AppAlertState.General(
+                            title = "Error!",
+                            message = "Unable to load wallet: $message",
+                        ),
+                    )
+                didShowLoadFailureAlert = true
+            }
 
             // leave the alert visible before route recovery replaces this screen
             delay(WALLET_LOAD_ERROR_RECOVERY_DELAY_MS)
             ensureActive()
 
-            try {
-                app.selectLatestOrNewWallet()
-            } catch (recoveryError: Exception) {
-                android.util.Log.e(tag, "failed to recover wallet selection", recoveryError)
-            }
+            startWalletSelectionRecovery(message)
         }
     }
 
     // render
     when (val state = loadState) {
-        WalletSettingsLoadState.Loading -> {
+        WalletSettingsLoadState.Loading,
+        is WalletSettingsLoadState.Recovering -> {
             Box(
                 modifier = modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
@@ -91,7 +118,7 @@ fun WalletSettingsContainer(
         }
 
         is WalletSettingsLoadState.Failed -> {
-            val recoverWalletSelection = { app.trySelectLatestOrNewWallet() }
+            val recoverWalletSelection = { startWalletSelectionRecovery(state.message) }
 
             BackHandler(onBack = recoverWalletSelection)
 
@@ -132,6 +159,10 @@ private sealed interface WalletSettingsLoadState {
     ) : WalletSettingsLoadState
 
     data class Failed(
+        val message: String,
+    ) : WalletSettingsLoadState
+
+    data class Recovering(
         val message: String,
     ) : WalletSettingsLoadState
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -61,7 +61,7 @@ fun WalletSettingsContainer(
             val result =
                 recoverWalletSelectionOrPopRoute(
                     selectLatestOrNewWallet = app::selectLatestOrNewWallet,
-                    popRoute = app::popRoute,
+                    popRoute = app::popRouteForRecovery,
                 )
         ) {
             WalletSelectionRecoveryResult.Recovered -> {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.ensureActive
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.WalletManager
@@ -46,12 +45,14 @@ fun WalletSettingsContainer(
         mutableStateOf<WalletSettingsLoadState>(WalletSettingsLoadState.Loading)
     }
     var loadAttempt by remember(id) { mutableStateOf(0) }
+    var recoveryGeneration by remember(id) { mutableStateOf(0) }
     var didShowLoadFailureAlert by remember(id, route) { mutableStateOf(false) }
     val tag = "WalletSettingsContainer"
 
     fun startWalletSelectionRecovery(message: String) {
         if (loadState is WalletSettingsLoadState.Recovering && !app.isNavigationSettled) return
 
+        recoveryGeneration += 1
         loadState = WalletSettingsLoadState.Recovering(message)
 
         try {
@@ -84,6 +85,8 @@ fun WalletSettingsContainer(
             val message = e.message ?: "Unknown error"
 
             android.util.Log.e(tag, "failed to load wallet", e)
+            recoveryGeneration += 1
+            val failureGeneration = recoveryGeneration
             loadState = WalletSettingsLoadState.Failed(message)
 
             if (!didShowLoadFailureAlert) {
@@ -99,9 +102,15 @@ fun WalletSettingsContainer(
 
             // leave the alert visible before route recovery replaces this screen
             delay(WALLET_LOAD_ERROR_RECOVERY_DELAY_MS)
-            ensureActive()
 
-            startWalletSelectionRecovery(message)
+            val state = loadState
+            if (
+                recoveryGeneration == failureGeneration &&
+                state is WalletSettingsLoadState.Failed &&
+                state.message == message
+            ) {
+                startWalletSelectionRecovery(message)
+            }
         }
     }
 
@@ -124,7 +133,10 @@ fun WalletSettingsContainer(
 
             WalletSettingsLoadError(
                 message = state.message,
-                onRetry = { loadAttempt++ },
+                onRetry = {
+                    recoveryGeneration += 1
+                    loadAttempt++
+                },
                 onBack = recoverWalletSelection,
                 modifier = modifier,
             )

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -152,6 +152,7 @@ fun WalletSettingsContainer(
             WalletSettingsLoadError(
                 message = state.message,
                 onRetry = {
+                    lastLoadFailureAlertMessage = null
                     loadAttempt++
                 },
                 onBack = recoverWalletSelection,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.WalletManager
@@ -66,8 +67,9 @@ fun WalletSettingsContainer(
                     ),
                 )
 
-            // five seconds gives the alert time to be read before route recovery replaces this screen
+            // leave the alert visible before route recovery replaces this screen
             delay(WALLET_LOAD_ERROR_RECOVERY_DELAY_MS)
+            ensureActive()
 
             try {
                 app.selectLatestOrNewWallet()

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.delay
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.WalletManager
+import org.bitcoinppl.cove.WalletSelectionRecoveryResult
+import org.bitcoinppl.cove.recoverWalletSelectionOrPopRoute
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.AppAlertState
 import org.bitcoinppl.cove_core.types.*
@@ -55,13 +57,22 @@ fun WalletSettingsContainer(
         recoveryGeneration += 1
         loadState = WalletSettingsLoadState.Recovering(message)
 
-        try {
-            app.selectLatestOrNewWallet()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (recoveryError: Exception) {
-            android.util.Log.e(tag, "failed to recover wallet selection", recoveryError)
-            loadState = WalletSettingsLoadState.Failed(message)
+        when (
+            val result =
+                recoverWalletSelectionOrPopRoute(
+                    selectLatestOrNewWallet = app::selectLatestOrNewWallet,
+                    popRoute = app::popRoute,
+                )
+        ) {
+            WalletSelectionRecoveryResult.Recovered -> Unit
+            is WalletSelectionRecoveryResult.PoppedRoute -> {
+                android.util.Log.e(tag, "failed to recover wallet selection", result.recoveryError)
+            }
+            is WalletSelectionRecoveryResult.FailedToPopRoute -> {
+                android.util.Log.e(tag, "failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e(tag, "failed to leave wallet settings after recovery failure", result.navigationError)
+                loadState = WalletSettingsLoadState.Failed(message)
+            }
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -1,8 +1,16 @@
 package org.bitcoinppl.cove.flows.SettingsFlow
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -11,8 +19,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.TaggedItem
+import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.AppAlertState
 import org.bitcoinppl.cove_core.types.*
@@ -23,36 +35,51 @@ import org.bitcoinppl.cove_core.types.*
  */
 @Composable
 fun WalletSettingsContainer(
-    app: org.bitcoinppl.cove.AppManager,
+    app: AppManager,
     id: WalletId,
     route: WalletSettingsRoute,
     modifier: Modifier = Modifier,
 ) {
-    var manager by remember(id) { mutableStateOf<org.bitcoinppl.cove.WalletManager?>(null) }
+    var loadState by remember(id) {
+        mutableStateOf<WalletSettingsLoadState>(WalletSettingsLoadState.Loading)
+    }
+    var loadAttempt by remember(id) { mutableStateOf(0) }
     val tag = "WalletSettingsContainer"
 
     // lazy load wallet manager
-    LaunchedEffect(id) {
+    LaunchedEffect(id, loadAttempt) {
+        loadState = WalletSettingsLoadState.Loading
+
         try {
             android.util.Log.d(tag, "getting wallet $id")
-            manager = app.getWalletManager(id)
+            loadState = WalletSettingsLoadState.Ready(app.getWalletManager(id))
         } catch (e: Exception) {
+            val message = e.message ?: "Unknown error"
+
             android.util.Log.e(tag, "failed to load wallet", e)
+            loadState = WalletSettingsLoadState.Failed(message)
             app.alertState =
                 TaggedItem(
                     AppAlertState.General(
                         title = "Error!",
-                        message = "Unable to load wallet: ${e.message}",
+                        message = "Unable to load wallet: $message",
                     ),
                 )
+
+            // five seconds gives the alert time to be read before route recovery replaces this screen
             delay(WALLET_LOAD_ERROR_RECOVERY_DELAY_MS)
-            app.trySelectLatestOrNewWallet()
+
+            try {
+                app.selectLatestOrNewWallet()
+            } catch (recoveryError: Exception) {
+                android.util.Log.e(tag, "failed to recover wallet selection", recoveryError)
+            }
         }
     }
 
     // render
-    when (val wm = manager) {
-        null -> {
+    when (val state = loadState) {
+        WalletSettingsLoadState.Loading -> {
             Box(
                 modifier = modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
@@ -60,22 +87,86 @@ fun WalletSettingsContainer(
                 CircularProgressIndicator()
             }
         }
-        else -> {
+
+        is WalletSettingsLoadState.Failed -> {
+            val recoverWalletSelection = { app.trySelectLatestOrNewWallet() }
+
+            BackHandler(onBack = recoverWalletSelection)
+
+            WalletSettingsLoadError(
+                message = state.message,
+                onRetry = { loadAttempt++ },
+                onBack = recoverWalletSelection,
+                modifier = modifier,
+            )
+        }
+
+        is WalletSettingsLoadState.Ready -> {
             when (route) {
                 WalletSettingsRoute.MAIN -> {
                     WalletSettingsScreen(
                         app = app,
-                        manager = wm,
+                        manager = state.manager,
                         modifier = modifier,
                     )
                 }
                 WalletSettingsRoute.CHANGE_NAME -> {
                     WalletSettingsChangeNameScreen(
                         app = app,
-                        manager = wm,
+                        manager = state.manager,
                         modifier = modifier,
                     )
                 }
+            }
+        }
+    }
+}
+
+private sealed interface WalletSettingsLoadState {
+    data object Loading : WalletSettingsLoadState
+
+    data class Ready(
+        val manager: WalletManager,
+    ) : WalletSettingsLoadState
+
+    data class Failed(
+        val message: String,
+    ) : WalletSettingsLoadState
+}
+
+@Composable
+private fun WalletSettingsLoadError(
+    message: String,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Unable to load wallet settings",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Button(onClick = onRetry) {
+                Text("Try again")
+            }
+            TextButton(onClick = onBack) {
+                Text("Go back")
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -150,7 +150,6 @@ fun WalletSettingsContainer(
             WalletSettingsLoadError(
                 message = state.message,
                 onRetry = {
-                    recoveryGeneration += 1
                     loadAttempt++
                 },
                 onBack = recoverWalletSelection,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.delay
 import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove_core.*
 import org.bitcoinppl.cove_core.AppAlertState
@@ -44,6 +45,7 @@ fun WalletSettingsContainer(
                         message = "Unable to load wallet: ${e.message}",
                     ),
                 )
+            delay(WALLET_LOAD_ERROR_RECOVERY_DELAY_MS)
             app.trySelectLatestOrNewWallet()
         }
     }
@@ -78,3 +80,5 @@ fun WalletSettingsContainer(
         }
     }
 }
+
+private const val WALLET_LOAD_ERROR_RECOVERY_DELAY_MS = 5_000L

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -48,7 +48,7 @@ fun WalletSettingsContainer(
     }
     var loadAttempt by remember(id) { mutableStateOf(0) }
     var recoveryGeneration by remember(id) { mutableStateOf(0) }
-    var didShowLoadFailureAlert by remember(id, route) { mutableStateOf(false) }
+    var lastLoadFailureAlertMessage by remember(id, route) { mutableStateOf<String?>(null) }
     val tag = "WalletSettingsContainer"
 
     fun startWalletSelectionRecovery(message: String) {
@@ -67,6 +67,11 @@ fun WalletSettingsContainer(
             WalletSelectionRecoveryResult.Recovered -> Unit
             is WalletSelectionRecoveryResult.PoppedRoute -> {
                 android.util.Log.e(tag, "failed to recover wallet selection", result.recoveryError)
+            }
+            is WalletSelectionRecoveryResult.NoRouteToPop -> {
+                android.util.Log.e(tag, "failed to recover wallet selection", result.recoveryError)
+                android.util.Log.e(tag, "no route available to leave wallet settings after recovery failure")
+                loadState = WalletSettingsLoadState.Failed(message)
             }
             is WalletSelectionRecoveryResult.FailedToPopRoute -> {
                 android.util.Log.e(tag, "failed to recover wallet selection", result.recoveryError)
@@ -100,7 +105,7 @@ fun WalletSettingsContainer(
             val failureGeneration = recoveryGeneration
             loadState = WalletSettingsLoadState.Failed(message)
 
-            if (!didShowLoadFailureAlert) {
+            if (lastLoadFailureAlertMessage != message) {
                 app.alertState =
                     TaggedItem(
                         AppAlertState.General(
@@ -108,7 +113,7 @@ fun WalletSettingsContainer(
                             message = "Unable to load wallet: $message",
                         ),
                     )
-                didShowLoadFailureAlert = true
+                lastLoadFailureAlertMessage = message
             }
 
             // leave the alert visible before route recovery replaces this screen

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -64,7 +64,9 @@ fun WalletSettingsContainer(
                     popRoute = app::popRoute,
                 )
         ) {
-            WalletSelectionRecoveryResult.Recovered -> Unit
+            WalletSelectionRecoveryResult.Recovered -> {
+                loadState = WalletSettingsLoadState.Loading
+            }
             is WalletSelectionRecoveryResult.PoppedRoute -> {
                 android.util.Log.e(tag, "failed to recover wallet selection", result.recoveryError)
             }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -44,6 +44,7 @@ fun WalletSettingsContainer(
                         message = "Unable to load wallet: ${e.message}",
                     ),
                 )
+            app.trySelectLatestOrNewWallet()
         }
     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/navigation/CoveNavDisplay.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/navigation/CoveNavDisplay.kt
@@ -64,9 +64,8 @@ fun CoveNavDisplay(
         backStack = backStack,
         onBack = {
             // directly modify backStack for predictive back support
-            if (backStack.size > 1) {
+            if (backStack.size > 1 && app.popRoute()) {
                 backStack.removeAt(backStack.lastIndex)
-                app.popRoute()
             }
         },
         modifier = modifier,

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -125,6 +125,20 @@ class OnboardingHelpersTest {
     }
 
     @Test
+    fun onboardingStartupModeKeepsPersistedProgressEvenWithWallets() {
+        assertEquals(
+            StartupMode.ONBOARDING,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.ONBOARDING,
+                termsAccepted = true,
+                hasWallets = true,
+                cloudBackupLifecycle = configuredLifecycle(),
+                hasPersistedOnboardingProgress = true,
+            ),
+        )
+    }
+
+    @Test
     fun onboardingStartupModeDoesNotUseReadyShortcut() {
         assertEquals(
             StartupMode.ONBOARDING,
@@ -172,6 +186,39 @@ class OnboardingHelpersTest {
         assertFalse(hasPersistedOnboardingProgress(""))
         assertFalse(hasPersistedOnboardingProgress("   "))
         assertTrue(hasPersistedOnboardingProgress("""{"step":"backup_wallet"}"""))
+    }
+
+    @Test
+    fun effectiveOnboardingProgressUsesFreshValueOnSuccess() {
+        assertEquals(
+            """{"step":"backup_wallet"}""",
+            resolveEffectiveOnboardingProgress(
+                freshProgress = Result.success("""{"step":"backup_wallet"}"""),
+                previousProgress = """{"step":"terms"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun effectiveOnboardingProgressClearsPreviousValueOnSuccessfulNull() {
+        assertEquals(
+            null,
+            resolveEffectiveOnboardingProgress(
+                freshProgress = Result.success(null),
+                previousProgress = """{"step":"backup_wallet"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun effectiveOnboardingProgressKeepsPreviousValueOnFailure() {
+        assertEquals(
+            """{"step":"backup_wallet"}""",
+            resolveEffectiveOnboardingProgress(
+                freshProgress = Result.failure(IllegalStateException("read failed")),
+                previousProgress = """{"step":"backup_wallet"}""",
+            ),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -106,6 +106,7 @@ class OnboardingHelpersTest {
                 hasWallets = false,
                 cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
                 hasPersistedOnboardingProgress = false,
+                hasRecoveredOnboardingProgressAfterReadFailure = false,
             ),
         )
 
@@ -132,6 +133,7 @@ class OnboardingHelpersTest {
                 hasWallets = true,
                 cloudBackupLifecycle = configuredLifecycle(),
                 hasPersistedOnboardingProgress = false,
+                hasRecoveredOnboardingProgressAfterReadFailure = false,
             ),
         )
     }
@@ -146,6 +148,7 @@ class OnboardingHelpersTest {
                 hasWallets = true,
                 cloudBackupLifecycle = configuredLifecycle(),
                 hasPersistedOnboardingProgress = true,
+                hasRecoveredOnboardingProgressAfterReadFailure = false,
             ),
         )
     }
@@ -236,6 +239,7 @@ class OnboardingHelpersTest {
                 hasWallets = true,
                 cloudBackupLifecycle = configuredLifecycle(),
                 hasPersistedOnboardingProgress = false,
+                hasRecoveredOnboardingProgressAfterReadFailure = false,
             ),
         )
     }

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -111,6 +111,34 @@ class OnboardingHelpersTest {
     }
 
     @Test
+    fun onboardingStartupModePromotesToReadyWhenSetupIsComplete() {
+        assertEquals(
+            StartupMode.READY,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.ONBOARDING,
+                termsAccepted = true,
+                hasWallets = true,
+                cloudBackupLifecycle = configuredLifecycle(),
+                hasPersistedOnboardingProgress = false,
+            ),
+        )
+    }
+
+    @Test
+    fun readyStartupModeIgnoresStalePersistedOnboardingProgress() {
+        assertEquals(
+            StartupMode.READY,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.READY,
+                termsAccepted = true,
+                hasWallets = false,
+                cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
+                hasPersistedOnboardingProgress = true,
+            ),
+        )
+    }
+
+    @Test
     fun readyStartupModeStillRequiresAcceptedTerms() {
         assertEquals(
             StartupMode.ONBOARDING,

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -111,6 +111,20 @@ class OnboardingHelpersTest {
     }
 
     @Test
+    fun readyStartupModeStillRequiresAcceptedTerms() {
+        assertEquals(
+            StartupMode.ONBOARDING,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.READY,
+                termsAccepted = false,
+                hasWallets = true,
+                cloudBackupLifecycle = configuredLifecycle(),
+                hasPersistedOnboardingProgress = false,
+            ),
+        )
+    }
+
+    @Test
     fun persistedOnboardingProgressRequiresNonBlankState() {
         assertFalse(hasPersistedOnboardingProgress(null))
         assertFalse(hasPersistedOnboardingProgress(""))

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -97,7 +97,7 @@ class OnboardingHelpersTest {
     }
 
     @Test
-    fun readyStartupModeDoesNotReenterOnboardingWhenLastWalletIsDeleted() {
+    fun readyShortcutOnlyAppliesToReadyStartupMode() {
         assertEquals(
             StartupMode.READY,
             resolveStartupModeTransition(
@@ -106,6 +106,18 @@ class OnboardingHelpersTest {
                 hasWallets = false,
                 cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
                 hasPersistedOnboardingProgress = false,
+            ),
+        )
+
+        assertEquals(
+            StartupMode.ONBOARDING,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.ONBOARDING,
+                termsAccepted = true,
+                hasWallets = false,
+                cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
+                hasPersistedOnboardingProgress = false,
+                hasRecoveredOnboardingProgressAfterReadFailure = false,
             ),
         )
     }
@@ -134,20 +146,6 @@ class OnboardingHelpersTest {
                 hasWallets = true,
                 cloudBackupLifecycle = configuredLifecycle(),
                 hasPersistedOnboardingProgress = true,
-            ),
-        )
-    }
-
-    @Test
-    fun onboardingStartupModeDoesNotUseReadyShortcut() {
-        assertEquals(
-            StartupMode.ONBOARDING,
-            resolveStartupModeTransition(
-                currentMode = StartupMode.ONBOARDING,
-                termsAccepted = true,
-                hasWallets = false,
-                cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
-                hasPersistedOnboardingProgress = false,
             ),
         )
     }
@@ -196,6 +194,34 @@ class OnboardingHelpersTest {
                 cloudBackupLifecycle = configuredLifecycle(),
                 hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(freshProgress.getOrNull()),
                 hasRecoveredOnboardingProgressAfterReadFailure = recoveredProgress,
+            ),
+        )
+    }
+
+    @Test
+    fun recoveredOnboardingProgressRequiresNewProgressAfterPreviousReadFailure() {
+        assertFalse(
+            hasRecoveredOnboardingProgressAfterReadFailure(
+                freshProgress = Result.success("""{"step":"backup_wallet"}"""),
+                previousProgress = """{"step":"terms"}""",
+                previousReadFailed = true,
+            ),
+        )
+        assertFalse(
+            hasRecoveredOnboardingProgressAfterReadFailure(
+                freshProgress = Result.success(null),
+                previousProgress = null,
+                previousReadFailed = true,
+            ),
+        )
+
+        val failedRead: Result<String?> = Result.failure(IllegalStateException("read failed"))
+
+        assertFalse(
+            hasRecoveredOnboardingProgressAfterReadFailure(
+                freshProgress = failedRead,
+                previousProgress = null,
+                previousReadFailed = true,
             ),
         )
     }

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -97,6 +97,20 @@ class OnboardingHelpersTest {
     }
 
     @Test
+    fun readyStartupModeDoesNotReenterOnboardingWhenLastWalletIsDeleted() {
+        assertEquals(
+            StartupMode.READY,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.READY,
+                termsAccepted = true,
+                hasWallets = false,
+                cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
+                hasPersistedOnboardingProgress = false,
+            ),
+        )
+    }
+
+    @Test
     fun persistedOnboardingProgressRequiresNonBlankState() {
         assertFalse(hasPersistedOnboardingProgress(null))
         assertFalse(hasPersistedOnboardingProgress(""))

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -189,13 +189,24 @@ class OnboardingHelpersTest {
 
         assertTrue(recoveredProgress)
         assertEquals(
+            StartupMode.READY,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.READY,
+                termsAccepted = true,
+                hasWallets = true,
+                cloudBackupLifecycle = configuredLifecycle(),
+                hasPersistedOnboardingProgress = true,
+                hasRecoveredOnboardingProgressAfterReadFailure = false,
+            ),
+        )
+        assertEquals(
             StartupMode.ONBOARDING,
             resolveStartupModeTransition(
                 currentMode = StartupMode.READY,
                 termsAccepted = true,
                 hasWallets = true,
                 cloudBackupLifecycle = configuredLifecycle(),
-                hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(freshProgress.getOrNull()),
+                hasPersistedOnboardingProgress = true,
                 hasRecoveredOnboardingProgressAfterReadFailure = recoveredProgress,
             ),
         )

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -125,6 +125,20 @@ class OnboardingHelpersTest {
     }
 
     @Test
+    fun onboardingStartupModeDoesNotUseReadyShortcut() {
+        assertEquals(
+            StartupMode.ONBOARDING,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.ONBOARDING,
+                termsAccepted = true,
+                hasWallets = false,
+                cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
+                hasPersistedOnboardingProgress = false,
+            ),
+        )
+    }
+
+    @Test
     fun readyStartupModeIgnoresStalePersistedOnboardingProgress() {
         assertEquals(
             StartupMode.READY,

--- a/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/OnboardingHelpersTest.kt
@@ -154,6 +154,15 @@ class OnboardingHelpersTest {
 
     @Test
     fun readyStartupModeIgnoresStalePersistedOnboardingProgress() {
+        val freshProgress = Result.success("""{"step":"backup_wallet"}""")
+        val recoveredProgress =
+            hasRecoveredOnboardingProgressAfterReadFailure(
+                freshProgress = freshProgress,
+                previousProgress = null,
+                previousReadFailed = false,
+            )
+
+        assertFalse(recoveredProgress)
         assertEquals(
             StartupMode.READY,
             resolveStartupModeTransition(
@@ -162,6 +171,31 @@ class OnboardingHelpersTest {
                 hasWallets = false,
                 cloudBackupLifecycle = CloudBackupLifecycle.Disabled,
                 hasPersistedOnboardingProgress = true,
+                hasRecoveredOnboardingProgressAfterReadFailure = recoveredProgress,
+            ),
+        )
+    }
+
+    @Test
+    fun readyStartupModeReevaluatesRecoveredPersistedOnboardingProgress() {
+        val freshProgress = Result.success("""{"step":"backup_wallet"}""")
+        val recoveredProgress =
+            hasRecoveredOnboardingProgressAfterReadFailure(
+                freshProgress = freshProgress,
+                previousProgress = null,
+                previousReadFailed = true,
+            )
+
+        assertTrue(recoveredProgress)
+        assertEquals(
+            StartupMode.ONBOARDING,
+            resolveStartupModeTransition(
+                currentMode = StartupMode.READY,
+                termsAccepted = true,
+                hasWallets = true,
+                cloudBackupLifecycle = configuredLifecycle(),
+                hasPersistedOnboardingProgress = hasPersistedOnboardingProgress(freshProgress.getOrNull()),
+                hasRecoveredOnboardingProgressAfterReadFailure = recoveredProgress,
             ),
         )
     }

--- a/android/app/src/test/java/org/bitcoinppl/cove/WalletSelectionRecoveryTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/WalletSelectionRecoveryTest.kt
@@ -15,7 +15,10 @@ class WalletSelectionRecoveryTest {
         val result =
             recoverWalletSelectionOrPopRoute(
                 selectLatestOrNewWallet = {},
-                popRoute = { didPopRoute = true },
+                popRoute = {
+                    didPopRoute = true
+                    true
+                },
             )
 
         assertEquals(WalletSelectionRecoveryResult.Recovered, result)
@@ -30,11 +33,27 @@ class WalletSelectionRecoveryTest {
         val result =
             recoverWalletSelectionOrPopRoute(
                 selectLatestOrNewWallet = { throw recoveryError },
-                popRoute = { didPopRoute = true },
+                popRoute = {
+                    didPopRoute = true
+                    true
+                },
             )
 
         assertTrue(didPopRoute)
         assertSame(recoveryError, (result as WalletSelectionRecoveryResult.PoppedRoute).recoveryError)
+    }
+
+    @Test
+    fun reportsNoRouteToPopWhenRecoveryFailsAndPopIsNoop() {
+        val recoveryError = IllegalStateException("wallet selection failed")
+
+        val result =
+            recoverWalletSelectionOrPopRoute(
+                selectLatestOrNewWallet = { throw recoveryError },
+                popRoute = { false },
+            ) as WalletSelectionRecoveryResult.NoRouteToPop
+
+        assertSame(recoveryError, result.recoveryError)
     }
 
     @Test
@@ -59,7 +78,10 @@ class WalletSelectionRecoveryTest {
         try {
             recoverWalletSelectionOrPopRoute(
                 selectLatestOrNewWallet = { throw CancellationException("cancelled") },
-                popRoute = { didPopRoute = true },
+                popRoute = {
+                    didPopRoute = true
+                    true
+                },
             )
         } finally {
             assertFalse(didPopRoute)

--- a/android/app/src/test/java/org/bitcoinppl/cove/WalletSelectionRecoveryTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/WalletSelectionRecoveryTest.kt
@@ -1,0 +1,76 @@
+package org.bitcoinppl.cove
+
+import kotlin.coroutines.cancellation.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WalletSelectionRecoveryTest {
+    @Test
+    fun recoversWalletSelectionWithoutPoppingRoute() {
+        var didPopRoute = false
+
+        val result =
+            recoverWalletSelectionOrPopRoute(
+                selectLatestOrNewWallet = {},
+                popRoute = { didPopRoute = true },
+            )
+
+        assertEquals(WalletSelectionRecoveryResult.Recovered, result)
+        assertFalse(didPopRoute)
+    }
+
+    @Test
+    fun popsRouteWhenWalletSelectionRecoveryFails() {
+        val recoveryError = IllegalStateException("wallet selection failed")
+        var didPopRoute = false
+
+        val result =
+            recoverWalletSelectionOrPopRoute(
+                selectLatestOrNewWallet = { throw recoveryError },
+                popRoute = { didPopRoute = true },
+            )
+
+        assertTrue(didPopRoute)
+        assertSame(recoveryError, (result as WalletSelectionRecoveryResult.PoppedRoute).recoveryError)
+    }
+
+    @Test
+    fun reportsNavigationFailureWhenRecoveryAndRoutePopFail() {
+        val recoveryError = IllegalStateException("wallet selection failed")
+        val navigationError = IllegalStateException("pop route failed")
+
+        val result =
+            recoverWalletSelectionOrPopRoute(
+                selectLatestOrNewWallet = { throw recoveryError },
+                popRoute = { throw navigationError },
+            ) as WalletSelectionRecoveryResult.FailedToPopRoute
+
+        assertSame(recoveryError, result.recoveryError)
+        assertSame(navigationError, result.navigationError)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun rethrowsWalletSelectionCancellationWithoutPoppingRoute() {
+        var didPopRoute = false
+
+        try {
+            recoverWalletSelectionOrPopRoute(
+                selectLatestOrNewWallet = { throw CancellationException("cancelled") },
+                popRoute = { didPopRoute = true },
+            )
+        } finally {
+            assertFalse(didPopRoute)
+        }
+    }
+
+    @Test(expected = CancellationException::class)
+    fun rethrowsRoutePopCancellation() {
+        recoverWalletSelectionOrPopRoute(
+            selectLatestOrNewWallet = { throw IllegalStateException("wallet selection failed") },
+            popRoute = { throw CancellationException("cancelled") },
+        )
+    }
+}

--- a/android/app/src/test/java/org/bitcoinppl/cove/WalletSelectionRecoveryTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/WalletSelectionRecoveryTest.kt
@@ -17,7 +17,7 @@ class WalletSelectionRecoveryTest {
                 selectLatestOrNewWallet = {},
                 popRoute = {
                     didPopRoute = true
-                    true
+                    RoutePopResult.Popped
                 },
             )
 
@@ -35,7 +35,7 @@ class WalletSelectionRecoveryTest {
                 selectLatestOrNewWallet = { throw recoveryError },
                 popRoute = {
                     didPopRoute = true
-                    true
+                    RoutePopResult.Popped
                 },
             )
 
@@ -50,10 +50,25 @@ class WalletSelectionRecoveryTest {
         val result =
             recoverWalletSelectionOrPopRoute(
                 selectLatestOrNewWallet = { throw recoveryError },
-                popRoute = { false },
+                popRoute = { RoutePopResult.NoRouteToPop },
             ) as WalletSelectionRecoveryResult.NoRouteToPop
 
         assertSame(recoveryError, result.recoveryError)
+    }
+
+    @Test
+    fun reportsNavigationFailureWhenRoutePopFailsWithResult() {
+        val recoveryError = IllegalStateException("wallet selection failed")
+        val navigationError = IllegalStateException("pop route failed")
+
+        val result =
+            recoverWalletSelectionOrPopRoute(
+                selectLatestOrNewWallet = { throw recoveryError },
+                popRoute = { RoutePopResult.Failed(navigationError) },
+            ) as WalletSelectionRecoveryResult.FailedToPopRoute
+
+        assertSame(recoveryError, result.recoveryError)
+        assertSame(navigationError, result.navigationError)
     }
 
     @Test
@@ -80,7 +95,7 @@ class WalletSelectionRecoveryTest {
                 selectLatestOrNewWallet = { throw CancellationException("cancelled") },
                 popRoute = {
                     didPopRoute = true
-                    true
+                    RoutePopResult.Popped
                 },
             )
         } finally {


### PR DESCRIPTION
## Summary
- Keep Android startup in `READY` once reached so deleting the last wallet does not send users back through onboarding
- Route wallet loading failures to the latest available wallet in settings and transaction detail flows
- Replace the cloud backup wallet action alert with a dedicated dialog layout that presents restore, delete, and cancel actions more clearly
- Add a regression test covering the `READY` startup transition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup and onboarding handling to better recover from interrupted or failed progress reads.
  * Added wallet-selection recovery flows for wallet details and settings screens, including a new “Open wallet” action when needed.
  * Updated navigation so back actions only remove routes when navigation can actually move back.

* **Bug Fixes**
  * Made wallet loading more resilient by handling failures, cancellations, and recovery states more safely.
  * Improved route handling to avoid inconsistent navigation after recovery attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->