### PR TITLE
Persist payjoin sender session and resume on cold restart

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -53081,6 +53081,9 @@ sealed class WalletDataKey {
     object ReceiveAddressCache : WalletDataKey()
 
 
+    object PayjoinSenderSession : WalletDataKey()
+
+
 
 
 
@@ -53101,6 +53104,7 @@ public object FfiConverterTypeWalletDataKey : FfiConverterRustBuffer<WalletDataK
                 FfiConverterTypeWalletAddressType.read(buf),
                 )
             2 -> WalletDataKey.ReceiveAddressCache
+            3 -> WalletDataKey.PayjoinSenderSession
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -53119,6 +53123,12 @@ public object FfiConverterTypeWalletDataKey : FfiConverterRustBuffer<WalletDataK
                 4UL
             )
         }
+        is WalletDataKey.PayjoinSenderSession -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
     }
 
     override fun write(value: WalletDataKey, buf: ByteBuffer) {
@@ -53130,6 +53140,10 @@ public object FfiConverterTypeWalletDataKey : FfiConverterRustBuffer<WalletDataK
             }
             is WalletDataKey.ReceiveAddressCache -> {
                 buf.putInt(2)
+                Unit
+            }
+            is WalletDataKey.PayjoinSenderSession -> {
+                buf.putInt(3)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -33936,6 +33936,7 @@ public enum WalletDataKey: Equatable, Hashable {
     case scanState(WalletAddressType
     )
     case receiveAddressCache
+    case payjoinSenderSession
 
 
 
@@ -33962,6 +33963,8 @@ public struct FfiConverterTypeWalletDataKey: FfiConverterRustBuffer {
 
         case 2: return .receiveAddressCache
 
+        case 3: return .payjoinSenderSession
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
@@ -33977,6 +33980,10 @@ public struct FfiConverterTypeWalletDataKey: FfiConverterRustBuffer {
 
         case .receiveAddressCache:
             writeInt(&buf, Int32(2))
+
+
+        case .payjoinSenderSession:
+            writeInt(&buf, Int32(3))
 
         }
     }

--- a/rust/src/database/wallet_data.rs
+++ b/rust/src/database/wallet_data.rs
@@ -86,15 +86,17 @@ impl ReceiveAddressCache {
 /// `bitcoin::Transaction` does not implement serde natively; storing the consensus-encoded
 /// bytes avoids an orphan-impl problem while keeping the format identical to what is broadcast.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, Eq, PartialEq, derive_more::From, derive_more::Into,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::AsRef,
 )]
 pub struct TransactionBytes(Vec<u8>);
-
-impl AsRef<[u8]> for TransactionBytes {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
 
 /// Terminal action decided for a payjoin session before the broadcast completes
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/rust/src/database/wallet_data.rs
+++ b/rust/src/database/wallet_data.rs
@@ -81,18 +81,33 @@ impl ReceiveAddressCache {
     }
 }
 
+/// Consensus-encoded bytes of a bitcoin transaction stored in the database.
+///
+/// `bitcoin::Transaction` does not implement serde natively; storing the consensus-encoded
+/// bytes avoids an orphan-impl problem while keeping the format identical to what is broadcast.
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Eq, PartialEq, derive_more::From, derive_more::Into,
+)]
+pub struct TransactionBytes(Vec<u8>);
+
+impl AsRef<[u8]> for TransactionBytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// Terminal action decided for a payjoin session before the broadcast completes
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PendingAction {
     BroadcastFallback,
-    BroadcastProposal { transaction: Vec<u8> },
+    BroadcastProposal { transaction: TransactionBytes },
 }
 
 /// Event log for an in-flight payjoin sender session, allowing it to survive app restarts
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PayjoinSenderSession {
     pub events: Vec<String>,
-    pub fallback_tx: Vec<u8>,
+    pub fallback_tx: TransactionBytes,
     #[serde(default)]
     pub created_at_secs: Option<u64>,
     #[serde(default)]
@@ -442,7 +457,7 @@ mod tests {
         let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
         let session = PayjoinSenderSession {
             events: vec![r#"{"PostedOriginalPsbt":[]}"#.to_string()],
-            fallback_tx: vec![0x02, 0x00, 0x00, 0x00],
+            fallback_tx: vec![0x02, 0x00, 0x00, 0x00].into(),
             created_at_secs: None,
             pending_action: None,
         };
@@ -458,7 +473,7 @@ mod tests {
         let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
         let session = PayjoinSenderSession {
             events: vec![r#"{"Closed":"Failure"}"#.to_string()],
-            fallback_tx: vec![0x02, 0x00, 0x00, 0x00],
+            fallback_tx: vec![0x02, 0x00, 0x00, 0x00].into(),
             created_at_secs: None,
             pending_action: None,
         };

--- a/rust/src/database/wallet_data.rs
+++ b/rust/src/database/wallet_data.rs
@@ -85,6 +85,7 @@ impl ReceiveAddressCache {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PendingAction {
     BroadcastFallback,
+    BroadcastProposal { transaction: Vec<u8> },
 }
 
 /// Event log for an in-flight payjoin sender session, allowing it to survive app restarts

--- a/rust/src/database/wallet_data.rs
+++ b/rust/src/database/wallet_data.rs
@@ -42,12 +42,14 @@ pub enum WalletData {
     /// number of addresses scanned
     ScanState(ScanState),
     ReceiveAddressCache(ReceiveAddressCache),
+    PayjoinSenderSession(PayjoinSenderSession),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Enum)]
 pub enum WalletDataKey {
     ScanState(WalletAddressType),
     ReceiveAddressCache,
+    PayjoinSenderSession,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, uniffi::Enum)]
@@ -77,6 +79,23 @@ impl ReceiveAddressCache {
         self.first_shown_at_secs = now_secs;
         self
     }
+}
+
+/// Terminal action decided for a payjoin session before the broadcast completes
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum PendingAction {
+    BroadcastFallback,
+}
+
+/// Event log for an in-flight payjoin sender session, allowing it to survive app restarts
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct PayjoinSenderSession {
+    pub events: Vec<String>,
+    pub fallback_tx: Vec<u8>,
+    #[serde(default)]
+    pub created_at_secs: Option<u64>,
+    #[serde(default)]
+    pub pending_action: Option<PendingAction>,
 }
 
 #[derive(Debug, Clone, uniffi::Object)]
@@ -177,6 +196,24 @@ impl WalletDataDb {
 
     pub fn delete_receive_address_cache(&self) -> Result<()> {
         self.delete(WalletDataKey::ReceiveAddressCache)
+    }
+
+    pub fn get_payjoin_sender_session(&self) -> Result<Option<PayjoinSenderSession>> {
+        let value = self.get(WalletDataKey::PayjoinSenderSession)?;
+
+        let Some(WalletData::PayjoinSenderSession(session)) = value else {
+            return Ok(None);
+        };
+
+        Ok(Some(session))
+    }
+
+    pub fn set_payjoin_sender_session(&self, session: PayjoinSenderSession) -> Result<()> {
+        self.set(WalletDataKey::PayjoinSenderSession, WalletData::PayjoinSenderSession(session))
+    }
+
+    pub fn delete_payjoin_sender_session(&self) -> Result<()> {
+        self.delete(WalletDataKey::PayjoinSenderSession)
     }
 
     fn get(&self, key: WalletDataKey) -> Result<Option<WalletData>> {
@@ -298,6 +335,7 @@ impl WalletDataKey {
             Self::ScanState(WalletAddressType::WrappedSegwit) => "scan_state_wrapped_segwit",
             Self::ScanState(WalletAddressType::Legacy) => "scan_state_legacy",
             Self::ReceiveAddressCache => "receive_address_cache",
+            Self::PayjoinSenderSession => "payjoin_sender_session",
         }
     }
 }
@@ -395,5 +433,48 @@ mod tests {
         db.delete_receive_address_cache().unwrap();
 
         assert_eq!(db.get_receive_address_cache().unwrap(), None);
+    }
+
+    #[test]
+    fn payjoin_sender_session_round_trips() {
+        let wallet_id = WalletId::preview_new_random();
+        let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
+        let session = PayjoinSenderSession {
+            events: vec![r#"{"PostedOriginalPsbt":[]}"#.to_string()],
+            fallback_tx: vec![0x02, 0x00, 0x00, 0x00],
+            created_at_secs: None,
+            pending_action: None,
+        };
+
+        db.set_payjoin_sender_session(session.clone()).unwrap();
+
+        assert_eq!(db.get_payjoin_sender_session().unwrap(), Some(session));
+    }
+
+    #[test]
+    fn delete_payjoin_sender_session_clears_session() {
+        let wallet_id = WalletId::preview_new_random();
+        let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
+        let session = PayjoinSenderSession {
+            events: vec![r#"{"Closed":"Failure"}"#.to_string()],
+            fallback_tx: vec![0x02, 0x00, 0x00, 0x00],
+            created_at_secs: None,
+            pending_action: None,
+        };
+
+        db.set_payjoin_sender_session(session).unwrap();
+        db.delete_payjoin_sender_session().unwrap();
+
+        assert_eq!(db.get_payjoin_sender_session().unwrap(), None);
+    }
+
+    #[test]
+    fn delete_missing_payjoin_sender_session_succeeds() {
+        let wallet_id = WalletId::preview_new_random();
+        let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
+
+        db.delete_payjoin_sender_session().unwrap();
+
+        assert_eq!(db.get_payjoin_sender_session().unwrap(), None);
     }
 }

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -211,6 +211,13 @@ impl WalletActor {
         Produces::ok(())
     }
 
+    pub async fn notify_payjoin_error(&mut self, msg: String) -> ActorResult<()> {
+        self.send(WalletManagerReconcileMessage::SendFlowError(
+            SendFlowErrorAlert::SignAndBroadcast(msg),
+        ));
+        Produces::ok(())
+    }
+
     #[into_actor_result]
     pub async fn unlocked_trusted_spendable_balance(&mut self) -> Result<Amount, Error> {
         self.unlocked_trusted_spendable_balance_inner()

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -17,7 +17,7 @@ mod scan;
 mod transaction_confirmation;
 mod transactions;
 
-use super::payjoin::PayjoinActor;
+use super::payjoin::{PayjoinActor, SessionResumption, resume_session};
 use act_zero::{runtimes::tokio::spawn_actor, *};
 use act_zero_ext::into_actor_result;
 use ahash::HashMap;
@@ -108,6 +108,7 @@ impl Actor for WalletActor {
         self.addr = addr.downgrade();
         self.spawn_scan_actor();
         send!(addr.check_node_connection());
+        send!(addr.resume_payjoin_session());
         Produces::ok(())
     }
 
@@ -183,6 +184,31 @@ impl WalletActor {
     pub async fn balance(&mut self) -> ActorResult<Balance> {
         let balance = self.wallet.balance();
         Produces::ok(balance)
+    }
+
+    /// Resumes a persisted payjoin session from a previous app run, if one exists
+    pub async fn resume_payjoin_session(&mut self) -> ActorResult<()> {
+        if self.payjoin_actor.is_some() {
+            return Produces::ok(());
+        }
+
+        match resume_session(self.db.clone(), self.addr.clone()) {
+            SessionResumption::None => {}
+
+            SessionResumption::Resume(actor) => {
+                self.payjoin_actor = Some(spawn_actor(*actor));
+            }
+
+            SessionResumption::BroadcastProposal { proposal_psbt, fallback_tx } => {
+                send!(self.addr.handle_payjoin_success(proposal_psbt, fallback_tx));
+            }
+
+            SessionResumption::BroadcastFallback { fallback_tx } => {
+                send!(self.addr.handle_payjoin_fallback(fallback_tx));
+            }
+        }
+
+        Produces::ok(())
     }
 
     #[into_actor_result]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -199,12 +199,20 @@ impl WalletActor {
                 self.payjoin_actor = Some(spawn_actor(*actor));
             }
 
+            SessionResumption::BroadcastStoredProposal { proposal_tx } => {
+                send!(self.addr.handle_payjoin_proposal_broadcast(proposal_tx));
+            }
+
             SessionResumption::BroadcastProposal { proposal_psbt, fallback_tx } => {
                 send!(self.addr.handle_payjoin_success(proposal_psbt, fallback_tx));
             }
 
             SessionResumption::BroadcastFallback { fallback_tx } => {
                 send!(self.addr.handle_payjoin_fallback(fallback_tx));
+            }
+
+            SessionResumption::ReportError { message } => {
+                send!(self.addr.notify_payjoin_error(message));
             }
         }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -203,8 +203,8 @@ impl WalletActor {
                 send!(self.addr.handle_payjoin_proposal_broadcast(proposal_tx));
             }
 
-            SessionResumption::SignRecoveredProposal { proposal_psbt } => {
-                send!(self.addr.handle_recovered_payjoin_success(proposal_psbt));
+            SessionResumption::SignRecoveredProposal { proposal_psbt, fallback_tx } => {
+                send!(self.addr.handle_recovered_payjoin_success(proposal_psbt, fallback_tx));
             }
 
             SessionResumption::BroadcastFallback { fallback_tx } => {
@@ -220,9 +220,7 @@ impl WalletActor {
     }
 
     pub async fn notify_payjoin_error(&mut self, msg: String) -> ActorResult<()> {
-        self.send(WalletManagerReconcileMessage::SendFlowError(
-            SendFlowErrorAlert::SignAndBroadcast(msg),
-        ));
+        self.send(WalletManagerReconcileMessage::WalletError(Error::SignAndBroadcastError(msg)));
         Produces::ok(())
     }
 
@@ -2618,6 +2616,163 @@ mod tests {
         assert_eq!(
             wallet_scan_progress_start(true, true),
             ScanProgressStart::Delayed(EMPTY_WALLET_SCAN_PROGRESS_DELAY)
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_gate_rejects_when_payjoin_session_pending_and_tx_not_in_wallet() {
+        crate::database::test_support::init_test_database();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+
+        let fallback_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+        crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone())
+            .create_session(&fallback_tx)
+            .unwrap();
+
+        actor.db = db;
+
+        let empty_psbt = bitcoin::Psbt::from_unsigned_tx(fallback_tx).unwrap();
+        let result = actor.initiate_payment(empty_psbt, None).await;
+        let outcome = actor_value(result).await;
+
+        assert!(
+            matches!(
+                &outcome,
+                Err(super::Error::SignAndBroadcastError(msg)) if msg.contains("pending recovery")
+            ),
+            "expected 'pending recovery' error but got: {outcome:?}",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_gate_clears_stale_session_when_terminal_tx_already_in_wallet() {
+        crate::database::test_support::init_test_database();
+        test_keychain();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([4; 32]) },
+        );
+
+        let outpoint = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(10_000));
+        let terminal_tx =
+            (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+
+        let persister =
+            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
+        persister.create_session(&terminal_tx).unwrap();
+        persister.set_pending_fallback().unwrap();
+
+        actor.db = db;
+
+        let dummy_psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        })
+        .unwrap();
+        let result = actor.initiate_payment(dummy_psbt, None).await;
+        let _ = actor_value(result).await;
+
+        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
+        assert!(session.is_none(), "gate should have cleared the stale session record");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_payjoin_terminal_skips_rebroadcast_when_tx_already_in_wallet() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([5; 32]) },
+        );
+
+        let outpoint = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(10_000));
+        let terminal_tx =
+            (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+
+        let persister =
+            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
+        persister.create_session(&terminal_tx).unwrap();
+        persister.set_pending_proposal(&terminal_tx).unwrap();
+
+        actor.db = db;
+
+        let result = actor.handle_payjoin_proposal_broadcast(terminal_tx).await;
+        actor_value(result).await;
+
+        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
+        assert!(
+            session.is_none(),
+            "session should be cleared when terminal tx is already in wallet"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn recovered_payjoin_signing_failure_retains_session_record() {
+        crate::database::test_support::init_test_database();
+        test_keychain();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+
+        let fallback_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+        crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone())
+            .create_session(&fallback_tx)
+            .unwrap();
+
+        actor.db = db;
+
+        let proposal_psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        })
+        .unwrap();
+
+        let result = actor.handle_recovered_payjoin_success(proposal_psbt, fallback_tx).await;
+        actor_value(result).await;
+
+        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
+        assert!(session.is_some(), "session must be retained when signing fails");
+        assert!(
+            session.unwrap().pending_action.is_none(),
+            "signing failure must not select fallback"
         );
     }
 }

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -203,8 +203,8 @@ impl WalletActor {
                 send!(self.addr.handle_payjoin_proposal_broadcast(proposal_tx));
             }
 
-            SessionResumption::BroadcastProposal { proposal_psbt, fallback_tx } => {
-                send!(self.addr.handle_payjoin_success(proposal_psbt, fallback_tx));
+            SessionResumption::SignRecoveredProposal { proposal_psbt } => {
+                send!(self.addr.handle_recovered_payjoin_success(proposal_psbt));
             }
 
             SessionResumption::BroadcastFallback { fallback_tx } => {

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -1218,7 +1218,6 @@ mod tests {
 
     use crate::wallet::metadata::WalletMetadata;
 
-    use super::transactions::BroadcastTransactionError;
     use super::{
         ActorState, EMPTY_WALLET_SCAN_PROGRESS_DELAY, FullScanType, InitialScanRoute,
         RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart, SingleOrMany,
@@ -1229,7 +1228,7 @@ mod tests {
     };
     use crate::{
         database::wallet_data::{
-            label::test_support::wallet_data_db_with_mismatched_output_table,
+            WalletDataDb, label::test_support::wallet_data_db_with_mismatched_output_table,
             test_support::new_test_wallet_data_db,
         },
         manager::wallet_manager::{
@@ -1287,6 +1286,12 @@ mod tests {
     impl super::WalletActor {
         async fn in_memory_wallet_metadata(&mut self) -> act_zero::ActorResult<WalletMetadata> {
             act_zero::Produces::ok(self.wallet.metadata.clone())
+        }
+
+        async fn set_test_wallet_data_db(&mut self, db: WalletDataDb) -> act_zero::ActorResult<()> {
+            self.db = db;
+
+            act_zero::Produces::ok(())
         }
 
         async fn set_last_height_fetched_for_test(
@@ -1671,20 +1676,6 @@ mod tests {
         });
 
         BroadcastEsploraNode { broadcast_requests, server }
-    }
-
-    async fn wait_for_broadcast_count(server: &BroadcastEsploraNode, count: usize) {
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if server.broadcast_requests.load(Ordering::SeqCst) == count {
-                    return;
-                }
-
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("broadcast count is reached");
     }
 
     fn restore_default_bitcoin_node() {
@@ -2215,47 +2206,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn payjoin_proposal_falls_back_only_when_network_broadcast_failed() {
-        let _guard = crate::test_support::global_state_test_lock().lock().await;
-
-        crate::database::test_support::init_test_database();
-        let server = set_broadcast_esplora_node(200).await;
-
-        let metadata = WalletMetadata::preview_new();
-        let mut wallet = persisted_preview_wallet(metadata.clone());
-        mark_wallet_ledger_ready(&mut wallet);
-        let (addr, _receiver) = spawn_test_wallet_actor(wallet);
-
-        call!(addr.handle_payjoin_proposal_broadcast_result(
-            Err(BroadcastTransactionError::PostBroadcastFailed(
-                super::Error::SignAndBroadcastError("bookkeeping failed".to_string())
-            )),
-            test_broadcast_transaction()
-        ))
-        .await
-        .expect("payjoin bookkeeping result is handled");
-
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 0);
-
-        call!(addr.handle_payjoin_proposal_broadcast_result(
-            Err(BroadcastTransactionError::BroadcastFailed(super::Error::SignAndBroadcastError(
-                "proposal failed".to_string()
-            ))),
-            test_broadcast_transaction()
-        ))
-        .await
-        .expect("payjoin network result is handled");
-        wait_for_broadcast_count(&server, 1).await;
-
-        restore_default_bitcoin_node();
-        server.server.abort();
-        let _ = crate::wallet::delete_wallet_specific_data(&metadata.id);
-
-        assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
     async fn slow_height_refresh_does_not_block_unrelated_actor_messages() {
         let _guard = crate::test_support::global_state_test_lock().lock().await;
 
@@ -2626,8 +2576,10 @@ mod tests {
         mark_wallet_ledger_ready(&mut wallet);
 
         let (sender, _receiver) = flume::bounded(10);
+        let wallet_snapshot = test_wallet_snapshot(&wallet);
         let mut actor =
-            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+            super::WalletActor::new(wallet, sender, test_scan_status(), wallet_snapshot)
+                .expect("actor is created");
         let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
 
         let fallback_tx = bitcoin::Transaction {
@@ -2671,8 +2623,10 @@ mod tests {
             (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
 
         let (sender, _receiver) = flume::bounded(10);
+        let wallet_snapshot = test_wallet_snapshot(&wallet);
         let mut actor =
-            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+            super::WalletActor::new(wallet, sender, test_scan_status(), wallet_snapshot)
+                .expect("actor is created");
         let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
 
         let persister =
@@ -2711,26 +2665,28 @@ mod tests {
         let terminal_tx =
             (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
 
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor =
-            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
 
         let persister =
             crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
         persister.create_session(&terminal_tx).unwrap();
         persister.set_pending_proposal(&terminal_tx).unwrap();
 
-        actor.db = db;
+        let (addr, _receiver) = spawn_test_wallet_actor(wallet);
+        call!(addr.set_test_wallet_data_db(db.clone())).await.expect("actor responds");
 
-        let result = actor.handle_payjoin_proposal_broadcast(terminal_tx).await;
-        actor_value(result).await;
+        call!(addr.handle_payjoin_proposal_broadcast(terminal_tx)).await.expect("actor responds");
 
-        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
-        assert!(
-            session.is_none(),
-            "session should be cleared when terminal tx is already in wallet"
-        );
+        for _ in 0..50 {
+            let session = db.get_payjoin_sender_session().expect("db query succeeded");
+            if session.is_none() {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        panic!("session should be cleared when terminal tx is already in wallet");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -2741,8 +2697,10 @@ mod tests {
         mark_wallet_ledger_ready(&mut wallet);
 
         let (sender, _receiver) = flume::bounded(10);
+        let wallet_snapshot = test_wallet_snapshot(&wallet);
         let mut actor =
-            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+            super::WalletActor::new(wallet, sender, test_scan_status(), wallet_snapshot)
+                .expect("actor is created");
         let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
 
         let fallback_tx = bitcoin::Transaction {

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2570,7 +2570,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn send_gate_rejects_when_payjoin_session_pending_and_tx_not_in_wallet() {
+    async fn send_gate_retries_pending_terminal_action_and_rejects_new_send() {
         crate::database::test_support::init_test_database();
         let mut wallet = Wallet::preview_new_wallet();
         mark_wallet_ledger_ready(&mut wallet);
@@ -2601,9 +2601,9 @@ mod tests {
         assert!(
             matches!(
                 &outcome,
-                Err(super::Error::SignAndBroadcastError(msg)) if msg.contains("pending recovery")
+                Err(super::Error::SignAndBroadcastError(msg)) if msg.contains("retrying")
             ),
-            "expected 'pending recovery' error but got: {outcome:?}",
+            "expected 'retrying' error but got: {outcome:?}",
         );
     }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2610,6 +2610,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn send_gate_clears_stale_session_when_terminal_tx_already_in_wallet() {
         crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
         test_keychain();
         let mut wallet = Wallet::preview_new_wallet();
         mark_wallet_ledger_ready(&mut wallet);
@@ -2644,10 +2645,11 @@ mod tests {
         })
         .unwrap();
         let result = actor.initiate_payment(dummy_psbt, None).await;
-        let _ = actor_value(result).await;
+        let outcome = actor_value(result).await;
 
         let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
         assert!(session.is_none(), "gate should have cleared the stale session record");
+        assert!(matches!(outcome, Err(super::Error::SignAndBroadcastError(_))));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -28,7 +28,7 @@ use crate::{
         Error, SendFlowErrorAlert, WalletManagerBuildTxError, WalletManagerError,
         WalletManagerFeesError, WalletManagerReconcileMessage,
         actor::{WalletActor, current_wallet_unspent_outpoints_for_txid, exclude_locked_outpoints},
-        payjoin::{PayjoinActor, PayjoinSender, build_sender},
+        payjoin::{PayjoinActor, PayjoinSessionPersister, build_sender},
     },
     mnemonic::{Mnemonic, MnemonicExt as _},
     node::client::NodeClient,
@@ -454,6 +454,24 @@ impl WalletActor {
             )));
         }
 
+        match self.db.get_payjoin_sender_session() {
+            Ok(None) => {}
+
+            Ok(Some(_)) => {
+                return Produces::ok(Err(Error::SignAndBroadcastError(
+                    "a previous payjoin session is pending recovery; please try again later"
+                        .to_string(),
+                )));
+            }
+
+            Err(error) => {
+                error!("failed to check for pending payjoin session: {error}");
+                return Produces::ok(Err(Error::SignAndBroadcastError(
+                    "unable to verify payjoin session state; please try again later".to_string(),
+                )));
+            }
+        }
+
         match payjoin_endpoint {
             None => {
                 let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
@@ -478,14 +496,23 @@ impl WalletActor {
         let (signed_psbt, fallback_tx) = self.do_sign_original_psbt(psbt).await?;
         let network: bitcoin::Network = self.wallet.network.into();
 
-        let Ok(sender) = build_sender(signed_psbt, &fallback_tx, endpoint, network)
+        // persist the session before the first network request so it survives app restarts
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.create_session(&fallback_tx) {
+            warn!("payjoin session could not be persisted, broadcasting fallback tx: {error}");
+            send!(self.addr.handle_payjoin_fallback(fallback_tx));
+            return Ok(());
+        }
+
+        let Ok(sender) = build_sender(signed_psbt, &fallback_tx, endpoint, network, &persister)
             .inspect_err(|error| warn!("payjoin setup failed, broadcasting fallback tx: {error}"))
         else {
             send!(self.addr.handle_payjoin_fallback(fallback_tx));
             return Ok(());
         };
 
-        self.spawn_payjoin_actor(sender, fallback_tx);
+        let actor = PayjoinActor::new(self.addr.clone(), persister, sender, fallback_tx);
+        self.spawn_payjoin_actor(actor);
         Ok(())
     }
 
@@ -640,6 +667,22 @@ impl WalletActor {
         });
     }
 
+    fn start_payjoin_fallback_broadcast(&mut self, tx: BdkTransaction) {
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.set_pending_fallback() {
+            error!("failed to persist fallback intent before broadcast, aborting: {error}");
+            self.send(WalletManagerReconcileMessage::SendFlowError(
+                SendFlowErrorAlert::SignAndBroadcast(
+                    "failed to persist recovery state; please restart the app".to_string(),
+                ),
+            ));
+            self.payjoin_actor = None;
+            return;
+        }
+
+        self.start_payjoin_broadcast_and_notify(tx);
+    }
+
     fn start_payjoin_proposal_broadcast(
         &mut self,
         proposal_tx: BdkTransaction,
@@ -654,17 +697,32 @@ impl WalletActor {
         });
     }
 
+    fn clear_payjoin_sender_session(&self) {
+        if let Err(error) = self.db.delete_payjoin_sender_session() {
+            warn!("failed to clear payjoin session record: {error}");
+        }
+    }
+
     async fn handle_payjoin_broadcast_result(
         &mut self,
         result: Result<(), BroadcastTransactionError>,
     ) -> ActorResult<()> {
         match result {
             Ok(()) => {
+                self.clear_payjoin_sender_session();
                 self.send(WalletManagerReconcileMessage::PayjoinTxBroadcast);
             }
-            Err(error) => {
-                let error = error.into_error();
+
+            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
                 error!("payjoin broadcast failed: {error}");
+                self.send(WalletManagerReconcileMessage::SendFlowError(
+                    SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
+                ));
+            }
+
+            Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
+                self.clear_payjoin_sender_session();
+                error!("payjoin broadcast bookkeeping failed: {error}");
                 self.send(WalletManagerReconcileMessage::SendFlowError(
                     SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
                 ));
@@ -682,6 +740,7 @@ impl WalletActor {
     ) -> ActorResult<()> {
         match result {
             Ok(()) => {
+                self.clear_payjoin_sender_session();
                 self.send(WalletManagerReconcileMessage::PayjoinTxBroadcast);
                 self.payjoin_actor = None;
             }
@@ -689,9 +748,10 @@ impl WalletActor {
                 error!(
                     "failed to broadcast payjoin proposal, falling back to original tx: {error:?}"
                 );
-                self.start_payjoin_broadcast_and_notify(fallback_tx);
+                self.start_payjoin_fallback_broadcast(fallback_tx);
             }
             Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
+                self.clear_payjoin_sender_session();
                 error!("payjoin proposal broadcast bookkeeping failed: {error}");
                 self.send(WalletManagerReconcileMessage::SendFlowError(
                     SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
@@ -713,7 +773,7 @@ impl WalletActor {
                 error!("failed to sign payjoin proposal, falling back to original tx: {error:?}")
             })
         else {
-            self.start_payjoin_broadcast_and_notify(fallback_tx);
+            self.start_payjoin_fallback_broadcast(fallback_tx);
             return Produces::ok(());
         };
 
@@ -729,9 +789,8 @@ impl WalletActor {
         Produces::ok(())
     }
 
-    fn spawn_payjoin_actor(&mut self, sender: PayjoinSender, fallback_tx: BdkTransaction) {
-        self.payjoin_actor =
-            Some(spawn_actor(PayjoinActor::new(self.addr.clone(), sender, fallback_tx)));
+    fn spawn_payjoin_actor(&mut self, actor: PayjoinActor) {
+        self.payjoin_actor = Some(spawn_actor(actor));
     }
 
     fn get_max_send_for_utxos(

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -658,19 +658,53 @@ impl WalletActor {
         send!(self.addr.start_transaction_watcher(txid));
     }
 
-    fn start_payjoin_broadcast_and_notify(&mut self, tx: BdkTransaction) {
+    fn start_payjoin_terminal_broadcast(&mut self, tx: BdkTransaction) {
         let connection = self.deferred_node_connection();
 
         self.addr.send_fut_with(|addr| async move {
-            let result = broadcast_transaction_with_connection(addr.clone(), connection, tx).await;
-            send!(addr.handle_payjoin_broadcast_result(result));
+            let result =
+                broadcast_payjoin_terminal_with_connection(addr.clone(), connection, tx).await;
+            send!(addr.handle_payjoin_terminal_broadcast_result(result));
         });
     }
 
     fn start_payjoin_fallback_broadcast(&mut self, tx: BdkTransaction) {
+        match self.db.get_payjoin_sender_session() {
+            Ok(None) => {}
+
+            Ok(Some(_)) => {
+                let persister = PayjoinSessionPersister::new(self.db.clone());
+                if let Err(error) = persister.set_pending_fallback() {
+                    error!("failed to persist fallback intent before broadcast, aborting: {error}");
+                    self.send(WalletManagerReconcileMessage::SendFlowError(
+                        SendFlowErrorAlert::SignAndBroadcast(
+                            "failed to persist recovery state; please restart the app".to_string(),
+                        ),
+                    ));
+                    self.payjoin_actor = None;
+                    return;
+                }
+            }
+
+            Err(error) => {
+                error!("failed to check for payjoin session before fallback, aborting: {error}");
+                self.send(WalletManagerReconcileMessage::SendFlowError(
+                    SendFlowErrorAlert::SignAndBroadcast(
+                        "failed to persist recovery state; please restart the app".to_string(),
+                    ),
+                ));
+                self.payjoin_actor = None;
+                return;
+            }
+        }
+
+        self.start_payjoin_terminal_broadcast(tx);
+    }
+
+    fn start_payjoin_proposal_broadcast(&mut self, proposal_tx: BdkTransaction) {
         let persister = PayjoinSessionPersister::new(self.db.clone());
-        if let Err(error) = persister.set_pending_fallback() {
-            error!("failed to persist fallback intent before broadcast, aborting: {error}");
+        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
+            error!("failed to persist proposal broadcast intent, aborting: {error}");
             self.send(WalletManagerReconcileMessage::SendFlowError(
                 SendFlowErrorAlert::SignAndBroadcast(
                     "failed to persist recovery state; please restart the app".to_string(),
@@ -680,38 +714,57 @@ impl WalletActor {
             return;
         }
 
-        self.start_payjoin_broadcast_and_notify(tx);
+        self.start_payjoin_terminal_broadcast(proposal_tx);
     }
 
-    fn start_payjoin_proposal_broadcast(
+    async fn apply_payjoin_terminal_broadcast(
         &mut self,
-        proposal_tx: BdkTransaction,
-        fallback_tx: BdkTransaction,
-    ) {
-        let connection = self.deferred_node_connection();
+        tx: BdkTransaction,
+    ) -> ActorResult<Result<(), Error>> {
+        use WalletManagerReconcileMessage as Msg;
 
-        self.addr.send_fut_with(|addr| async move {
-            let result =
-                broadcast_transaction_with_connection(addr.clone(), connection, proposal_tx).await;
-            send!(addr.handle_payjoin_proposal_broadcast_result(result, fallback_tx));
-        });
-    }
+        let now =
+            SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_else(|e| {
+                warn!("System clock skew detected: {e}");
+                u64::MAX
+            });
+        let txid = tx.compute_txid();
 
-    fn clear_payjoin_sender_session(&self) {
+        self.wallet.bdk.apply_unconfirmed_txs([(tx, now)]);
+
+        // keep the session record until wallet state is durable so startup can recover
+        if let Err(error) = self.wallet.persist() {
+            error!(
+                "failed to persist wallet after payjoin broadcast; retaining session record for recovery: {error}"
+            );
+            return Produces::ok(Err(Error::SignAndBroadcastError(
+                "transaction was broadcast but wallet state could not be saved; please restart the app"
+                    .to_string(),
+            )));
+        }
+
         if let Err(error) = self.db.delete_payjoin_sender_session() {
             warn!("failed to clear payjoin session record: {error}");
         }
+
+        let balance = self.wallet.balance();
+        self.send(Msg::WalletBalanceChanged(balance.into()));
+
+        let transactions = self.do_transactions().await;
+        self.send(Msg::UpdatedTransactions(transactions));
+
+        send!(self.addr.start_transaction_watcher(txid));
+        self.send(Msg::PayjoinTxBroadcast);
+
+        Produces::ok(Ok(()))
     }
 
-    async fn handle_payjoin_broadcast_result(
+    async fn handle_payjoin_terminal_broadcast_result(
         &mut self,
         result: Result<(), BroadcastTransactionError>,
     ) -> ActorResult<()> {
         match result {
-            Ok(()) => {
-                self.clear_payjoin_sender_session();
-                self.send(WalletManagerReconcileMessage::PayjoinTxBroadcast);
-            }
+            Ok(()) => {}
 
             Err(BroadcastTransactionError::BroadcastFailed(error)) => {
                 error!("payjoin broadcast failed: {error}");
@@ -721,7 +774,6 @@ impl WalletActor {
             }
 
             Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
-                self.clear_payjoin_sender_session();
                 error!("payjoin broadcast bookkeeping failed: {error}");
                 self.send(WalletManagerReconcileMessage::SendFlowError(
                     SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
@@ -730,36 +782,6 @@ impl WalletActor {
         }
 
         self.payjoin_actor = None;
-        Produces::ok(())
-    }
-
-    pub(crate) async fn handle_payjoin_proposal_broadcast_result(
-        &mut self,
-        result: Result<(), BroadcastTransactionError>,
-        fallback_tx: BdkTransaction,
-    ) -> ActorResult<()> {
-        match result {
-            Ok(()) => {
-                self.clear_payjoin_sender_session();
-                self.send(WalletManagerReconcileMessage::PayjoinTxBroadcast);
-                self.payjoin_actor = None;
-            }
-            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
-                error!(
-                    "failed to broadcast payjoin proposal, falling back to original tx: {error:?}"
-                );
-                self.start_payjoin_fallback_broadcast(fallback_tx);
-            }
-            Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
-                self.clear_payjoin_sender_session();
-                error!("payjoin proposal broadcast bookkeeping failed: {error}");
-                self.send(WalletManagerReconcileMessage::SendFlowError(
-                    SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
-                ));
-                self.payjoin_actor = None;
-            }
-        }
-
         Produces::ok(())
     }
 
@@ -777,7 +799,15 @@ impl WalletActor {
             return Produces::ok(());
         };
 
-        self.start_payjoin_proposal_broadcast(proposal_tx, fallback_tx);
+        self.start_payjoin_proposal_broadcast(proposal_tx);
+        Produces::ok(())
+    }
+
+    pub async fn handle_payjoin_proposal_broadcast(
+        &mut self,
+        proposal_tx: BdkTransaction,
+    ) -> ActorResult<()> {
+        self.start_payjoin_terminal_broadcast(proposal_tx);
         Produces::ok(())
     }
 
@@ -785,7 +815,7 @@ impl WalletActor {
         &mut self,
         fallback_tx: BdkTransaction,
     ) -> ActorResult<()> {
-        self.start_payjoin_broadcast_and_notify(fallback_tx);
+        self.start_payjoin_fallback_broadcast(fallback_tx);
         Produces::ok(())
     }
 
@@ -965,6 +995,36 @@ async fn broadcast_transaction_with_connection(
     connection: Produces<Result<(), Error>>,
     transaction: BdkTransaction,
 ) -> Result<(), BroadcastTransactionError> {
+    broadcast_to_node_with_connection(addr.clone(), connection, &transaction).await?;
+
+    call!(addr.apply_broadcast_transaction(transaction))
+        .await
+        .map_err(|_| BroadcastTransactionError::PostBroadcastFailed(Error::ActorNotFound))?
+        .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
+
+    Ok(())
+}
+
+async fn broadcast_payjoin_terminal_with_connection(
+    addr: WeakAddr<WalletActor>,
+    connection: Produces<Result<(), Error>>,
+    transaction: BdkTransaction,
+) -> Result<(), BroadcastTransactionError> {
+    broadcast_to_node_with_connection(addr.clone(), connection, &transaction).await?;
+
+    call!(addr.apply_payjoin_terminal_broadcast(transaction))
+        .await
+        .map_err(|_| BroadcastTransactionError::PostBroadcastFailed(Error::ActorNotFound))?
+        .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
+
+    Ok(())
+}
+
+async fn broadcast_to_node_with_connection(
+    addr: WeakAddr<WalletActor>,
+    connection: Produces<Result<(), Error>>,
+    transaction: &BdkTransaction,
+) -> Result<(), BroadcastTransactionError> {
     connection
         .await
         .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?
@@ -984,11 +1044,6 @@ async fn broadcast_transaction_with_connection(
             "failed to broadcast transaction, try again: {error:?}"
         )))
     })?;
-
-    call!(addr.apply_broadcast_transaction(transaction))
-        .await
-        .map_err(|_| BroadcastTransactionError::PostBroadcastFailed(Error::ActorNotFound))?
-        .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
 
     Ok(())
 }

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -811,6 +811,47 @@ impl WalletActor {
         Produces::ok(())
     }
 
+    /// Handles a recovered session that closed with a receiver proposal but no stored tx.
+    /// On signing failure the session record is kept for retry — the receiver's proposal was valid
+    /// and the original transaction must not be broadcast as a fallback.
+    pub async fn handle_recovered_payjoin_success(
+        &mut self,
+        proposal_psbt: Psbt,
+    ) -> ActorResult<()> {
+        let proposal_tx = match self.do_sign_original_psbt(proposal_psbt).await {
+            Ok((_, tx)) => tx,
+            Err(error) => {
+                error!("failed to sign recovered payjoin proposal, pausing for retry: {error:?}");
+                // retain the session record — the receiver's proposal was valid;
+                // do not broadcast the fallback or write any terminal marker
+                self.send(WalletManagerReconcileMessage::SendFlowError(
+                    SendFlowErrorAlert::SignAndBroadcast(
+                        "could not sign the recovered payjoin proposal; unlock the wallet and restart"
+                            .to_string(),
+                    ),
+                ));
+                self.payjoin_actor = None;
+                return Produces::ok(());
+            }
+        };
+
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
+            error!("failed to persist recovered proposal intent, aborting: {error}");
+            self.send(WalletManagerReconcileMessage::SendFlowError(
+                SendFlowErrorAlert::SignAndBroadcast(
+                    "failed to persist recovery state; please restart the app".to_string(),
+                ),
+            ));
+            self.payjoin_actor = None;
+            return Produces::ok(());
+        }
+
+        self.broadcast_payjoin_terminal(proposal_tx).await;
+        self.payjoin_actor = None;
+        Produces::ok(())
+    }
+
     pub async fn handle_payjoin_fallback(
         &mut self,
         fallback_tx: BdkTransaction,

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -467,8 +467,10 @@ impl WalletActor {
                     .is_some_and(|txid| self.wallet.bdk.get_tx(txid).is_some());
 
                 if !can_cleanup {
+                    // Broadcast hasn't completed yet, re-dispatch so the user doesn't need to restart.
+                    send!(self.addr.resume_payjoin_session());
                     return Produces::ok(Err(Error::SignAndBroadcastError(
-                        "a previous payjoin session is pending recovery; please try again later"
+                        "retrying a previous payjoin broadcast; please try again in a moment"
                             .to_string(),
                     )));
                 }
@@ -1129,7 +1131,8 @@ async fn payjoin_tx_known_to_node(addr: WeakAddr<WalletActor>, txid: Txid) -> bo
         _ => return false,
     };
 
-    matches!(node_client.get_transaction(txid).await, Ok(Some(ref found)) if found.compute_txid() == txid)
+    let response = node_client.get_transaction(txid).await;
+    matches!(response, Ok(Some(ref found)) if found.compute_txid() == txid)
 }
 
 async fn broadcast_to_node_with_connection(

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -664,7 +664,7 @@ impl WalletActor {
         let now =
             SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_else(|e| {
                 warn!("System clock skew detected: {e}");
-                u64::MAX
+                0
             });
         let txid = transaction.compute_txid();
 
@@ -759,7 +759,7 @@ impl WalletActor {
         let now =
             SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_else(|e| {
                 warn!("System clock skew detected: {e}");
-                u64::MAX
+                0
             });
         let txid = tx.compute_txid();
 
@@ -797,7 +797,8 @@ impl WalletActor {
         } else {
             // tx is broadcast and wallet-persisted, but the session record remains
             // initiate_payment will reject new sends until the record is gone
-            // the next startup will clear it automatically via the wallet pre-check
+            // on restart resume_payjoin_session re-dispatches the stored terminal tx
+            // because it is already in the wallet, broadcast is skipped and cleanup is retried
             self.send(Msg::SendFlowError(SendFlowErrorAlert::SignAndBroadcast(
                 "transaction was broadcast; restart the app to unlock sending".to_string(),
             )));
@@ -859,24 +860,26 @@ impl WalletActor {
     }
 
     /// Handles a recovered session that closed with a receiver proposal but no stored tx.
-    /// On signing failure the session record is kept for retry — the receiver's proposal was valid
-    /// and the original transaction must not be broadcast as a fallback.
+    /// On signing failure the session record is retained — the receiver's proposal was valid
+    /// and the user should retry after resolving the signing issue.
+    /// If the proposal intent cannot be persisted, `fallback_tx` is broadcast instead —
+    /// no terminal marker was written so falling back is safe at that point.
     pub async fn handle_recovered_payjoin_success(
         &mut self,
         proposal_psbt: Psbt,
+        fallback_tx: BdkTransaction,
     ) -> ActorResult<()> {
         let proposal_tx = match self.do_sign_original_psbt(proposal_psbt).await {
             Ok((_, tx)) => tx,
             Err(error) => {
                 error!("failed to sign recovered payjoin proposal, pausing for retry: {error:?}");
-                // retain the session record — the receiver's proposal was valid;
-                // do not broadcast the fallback or write any terminal marker
-                self.send(WalletManagerReconcileMessage::SendFlowError(
-                    SendFlowErrorAlert::SignAndBroadcast(
-                        "could not sign the recovered payjoin proposal; unlock the wallet and restart"
-                            .to_string(),
-                    ),
-                ));
+                // the receiver accepted a valid proposal; do not fall back — retain the record
+                // so the user can retry after resolving the signing failure
+                self
+                    .send(WalletManagerReconcileMessage::WalletError(Error::SignAndBroadcastError(
+                    "could not sign the recovered payjoin proposal; unlock the wallet and restart"
+                        .to_string(),
+                )));
                 self.payjoin_actor = None;
                 return Produces::ok(());
             }
@@ -884,13 +887,9 @@ impl WalletActor {
 
         let persister = PayjoinSessionPersister::new(self.db.clone());
         if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
-            error!("failed to persist recovered proposal intent, aborting: {error}");
-            self.send(WalletManagerReconcileMessage::SendFlowError(
-                SendFlowErrorAlert::SignAndBroadcast(
-                    "failed to persist recovery state; please restart the app".to_string(),
-                ),
-            ));
-            self.payjoin_actor = None;
+            error!("failed to persist recovered proposal intent, falling back: {error}");
+            // no terminal marker was written yet; safe to fall back to the original tx
+            self.start_payjoin_fallback_broadcast(fallback_tx);
             return Produces::ok(());
         }
 

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -717,6 +717,10 @@ impl WalletActor {
         self.start_payjoin_terminal_broadcast(proposal_tx);
     }
 
+    async fn payjoin_terminal_tx_in_wallet(&mut self, txid: Txid) -> ActorResult<bool> {
+        Produces::ok(self.wallet.bdk.get_tx(txid).is_some())
+    }
+
     async fn apply_payjoin_terminal_broadcast(
         &mut self,
         tx: BdkTransaction,
@@ -847,8 +851,7 @@ impl WalletActor {
             return Produces::ok(());
         }
 
-        self.broadcast_payjoin_terminal(proposal_tx).await;
-        self.payjoin_actor = None;
+        self.start_payjoin_terminal_broadcast(proposal_tx);
         Produces::ok(())
     }
 
@@ -1051,7 +1054,24 @@ async fn broadcast_payjoin_terminal_with_connection(
     connection: Produces<Result<(), Error>>,
     transaction: BdkTransaction,
 ) -> Result<(), BroadcastTransactionError> {
-    broadcast_to_node_with_connection(addr.clone(), connection, &transaction).await?;
+    let txid = transaction.compute_txid();
+    let already_in_wallet = call!(addr.payjoin_terminal_tx_in_wallet(txid))
+        .await
+        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?;
+
+    if !already_in_wallet {
+        match broadcast_to_node_with_connection(addr.clone(), connection, &transaction).await {
+            Ok(()) => {}
+
+            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
+                if !payjoin_tx_known_to_node(addr.clone(), txid).await {
+                    return Err(BroadcastTransactionError::BroadcastFailed(error));
+                }
+            }
+
+            Err(error) => return Err(error),
+        }
+    }
 
     call!(addr.apply_payjoin_terminal_broadcast(transaction))
         .await
@@ -1059,6 +1079,15 @@ async fn broadcast_payjoin_terminal_with_connection(
         .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
 
     Ok(())
+}
+
+async fn payjoin_tx_known_to_node(addr: WeakAddr<WalletActor>, txid: Txid) -> bool {
+    let node_client = match call!(addr.node_client_for_broadcast()).await {
+        Ok(Ok(node_client)) => node_client,
+        _ => return false,
+    };
+
+    matches!(node_client.get_transaction(txid).await, Ok(Some(ref found)) if found.compute_txid() == txid)
 }
 
 async fn broadcast_to_node_with_connection(

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -492,7 +492,14 @@ impl WalletActor {
                             .to_string(),
                     )));
                 }
-                // record cleared — fall through to allow this send
+
+                // The completed tx may have been the payjoin proposal, so reusing the
+                // supplied PSBT (which is still the fallback) could cause a conflict.
+                // Ask the user to confirm again now that the record is cleared.
+                return Produces::ok(Err(Error::SignAndBroadcastError(
+                    "previous payjoin session cleared; please confirm your payment again"
+                        .to_string(),
+                )));
             }
 
             Err(error) => {

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -458,10 +458,39 @@ impl WalletActor {
             Ok(None) => {}
 
             Ok(Some(_)) => {
-                return Produces::ok(Err(Error::SignAndBroadcastError(
-                    "a previous payjoin session is pending recovery; please try again later"
-                        .to_string(),
-                )));
+                // If the session has a terminal marker and the tx is already in the local
+                // wallet, the only remaining work is session cleanup — no network needed.
+                // Attempt it here so this send can proceed without requiring a restart.
+                let persister = PayjoinSessionPersister::new(self.db.clone());
+                let can_cleanup = persister
+                    .pending_txid()
+                    .is_some_and(|txid| self.wallet.bdk.get_tx(txid).is_some());
+
+                if !can_cleanup {
+                    return Produces::ok(Err(Error::SignAndBroadcastError(
+                        "a previous payjoin session is pending recovery; please try again later"
+                            .to_string(),
+                    )));
+                }
+
+                // Retry persistence before cleanup — a prior broadcast may have applied the tx
+                // in memory without flushing to disk; only drop the session once it is durable.
+                if let Err(error) = self.wallet.persist() {
+                    warn!("failed to persist wallet at send gate before payjoin cleanup: {error}");
+                    return Produces::ok(Err(Error::SignAndBroadcastError(
+                        "a previous payjoin session is pending cleanup; please try again later"
+                            .to_string(),
+                    )));
+                }
+
+                if let Err(error) = self.db.delete_payjoin_sender_session() {
+                    warn!("payjoin session cleanup at send gate failed: {error}");
+                    return Produces::ok(Err(Error::SignAndBroadcastError(
+                        "a previous payjoin session is pending cleanup; please try again later"
+                            .to_string(),
+                    )));
+                }
+                // record cleared — fall through to allow this send
             }
 
             Err(error) => {
@@ -747,9 +776,13 @@ impl WalletActor {
             )));
         }
 
-        if let Err(error) = self.db.delete_payjoin_sender_session() {
-            warn!("failed to clear payjoin session record: {error}");
-        }
+        let session_cleared = match self.db.delete_payjoin_sender_session() {
+            Ok(()) => true,
+            Err(error) => {
+                warn!("failed to clear payjoin session record: {error}");
+                false
+            }
+        };
 
         let balance = self.wallet.balance();
         self.send(Msg::WalletBalanceChanged(balance.into()));
@@ -758,7 +791,17 @@ impl WalletActor {
         self.send(Msg::UpdatedTransactions(transactions));
 
         send!(self.addr.start_transaction_watcher(txid));
-        self.send(Msg::PayjoinTxBroadcast);
+
+        if session_cleared {
+            self.send(Msg::PayjoinTxBroadcast);
+        } else {
+            // tx is broadcast and wallet-persisted, but the session record remains
+            // initiate_payment will reject new sends until the record is gone
+            // the next startup will clear it automatically via the wallet pre-check
+            self.send(Msg::SendFlowError(SendFlowErrorAlert::SignAndBroadcast(
+                "transaction was broadcast; restart the app to unlock sending".to_string(),
+            )));
+        }
 
         Produces::ok(Ok(()))
     }

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -682,8 +682,10 @@ pub(crate) enum SessionResumption {
     Resume(Box<PayjoinActor>),
     /// A BroadcastProposal marker was stored: broadcast this exact consensus-encoded tx
     BroadcastStoredProposal { proposal_tx: BdkTransaction },
-    /// Session closed with a success outcome but no stored tx: re-sign and broadcast
-    BroadcastProposal { proposal_psbt: Psbt, fallback_tx: BdkTransaction },
+    /// Session closed with a success outcome but no stored tx: sign the recovered PSBT and broadcast.
+    /// `fallback_tx` is intentionally omitted — a local signing failure during recovery must pause
+    /// and preserve the record rather than downgrade to the original transaction.
+    SignRecoveredProposal { proposal_psbt: Psbt },
     /// Session ended without a proposal, broadcast the original tx
     BroadcastFallback { fallback_tx: BdkTransaction },
     /// The stored proposal tx is corrupt; the record is retained and the user must be notified.
@@ -755,7 +757,7 @@ pub(crate) fn resume_session(
         }
 
         SendSession::Closed(SessionOutcome::Success(proposal_psbt)) => {
-            SessionResumption::BroadcastProposal { proposal_psbt, fallback_tx }
+            SessionResumption::SignRecoveredProposal { proposal_psbt }
         }
 
         SendSession::Closed(_) => SessionResumption::BroadcastFallback { fallback_tx },

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -136,6 +136,25 @@ impl PayjoinSessionPersister {
         };
         self.db.set_payjoin_sender_session(session)
     }
+
+    /// Returns the txid committed in the session's terminal marker, if any.
+    /// Used by the send gate to detect stale-cleanup state without a network call.
+    pub(crate) fn pending_txid(&self) -> Option<bitcoin::Txid> {
+        let session = self.db.get_payjoin_sender_session().ok()??;
+        match &session.pending_action {
+            None => None,
+            Some(PendingAction::BroadcastFallback) => {
+                consensus::deserialize::<BdkTransaction>(&session.fallback_tx)
+                    .ok()
+                    .map(|tx| tx.compute_txid())
+            }
+            Some(PendingAction::BroadcastProposal { transaction }) => {
+                consensus::deserialize::<BdkTransaction>(transaction)
+                    .ok()
+                    .map(|tx| tx.compute_txid())
+            }
+        }
+    }
 }
 
 impl SessionPersister for PayjoinSessionPersister {
@@ -704,7 +723,9 @@ pub(crate) fn resume_session(
         Ok(None) => return SessionResumption::None,
         Err(error) => {
             error!("failed to read payjoin session record: {error}");
-            return SessionResumption::None;
+            return SessionResumption::ReportError {
+                message: "could not read payjoin session; reopen the wallet to retry".to_string(),
+            };
         }
     };
 
@@ -764,16 +785,32 @@ pub(crate) fn resume_session(
     }
 }
 
-/// Recovers the fallback tx stored in the session record when replay is not possible
+/// Recovers the fallback tx from the session record when replay is not possible.
 fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
     match consensus::deserialize(&record.fallback_tx) {
         Ok(fallback_tx) => SessionResumption::BroadcastFallback { fallback_tx },
-        Err(error) => {
-            error!("stored payjoin fallback tx is corrupt, abandoning session: {error}");
-            if let Err(error) = db.delete_payjoin_sender_session() {
-                warn!("failed to clear corrupt payjoin session record: {error}");
+
+        Err(error) if matches!(record.pending_action, Some(PendingAction::BroadcastFallback)) => {
+            // Marker was written before broadcast, so the fallback may have reached the node.
+            // Retain the record — we can't know the outcome.
+            error!(
+                "committed payjoin fallback tx is unreadable; retaining session record: {error}"
+            );
+            SessionResumption::ReportError {
+                message: "payjoin fallback data is unreadable — check your transaction history before retrying".to_string(),
             }
-            SessionResumption::None
+        }
+
+        Err(error) => {
+            // No terminal marker means the fallback was never dispatched; safe to clear.
+            error!("payjoin fallback tx is corrupt, clearing session: {error}");
+            if let Err(delete_error) = db.delete_payjoin_sender_session() {
+                warn!("failed to clear corrupt payjoin session record: {delete_error}");
+            }
+            SessionResumption::ReportError {
+                message: "saved payjoin recovery data was unreadable; the payment was not sent"
+                    .to_string(),
+            }
         }
     }
 }
@@ -1133,7 +1170,37 @@ mod tests {
 
         let resumption = resume_session(db.clone(), WeakAddr::default());
 
-        assert!(matches!(resumption, SessionResumption::None));
-        assert_eq!(db.get_payjoin_sender_session().unwrap(), None);
+        assert!(
+            matches!(resumption, SessionResumption::ReportError { .. }),
+            "corrupt fallback with no marker must surface an error"
+        );
+        assert_eq!(
+            db.get_payjoin_sender_session().unwrap(),
+            None,
+            "record must be cleared when fallback was never dispatched"
+        );
+    }
+
+    #[test]
+    fn resume_with_corrupt_committed_fallback_retains_the_record() {
+        let (_persister, db, _tmp) = new_test_persister();
+        let session = PayjoinSenderSession {
+            events: vec![],
+            fallback_tx: vec![0xff],
+            created_at_secs: None,
+            pending_action: Some(PendingAction::BroadcastFallback), // marker written before crash
+        };
+        db.set_payjoin_sender_session(session).unwrap();
+
+        let resumption = resume_session(db.clone(), WeakAddr::default());
+
+        assert!(
+            matches!(resumption, SessionResumption::ReportError { .. }),
+            "corrupt committed fallback must surface an error"
+        );
+        assert!(
+            db.get_payjoin_sender_session().unwrap().is_some(),
+            "record must be retained when broadcast outcome is unknown"
+        );
     }
 }

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -50,8 +50,8 @@ impl PayjoinSessionPersister {
     }
 
     /// Marks the session as committed to broadcasting the fallback transaction.
-    /// Must be called before the fallback broadcast begins so a crash mid-broadcast
-    /// causes the next startup to go straight to fallback instead of resuming negotiation.
+    /// Idempotent: `None → BroadcastFallback` and `BroadcastFallback → ok`.
+    /// Rejects an attempt to downgrade a `BroadcastProposal` commitment.
     pub(crate) fn set_pending_fallback(&self) -> Result<(), WalletDataError> {
         let _guard = self
             .lock
@@ -63,7 +63,54 @@ impl PayjoinSessionPersister {
             .get_payjoin_sender_session()?
             .ok_or_else(|| WalletDataError::Save("no payjoin session record".to_string()))?;
 
+        match &session.pending_action {
+            None => {}
+
+            Some(PendingAction::BroadcastFallback) => return Ok(()),
+
+            Some(PendingAction::BroadcastProposal { .. }) => {
+                return Err(WalletDataError::Save(
+                    "cannot overwrite BroadcastProposal commitment with BroadcastFallback"
+                        .to_string(),
+                ));
+            }
+        }
+
         session.pending_action = Some(PendingAction::BroadcastFallback);
+        self.db.set_payjoin_sender_session(session)
+    }
+
+    /// Persists the exact consensus-encoded proposal transaction before broadcasting.
+    /// Idempotent when called with the same transaction bytes.
+    /// Rejects overwriting with a different transaction or any other pending action.
+    pub(crate) fn set_pending_proposal(&self, tx: &BdkTransaction) -> Result<(), WalletDataError> {
+        let tx_bytes = consensus::serialize(tx);
+
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| WalletDataError::Save("session lock poisoned".to_string()))?;
+
+        let mut session = self
+            .db
+            .get_payjoin_sender_session()?
+            .ok_or_else(|| WalletDataError::Save("no payjoin session record".to_string()))?;
+
+        match &session.pending_action {
+            None => {}
+
+            Some(PendingAction::BroadcastProposal { transaction }) if *transaction == tx_bytes => {
+                return Ok(());
+            }
+
+            Some(_) => {
+                return Err(WalletDataError::Save(
+                    "cannot overwrite existing terminal action with BroadcastProposal".to_string(),
+                ));
+            }
+        }
+
+        session.pending_action = Some(PendingAction::BroadcastProposal { transaction: tx_bytes });
         self.db.set_payjoin_sender_session(session)
     }
 
@@ -106,13 +153,12 @@ impl SessionPersister for PayjoinSessionPersister {
             .get_payjoin_sender_session()?
             .ok_or_else(|| WalletDataError::Save("no payjoin session record".to_string()))?;
 
-        // Reject late events after the fallback commitment is written: an in-flight
-        // poll response arriving after complete_with_fallback must not overwrite
-        // pending_action back to None and corrupt the crash-recovery marker.
-        // The shared lock ensures this check-then-write is atomic with set_pending_fallback.
-        if matches!(session.pending_action, Some(PendingAction::BroadcastFallback)) {
+        // Reject late events once any terminal intent is committed: an in-flight poll
+        // response must not overwrite a BroadcastFallback or BroadcastProposal marker.
+        // The shared lock ensures this check-then-write is atomic with set_pending_action.
+        if session.pending_action.is_some() {
             return Err(WalletDataError::Save(
-                "session is committed to fallback; rejecting late event".to_string(),
+                "session has a committed terminal action; rejecting late event".to_string(),
             ));
         }
 
@@ -634,10 +680,16 @@ pub(crate) enum SessionResumption {
     None,
     /// Session is still in flight, spawn this actor to continue it
     Resume(Box<PayjoinActor>),
-    /// Session already completed with a proposal, sign and broadcast it
+    /// A BroadcastProposal marker was stored: broadcast this exact consensus-encoded tx
+    BroadcastStoredProposal { proposal_tx: BdkTransaction },
+    /// Session closed with a success outcome but no stored tx: re-sign and broadcast
     BroadcastProposal { proposal_psbt: Psbt, fallback_tx: BdkTransaction },
     /// Session ended without a proposal, broadcast the original tx
     BroadcastFallback { fallback_tx: BdkTransaction },
+    /// The stored proposal tx is corrupt; the record is retained and the user must be notified.
+    /// Cove cannot know whether that proposal reached the network before the corruption/restart,
+    /// so it must not fall back automatically.
+    ReportError { message: String },
 }
 
 /// Replays a persisted payjoin session from the wallet's database, if one exists
@@ -658,6 +710,12 @@ pub(crate) fn resume_session(
     // non-terminal events in the log; honour the stored intent instead of replaying them.
     if matches!(record.pending_action, Some(PendingAction::BroadcastFallback)) {
         return fallback_from_record(&db, record);
+    }
+
+    // A crash after set_pending_proposal but before the broadcast completed means the
+    // proposal tx is committed — re-broadcast it without re-signing instead of replaying.
+    if matches!(record.pending_action, Some(PendingAction::BroadcastProposal { .. })) {
+        return proposal_from_record(&db, record);
     }
 
     let persister = PayjoinSessionPersister::new(db.clone());
@@ -714,6 +772,30 @@ fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> Sess
                 warn!("failed to clear corrupt payjoin session record: {error}");
             }
             SessionResumption::None
+        }
+    }
+}
+
+/// Recovers the proposal tx committed in a `BroadcastProposal` marker so it can be
+/// re-broadcast on the next startup without re-signing.
+///
+/// If the stored bytes are corrupt the record is **retained** and `ReportError` is returned.
+/// We cannot know whether that proposal reached the network before the corruption/restart,
+/// so deleting the record or broadcasting the fallback would be unsafe.
+fn proposal_from_record(_db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
+    let tx_bytes = match &record.pending_action {
+        Some(PendingAction::BroadcastProposal { transaction }) => transaction.clone(),
+        _ => unreachable!("proposal_from_record called without BroadcastProposal action"),
+    };
+    match consensus::deserialize::<BdkTransaction>(&tx_bytes) {
+        Ok(proposal_tx) => SessionResumption::BroadcastStoredProposal { proposal_tx },
+        Err(error) => {
+            error!(
+                "stored payjoin proposal tx is corrupt; retaining record for manual recovery: {error}"
+            );
+            SessionResumption::ReportError {
+                message: "payjoin proposal data is unreadable — check your transaction history before retrying".to_string(),
+            }
         }
     }
 }
@@ -955,6 +1037,85 @@ mod tests {
             SessionResumption::BroadcastFallback { fallback_tx } => assert_eq!(fallback_tx, tx),
             _ => panic!("expected BroadcastFallback"),
         }
+    }
+
+    #[test]
+    fn set_pending_fallback_rejects_overwrite_of_proposal() {
+        let (persister, _db, _tmp) = new_test_persister();
+        let tx = empty_transaction();
+        persister.create_session(&test_fallback_tx()).unwrap();
+        persister.set_pending_proposal(&tx).unwrap();
+
+        let result = persister.set_pending_fallback();
+
+        assert!(result.is_err(), "BroadcastFallback must not overwrite BroadcastProposal");
+    }
+
+    #[test]
+    fn set_pending_proposal_is_idempotent() {
+        let (persister, db, _tmp) = new_test_persister();
+        let tx = empty_transaction();
+        persister.create_session(&test_fallback_tx()).unwrap();
+        persister.set_pending_proposal(&tx).unwrap();
+
+        // calling again with the same tx must succeed
+        persister.set_pending_proposal(&tx).unwrap();
+
+        let session = db.get_payjoin_sender_session().unwrap().unwrap();
+        assert!(
+            matches!(session.pending_action, Some(PendingAction::BroadcastProposal { .. })),
+            "action must still be BroadcastProposal after idempotent call"
+        );
+    }
+
+    #[test]
+    fn resume_with_proposal_marker_returns_broadcast_stored_proposal() {
+        let (_persister, db, _tmp) = new_test_persister();
+        let tx = empty_transaction();
+        let session = PayjoinSenderSession {
+            events: vec![],
+            fallback_tx: consensus::serialize(&test_fallback_tx()),
+            created_at_secs: None,
+            pending_action: Some(PendingAction::BroadcastProposal {
+                transaction: consensus::serialize(&tx),
+            }),
+        };
+        db.set_payjoin_sender_session(session).unwrap();
+
+        let resumption = resume_session(db, WeakAddr::default());
+
+        match resumption {
+            SessionResumption::BroadcastStoredProposal { proposal_tx } => {
+                assert_eq!(proposal_tx, tx)
+            }
+            _ => panic!("expected BroadcastStoredProposal"),
+        }
+    }
+
+    #[test]
+    fn resume_with_corrupt_proposal_retains_record_and_reports_error() {
+        let (_persister, db, _tmp) = new_test_persister();
+        let session = PayjoinSenderSession {
+            events: vec![],
+            fallback_tx: consensus::serialize(&test_fallback_tx()),
+            created_at_secs: None,
+            pending_action: Some(PendingAction::BroadcastProposal {
+                transaction: vec![0xff], // corrupt bytes
+            }),
+        };
+        db.set_payjoin_sender_session(session).unwrap();
+
+        let resumption = resume_session(db.clone(), WeakAddr::default());
+
+        assert!(
+            matches!(resumption, SessionResumption::ReportError { .. }),
+            "corrupt proposal must return ReportError, not None or BroadcastFallback"
+        );
+        // record must be retained so a human can investigate before retrying
+        assert!(
+            db.get_payjoin_sender_session().unwrap().is_some(),
+            "session record must not be deleted when proposal bytes are corrupt"
+        );
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -36,8 +36,10 @@ const OHTTP_RELAYS: [&str; 3] =
 
 /// Persists payjoin session events to the wallet's database so sessions survive app restarts.
 ///
-/// `lock` is shared across all clones and serialises `save_event` against `set_pending_fallback`
-/// so that a late in-flight poll response cannot overwrite the fallback-intent marker.
+/// `lock` serialises concurrent calls within a single actor lifetime — the `PayjoinActor`
+/// clones this persister for poll tasks, and all clones share the same lock.  Independently
+/// constructed instances (e.g. in `WalletActor` terminal handlers) do not share the lock
+/// and are safe because the actor is always closed before those handlers run.
 #[derive(Debug, Clone)]
 pub(crate) struct PayjoinSessionPersister {
     db: WalletDataDb,
@@ -174,7 +176,8 @@ impl SessionPersister for PayjoinSessionPersister {
 
         // Reject late events once any terminal intent is committed: an in-flight poll
         // response must not overwrite a BroadcastFallback or BroadcastProposal marker.
-        // The shared lock ensures this check-then-write is atomic with set_pending_action.
+        // The shared lock makes this check-then-write atomic with set_pending_fallback
+        // and set_pending_proposal within the same actor lifetime.
         if session.pending_action.is_some() {
             return Err(WalletDataError::Save(
                 "session has a committed terminal action; rejecting late event".to_string(),
@@ -701,15 +704,16 @@ pub(crate) enum SessionResumption {
     Resume(Box<PayjoinActor>),
     /// A BroadcastProposal marker was stored: broadcast this exact consensus-encoded tx
     BroadcastStoredProposal { proposal_tx: BdkTransaction },
-    /// Session closed with a success outcome but no stored tx: sign the recovered PSBT and broadcast.
-    /// `fallback_tx` is intentionally omitted — a local signing failure during recovery must pause
-    /// and preserve the record rather than downgrade to the original transaction.
-    SignRecoveredProposal { proposal_psbt: Psbt },
+    /// Session closed with a success outcome but no stored tx: sign the recovered PSBT and
+    /// broadcast.  `fallback_tx` is carried so that if persisting the proposal intent fails,
+    /// the actor can fall back to the original transaction.  A signing failure retains the
+    /// session without selecting the fallback — the user must retry.
+    SignRecoveredProposal { proposal_psbt: Psbt, fallback_tx: BdkTransaction },
     /// Session ended without a proposal, broadcast the original tx
     BroadcastFallback { fallback_tx: BdkTransaction },
-    /// The stored proposal tx is corrupt; the record is retained and the user must be notified.
-    /// Cove cannot know whether that proposal reached the network before the corruption/restart,
-    /// so it must not fall back automatically.
+    /// The session data is unreadable or the session is in an unrecoverable state; the user
+    /// must be shown `message`.  Whether the record is retained or cleared depends on which
+    /// producer returned this variant.
     ReportError { message: String },
 }
 
@@ -752,9 +756,11 @@ pub(crate) fn resume_session(
 
     let fallback_tx = history.fallback_tx();
     match session {
-        SendSession::WithReplyKey(sender) => SessionResumption::Resume(Box::new(
-            PayjoinActor::new(wallet_addr, persister, sender, fallback_tx),
-        )),
+        SendSession::WithReplyKey(_) => {
+            // The POST may have already reached the directory before the crash;
+            // re-posting is not retry-safe so fall back to the original transaction.
+            SessionResumption::BroadcastFallback { fallback_tx }
+        }
 
         SendSession::PollingForProposal(polling_sender) => {
             let now_secs =
@@ -778,7 +784,7 @@ pub(crate) fn resume_session(
         }
 
         SendSession::Closed(SessionOutcome::Success(proposal_psbt)) => {
-            SessionResumption::SignRecoveredProposal { proposal_psbt }
+            SessionResumption::SignRecoveredProposal { proposal_psbt, fallback_tx }
         }
 
         SendSession::Closed(_) => SessionResumption::BroadcastFallback { fallback_tx },
@@ -824,7 +830,14 @@ fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> Sess
 fn proposal_from_record(_db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
     let tx_bytes = match &record.pending_action {
         Some(PendingAction::BroadcastProposal { transaction }) => transaction.clone(),
-        _ => unreachable!("proposal_from_record called without BroadcastProposal action"),
+        _ => {
+            error!(
+                "proposal_from_record called without BroadcastProposal action; retaining record"
+            );
+            return SessionResumption::ReportError {
+                message: "payjoin session state is inconsistent; check your transaction history before retrying".to_string(),
+            };
+        }
     };
     match consensus::deserialize::<BdkTransaction>(&tx_bytes) {
         Ok(proposal_tx) => SessionResumption::BroadcastStoredProposal { proposal_tx },
@@ -1088,6 +1101,20 @@ mod tests {
         let result = persister.set_pending_fallback();
 
         assert!(result.is_err(), "BroadcastFallback must not overwrite BroadcastProposal");
+    }
+
+    #[test]
+    fn set_pending_proposal_rejects_overwrite_with_different_tx() {
+        let (persister, _db, _tmp) = new_test_persister();
+        let tx_a = empty_transaction();
+        let mut tx_b = empty_transaction();
+        tx_b.version = Version::ONE;
+        persister.create_session(&test_fallback_tx()).unwrap();
+        persister.set_pending_proposal(&tx_a).unwrap();
+
+        let result = persister.set_pending_proposal(&tx_b);
+
+        assert!(result.is_err(), "BroadcastProposal must not be overwritten with a different tx");
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -1,21 +1,29 @@
 use act_zero::*;
 use bdk_wallet::chain::bitcoin::Psbt;
-use bitcoin::{Amount, FeeRate as BdkFeeRate, Transaction as BdkTransaction, params::Params};
+use bitcoin::{
+    Amount, FeeRate as BdkFeeRate, Transaction as BdkTransaction, consensus, params::Params,
+};
+use cove_util::result_ext::ResultExt as _;
 use eyre::Result;
 use payjoin::{
     PjParam, Uri, UriExt,
-    persist::{NoopSessionPersister, OptionalTransitionOutcome},
+    persist::{OptionalTransitionOutcome, SessionPersister},
     send::{
         ResponseError,
         v2::{
-            PollingForProposal, Sender as V2Sender, SenderBuilder,
-            SessionEvent as PayjoinSessionEvent, WithReplyKey,
+            PollingForProposal, SendSession, Sender as V2Sender, SenderBuilder,
+            SessionEvent as PayjoinSessionEvent, SessionOutcome, WithReplyKey, replay_event_log,
         },
     },
 };
 use rand::seq::SliceRandom as _;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, warn};
+
+use crate::database::wallet_data::{
+    PayjoinSenderSession, PendingAction, WalletDataDb, WalletDataError,
+};
 
 use super::actor::WalletActor;
 
@@ -26,8 +34,118 @@ const PAYJOIN_SESSION_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const OHTTP_RELAYS: [&str; 3] =
     ["https://relay.payjoin.org", "https://ohttp.achow101.com", "https://pj.bobspacebkk.com"];
 
-/// Opaque alias so `actor.rs` can name the initial sender state without importing payjoin internals
-pub(crate) type PayjoinSender = V2Sender<WithReplyKey>;
+/// Persists payjoin session events to the wallet's database so sessions survive app restarts.
+///
+/// `lock` is shared across all clones and serialises `save_event` against `set_pending_fallback`
+/// so that a late in-flight poll response cannot overwrite the fallback-intent marker.
+#[derive(Debug, Clone)]
+pub(crate) struct PayjoinSessionPersister {
+    db: WalletDataDb,
+    lock: Arc<Mutex<()>>,
+}
+
+impl PayjoinSessionPersister {
+    pub(crate) fn new(db: WalletDataDb) -> Self {
+        Self { db, lock: Arc::new(Mutex::new(())) }
+    }
+
+    /// Marks the session as committed to broadcasting the fallback transaction.
+    /// Must be called before the fallback broadcast begins so a crash mid-broadcast
+    /// causes the next startup to go straight to fallback instead of resuming negotiation.
+    pub(crate) fn set_pending_fallback(&self) -> Result<(), WalletDataError> {
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| WalletDataError::Save("session lock poisoned".to_string()))?;
+
+        let mut session = self
+            .db
+            .get_payjoin_sender_session()?
+            .ok_or_else(|| WalletDataError::Save("no payjoin session record".to_string()))?;
+
+        session.pending_action = Some(PendingAction::BroadcastFallback);
+        self.db.set_payjoin_sender_session(session)
+    }
+
+    /// Creates a fresh session record; errors if a session record already exists.
+    /// The caller must clear any existing record before creating a new one.
+    pub(crate) fn create_session(
+        &self,
+        fallback_tx: &BdkTransaction,
+    ) -> Result<(), WalletDataError> {
+        if self.db.get_payjoin_sender_session()?.is_some() {
+            return Err(WalletDataError::Save(
+                "payjoin session already exists; clear it before creating a new one".to_string(),
+            ));
+        }
+
+        let created_at_secs =
+            SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs());
+        let session = PayjoinSenderSession {
+            events: vec![],
+            fallback_tx: consensus::serialize(fallback_tx),
+            created_at_secs,
+            pending_action: None,
+        };
+        self.db.set_payjoin_sender_session(session)
+    }
+}
+
+impl SessionPersister for PayjoinSessionPersister {
+    type InternalStorageError = WalletDataError;
+    type SessionEvent = PayjoinSessionEvent;
+
+    fn save_event(&self, event: Self::SessionEvent) -> Result<(), Self::InternalStorageError> {
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| WalletDataError::Save("session lock poisoned".to_string()))?;
+
+        let mut session = self
+            .db
+            .get_payjoin_sender_session()?
+            .ok_or_else(|| WalletDataError::Save("no payjoin session record".to_string()))?;
+
+        // Reject late events after the fallback commitment is written: an in-flight
+        // poll response arriving after complete_with_fallback must not overwrite
+        // pending_action back to None and corrupt the crash-recovery marker.
+        // The shared lock ensures this check-then-write is atomic with set_pending_fallback.
+        if matches!(session.pending_action, Some(PendingAction::BroadcastFallback)) {
+            return Err(WalletDataError::Save(
+                "session is committed to fallback; rejecting late event".to_string(),
+            ));
+        }
+
+        let event_json = serde_json::to_string(&event).map_err_str(WalletDataError::Save)?;
+        session.events.push(event_json);
+
+        self.db.set_payjoin_sender_session(session)
+    }
+
+    fn load(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Self::SessionEvent>>, Self::InternalStorageError> {
+        let session = self
+            .db
+            .get_payjoin_sender_session()?
+            .ok_or_else(|| WalletDataError::Read("no payjoin session record".to_string()))?;
+
+        let events = session
+            .events
+            .iter()
+            .map(|event| serde_json::from_str(event))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err_str(WalletDataError::Read)?;
+
+        Ok(Box::new(events.into_iter()))
+    }
+
+    // the record is cleared by the wallet actor after the terminal broadcast, so a crash
+    // between the library closing the session and the broadcast can still be resumed
+    fn close(&self) -> Result<(), Self::InternalStorageError> {
+        Ok(())
+    }
+}
 
 // send a payjoin HTTP request via reqwest and return the response bytes
 async fn http_post(
@@ -111,7 +229,8 @@ pub(crate) fn build_sender(
     fallback_tx: &BdkTransaction,
     endpoint: String,
     network: bitcoin::Network,
-) -> Result<PayjoinSender> {
+    persister: &PayjoinSessionPersister,
+) -> Result<V2Sender<WithReplyKey>> {
     // TODO: anti-probing (inputs_seen), verify our inputs have not appeared in a prior session
     // TODO: surface payjoin downgrade to the user when the fallback tx is broadcast instead of the proposal
 
@@ -157,19 +276,22 @@ pub(crate) fn build_sender(
         })
         .unwrap_or(BdkFeeRate::BROADCAST_MIN);
 
-    let persister = NoopSessionPersister::<PayjoinSessionEvent>::default();
     let sender = SenderBuilder::new(signed_psbt, pj_uri)
         .always_disable_output_substitution()
         .build_recommended(fee_rate)
         .map_err(|e| eyre::eyre!("failed to build payjoin sender: {e:?}"))?
-        .save(&persister)
-        .expect("NoopSessionPersister cannot fail");
+        .save(persister)
+        .map_err(|e| eyre::eyre!("failed to persist payjoin session: {e:?}"))?;
 
     Ok(sender)
 }
 
 // polls the payjoin directory for a receiver proposal; called from begin_poll via send_fut_with
-async fn do_poll(addr: WeakAddr<PayjoinActor>, polling_sender: V2Sender<PollingForProposal>) {
+async fn do_poll(
+    addr: WeakAddr<PayjoinActor>,
+    polling_sender: V2Sender<PollingForProposal>,
+    persister: PayjoinSessionPersister,
+) {
     let client = match cove_http::new_client() {
         Ok(c) => c,
         Err(e) => {
@@ -197,7 +319,6 @@ async fn do_poll(addr: WeakAddr<PayjoinActor>, polling_sender: V2Sender<PollingF
             }
         };
 
-    let persister = NoopSessionPersister::<PayjoinSessionEvent>::default();
     match polling_sender.process_response(&poll_response, poll_ctx).save(&persister) {
         Ok(OptionalTransitionOutcome::Progress(proposal_psbt)) => {
             send!(addr.complete_with_success(proposal_psbt));
@@ -239,6 +360,7 @@ enum PayjoinSession {
 pub(crate) struct PayjoinActor {
     addr: WeakAddr<Self>,
     wallet_addr: WeakAddr<WalletActor>,
+    persister: PayjoinSessionPersister,
     fallback_tx: BdkTransaction,
     session: PayjoinSession,
     poll_deadline: Option<Instant>,
@@ -247,15 +369,45 @@ pub(crate) struct PayjoinActor {
 impl PayjoinActor {
     pub(crate) fn new(
         wallet_addr: WeakAddr<WalletActor>,
+        persister: PayjoinSessionPersister,
         sender: V2Sender<WithReplyKey>,
         fallback_tx: BdkTransaction,
     ) -> Self {
         Self {
             addr: WeakAddr::default(),
             wallet_addr,
+            persister,
             fallback_tx,
             session: PayjoinSession::PrePost { sender },
             poll_deadline: None,
+        }
+    }
+
+    /// Recreates the actor from a replayed session that was already polling for a proposal
+    pub(crate) fn resume_polling(
+        wallet_addr: WeakAddr<WalletActor>,
+        persister: PayjoinSessionPersister,
+        polling_sender: V2Sender<PollingForProposal>,
+        fallback_tx: BdkTransaction,
+        created_at_secs: Option<u64>,
+    ) -> Self {
+        let poll_deadline = Some(match created_at_secs {
+            None => Instant::now() + PAYJOIN_SESSION_TIMEOUT,
+
+            Some(start) => {
+                let now_secs =
+                    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+                let elapsed = Duration::from_secs(now_secs.saturating_sub(start));
+                Instant::now() + PAYJOIN_SESSION_TIMEOUT.saturating_sub(elapsed)
+            }
+        });
+        Self {
+            addr: WeakAddr::default(),
+            wallet_addr,
+            persister,
+            fallback_tx,
+            session: PayjoinSession::Polling { polling_sender },
+            poll_deadline,
         }
     }
 }
@@ -264,7 +416,11 @@ impl PayjoinActor {
 impl Actor for PayjoinActor {
     async fn started(&mut self, addr: Addr<Self>) -> ActorResult<()> {
         self.addr = addr.downgrade();
-        send!(addr.start_post());
+        match &self.session {
+            PayjoinSession::PrePost { .. } => send!(addr.start_post()),
+            PayjoinSession::Polling { .. } => send!(addr.begin_poll()),
+            _ => {}
+        }
         Produces::ok(())
     }
 
@@ -291,6 +447,8 @@ impl PayjoinActor {
             }
         };
 
+        let persister = self.persister.clone();
+
         self.addr.send_fut_with(|addr| async move {
             let client = match cove_http::new_client() {
                 Ok(c) => c,
@@ -315,7 +473,6 @@ impl PayjoinActor {
                     }
                 };
 
-            let persister = NoopSessionPersister::<PayjoinSessionEvent>::default();
             let polling_sender =
                 match sender.process_response(&post_response, post_ctx).save(&persister) {
                     Ok(ps) => ps,
@@ -373,7 +530,8 @@ impl PayjoinActor {
             }
         };
 
-        self.addr.send_fut_with(|addr| do_poll(addr, polling_sender));
+        let persister = self.persister.clone();
+        self.addr.send_fut_with(|addr| do_poll(addr, polling_sender, persister));
 
         Produces::ok(())
     }
@@ -440,6 +598,18 @@ impl PayjoinActor {
             return;
         }
 
+        // Persist fallback intent before dispatching so a crash between here and the
+        // actual broadcast causes the next startup to go straight to fallback instead
+        // of replaying negotiation events and resuming polling or re-posting.
+        // Fail closed: do not dispatch if the intent cannot be persisted — the next
+        // restart will replay the event log and expire into a fallback via the deadline.
+        if let Err(error) = self.persister.set_pending_fallback() {
+            error!(
+                "failed to persist fallback intent, aborting fallback dispatch to preserve recovery state: {error}"
+            );
+            return;
+        }
+
         let fallback_tx = self.fallback_tx.clone();
         send!(self.wallet_addr.handle_payjoin_fallback(fallback_tx));
     }
@@ -455,12 +625,117 @@ impl PayjoinActor {
     }
 }
 
+/// What to do with a persisted payjoin session found on startup
+pub(crate) enum SessionResumption {
+    /// No session was persisted
+    None,
+    /// Session is still in flight, spawn this actor to continue it
+    Resume(Box<PayjoinActor>),
+    /// Session already completed with a proposal, sign and broadcast it
+    BroadcastProposal { proposal_psbt: Psbt, fallback_tx: BdkTransaction },
+    /// Session ended without a proposal, broadcast the original tx
+    BroadcastFallback { fallback_tx: BdkTransaction },
+}
+
+/// Replays a persisted payjoin session from the wallet's database, if one exists
+pub(crate) fn resume_session(
+    db: WalletDataDb,
+    wallet_addr: WeakAddr<WalletActor>,
+) -> SessionResumption {
+    let record = match db.get_payjoin_sender_session() {
+        Ok(Some(record)) => record,
+        Ok(None) => return SessionResumption::None,
+        Err(error) => {
+            error!("failed to read payjoin session record: {error}");
+            return SessionResumption::None;
+        }
+    };
+
+    // A crash after complete_with_fallback but before the broadcast completed would leave
+    // non-terminal events in the log; honour the stored intent instead of replaying them.
+    if matches!(record.pending_action, Some(PendingAction::BroadcastFallback)) {
+        return fallback_from_record(&db, record);
+    }
+
+    let persister = PayjoinSessionPersister::new(db.clone());
+    let (session, history) = match replay_event_log(&persister) {
+        Ok(pair) => pair,
+        Err(error) => {
+            warn!("payjoin session replay failed, broadcasting fallback: {error:?}");
+            return fallback_from_record(&db, record);
+        }
+    };
+
+    let fallback_tx = history.fallback_tx();
+    match session {
+        SendSession::WithReplyKey(sender) => SessionResumption::Resume(Box::new(
+            PayjoinActor::new(wallet_addr, persister, sender, fallback_tx),
+        )),
+
+        SendSession::PollingForProposal(polling_sender) => {
+            let now_secs =
+                SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+            let elapsed = record
+                .created_at_secs
+                .map(|start| Duration::from_secs(now_secs.saturating_sub(start)));
+
+            if elapsed.is_some_and(|e| e >= PAYJOIN_SESSION_TIMEOUT) {
+                warn!("payjoin session expired before resume, broadcasting fallback");
+                return fallback_from_record(&db, record);
+            }
+
+            SessionResumption::Resume(Box::new(PayjoinActor::resume_polling(
+                wallet_addr,
+                persister,
+                polling_sender,
+                fallback_tx,
+                record.created_at_secs,
+            )))
+        }
+
+        SendSession::Closed(SessionOutcome::Success(proposal_psbt)) => {
+            SessionResumption::BroadcastProposal { proposal_psbt, fallback_tx }
+        }
+
+        SendSession::Closed(_) => SessionResumption::BroadcastFallback { fallback_tx },
+    }
+}
+
+/// Recovers the fallback tx stored in the session record when replay is not possible
+fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
+    match consensus::deserialize(&record.fallback_tx) {
+        Ok(fallback_tx) => SessionResumption::BroadcastFallback { fallback_tx },
+        Err(error) => {
+            error!("stored payjoin fallback tx is corrupt, abandoning session: {error}");
+            if let Err(error) = db.delete_payjoin_sender_session() {
+                warn!("failed to clear corrupt payjoin session record: {error}");
+            }
+            SessionResumption::None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{database::wallet_data::test_support, wallet::metadata::WalletId};
     use bitcoin::{
         ScriptBuf, Transaction, TxOut, psbt::Output as PsbtOutput, transaction::Version,
     };
+
+    fn new_test_persister() -> (PayjoinSessionPersister, WalletDataDb, tempfile::TempDir) {
+        let (db, tmp) = test_support::new_test_wallet_data_db(WalletId::preview_new_random());
+        (PayjoinSessionPersister::new(db.clone()), db, tmp)
+    }
+
+    fn test_fallback_tx() -> BdkTransaction {
+        BdkTransaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        }
+    }
 
     // secp256k1 generator point G — a well-known valid compressed public key (33 bytes)
     const SECP_G: [u8; 33] = [
@@ -504,9 +779,11 @@ mod tests {
 
     #[test]
     fn test_close_session_is_idempotent() {
+        let (persister, _db, _tmp) = new_test_persister();
         let mut actor = PayjoinActor {
             addr: WeakAddr::default(),
             wallet_addr: WeakAddr::default(),
+            persister,
             fallback_tx: empty_transaction(),
             session: PayjoinSession::Posting,
             poll_deadline: Some(Instant::now()),
@@ -569,5 +846,97 @@ mod tests {
             let formatted = format!("{btc:.8}");
             assert_eq!(formatted, expected, "sats={sats}");
         }
+    }
+
+    #[test]
+    fn save_event_requires_a_session_record() {
+        let (persister, _db, _tmp) = new_test_persister();
+
+        let result = persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt());
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn events_round_trip_in_order() {
+        let (persister, _db, _tmp) = new_test_persister();
+        persister.create_session(&test_fallback_tx()).unwrap();
+
+        persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
+        persister.save_event(PayjoinSessionEvent::Closed(SessionOutcome::Failure)).unwrap();
+
+        let events: Vec<_> = persister.load().unwrap().collect();
+        assert_eq!(
+            events,
+            vec![
+                PayjoinSessionEvent::PostedOriginalPsbt(),
+                PayjoinSessionEvent::Closed(SessionOutcome::Failure)
+            ]
+        );
+    }
+
+    #[test]
+    fn create_session_rejects_when_session_exists() {
+        let (persister, _db, _tmp) = new_test_persister();
+        persister.create_session(&test_fallback_tx()).unwrap();
+        persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
+
+        let result = persister.create_session(&test_fallback_tx());
+
+        assert!(result.is_err(), "expected error when session already exists");
+        assert_eq!(persister.load().unwrap().count(), 1, "existing session must be unchanged");
+    }
+
+    #[test]
+    fn close_keeps_the_session_record() {
+        let (persister, _db, _tmp) = new_test_persister();
+        persister.create_session(&test_fallback_tx()).unwrap();
+        persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
+
+        persister.close().unwrap();
+
+        assert_eq!(persister.load().unwrap().count(), 1);
+    }
+
+    #[test]
+    fn resume_with_no_record_is_none() {
+        let (_persister, db, _tmp) = new_test_persister();
+
+        let resumption = resume_session(db, WeakAddr::default());
+
+        assert!(matches!(resumption, SessionResumption::None));
+    }
+
+    #[test]
+    fn resume_with_unreplayable_log_broadcasts_stored_fallback() {
+        let (persister, db, _tmp) = new_test_persister();
+        let tx = test_fallback_tx();
+        persister.create_session(&tx).unwrap();
+        // a log that does not start with a Created event cannot be replayed
+        persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
+
+        let resumption = resume_session(db, WeakAddr::default());
+
+        match resumption {
+            SessionResumption::BroadcastFallback { fallback_tx } => assert_eq!(fallback_tx, tx),
+            _ => panic!("expected BroadcastFallback"),
+        }
+    }
+
+    #[test]
+    fn resume_with_corrupt_fallback_clears_the_record() {
+        let (_persister, db, _tmp) = new_test_persister();
+        let session = PayjoinSenderSession {
+            events: vec![],
+            fallback_tx: vec![0xff],
+            created_at_secs: None,
+            pending_action: None,
+        };
+        db.set_payjoin_sender_session(session).unwrap();
+
+        let resumption = resume_session(db.clone(), WeakAddr::default());
+
+        assert!(matches!(resumption, SessionResumption::None));
+        assert_eq!(db.get_payjoin_sender_session().unwrap(), None);
     }
 }

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -607,6 +607,9 @@ impl PayjoinActor {
             error!(
                 "failed to persist fallback intent, aborting fallback dispatch to preserve recovery state: {error}"
             );
+            send!(self.wallet_addr.notify_payjoin_error(
+                "payment is paused — please restart the app to complete or cancel it".to_string()
+            ));
             return;
         }
 
@@ -914,6 +917,37 @@ mod tests {
         persister.create_session(&tx).unwrap();
         // a log that does not start with a Created event cannot be replayed
         persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
+
+        let resumption = resume_session(db, WeakAddr::default());
+
+        match resumption {
+            SessionResumption::BroadcastFallback { fallback_tx } => assert_eq!(fallback_tx, tx),
+            _ => panic!("expected BroadcastFallback"),
+        }
+    }
+
+    #[test]
+    fn save_event_rejected_after_set_pending_fallback() {
+        let (persister, _db, _tmp) = new_test_persister();
+        persister.create_session(&test_fallback_tx()).unwrap();
+        persister.set_pending_fallback().unwrap();
+
+        let result = persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt());
+
+        assert!(result.is_err(), "save_event must be rejected after fallback is committed");
+    }
+
+    #[test]
+    fn resume_prioritises_pending_fallback_over_event_log() {
+        let (_persister, db, _tmp) = new_test_persister();
+        let tx = test_fallback_tx();
+        let session = PayjoinSenderSession {
+            events: vec!["irrelevant_event".to_string()],
+            fallback_tx: consensus::serialize(&tx),
+            created_at_secs: None,
+            pending_action: Some(PendingAction::BroadcastFallback),
+        };
+        db.set_payjoin_sender_session(session).unwrap();
 
         let resumption = resume_session(db, WeakAddr::default());
 

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -101,7 +101,9 @@ impl PayjoinSessionPersister {
         match &session.pending_action {
             None => {}
 
-            Some(PendingAction::BroadcastProposal { transaction }) if *transaction == tx_bytes => {
+            Some(PendingAction::BroadcastProposal { transaction })
+                if transaction.as_ref() == tx_bytes.as_slice() =>
+            {
                 return Ok(());
             }
 
@@ -112,7 +114,8 @@ impl PayjoinSessionPersister {
             }
         }
 
-        session.pending_action = Some(PendingAction::BroadcastProposal { transaction: tx_bytes });
+        session.pending_action =
+            Some(PendingAction::BroadcastProposal { transaction: tx_bytes.into() });
         self.db.set_payjoin_sender_session(session)
     }
 
@@ -132,7 +135,7 @@ impl PayjoinSessionPersister {
             SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs());
         let session = PayjoinSenderSession {
             events: vec![],
-            fallback_tx: consensus::serialize(fallback_tx),
+            fallback_tx: consensus::serialize(fallback_tx).into(),
             created_at_secs,
             pending_action: None,
         };
@@ -146,12 +149,12 @@ impl PayjoinSessionPersister {
         match &session.pending_action {
             None => None,
             Some(PendingAction::BroadcastFallback) => {
-                consensus::deserialize::<BdkTransaction>(&session.fallback_tx)
+                consensus::deserialize::<BdkTransaction>(session.fallback_tx.as_ref())
                     .ok()
                     .map(|tx| tx.compute_txid())
             }
             Some(PendingAction::BroadcastProposal { transaction }) => {
-                consensus::deserialize::<BdkTransaction>(transaction)
+                consensus::deserialize::<BdkTransaction>(transaction.as_ref())
                     .ok()
                     .map(|tx| tx.compute_txid())
             }
@@ -793,7 +796,7 @@ pub(crate) fn resume_session(
 
 /// Recovers the fallback tx from the session record when replay is not possible.
 fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
-    match consensus::deserialize(&record.fallback_tx) {
+    match consensus::deserialize(record.fallback_tx.as_ref()) {
         Ok(fallback_tx) => SessionResumption::BroadcastFallback { fallback_tx },
 
         Err(error) if matches!(record.pending_action, Some(PendingAction::BroadcastFallback)) => {
@@ -829,7 +832,7 @@ fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> Sess
 /// so deleting the record or broadcasting the fallback would be unsafe.
 fn proposal_from_record(_db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
     let tx_bytes = match &record.pending_action {
-        Some(PendingAction::BroadcastProposal { transaction }) => transaction.clone(),
+        Some(PendingAction::BroadcastProposal { transaction }) => transaction.as_ref().to_vec(),
         _ => {
             error!(
                 "proposal_from_record called without BroadcastProposal action; retaining record"
@@ -1077,7 +1080,7 @@ mod tests {
         let tx = test_fallback_tx();
         let session = PayjoinSenderSession {
             events: vec!["irrelevant_event".to_string()],
-            fallback_tx: consensus::serialize(&tx),
+            fallback_tx: consensus::serialize(&tx).into(),
             created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastFallback),
         };
@@ -1140,10 +1143,10 @@ mod tests {
         let tx = empty_transaction();
         let session = PayjoinSenderSession {
             events: vec![],
-            fallback_tx: consensus::serialize(&test_fallback_tx()),
+            fallback_tx: consensus::serialize(&test_fallback_tx()).into(),
             created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastProposal {
-                transaction: consensus::serialize(&tx),
+                transaction: consensus::serialize(&tx).into(),
             }),
         };
         db.set_payjoin_sender_session(session).unwrap();
@@ -1163,10 +1166,10 @@ mod tests {
         let (_persister, db, _tmp) = new_test_persister();
         let session = PayjoinSenderSession {
             events: vec![],
-            fallback_tx: consensus::serialize(&test_fallback_tx()),
+            fallback_tx: consensus::serialize(&test_fallback_tx()).into(),
             created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastProposal {
-                transaction: vec![0xff], // corrupt bytes
+                transaction: vec![0xff].into(),
             }),
         };
         db.set_payjoin_sender_session(session).unwrap();
@@ -1189,7 +1192,7 @@ mod tests {
         let (_persister, db, _tmp) = new_test_persister();
         let session = PayjoinSenderSession {
             events: vec![],
-            fallback_tx: vec![0xff],
+            fallback_tx: vec![0xff].into(),
             created_at_secs: None,
             pending_action: None,
         };
@@ -1213,7 +1216,7 @@ mod tests {
         let (_persister, db, _tmp) = new_test_persister();
         let session = PayjoinSenderSession {
             events: vec![],
-            fallback_tx: vec![0xff],
+            fallback_tx: vec![0xff].into(),
             created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastFallback), // marker written before crash
         };

--- a/rust/src/node/client.rs
+++ b/rust/src/node/client.rs
@@ -249,6 +249,14 @@ impl NodeClient {
         }
     }
 
+    /// Fetches a transaction from the mempool or chain; returns `None` if not found.
+    pub async fn get_transaction(&self, txid: Txid) -> Result<Option<bitcoin::Transaction>, Error> {
+        match self {
+            Self::Esplora(client) => client.get_transaction(txid).await,
+            Self::Electrum(client) => client.get_transaction(txid).await,
+        }
+    }
+
     pub async fn get_block_id(&self) -> Result<BlockId, Error> {
         match self {
             Self::Esplora(client) => client.get_block_id().await,

--- a/rust/src/node/client/electrum.rs
+++ b/rust/src/node/client/electrum.rs
@@ -173,10 +173,12 @@ impl ElectrumClient {
             .await
             .map(Some)
             .or_else(|e| match e {
-                // Only a null response is a definitive "not found"; all other
-                // protocol errors (malformed request, server failure, unsupported
-                // method) are propagated so the caller can fail safely.
-                electrum_client::Error::InvalidResponse(Value::Null) => Ok(None),
+                // Electrum returns a Protocol error when the transaction is not in the
+                // mempool or chain; map to Ok(None) for consistent "not found" semantics
+                // across node backends.  Some server implementations may also return a
+                // null response, so that is handled here too.
+                electrum_client::Error::Protocol(_)
+                | electrum_client::Error::InvalidResponse(Value::Null) => Ok(None),
                 other => Err(Error::ElectrumGetTransaction(other)),
             })
     }

--- a/rust/src/node/client/electrum.rs
+++ b/rust/src/node/client/electrum.rs
@@ -166,6 +166,21 @@ impl ElectrumClient {
         Ok(Some(txn))
     }
 
+    /// Fetches a transaction from the mempool or chain; returns `None` if not found.
+    pub async fn get_transaction(&self, txid: Txid) -> Result<Option<bitcoin::Transaction>, Error> {
+        let client = self.client.clone();
+        cove_tokio::unblock::run_blocking(move || client.inner.transaction_get(&txid))
+            .await
+            .map(Some)
+            .or_else(|e| match e {
+                // Only a null response is a definitive "not found"; all other
+                // protocol errors (malformed request, server failure, unsupported
+                // method) are propagated so the caller can fail safely.
+                electrum_client::Error::InvalidResponse(Value::Null) => Ok(None),
+                other => Err(Error::ElectrumGetTransaction(other)),
+            })
+    }
+
     async fn get_confirmed_transaction_fallback(
         &self,
         txid: Txid,

--- a/rust/src/node/client/esplora.rs
+++ b/rust/src/node/client/esplora.rs
@@ -128,6 +128,11 @@ impl EsploraClient {
         Ok(tx)
     }
 
+    /// Fetches a transaction from the mempool or chain; returns `None` if not found
+    pub async fn get_transaction(&self, txid: Txid) -> Result<Option<bitcoin::Transaction>, Error> {
+        self.client.get_tx(&txid).await.map_err(Error::EsploraGetTransaction)
+    }
+
     pub async fn broadcast_transaction(&self, txn: bitcoin::Transaction) -> Result<Txid, Error> {
         self.client.broadcast(&txn).await.map_err(Error::EsploraBroadcast)?;
 


### PR DESCRIPTION
## summary

this pr makes payjoin sender sessions recoverable after a cold restart.

the payjoin sender pr (#772) used `NoopSessionPersister`, so any in flight payjoin session was lost if the app restarted before the negotiation finished. this implements a real `SessionPersister` backed by `redb`.

## changes

the session event log is now persisted before the first network request, along with the consensus-encoded fallback transaction. on startup, the stored event log is replayed so the app can continue the payjoin flow safely.

depending on the recovered state, the sender can now resume polling, broadcast an already completed proposal, or fall back to the original transaction if the session cannot be reconstructed.


## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payjoin sessions now persist across app restarts, letting in-progress send flows resume automatically.
  * Added transaction lookup support (mempool-or-chain) to improve terminal handling during send recovery.

* **Bug Fixes**
  * Improved recovery for saved payjoin sessions, including more reliable fallback/proposal resumption and protection against corrupt saved state.
  * More consistent session cleanup and safer retry behavior when persistence or broadcasting fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->