### PR TITLE
Fix Android cancellation handling

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletContainer.kt
@@ -81,6 +81,8 @@ fun SelectedWalletContainer(
                 // until AppManager replaces it for another wallet
                 android.util.Log.d(tag, "discarding stale wallet load for $requestedId, now loading $id")
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: WalletManagerException.DatabaseCorruption) {
             android.util.Log.e(tag, "wallet database corrupted for ${e.`id`}: ${e.`error`}", e)
             app.alertState = TaggedItem(

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsContainer.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import org.bitcoinppl.cove.AppManager
 import org.bitcoinppl.cove.WalletManager
 import org.bitcoinppl.cove.components.FullPageLoadingView
@@ -44,6 +45,8 @@ fun TransactionDetailsContainer(
         try {
             manager = app.getWalletManager(walletId)
             loading = false
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             error = e.message ?: "failed to load wallet"
             loading = false
@@ -61,6 +64,8 @@ fun TransactionDetailsContainer(
         try {
             currentManager.transactionDetails(txId)
             didLoadInitialDetails = true
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             detailsError = e.message ?: "failed to load transaction"
             android.util.Log.e("TransactionDetails", "Failed to load transaction details", e)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/TransactionDetails/TransactionDetailsScreen.kt
@@ -141,6 +141,8 @@ fun TransactionDetailsScreen(
         try {
             lockState = manager.transactionLockState(txId)
             lockStateLoadFailed = false
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("TransactionDetails", "error fetching transaction lock state", e)
             lockStateLoadFailed = true
@@ -165,6 +167,8 @@ fun TransactionDetailsScreen(
         scope.launch {
             try {
                 lockState = manager.toggleTransactionLockState(txId)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("TransactionDetails", "error toggling transaction lock state", e)
                 snackbarHostState.showSnackbar(transactionLockUpdateErrorMessage)
@@ -181,6 +185,8 @@ fun TransactionDetailsScreen(
         try {
             val freshDetails = manager.rust.transactionDetails(txId = txId)
             manager.updateTransactionDetailsCache(txId, freshDetails)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("TransactionDetails", "error fetching fresh details", e)
         }
@@ -193,6 +199,8 @@ fun TransactionDetailsScreen(
         feeFiatFmt =
             try {
                 transactionDetails.feeFiatFmt()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("TransactionDetails", "Failed to fetch fiat fee amount", e)
                 feeFiatFmt // keep cached value on error
@@ -200,6 +208,8 @@ fun TransactionDetailsScreen(
         sentSansFeeFiatFmt =
             try {
                 transactionDetails.sentSansFeeFiatFmt()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("TransactionDetails", "Failed to fetch sent sans fee fiat amount", e)
                 sentSansFeeFiatFmt // keep cached value on error
@@ -207,6 +217,8 @@ fun TransactionDetailsScreen(
         totalSpentFiatFmt =
             try {
                 transactionDetails.amountFiatFmt()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("TransactionDetails", "Failed to fetch total fiat amount", e)
                 totalSpentFiatFmt // keep cached value on error
@@ -214,6 +226,8 @@ fun TransactionDetailsScreen(
         historicalFiatFmt =
             try {
                 transactionDetails.historicalFiatFmt()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("TransactionDetails", "Failed to fetch historical fiat amount", e)
                 historicalFiatFmt // keep cached value on error
@@ -413,6 +427,8 @@ fun TransactionDetailsScreen(
                             val confirmations = manager.rust.numberOfConfirmations(blockHeight = blockNumber)
                             numberOfConfirmations = confirmations.toInt()
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         android.util.Log.e("TransactionDetails", "error refreshing details", e)
                     }


### PR DESCRIPTION
## Summary

- rethrow Compose coroutine cancellation before generic transaction detail error handling
- prevent selected wallet fallback navigation from running during normal composition cancellation
- reduce transaction detail cancellation noise in logcat

## Root cause

Transaction detail navigation can cancel active Compose effects. Those cancellations were caught by broad `Exception` handlers, including the selected wallet fallback path, which could reset navigation and take the user to another wallet.

## Validation

- `just fmt`
- `just clippy`
- `just compile-android`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted wallet and transaction detail loading so cancellations are no longer treated as errors.
  * Kept existing fallback behavior for real failures, including cached values and error messages.
  * Made pull-to-refresh and transaction update flows more reliable when screens are closed or requests are stopped mid-load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->