### PR TITLE
Remove hard 5000sats min send limit

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlCustomAmountSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlCustomAmountSheet.kt
@@ -31,6 +31,7 @@ import org.bitcoinppl.cove.flows.CoinControlFlow.displayDate
 import org.bitcoinppl.cove.flows.CoinControlFlow.displayName
 import org.bitcoinppl.cove.ui.theme.CoveColor
 import org.bitcoinppl.cove_core.SendFlowManagerAction
+import org.bitcoinppl.cove_core.ffiConservativeDustLimitSats
 import org.bitcoinppl.cove_core.types.Amount
 import org.bitcoinppl.cove_core.types.Utxo
 import org.bitcoinppl.cove_core.types.UtxoType
@@ -66,21 +67,22 @@ fun CoinControlCustomAmountSheet(
     var debounceJob: Job? by remember { mutableStateOf(null) }
 
     // min/max calculations
-    val minSendSats = 546L
-    val minSend = if (isSats) minSendSats.toDouble() else minSendSats / 100_000_000.0
+    val conservativeDustLimitSatsU = remember { ffiConservativeDustLimitSats() }
+    val conservativeDustLimitSats = conservativeDustLimitSatsU.toLong()
+    val minSend = if (isSats) conservativeDustLimitSats.toDouble() else conservativeDustLimitSats.toDouble() / 100_000_000.0
 
     val step = if (isSats) 10.0 else 0.0000001
 
     val maxSend =
         remember(sendFlowManager.amount, unit) {
-            val amount = sendFlowManager.maxSendMinusFees() ?: Amount.fromSat(minSendSats.toULong() + 1000u)
+            val amount = sendFlowManager.maxSendMinusFees() ?: Amount.fromSat(conservativeDustLimitSatsU + 1_000uL)
             val value = if (isSats) amount.asSats().toDouble() else amount.asBtc()
             value.coerceAtLeast(minSend)
         }
 
     val softMaxSend =
         remember(sendFlowManager.amount, unit) {
-            val amount = sendFlowManager.maxSendMinusFeesAndSmallUtxo() ?: Amount.fromSat(minSendSats.toULong())
+            val amount = sendFlowManager.maxSendMinusFeesAndSmallUtxo() ?: Amount.fromSat(conservativeDustLimitSatsU)
             val value = if (isSats) amount.asSats().toDouble() else amount.asBtc()
             value.coerceAtLeast(minSend)
         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlCustomAmountSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/CoinControlCustomAmountSheet.kt
@@ -75,7 +75,11 @@ fun CoinControlCustomAmountSheet(
 
     val maxSend =
         remember(sendFlowManager.amount, unit) {
-            val amount = sendFlowManager.maxSendMinusFees() ?: Amount.fromSat(conservativeDustLimitSatsU + 1_000uL)
+            var amount = sendFlowManager.maxSendMinusFees() ?: Amount.fromSat(conservativeDustLimitSatsU + 1_000uL)
+            if (amount.asSats() <= conservativeDustLimitSatsU) {
+                amount = Amount.fromSat(conservativeDustLimitSatsU + 1_000uL)
+            }
+
             val value = if (isSats) amount.asSats().toDouble() else amount.asBtc()
             value.coerceAtLeast(minSend)
         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -658,6 +658,7 @@ private fun SendFlowRouteToScreen(
                         TextButton(
                             onClick = {
                                 presenter.setDisappearing()
+                                presenter.alertState = null
                                 sendFlowManager.dispatch(
                                     SendFlowManagerAction.AcknowledgeWarningAndFinalize(alert.kind),
                                 )

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -643,6 +643,8 @@ private fun SendFlowRouteToScreen(
 
     // validation alert dialog (shown across all send routes)
     if (presenter.isShowingAlert) {
+        val alert = presenter.alertState?.item
+
         AlertDialog(
             onDismissRequest = {
                 presenter.setDisappearing()
@@ -651,13 +653,41 @@ private fun SendFlowRouteToScreen(
             title = { Text(presenter.alertTitle()) },
             text = { Text(presenter.alertMessage()) },
             confirmButton = {
-                TextButton(
-                    onClick = {
-                        presenter.setDisappearing()
-                        presenter.alertButtonAction()?.invoke()
-                    },
-                ) {
-                    Text("OK")
+                when (alert) {
+                    is SendFlowAlertState.Warning -> {
+                        TextButton(
+                            onClick = {
+                                presenter.setDisappearing()
+                                sendFlowManager.dispatch(
+                                    SendFlowManagerAction.AcknowledgeWarningAndFinalize(alert.kind),
+                                )
+                            },
+                        ) {
+                            Text("Send Anyway")
+                        }
+                    }
+                    else -> {
+                        TextButton(
+                            onClick = {
+                                presenter.setDisappearing()
+                                presenter.alertButtonAction()?.invoke()
+                            },
+                        ) {
+                            Text("OK")
+                        }
+                    }
+                }
+            },
+            dismissButton = {
+                if (alert is SendFlowAlertState.Warning) {
+                    TextButton(
+                        onClick = {
+                            presenter.setDisappearing()
+                            presenter.alertState = null
+                        },
+                    ) {
+                        Text("Cancel")
+                    }
                 }
             },
         )

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -309,25 +309,24 @@ class SendFlowManager internal constructor(
             is SendFlowManagerReconcileMessage.SetAlert -> {
                 logWarn("setAlert: ${message.v1}")
 
-                // capture previous state before modifying
                 val hadSheet = presenter.sheetState != null
                 val hadAlert = presenter.alertState != null
+                val isDismissingAlert = presenter.isDisappearing
 
-                presenter.alertState = TaggedItem(message.v1)
-
-                // handle alert/sheet conflict - delay only if there was a previous conflict
-                if (hadSheet || hadAlert) {
-                    presenter.alertState = null
+                if (hadSheet || hadAlert || isDismissingAlert) {
+                    presenter.clearAlert()
                     presenter.sheetState = null
                     mainScope.launch {
                         delay(ALERT_PRESENTATION_DELAY_MS)
                         presenter.alertState = TaggedItem(message.v1)
                     }
+                } else {
+                    presenter.alertState = TaggedItem(message.v1)
                 }
             }
 
             is SendFlowManagerReconcileMessage.ClearAlert -> {
-                presenter.alertState = null
+                presenter.clearAlert()
             }
 
             is SendFlowManagerReconcileMessage.SetMaxSelected -> {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowManager.kt
@@ -168,9 +168,7 @@ class SendFlowManager internal constructor(
      */
     fun validate(displayAlert: Boolean = false): Boolean {
         if (isClosed.get()) return false
-        return validateAmount(displayAlert) &&
-                validateAddress(displayAlert) &&
-                validateFeePercentage(displayAlert)
+        return validateAmount(displayAlert) && validateAddress(displayAlert)
     }
 
     suspend fun waitForInit(): Boolean =
@@ -222,11 +220,6 @@ class SendFlowManager internal constructor(
     fun validateAmount(displayAlert: Boolean = false): Boolean =
         withRustOr(false) {
             validateAmount(displayAlert)
-        }
-
-    fun validateFeePercentage(displayAlert: Boolean = false): Boolean =
-        withRustOr(false) {
-            validateFeePercentage(displayAlert)
         }
 
     fun updateAddress(address: Address) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowPresenter.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowPresenter.kt
@@ -72,6 +72,7 @@ class SendFlowPresenter(
         when (val state = alertState?.item) {
             is SendFlowAlertState.Error -> errorAlertTitle(state.v1)
             is SendFlowAlertState.General -> state.title
+            is SendFlowAlertState.Warning -> state.title
             null -> ""
         }
 
@@ -90,7 +91,7 @@ class SendFlowPresenter(
             is SendFlowException.NoBalance,
             -> "Insufficient Funds"
 
-            is SendFlowException.SendAmountToLow -> "Send Amount Too Low"
+            is SendFlowException.SendBelowDustLimit -> "Amount Below Dust Limit"
             is SendFlowException.UnableToGetFeeRate -> "Unable to get fee rate"
             is SendFlowException.UnableToBuildTxn -> "Unable to build transaction"
             is SendFlowException.UnableToGetMaxSend -> "Unable to get max send"
@@ -110,6 +111,7 @@ class SendFlowPresenter(
         when (val state = alertState?.item) {
             is SendFlowAlertState.Error -> errorAlertMessage(state.v1)
             is SendFlowAlertState.General -> state.message
+            is SendFlowAlertState.Warning -> state.message
             null -> ""
         }
 
@@ -136,8 +138,8 @@ class SendFlowPresenter(
             is SendFlowException.InsufficientFunds ->
                 "You do not have enough bitcoin in your wallet to cover the amount plus fees"
 
-            is SendFlowException.SendAmountToLow ->
-                "Send amount is too low. Please send at least 5000 sats"
+            is SendFlowException.SendBelowDustLimit ->
+                "This amount is below Bitcoin's dust limit for this address type. The network would reject it. Please send a bit more."
 
             is SendFlowException.UnableToGetFeeRate ->
                 "Are you connected to the internet?"
@@ -171,6 +173,9 @@ class SendFlowPresenter(
             is SendFlowAlertState.General -> {
                 { alertState = null }
             }
+            is SendFlowAlertState.Warning -> {
+                { alertState = null }
+            }
             null -> null
         }
 
@@ -195,7 +200,7 @@ class SendFlowPresenter(
 
             is SendFlowException.InvalidNumber,
             is SendFlowException.InsufficientFunds,
-            is SendFlowException.SendAmountToLow,
+            is SendFlowException.SendBelowDustLimit,
             is SendFlowException.ZeroAmount,
             is SendFlowException.WalletManager,
             is SendFlowException.UnableToGetFeeDetails,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowPresenter.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowPresenter.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -24,6 +25,7 @@ class SendFlowPresenter(
 ) : Closeable {
     // prevents alerts from reappearing during dismissal animations
     private var disappearing by mutableStateOf(false)
+    private var disappearingResetJob: Job? = null
 
     private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val isClosed = AtomicBoolean(false)
@@ -34,6 +36,9 @@ class SendFlowPresenter(
 
     val isShowingAlert: Boolean
         get() = alertState != null && !disappearing
+
+    val isDisappearing: Boolean
+        get() = disappearing
 
     var lastWorkingFeeRate by mutableStateOf<Float?>(null)
     var erroredFeeRate by mutableStateOf<Float?>(null)
@@ -58,11 +63,20 @@ class SendFlowPresenter(
     }
 
     fun setDisappearing() {
+        disappearingResetJob?.cancel()
         disappearing = true
-        mainScope.launch {
+        disappearingResetJob = mainScope.launch {
             delay(500)
             disappearing = false
         }
+    }
+
+    fun clearAlert() {
+        if (alertState != null) {
+            setDisappearing()
+        }
+
+        alertState = null
     }
 
     /**
@@ -218,6 +232,8 @@ class SendFlowPresenter(
 
     override fun close() {
         if (!isClosed.compareAndSet(false, true)) return
+        disappearingResetJob?.cancel()
+        disappearingResetJob = null
         mainScope.cancel()
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/sheets/CustomFeeRateSheet.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/sheets/CustomFeeRateSheet.kt
@@ -32,6 +32,7 @@ import org.bitcoinppl.cove.ui.theme.title3
 import org.bitcoinppl.cove.utils.toColor
 import org.bitcoinppl.cove_core.SendFlowAlertState
 import org.bitcoinppl.cove_core.SendFlowException
+import org.bitcoinppl.cove_core.WalletManagerException
 import org.bitcoinppl.cove_core.types.Amount
 import org.bitcoinppl.cove_core.types.FeeRate
 import org.bitcoinppl.cove_core.types.FeeRateOptionWithTotalFee
@@ -52,6 +53,13 @@ private object CustomFeeRateConstants {
     // delay before showing alert after dismissing sheet
     const val ALERT_DELAY_MS = 850L
 }
+
+internal fun isTooHighCustomFeeError(error: SendFlowException): Boolean =
+    when (error) {
+        is SendFlowException.InsufficientFunds -> true
+        is SendFlowException.WalletManager -> error.v1 is WalletManagerException.InsufficientFunds
+        else -> false
+    }
 
 /** custom fee rate sheet - allows user to set custom sats/vbyte with slider */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -141,8 +149,16 @@ fun CustomFeeRateSheet(
                             updatedFeeOptions = updatedFeeOptions.addCustomFeeRate(feeRateOption)
                             presenter.lastWorkingFeeRate = feeRate
                         }
-                    } catch (e: SendFlowException.WalletManager) {
-                        // handle insufficient funds - set max fee rate
+                    } catch (e: SendFlowException) {
+                        if (!isTooHighCustomFeeError(e)) {
+                            android.util.Log.e(
+                                "CustomFeeRateSheet",
+                                "Unexpected error calculating fee: ${e.javaClass.simpleName} - ${e.message}",
+                                e,
+                            )
+                            return@withContext
+                        }
+
                         withContext(Dispatchers.Main) {
                             presenter.erroredFeeRate = feeRate
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1181,9 +1181,13 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_func_wallet_display_sent_and_received_amount(
     ): Short
-    external fun uniffi_cove_checksum_func_ffi_min_send_amount(
+    external fun uniffi_cove_checksum_func_ffi_conservative_dust_limit_amount(
     ): Short
-    external fun uniffi_cove_checksum_func_ffi_min_send_sats(
+    external fun uniffi_cove_checksum_func_ffi_conservative_dust_limit_sats(
+    ): Short
+    external fun uniffi_cove_checksum_func_ffi_low_send_warning_amount(
+    ): Short
+    external fun uniffi_cove_checksum_func_ffi_low_send_warning_sats(
     ): Short
     external fun uniffi_cove_checksum_func_preview_new_legacy_found_address(
     ): Short
@@ -1558,8 +1562,6 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_cove_checksum_method_rustsendflowmanager_validate_address(
     ): Short
     external fun uniffi_cove_checksum_method_rustsendflowmanager_validate_amount(
-    ): Short
-    external fun uniffi_cove_checksum_method_rustsendflowmanager_validate_fee_percentage(
     ): Short
     external fun uniffi_cove_checksum_method_rustsendflowmanager_get_custom_fee_option(
     ): Short
@@ -2673,8 +2675,6 @@ internal object UniffiLib {
     ): Byte
     external fun uniffi_cove_fn_method_rustsendflowmanager_validate_amount(`ptr`: Long,`displayAlert`: Byte,uniffi_out_err: UniffiRustCallStatus,
     ): Byte
-    external fun uniffi_cove_fn_method_rustsendflowmanager_validate_fee_percentage(`ptr`: Long,`displayAlert`: Byte,uniffi_out_err: UniffiRustCallStatus,
-    ): Byte
     external fun uniffi_cove_fn_method_rustsendflowmanager_get_custom_fee_option(`ptr`: Long,`feeRate`: Long,`feeSpeed`: RustBufferFeeSpeed.ByValue,
     ): Long
     external fun uniffi_cove_fn_method_rustsendflowmanager_amount(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -3555,9 +3555,13 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_func_wallet_display_sent_and_received_amount(`metadata`: RustBuffer.ByValue,`sentAndReceived`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_func_ffi_min_send_amount(uniffi_out_err: UniffiRustCallStatus,
+    external fun uniffi_cove_fn_func_ffi_conservative_dust_limit_amount(uniffi_out_err: UniffiRustCallStatus,
     ): Long
-    external fun uniffi_cove_fn_func_ffi_min_send_sats(uniffi_out_err: UniffiRustCallStatus,
+    external fun uniffi_cove_fn_func_ffi_conservative_dust_limit_sats(uniffi_out_err: UniffiRustCallStatus,
+    ): Long
+    external fun uniffi_cove_fn_func_ffi_low_send_warning_amount(uniffi_out_err: UniffiRustCallStatus,
+    ): Long
+    external fun uniffi_cove_fn_func_ffi_low_send_warning_sats(uniffi_out_err: UniffiRustCallStatus,
     ): Long
     external fun uniffi_cove_fn_func_preview_new_legacy_found_address(uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
@@ -3854,10 +3858,16 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_func_wallet_display_sent_and_received_amount() != 2923.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_func_ffi_min_send_amount() != 61138.toShort()) {
+    if (lib.uniffi_cove_checksum_func_ffi_conservative_dust_limit_amount() != 11787.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_func_ffi_min_send_sats() != 550.toShort()) {
+    if (lib.uniffi_cove_checksum_func_ffi_conservative_dust_limit_sats() != 54311.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_ffi_low_send_warning_amount() != 6176.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_func_ffi_low_send_warning_sats() != 35697.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_func_preview_new_legacy_found_address() != 25458.toShort()) {
@@ -4419,9 +4429,6 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustsendflowmanager_validate_amount() != 64774.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_cove_checksum_method_rustsendflowmanager_validate_fee_percentage() != 52935.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustsendflowmanager_get_custom_fee_option() != 7512.toShort()) {
@@ -20595,8 +20602,6 @@ public interface RustSendFlowManagerInterface {
 
     fun `validateAmount`(`displayAlert`: kotlin.Boolean = false): kotlin.Boolean
 
-    fun `validateFeePercentage`(`displayAlert`: kotlin.Boolean = false): kotlin.Boolean
-
     /**
      * get the custom fee rate option
      */
@@ -20820,20 +20825,6 @@ open class RustSendFlowManager: Disposable, AutoCloseable, RustSendFlowManagerIn
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_cove_fn_method_rustsendflowmanager_validate_amount(
-        it,
-
-        FfiConverterBoolean.lower(`displayAlert`),_status)
-}
-    }
-    )
-    }
-
-
-    override fun `validateFeePercentage`(`displayAlert`: kotlin.Boolean): kotlin.Boolean {
-            return FfiConverterBoolean.lift(
-    callWithHandle {
-    uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_method_rustsendflowmanager_validate_fee_percentage(
         it,
 
         FfiConverterBoolean.lower(`displayAlert`),_status)
@@ -47571,6 +47562,17 @@ sealed class SendFlowAlertState {
         companion object
     }
 
+    data class Warning(
+        val `kind`: org.bitcoinppl.cove_core.SendFlowWarningKind,
+        val `title`: kotlin.String,
+        val `message`: kotlin.String) : SendFlowAlertState()
+
+    {
+
+
+        companion object
+    }
+
 
 
 
@@ -47594,6 +47596,11 @@ public object FfiConverterTypeSendFlowAlertState : FfiConverterRustBuffer<SendFl
                 FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
+            3 -> SendFlowAlertState.Warning(
+                FfiConverterTypeSendFlowWarningKind.read(buf),
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -47614,6 +47621,15 @@ public object FfiConverterTypeSendFlowAlertState : FfiConverterRustBuffer<SendFl
                 + FfiConverterString.allocationSize(value.`message`)
             )
         }
+        is SendFlowAlertState.Warning -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSendFlowWarningKind.allocationSize(value.`kind`)
+                + FfiConverterString.allocationSize(value.`title`)
+                + FfiConverterString.allocationSize(value.`message`)
+            )
+        }
     }
 
     override fun write(value: SendFlowAlertState, buf: ByteBuffer) {
@@ -47625,6 +47641,13 @@ public object FfiConverterTypeSendFlowAlertState : FfiConverterRustBuffer<SendFl
             }
             is SendFlowAlertState.General -> {
                 buf.putInt(2)
+                FfiConverterString.write(value.`title`, buf)
+                FfiConverterString.write(value.`message`, buf)
+                Unit
+            }
+            is SendFlowAlertState.Warning -> {
+                buf.putInt(3)
+                FfiConverterTypeSendFlowWarningKind.write(value.`kind`, buf)
                 FfiConverterString.write(value.`title`, buf)
                 FfiConverterString.write(value.`message`, buf)
                 Unit
@@ -47787,7 +47810,7 @@ sealed class SendFlowException: kotlin.Exception() {
             get() = ""
     }
 
-    class SendAmountToLow(
+    class SendBelowDustLimit(
         ) : SendFlowException() {
         override val message
             get() = ""
@@ -47875,7 +47898,7 @@ public object FfiConverterTypeSendFlowError : FfiConverterRustBuffer<SendFlowExc
                 FfiConverterString.read(buf),
                 )
             8 -> SendFlowException.InsufficientFunds()
-            9 -> SendFlowException.SendAmountToLow()
+            9 -> SendFlowException.SendBelowDustLimit()
             10 -> SendFlowException.UnableToGetFeeRate()
             11 -> SendFlowException.UnableToBuildTxn(
                 FfiConverterString.read(buf),
@@ -47932,7 +47955,7 @@ public object FfiConverterTypeSendFlowError : FfiConverterRustBuffer<SendFlowExc
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
             )
-            is SendFlowException.SendAmountToLow -> (
+            is SendFlowException.SendBelowDustLimit -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
             )
@@ -48002,7 +48025,7 @@ public object FfiConverterTypeSendFlowError : FfiConverterRustBuffer<SendFlowExc
                 buf.putInt(8)
                 Unit
             }
-            is SendFlowException.SendAmountToLow -> {
+            is SendFlowException.SendBelowDustLimit -> {
                 buf.putInt(9)
                 Unit
             }
@@ -48395,6 +48418,15 @@ sealed class SendFlowManagerAction: Disposable  {
     object FinalizeAndGoToNextScreen : SendFlowManagerAction()
 
 
+    data class AcknowledgeWarningAndFinalize(
+        val v1: org.bitcoinppl.cove_core.SendFlowWarningKind) : SendFlowManagerAction()
+
+    {
+
+
+        companion object
+    }
+
 
 
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -48536,6 +48568,13 @@ sealed class SendFlowManagerAction: Disposable  {
             }
             is SendFlowManagerAction.FinalizeAndGoToNextScreen -> {// Nothing to destroy
             }
+            is SendFlowManagerAction.AcknowledgeWarningAndFinalize -> {
+
+    Disposable.destroy(
+        this.v1
+    )
+
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
@@ -48615,6 +48654,9 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
                 FfiConverterTypeFeeRateOptionsWithTotalFee.read(buf),
                 )
             23 -> SendFlowManagerAction.FinalizeAndGoToNextScreen
+            24 -> SendFlowManagerAction.AcknowledgeWarningAndFinalize(
+                FfiConverterTypeSendFlowWarningKind.read(buf),
+                )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -48780,6 +48822,13 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
                 4UL
             )
         }
+        is SendFlowManagerAction.AcknowledgeWarningAndFinalize -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypeSendFlowWarningKind.allocationSize(value.v1)
+            )
+        }
     }
 
     override fun write(value: SendFlowManagerAction, buf: ByteBuffer) {
@@ -48896,6 +48945,11 @@ public object FfiConverterTypeSendFlowManagerAction : FfiConverterRustBuffer<Sen
             }
             is SendFlowManagerAction.FinalizeAndGoToNextScreen -> {
                 buf.putInt(23)
+                Unit
+            }
+            is SendFlowManagerAction.AcknowledgeWarningAndFinalize -> {
+                buf.putInt(24)
+                FfiConverterTypeSendFlowWarningKind.write(value.v1, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -49298,6 +49352,41 @@ public object FfiConverterTypeSendFlowManagerReconcileMessage : FfiConverterRust
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
+
+enum class SendFlowWarningKind {
+
+    SMALL_AMOUNT,
+    HIGH_FEE,
+    VERY_HIGH_FEE;
+
+
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSendFlowWarningKind: FfiConverterRustBuffer<SendFlowWarningKind> {
+    override fun read(buf: ByteBuffer) = try {
+        SendFlowWarningKind.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: SendFlowWarningKind) = 4UL
+
+    override fun write(value: SendFlowWarningKind, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
     }
 }
 
@@ -54390,6 +54479,12 @@ sealed class WalletManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
 
+    class OutputBelowDustLimit(
+        ) : WalletManagerException() {
+        override val message
+            get() = ""
+    }
+
     class LockedOutputsSelected(
         ) : WalletManagerException() {
         override val message
@@ -54575,42 +54670,43 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
             20 -> WalletManagerException.InsufficientFunds(
                 FfiConverterString.read(buf),
                 )
-            21 -> WalletManagerException.LockedOutputsSelected()
-            22 -> WalletManagerException.GetConfirmDetailsException(
+            21 -> WalletManagerException.OutputBelowDustLimit()
+            22 -> WalletManagerException.LockedOutputsSelected()
+            23 -> WalletManagerException.GetConfirmDetailsException(
                 FfiConverterString.read(buf),
                 )
-            23 -> WalletManagerException.SignAndBroadcastException(
+            24 -> WalletManagerException.SignAndBroadcastException(
                 FfiConverterString.read(buf),
                 )
-            24 -> WalletManagerException.Converter(
+            25 -> WalletManagerException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            25 -> WalletManagerException.UnknownException(
+            26 -> WalletManagerException.UnknownException(
                 FfiConverterString.read(buf),
                 )
-            26 -> WalletManagerException.PsbtFinalizeException(
+            27 -> WalletManagerException.PsbtFinalizeException(
                 FfiConverterString.read(buf),
                 )
-            27 -> WalletManagerException.GetHistoricalPricesException(
+            28 -> WalletManagerException.GetHistoricalPricesException(
                 FfiConverterString.read(buf),
                 )
-            28 -> WalletManagerException.CsvCreationException(
+            29 -> WalletManagerException.CsvCreationException(
                 FfiConverterString.read(buf),
                 )
-            29 -> WalletManagerException.AddUtxosException(
+            30 -> WalletManagerException.AddUtxosException(
                 FfiConverterString.read(buf),
                 )
-            30 -> WalletManagerException.OutputLabelsException(
+            31 -> WalletManagerException.OutputLabelsException(
                 FfiConverterString.read(buf),
                 )
-            31 -> WalletManagerException.DatabaseCorruption(
+            32 -> WalletManagerException.DatabaseCorruption(
                 FfiConverterTypeWalletId.read(buf),
                 FfiConverterString.read(buf),
                 )
-            32 -> WalletManagerException.PendingUnsignedTransactionsLoadException(
+            33 -> WalletManagerException.PendingUnsignedTransactionsLoadException(
                 FfiConverterString.read(buf),
                 )
-            33 -> WalletManagerException.ReceiveAddressException(
+            34 -> WalletManagerException.ReceiveAddressException(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
@@ -54715,6 +54811,10 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.OutputBelowDustLimit -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
             )
             is WalletManagerException.LockedOutputsSelected -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
@@ -54883,68 +54983,72 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.LockedOutputsSelected -> {
+            is WalletManagerException.OutputBelowDustLimit -> {
                 buf.putInt(21)
                 Unit
             }
-            is WalletManagerException.GetConfirmDetailsException -> {
+            is WalletManagerException.LockedOutputsSelected -> {
                 buf.putInt(22)
-                FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.SignAndBroadcastException -> {
+            is WalletManagerException.GetConfirmDetailsException -> {
                 buf.putInt(23)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.Converter -> {
+            is WalletManagerException.SignAndBroadcastException -> {
                 buf.putInt(24)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.Converter -> {
+                buf.putInt(25)
                 FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.UnknownException -> {
-                buf.putInt(25)
-                FfiConverterString.write(value.v1, buf)
-                Unit
-            }
-            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(26)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.GetHistoricalPricesException -> {
+            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(27)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.CsvCreationException -> {
+            is WalletManagerException.GetHistoricalPricesException -> {
                 buf.putInt(28)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.AddUtxosException -> {
+            is WalletManagerException.CsvCreationException -> {
                 buf.putInt(29)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.OutputLabelsException -> {
+            is WalletManagerException.AddUtxosException -> {
                 buf.putInt(30)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.DatabaseCorruption -> {
+            is WalletManagerException.OutputLabelsException -> {
                 buf.putInt(31)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.DatabaseCorruption -> {
+                buf.putInt(32)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
                 FfiConverterString.write(value.`error`, buf)
                 Unit
             }
             is WalletManagerException.PendingUnsignedTransactionsLoadException -> {
-                buf.putInt(32)
+                buf.putInt(33)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.ReceiveAddressException -> {
-                buf.putInt(33)
+                buf.putInt(34)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
@@ -60070,20 +60174,40 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
     )
     }
 
- fun `ffiMinSendAmount`(): Amount {
+ fun `ffiConservativeDustLimitAmount`(): Amount {
             return FfiConverterTypeAmount.lift(
     uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_ffi_min_send_amount(
+    UniffiLib.uniffi_cove_fn_func_ffi_conservative_dust_limit_amount(
 
         _status)
 }
     )
     }
 
- fun `ffiMinSendSats`(): kotlin.ULong {
+ fun `ffiConservativeDustLimitSats`(): kotlin.ULong {
             return FfiConverterULong.lift(
     uniffiRustCall() { _status ->
-    UniffiLib.uniffi_cove_fn_func_ffi_min_send_sats(
+    UniffiLib.uniffi_cove_fn_func_ffi_conservative_dust_limit_sats(
+
+        _status)
+}
+    )
+    }
+
+ fun `ffiLowSendWarningAmount`(): Amount {
+            return FfiConverterTypeAmount.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_ffi_low_send_warning_amount(
+
+        _status)
+}
+    )
+    }
+
+ fun `ffiLowSendWarningSats`(): kotlin.ULong {
+            return FfiConverterULong.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_fn_func_ffi_low_send_warning_sats(
 
         _status)
 }

--- a/android/app/src/test/java/org/bitcoinppl/cove/sheets/CustomFeeRateSheetTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/sheets/CustomFeeRateSheetTest.kt
@@ -1,0 +1,34 @@
+package org.bitcoinppl.cove.sheets
+
+import org.bitcoinppl.cove_core.SendFlowException
+import org.bitcoinppl.cove_core.WalletManagerException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomFeeRateSheetTest {
+    @Test
+    fun topLevelInsufficientFundsIsTooHighCustomFeeError() {
+        assertTrue(isTooHighCustomFeeError(SendFlowException.InsufficientFunds()))
+    }
+
+    @Test
+    fun wrappedWalletInsufficientFundsIsTooHighCustomFeeError() {
+        val error =
+            SendFlowException.WalletManager(
+                WalletManagerException.InsufficientFunds("not enough funds"),
+            )
+
+        assertTrue(isTooHighCustomFeeError(error))
+    }
+
+    @Test
+    fun otherWalletErrorsAreNotTooHighCustomFeeErrors() {
+        val error =
+            SendFlowException.WalletManager(
+                WalletManagerException.LockedOutputsSelected(),
+            )
+
+        assertFalse(isTooHighCustomFeeError(error))
+    }
+}

--- a/ios/Cove.xcodeproj/project.pbxproj
+++ b/ios/Cove.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C0B000102F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000112F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift */; };
 		C0B000122F00000000000001 /* TransactionsScanUiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000132F00000000000001 /* TransactionsScanUiTests.swift */; };
 		C0B000142F00000000000001 /* OnboardingBackupViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000152F00000000000001 /* OnboardingBackupViewsTests.swift */; };
+		C0B000162F00000000000001 /* CustomFeeRateErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000172F00000000000001 /* CustomFeeRateErrorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		C0B000112F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupPresentationCoordinatorTests.swift; sourceTree = "<group>"; };
 		C0B000132F00000000000001 /* TransactionsScanUiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsScanUiTests.swift; sourceTree = "<group>"; };
 		C0B000152F00000000000001 /* OnboardingBackupViewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackupViewsTests.swift; sourceTree = "<group>"; };
+		C0B000172F00000000000001 /* CustomFeeRateErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFeeRateErrorTests.swift; sourceTree = "<group>"; };
 		D0245F4C2C0F7B4E0042B447 /* Cove.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cove.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				C0B000112F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift */,
+				C0B000172F00000000000001 /* CustomFeeRateErrorTests.swift */,
 				C0B000152F00000000000001 /* OnboardingBackupViewsTests.swift */,
 				C0B000032F00000000000001 /* OnboardingPromptLayoutTests.swift */,
 				C0B000132F00000000000001 /* TransactionsScanUiTests.swift */,
@@ -304,6 +307,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0B000102F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift in Sources */,
+				C0B000162F00000000000001 /* CustomFeeRateErrorTests.swift in Sources */,
 				C0B000142F00000000000001 /* OnboardingBackupViewsTests.swift in Sources */,
 				C0B000012F00000000000001 /* OnboardingPromptLayoutTests.swift in Sources */,
 				C0B000122F00000000000001 /* TransactionsScanUiTests.swift in Sources */,

--- a/ios/Cove/Constants.swift
+++ b/ios/Cove/Constants.swift
@@ -7,10 +7,13 @@
 
 import SwiftUI
 
-let minSendSatsU = ffiMinSendSats()
-let minSendAmount = ffiMinSendAmount()
+let lowSendWarningSatsU = ffiLowSendWarningSats()
+let lowSendWarningAmount = ffiLowSendWarningAmount()
+let lowSendWarningSats = Int(lowSendWarningSatsU)
 
-let minSendSats = Int(minSendSatsU)
+let conservativeDustLimitSatsU = ffiConservativeDustLimitSats()
+let conservativeDustLimitAmount = ffiConservativeDustLimitAmount()
+let conservativeDustLimitSats = Int(conservativeDustLimitSatsU)
 
 let screenHeight = UIScreen.main.bounds.height
 let screenWidth = UIScreen.main.bounds.width

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -104,6 +104,10 @@ struct UtxoListScreen: View {
         return "Continue (\(manager.selected.count))"
     }
 
+    var canContinue: Bool {
+        !manager.selected.isEmpty && manager.totalSelectedSats > 0
+    }
+
     /// ─── Body ────────────────────────────────────────────────
     var body: some View {
         VStack(spacing: 24) {
@@ -244,17 +248,17 @@ struct UtxoListScreen: View {
                     )
                 }
                 .buttonStyle(
-                    manager.totalSelectedSats < conservativeDustLimitSats
-                        ? DarkButtonStyle(
+                    canContinue
+                        ? DarkButtonStyle()
+                        : DarkButtonStyle(
                             backgroundColor: .systemGray4, foregroundColor: .secondary
                         )
-                        : DarkButtonStyle()
                 )
                 .controlSize(.large)
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal)
                 .padding(.bottom, 4)
-                .disabled(manager.totalSelectedSats < conservativeDustLimitSats)
+                .disabled(!canContinue)
                 .contentTransition(.interpolate)
             }
         }

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -244,7 +244,7 @@ struct UtxoListScreen: View {
                     )
                 }
                 .buttonStyle(
-                    manager.totalSelectedSats < minSendSats
+                    manager.totalSelectedSats < conservativeDustLimitSats
                         ? DarkButtonStyle(
                             backgroundColor: .systemGray4, foregroundColor: .secondary
                         )
@@ -254,7 +254,7 @@ struct UtxoListScreen: View {
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal)
                 .padding(.bottom, 4)
-                .disabled(manager.totalSelectedSats < minSendSats)
+                .disabled(manager.totalSelectedSats < conservativeDustLimitSats)
                 .contentTransition(.interpolate)
             }
         }

--- a/ios/Cove/Flows/SendFlow/Common/SendFlowUtxoCustomAmountSheetView.swift
+++ b/ios/Cove/Flows/SendFlow/Common/SendFlowUtxoCustomAmountSheetView.swift
@@ -97,7 +97,7 @@ struct SendFlowUtxoCustomAmountSheetView: View {
 
     private var maxSend: Double {
         var amount = manager.rust.maxSendMinusFees() ?? Amount.fromSat(sats: conservativeDustLimitSatsU + 1000)
-        if amount.asSats() < conservativeDustLimitSatsU {
+        if amount.asSats() <= conservativeDustLimitSatsU {
             amount = Amount.fromSat(sats: conservativeDustLimitSatsU + 1000)
         }
         return amountToDouble(amount)

--- a/ios/Cove/Flows/SendFlow/Common/SendFlowUtxoCustomAmountSheetView.swift
+++ b/ios/Cove/Flows/SendFlow/Common/SendFlowUtxoCustomAmountSheetView.swift
@@ -14,7 +14,7 @@ struct SendFlowUtxoCustomAmountSheetView: View {
 
     // private
     @State private var customAmount: Double = 0.0
-    @State private var previousAmount: Double = .init(minSendSats)
+    @State private var previousAmount: Double = .init(conservativeDustLimitSats)
     @State private var isEditing: Bool = false
     @State private var pinState: PinState = .hard
     private enum PinState { case none, soft, hard }
@@ -88,7 +88,7 @@ struct SendFlowUtxoCustomAmountSheetView: View {
     }
 
     private var minSend: Double {
-        satToDouble(minSendSats)
+        satToDouble(conservativeDustLimitSats)
     }
 
     private var step: Double {
@@ -96,15 +96,17 @@ struct SendFlowUtxoCustomAmountSheetView: View {
     }
 
     private var maxSend: Double {
-        var amount = manager.rust.maxSendMinusFees() ?? Amount.fromSat(sats: minSendSatsU + 1000)
-        if amount.asSats() < minSendSatsU { amount = Amount.fromSat(sats: minSendSatsU + 1000) }
+        var amount = manager.rust.maxSendMinusFees() ?? Amount.fromSat(sats: conservativeDustLimitSatsU + 1000)
+        if amount.asSats() < conservativeDustLimitSatsU {
+            amount = Amount.fromSat(sats: conservativeDustLimitSatsU + 1000)
+        }
         return amountToDouble(amount)
     }
 
     /// softMaxSend is the next biggest amount below maxSend that can be selected
     /// any amount between softMaxSend and maxSend can NOT be selected, because that would create a dust UTXO
     private var softMaxSend: Double {
-        let amount = manager.rust.maxSendMinusFeesAndSmallUtxo() ?? minSendAmount
+        let amount = manager.rust.maxSendMinusFeesAndSmallUtxo() ?? conservativeDustLimitAmount
         return amountToDouble(amount)
     }
 

--- a/ios/Cove/Flows/SendFlow/SendFlowCoinControlSetAmountScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowCoinControlSetAmountScreen.swift
@@ -254,7 +254,11 @@ struct SendFlowCoinControlSetAmountScreen: View {
             presenter.alertTitle,
             isPresented: presenter.showingAlert,
             presenting: presenter.alertState,
-            actions: presenter.alertButtons,
+            actions: { alert in
+                presenter.alertButtons(alert: alert) { kind in
+                    sendFlowManager.dispatch(action: .acknowledgeWarningAndFinalize(kind))
+                }
+            },
             message: presenter.alertMessage
         )
     }

--- a/ios/Cove/Flows/SendFlow/SendFlowCustomFeeRateView.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowCustomFeeRateView.swift
@@ -7,6 +7,17 @@
 
 import SwiftUI
 
+func isTooHighCustomFeeError(_ error: Error) -> Bool {
+    switch error {
+    case SendFlowError.InsufficientFunds:
+        true
+    case SendFlowError.WalletManager(.InsufficientFunds(_)):
+        true
+    default:
+        false
+    }
+}
+
 struct SendFlowCustomFeeRateView: View {
     @Environment(AppManager.self) private var app
     @Environment(WalletManager.self) private var manager
@@ -90,7 +101,12 @@ struct SendFlowCustomFeeRateView: View {
                     self.feeOptions = feeOptions
                     presenter.lastWorkingFeeRate = feeRate.satPerVb()
                 }
-            } catch let SendFlowError.WalletManager(.InsufficientFunds(error)) {
+            } catch {
+                guard isTooHighCustomFeeError(error) else {
+                    Log.error("Unable to get accurate total sats \(error)")
+                    return
+                }
+
                 Log.error("Unable to get accurate total sats \(error), setting max fee rate to \(feeRate.satPerVb())")
                 let feeRate = feeRate.satPerVb()
 
@@ -104,8 +120,6 @@ struct SendFlowCustomFeeRateView: View {
                         presenter.alertState = .init(.general(title: "Fee too high!", message: "The fee rate you entered is too high, we automatically selected a lower fee"))
                     }
                 }
-            } catch {
-                Log.error("Unable to get accurate total sats \(error)")
             }
         }
     }

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -62,7 +62,6 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
     func validate(displayAlert: Bool = false) -> Bool {
         validateAmount(displayAlert: displayAlert)
             && validateAddress(displayAlert: displayAlert)
-            && validateFeePercentage(displayAlert: displayAlert)
     }
 
     func validateAddress(displayAlert: Bool = false) -> Bool {
@@ -71,10 +70,6 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
 
     func validateAmount(displayAlert: Bool = false) -> Bool {
         rust.validateAmount(displayAlert: displayAlert)
-    }
-
-    func validateFeePercentage(_: String? = nil, displayAlert: Bool = false) -> Bool {
-        rust.validateFeePercentage(displayAlert: displayAlert)
     }
 
     /// private
@@ -156,14 +151,17 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
 
         case let .setAlert(alertState):
             Log.warn("setAlert: \(alertState)")
-            self.presenter.alertState = .init(alertState)
+            let hadSheet = self.presenter.sheetState != .none
+            let hadAlert = self.presenter.alertState != .none
 
-            if self.presenter.sheetState != .none || self.presenter.alertState != .none {
+            if hadSheet || hadAlert {
                 self.presenter.alertState = .none
                 self.presenter.sheetState = .none
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                     self.presenter.alertState = .init(alertState)
                 }
+            } else {
+                self.presenter.alertState = .init(alertState)
             }
 
         case .clearAlert:

--- a/ios/Cove/Flows/SendFlow/SendFlowManager.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowManager.swift
@@ -153,9 +153,10 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
             Log.warn("setAlert: \(alertState)")
             let hadSheet = self.presenter.sheetState != .none
             let hadAlert = self.presenter.alertState != .none
+            let isDismissingAlert = self.presenter.isDisappearing
 
-            if hadSheet || hadAlert {
-                self.presenter.alertState = .none
+            if hadSheet || hadAlert || isDismissingAlert {
+                self.presenter.clearAlert()
                 self.presenter.sheetState = .none
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                     self.presenter.alertState = .init(alertState)
@@ -165,7 +166,7 @@ extension WeakReconciler: SendFlowManagerReconciler where Reconciler == SendFlow
             }
 
         case .clearAlert:
-            self.presenter.alertState = .none
+            self.presenter.clearAlert()
 
         case let .setMaxSelected(maxSelected):
             self.maxSelected = maxSelected

--- a/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
@@ -17,6 +17,11 @@ import SwiftUI
     let manager: WalletManager
 
     private var disappearing: Bool = false
+    @ObservationIgnored
+    private var disappearingResetWorkItem: DispatchWorkItem?
+    var isDisappearing: Bool {
+        disappearing
+    }
 
     var focusField: SetAmountFocusField?
     var sheetState: TaggedItem<SheetState>? = .none
@@ -38,7 +43,7 @@ import SwiftUI
     var showingAlert: Binding<Bool> {
         Binding(
             get: { self.alertState != nil && !self.disappearing },
-            set: { if !$0 { self.alertState = .none }}
+            set: { if !$0 { self.clearAlert() }}
         )
     }
 
@@ -65,10 +70,22 @@ import SwiftUI
     }
 
     func setDisappearing() {
+        disappearingResetWorkItem?.cancel()
         self.disappearing = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.disappearing = false
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.disappearing = false
         }
+        disappearingResetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: workItem)
+    }
+
+    func clearAlert() {
+        if alertState != nil {
+            setDisappearing()
+        }
+
+        alertState = .none
     }
 
     private func errorAlertTitle(_ error: SendFlowError) -> String {
@@ -149,13 +166,13 @@ import SwiftUI
         case let .error(error):
             errorAlertButtons(error)
         case .general:
-            Button("OK") { self.alertState = .none }
+            Button("OK") { self.clearAlert() }
         case let .warning(kind: kind, title: _, message: _):
             Button("Send Anyway") {
                 acknowledgeWarning(kind)
             }
             Button("Cancel", role: .cancel) {
-                self.alertState = .none
+                self.clearAlert()
             }
         }
     }
@@ -165,28 +182,28 @@ import SwiftUI
         switch error {
         case .EmptyAddress, .WrongNetwork, .InvalidAddress:
             Button("OK") {
-                self.alertState = .none
+                self.clearAlert()
                 self.focusField = .address
             }
         case .NoBalance:
             Button("Go Back") {
-                self.alertState = .none
+                self.clearAlert()
                 self.app.popRoute()
             }
         case .InvalidNumber, .InsufficientFunds, .SendBelowDustLimit, .ZeroAmount, .WalletManager, .UnableToGetFeeDetails:
             Button("OK") {
                 self.focusField = .amount
-                self.alertState = .none
+                self.clearAlert()
             }
         case .UnableToGetFeeRate, .UnableToBuildTxn, .UnableToSaveUnsignedTransaction:
             Button("OK") {
                 self.focusField = .amount
-                self.alertState = .none
+                self.clearAlert()
             }
         case .UnableToGetMaxSend:
             Button("OK") {
                 self.focusField = .amount
-                self.alertState = .none
+                self.clearAlert()
             }
         }
     }

--- a/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowPresenter.swift
@@ -57,6 +57,8 @@ import SwiftUI
             errorAlertTitle(error)
         case let .some(.general(title: title, message: _)):
             title
+        case let .some(.warning(kind: _, title: title, message: _)):
+            title
         case .none:
             ""
         }
@@ -75,7 +77,7 @@ import SwiftUI
             "Invalid Address"
         case .InvalidNumber, .ZeroAmount: "Invalid Amount"
         case .InsufficientFunds, .NoBalance: "Insufficient Funds"
-        case .SendAmountToLow: "Send Amount Too Low"
+        case .SendBelowDustLimit: "Amount Below Dust Limit"
         case .UnableToGetFeeRate: "Unable to get fee rate"
         case .UnableToBuildTxn: "Unable to build transaction"
         case .UnableToGetMaxSend:
@@ -98,6 +100,8 @@ import SwiftUI
             Text(errorAlertMessage(error))
         case let .general(title: _, message: message):
             Text(message)
+        case let .warning(kind: _, title: _, message: message):
+            Text(message)
         }
     }
 
@@ -117,8 +121,8 @@ import SwiftUI
             "The address \(address) is on the wrong network, is it for (\(validFor). You are on \(currentNetwork)"
         case .InsufficientFunds:
             "You do not have enough bitcoin in your wallet to cover the amount plus fees"
-        case .SendAmountToLow:
-            "Send amount is too low. Please send atleast 5000 sats"
+        case .SendBelowDustLimit:
+            "This amount is below Bitcoin's dust limit for this address type. The network would reject it. Please send a bit more."
         case .UnableToGetFeeRate:
             "Are you connected to the internet?"
         case .WalletManager(.LockedOutputsSelected):
@@ -137,12 +141,22 @@ import SwiftUI
     }
 
     @ViewBuilder
-    func alertButtons(alert: TaggedItem<SendFlowAlertState>) -> some View {
+    func alertButtons(
+        alert: TaggedItem<SendFlowAlertState>,
+        acknowledgeWarning: @escaping (SendFlowWarningKind) -> Void
+    ) -> some View {
         switch alert.item {
         case let .error(error):
             errorAlertButtons(error)
         case .general:
             Button("OK") { self.alertState = .none }
+        case let .warning(kind: kind, title: _, message: _):
+            Button("Send Anyway") {
+                acknowledgeWarning(kind)
+            }
+            Button("Cancel", role: .cancel) {
+                self.alertState = .none
+            }
         }
     }
 
@@ -159,7 +173,7 @@ import SwiftUI
                 self.alertState = .none
                 self.app.popRoute()
             }
-        case .InvalidNumber, .InsufficientFunds, .SendAmountToLow, .ZeroAmount, .WalletManager, .UnableToGetFeeDetails:
+        case .InvalidNumber, .InsufficientFunds, .SendBelowDustLimit, .ZeroAmount, .WalletManager, .UnableToGetFeeDetails:
             Button("OK") {
                 self.focusField = .amount
                 self.alertState = .none

--- a/ios/Cove/Flows/SendFlow/SendFlowSetAmountScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowSetAmountScreen.swift
@@ -285,7 +285,11 @@ struct SendFlowSetAmountScreen: View {
             presenter.alertTitle,
             isPresented: presenter.showingAlert,
             presenting: presenter.alertState,
-            actions: presenter.alertButtons,
+            actions: { alert in
+                presenter.alertButtons(alert: alert) { kind in
+                    sendFlowManager.dispatch(action: .acknowledgeWarningAndFinalize(kind))
+                }
+            },
             message: presenter.alertMessage
         )
     }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -8680,8 +8680,6 @@ public protocol RustSendFlowManagerProtocol: AnyObject, Sendable {
 
     func validateAmount(displayAlert: Bool)  -> Bool
 
-    func validateFeePercentage(displayAlert: Bool)  -> Bool
-
     /**
      * get the custom fee rate option
      */
@@ -8834,16 +8832,6 @@ open func validateAmount(displayAlert: Bool = false) -> Bool  {
     return try!  FfiConverterBool.lift(try! rustCall() {
         uniffiCallStatus in
     uniffi_cove_fn_method_rustsendflowmanager_validate_amount(
-            self.uniffiCloneHandle(),
-        FfiConverterBool.lower(displayAlert),uniffiCallStatus
-    )
-})
-}
-
-open func validateFeePercentage(displayAlert: Bool = false) -> Bool  {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-        uniffiCallStatus in
-    uniffi_cove_fn_method_rustsendflowmanager_validate_fee_percentage(
             self.uniffiCloneHandle(),
         FfiConverterBool.lower(displayAlert),uniffiCallStatus
     )
@@ -30269,6 +30257,8 @@ public enum SendFlowAlertState: Equatable, Hashable {
     )
     case general(title: String, message: String
     )
+    case warning(kind: SendFlowWarningKind, title: String, message: String
+    )
 
 
 
@@ -30296,6 +30286,9 @@ public struct FfiConverterTypeSendFlowAlertState: FfiConverterRustBuffer {
         case 2: return .general(title: try FfiConverterString.read(from: &buf), message: try FfiConverterString.read(from: &buf)
         )
 
+        case 3: return .warning(kind: try FfiConverterTypeSendFlowWarningKind.read(from: &buf), title: try FfiConverterString.read(from: &buf), message: try FfiConverterString.read(from: &buf)
+        )
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
@@ -30311,6 +30304,13 @@ public struct FfiConverterTypeSendFlowAlertState: FfiConverterRustBuffer {
 
         case let .general(title,message):
             writeInt(&buf, Int32(2))
+            FfiConverterString.write(title, into: &buf)
+            FfiConverterString.write(message, into: &buf)
+
+
+        case let .warning(kind,title,message):
+            writeInt(&buf, Int32(3))
+            FfiConverterTypeSendFlowWarningKind.write(kind, into: &buf)
             FfiConverterString.write(title, into: &buf)
             FfiConverterString.write(message, into: &buf)
 
@@ -30420,7 +30420,7 @@ enum SendFlowError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError 
     case UnableToGetMaxSend(String
     )
     case InsufficientFunds
-    case SendAmountToLow
+    case SendBelowDustLimit
     case UnableToGetFeeRate
     case UnableToBuildTxn(String
     )
@@ -30486,7 +30486,7 @@ public struct FfiConverterTypeSendFlowError: FfiConverterRustBuffer {
             try FfiConverterString.read(from: &buf)
             )
         case 8: return .InsufficientFunds
-        case 9: return .SendAmountToLow
+        case 9: return .SendBelowDustLimit
         case 10: return .UnableToGetFeeRate
         case 11: return .UnableToBuildTxn(
             try FfiConverterString.read(from: &buf)
@@ -30549,7 +30549,7 @@ public struct FfiConverterTypeSendFlowError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(8))
 
 
-        case .SendAmountToLow:
+        case .SendBelowDustLimit:
             writeInt(&buf, Int32(9))
 
 
@@ -30809,6 +30809,8 @@ public enum SendFlowManagerAction {
     case changeFeeRateOptions(FeeRateOptionsWithTotalFee
     )
     case finalizeAndGoToNextScreen
+    case acknowledgeWarningAndFinalize(SendFlowWarningKind
+    )
 
 
 
@@ -30892,6 +30894,9 @@ public struct FfiConverterTypeSendFlowManagerAction: FfiConverterRustBuffer {
         )
 
         case 23: return .finalizeAndGoToNextScreen
+
+        case 24: return .acknowledgeWarningAndFinalize(try FfiConverterTypeSendFlowWarningKind.read(from: &buf)
+        )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -31013,6 +31018,11 @@ public struct FfiConverterTypeSendFlowManagerAction: FfiConverterRustBuffer {
 
         case .finalizeAndGoToNextScreen:
             writeInt(&buf, Int32(23))
+
+
+        case let .acknowledgeWarningAndFinalize(v1):
+            writeInt(&buf, Int32(24))
+            FfiConverterTypeSendFlowWarningKind.write(v1, into: &buf)
 
         }
     }
@@ -31204,6 +31214,79 @@ public func FfiConverterTypeSendFlowManagerReconcileMessage_lift(_ buf: RustBuff
 #endif
 public func FfiConverterTypeSendFlowManagerReconcileMessage_lower(_ value: SendFlowManagerReconcileMessage) -> RustBuffer {
     return FfiConverterTypeSendFlowManagerReconcileMessage.lower(value)
+}
+
+
+
+
+public enum SendFlowWarningKind: Equatable, Hashable {
+
+    case smallAmount
+    case highFee
+    case veryHighFee
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension SendFlowWarningKind: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSendFlowWarningKind: FfiConverterRustBuffer {
+    typealias SwiftType = SendFlowWarningKind
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SendFlowWarningKind {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .smallAmount
+
+        case 2: return .highFee
+
+        case 3: return .veryHighFee
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SendFlowWarningKind, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .smallAmount:
+            writeInt(&buf, Int32(1))
+
+
+        case .highFee:
+            writeInt(&buf, Int32(2))
+
+
+        case .veryHighFee:
+            writeInt(&buf, Int32(3))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSendFlowWarningKind_lift(_ buf: RustBuffer) throws -> SendFlowWarningKind {
+    return try FfiConverterTypeSendFlowWarningKind.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSendFlowWarningKind_lower(_ value: SendFlowWarningKind) -> RustBuffer {
+    return FfiConverterTypeSendFlowWarningKind.lower(value)
 }
 
 
@@ -34881,6 +34964,7 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     )
     case InsufficientFunds(String
     )
+    case OutputBelowDustLimit
     case LockedOutputsSelected
     case GetConfirmDetailsError(String
     )
@@ -34999,42 +35083,43 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
         case 20: return .InsufficientFunds(
             try FfiConverterString.read(from: &buf)
             )
-        case 21: return .LockedOutputsSelected
-        case 22: return .GetConfirmDetailsError(
+        case 21: return .OutputBelowDustLimit
+        case 22: return .LockedOutputsSelected
+        case 23: return .GetConfirmDetailsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 23: return .SignAndBroadcastError(
+        case 24: return .SignAndBroadcastError(
             try FfiConverterString.read(from: &buf)
             )
-        case 24: return .Converter(
+        case 25: return .Converter(
             try FfiConverterTypeConverterError.read(from: &buf)
             )
-        case 25: return .UnknownError(
+        case 26: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
-        case 26: return .PsbtFinalizeError(
+        case 27: return .PsbtFinalizeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 27: return .GetHistoricalPricesError(
+        case 28: return .GetHistoricalPricesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 28: return .CsvCreationError(
+        case 29: return .CsvCreationError(
             try FfiConverterString.read(from: &buf)
             )
-        case 29: return .AddUtxosError(
+        case 30: return .AddUtxosError(
             try FfiConverterString.read(from: &buf)
             )
-        case 30: return .OutputLabelsError(
+        case 31: return .OutputLabelsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 31: return .DatabaseCorruption(
+        case 32: return .DatabaseCorruption(
             id: try FfiConverterTypeWalletId.read(from: &buf),
             error: try FfiConverterString.read(from: &buf)
             )
-        case 32: return .PendingUnsignedTransactionsLoadError(
+        case 33: return .PendingUnsignedTransactionsLoadError(
             try FfiConverterString.read(from: &buf)
             )
-        case 33: return .ReceiveAddressError(
+        case 34: return .ReceiveAddressError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -35146,68 +35231,72 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
 
 
-        case .LockedOutputsSelected:
+        case .OutputBelowDustLimit:
             writeInt(&buf, Int32(21))
 
 
-        case let .GetConfirmDetailsError(v1):
+        case .LockedOutputsSelected:
             writeInt(&buf, Int32(22))
-            FfiConverterString.write(v1, into: &buf)
 
 
-        case let .SignAndBroadcastError(v1):
+        case let .GetConfirmDetailsError(v1):
             writeInt(&buf, Int32(23))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .Converter(v1):
+        case let .SignAndBroadcastError(v1):
             writeInt(&buf, Int32(24))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .Converter(v1):
+            writeInt(&buf, Int32(25))
             FfiConverterTypeConverterError.write(v1, into: &buf)
 
 
         case let .UnknownError(v1):
-            writeInt(&buf, Int32(25))
-            FfiConverterString.write(v1, into: &buf)
-
-
-        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(26))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .GetHistoricalPricesError(v1):
+        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(27))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .CsvCreationError(v1):
+        case let .GetHistoricalPricesError(v1):
             writeInt(&buf, Int32(28))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .AddUtxosError(v1):
+        case let .CsvCreationError(v1):
             writeInt(&buf, Int32(29))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .OutputLabelsError(v1):
+        case let .AddUtxosError(v1):
             writeInt(&buf, Int32(30))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .DatabaseCorruption(id,error):
+        case let .OutputLabelsError(v1):
             writeInt(&buf, Int32(31))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .DatabaseCorruption(id,error):
+            writeInt(&buf, Int32(32))
             FfiConverterTypeWalletId.write(id, into: &buf)
             FfiConverterString.write(error, into: &buf)
 
 
         case let .PendingUnsignedTransactionsLoadError(v1):
-            writeInt(&buf, Int32(32))
+            writeInt(&buf, Int32(33))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .ReceiveAddressError(v1):
-            writeInt(&buf, Int32(33))
+            writeInt(&buf, Int32(34))
             FfiConverterString.write(v1, into: &buf)
 
         }
@@ -40262,17 +40351,31 @@ public func walletDisplaySentAndReceivedAmount(metadata: WalletMetadata, sentAnd
     )
 })
 }
-public func ffiMinSendAmount() -> Amount  {
+public func ffiConservativeDustLimitAmount() -> Amount  {
     return try!  FfiConverterTypeAmount_lift(try! rustCall() {
         uniffiCallStatus in
-    uniffi_cove_fn_func_ffi_min_send_amount(uniffiCallStatus
+    uniffi_cove_fn_func_ffi_conservative_dust_limit_amount(uniffiCallStatus
     )
 })
 }
-public func ffiMinSendSats() -> UInt64  {
+public func ffiConservativeDustLimitSats() -> UInt64  {
     return try!  FfiConverterUInt64.lift(try! rustCall() {
         uniffiCallStatus in
-    uniffi_cove_fn_func_ffi_min_send_sats(uniffiCallStatus
+    uniffi_cove_fn_func_ffi_conservative_dust_limit_sats(uniffiCallStatus
+    )
+})
+}
+public func ffiLowSendWarningAmount() -> Amount  {
+    return try!  FfiConverterTypeAmount_lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_ffi_low_send_warning_amount(uniffiCallStatus
+    )
+})
+}
+public func ffiLowSendWarningSats() -> UInt64  {
+    return try!  FfiConverterUInt64.lift(try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_fn_func_ffi_low_send_warning_sats(uniffiCallStatus
     )
 })
 }
@@ -40488,10 +40591,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_func_wallet_display_sent_and_received_amount() != 2923) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_func_ffi_min_send_amount() != 61138) {
+    if (uniffi_cove_checksum_func_ffi_conservative_dust_limit_amount() != 11787) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_func_ffi_min_send_sats() != 550) {
+    if (uniffi_cove_checksum_func_ffi_conservative_dust_limit_sats() != 54311) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_ffi_low_send_warning_amount() != 6176) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_func_ffi_low_send_warning_sats() != 35697) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_func_preview_new_legacy_found_address() != 25458) {
@@ -41053,9 +41162,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustsendflowmanager_validate_amount() != 64774) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_cove_checksum_method_rustsendflowmanager_validate_fee_percentage() != 52935) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustsendflowmanager_get_custom_fee_option() != 7512) {

--- a/ios/CoveTests/CustomFeeRateErrorTests.swift
+++ b/ios/CoveTests/CustomFeeRateErrorTests.swift
@@ -1,0 +1,20 @@
+@testable import Cove
+import XCTest
+
+final class CustomFeeRateErrorTests: XCTestCase {
+    func testTopLevelInsufficientFundsIsTooHighCustomFeeError() {
+        XCTAssertTrue(isTooHighCustomFeeError(SendFlowError.InsufficientFunds))
+    }
+
+    func testWrappedWalletInsufficientFundsIsTooHighCustomFeeError() {
+        let error = SendFlowError.WalletManager(.InsufficientFunds("not enough funds"))
+
+        XCTAssertTrue(isTooHighCustomFeeError(error))
+    }
+
+    func testOtherWalletErrorsAreNotTooHighCustomFeeErrors() {
+        let error = SendFlowError.WalletManager(.LockedOutputsSelected)
+
+        XCTAssertFalse(isTooHighCustomFeeError(error))
+    }
+}

--- a/rust/crates/cove-common/src/consts.rs
+++ b/rust/crates/cove-common/src/consts.rs
@@ -11,8 +11,13 @@ pub static WALLET_DATA_DIR: LazyLock<PathBuf> = LazyLock::new(wallet_data_dir_in
 pub static GAP_LIMIT: u8 = 30;
 pub static MAX_RESCAN_GAP_LIMIT: u32 = 2000;
 
-pub static MIN_SEND_SATS: u64 = 5000;
-pub static MIN_SEND_AMOUNT: Amount = Amount::from_sat(MIN_SEND_SATS);
+/// Warn users before sending on-chain payments below this amount
+pub static LOW_SEND_WARNING_SATS: u64 = 5000;
+pub static LOW_SEND_WARNING_AMOUNT: Amount = Amount::from_sat(LOW_SEND_WARNING_SATS);
+
+/// Conservative UI fallback when the recipient script is not available
+pub static CONSERVATIVE_DUST_LIMIT_SATS: u64 = 546;
+pub static CONSERVATIVE_DUST_LIMIT_AMOUNT: Amount = Amount::from_sat(CONSERVATIVE_DUST_LIMIT_SATS);
 
 /// Set custom root data directory (must be called before any database access)
 /// primarily for Android where we need to use app-specific storage

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -942,6 +942,42 @@ mod tests {
     }
 
     #[test]
+    fn coin_control_fee_update_preserves_amount_when_real_max_is_zero() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 900);
+        set_selected_fee_without_total(&manager);
+        {
+            let mut state = manager.state.lock();
+            state.address = Some(Arc::new(Address::preview_new()));
+            state.unlocked_spendable_sats = Some(50_000);
+        }
+
+        assert!(manager.handle_coin_control_amount_changed(850.0).is_some());
+
+        let selected =
+            fee_rate_option_with_total_fee(FeeSpeed::Custom { duration_mins: 20 }, 1_000);
+        manager.selected_fee_rate_changed(Arc::new(selected));
+
+        {
+            let state = manager.state.lock();
+            assert_eq!(state.amount_sats, Some(850));
+            assert!(
+                matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
+            );
+        }
+
+        drain_reconcile_messages(&manager);
+
+        manager.finalize_and_go_to_next_screen();
+
+        assert!(matches!(
+            next_reconcile_message(&manager),
+            super::Message::SetAlert(super::SendFlowAlertState::General { title, .. })
+                if title == "Fee Too High!"
+        ));
+    }
+
+    #[test]
     fn coin_control_amount_change_snaps_to_max_when_fee_adjusted_max_exceeded() {
         let manager = manager_for_validation();
         set_coin_control_mode_with_total(&manager, 1_500);

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -794,11 +794,33 @@ mod tests {
         message
     }
 
+    fn drain_reconcile_messages(manager: &super::RustSendFlowManager) -> Vec<super::Message> {
+        let mut messages = Vec::new();
+
+        while let Ok(message) = manager.reconcile_receiver.try_recv() {
+            match message {
+                SingleOrMany::Single(message) => messages.push(message),
+                SingleOrMany::Many(batch) => messages.extend(batch),
+            }
+        }
+
+        messages
+    }
+
     fn pending_warning_kind(
         manager: &super::RustSendFlowManager,
     ) -> Option<super::SendFlowWarningKind> {
         match manager.pending_send_warning()? {
             super::SendFlowAlertState::Warning { kind, .. } => Some(kind),
+            _ => None,
+        }
+    }
+
+    fn warning_message_kind(message: &super::Message) -> Option<super::SendFlowWarningKind> {
+        match message {
+            super::Message::SetAlert(super::SendFlowAlertState::Warning { kind, .. }) => {
+                Some(*kind)
+            }
             _ => None,
         }
     }
@@ -856,16 +878,93 @@ mod tests {
     }
 
     #[test]
-    fn acknowledging_small_amount_then_rerunning_finalize_reveals_high_fee() {
+    fn acknowledging_small_amount_through_finalize_reveals_high_fee() {
         let manager = manager_for_validation();
         set_valid_amount_and_address(&manager, 1_000);
         set_selected_fee_total(&manager, 60);
 
+        manager.finalize_and_go_to_next_screen();
+
+        let message = next_reconcile_message(&manager);
+        assert_eq!(warning_message_kind(&message), Some(super::SendFlowWarningKind::SmallAmount));
+
+        manager.clone().dispatch(super::Action::AcknowledgeWarningAndFinalize(
+            super::SendFlowWarningKind::SmallAmount,
+        ));
+
+        let messages = drain_reconcile_messages(&manager);
+        assert!(messages.contains(&super::Message::ClearAlert));
+        assert!(
+            messages.iter().any(|message| warning_message_kind(message)
+                == Some(super::SendFlowWarningKind::HighFee))
+        );
+    }
+
+    #[test]
+    fn acknowledging_final_warning_through_finalize_proceeds_past_warning_gate() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_total(&manager, 60);
+
+        manager.finalize_and_go_to_next_screen();
+        assert_eq!(
+            warning_message_kind(&next_reconcile_message(&manager)),
+            Some(super::SendFlowWarningKind::SmallAmount)
+        );
+
+        manager.clone().dispatch(super::Action::AcknowledgeWarningAndFinalize(
+            super::SendFlowWarningKind::SmallAmount,
+        ));
+        let messages = drain_reconcile_messages(&manager);
+        assert!(
+            messages.iter().any(|message| warning_message_kind(message)
+                == Some(super::SendFlowWarningKind::HighFee))
+        );
+
+        manager.clone().dispatch(super::Action::AcknowledgeWarningAndFinalize(
+            super::SendFlowWarningKind::HighFee,
+        ));
+
+        let messages = drain_reconcile_messages(&manager);
+        let focus_update_index = messages
+            .iter()
+            .position(|message| matches!(message, super::Message::UpdateFocusField(None)));
+        let alert_index =
+            messages.iter().position(|message| matches!(message, super::Message::SetAlert(_)));
+
+        assert!(messages.contains(&super::Message::ClearAlert));
+        assert!(focus_update_index.is_some());
+        assert!(alert_index.is_none_or(|alert_index| {
+            focus_update_index.is_some_and(|focus_update_index| focus_update_index < alert_index)
+        }));
+    }
+
+    #[test]
+    fn acknowledged_small_amount_rearms_when_amount_changes_through_dispatch() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_total(&manager, 60);
+
+        manager.finalize_and_go_to_next_screen();
+        assert_eq!(
+            warning_message_kind(&next_reconcile_message(&manager)),
+            Some(super::SendFlowWarningKind::SmallAmount)
+        );
+
+        manager.clone().dispatch(super::Action::AcknowledgeWarningAndFinalize(
+            super::SendFlowWarningKind::SmallAmount,
+        ));
+        assert!(drain_reconcile_messages(&manager).iter().any(|message| warning_message_kind(
+            message
+        ) == Some(
+            super::SendFlowWarningKind::HighFee
+        )));
+
+        manager
+            .clone()
+            .dispatch(super::Action::NotifyAmountChanged(Arc::new(super::Amount::from_sat(2_000))));
+
         assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::SmallAmount));
-
-        manager.state.lock().acknowledge_warning(super::SendFlowWarningKind::SmallAmount);
-
-        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::HighFee));
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -699,7 +699,7 @@ impl RustSendFlowManager {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use cove_types::fees::{
         FeeRateOption, FeeRateOptionWithTotalFee, FeeRateOptionsWithTotalFee, FeeSpeed,
@@ -928,6 +928,27 @@ mod tests {
         manager.finalize_and_go_to_next_screen();
 
         assert!(manager.reconcile_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn finalize_reports_dust_when_missing_total_fee_refresh_cannot_build_fee_totals() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1);
+        set_selected_fee_without_total(&manager);
+
+        manager.finalize_and_go_to_next_screen();
+
+        let message = manager
+            .reconcile_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("dust alert is reconciled");
+
+        assert!(matches!(
+            message,
+            SingleOrMany::Single(super::Message::SetAlert(super::SendFlowAlertState::Error(
+                super::SendFlowError::SendBelowDustLimit
+            )))
+        ));
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -786,12 +786,18 @@ mod tests {
         state.address = Some(Arc::new(Address::preview_new()));
     }
 
-    fn set_coin_control_mode(manager: &super::RustSendFlowManager) {
-        let utxo_list = Arc::new(UtxoList::from(preview_new_utxo_list(1, 0)));
+    fn set_coin_control_mode_with_total(manager: &super::RustSendFlowManager, total_sats: u64) {
+        let mut utxos = preview_new_utxo_list(1, 0);
+        utxos[0].amount = Arc::new(super::Amount::from_sat(total_sats));
+        let utxo_list = Arc::new(UtxoList::from(utxos));
 
         let mut state = manager.state.lock();
         state.metadata.selected_unit = super::BitcoinUnit::Sat;
         state.mode = super::EnterMode::coin_control_max(utxo_list);
+    }
+
+    fn set_coin_control_mode(manager: &super::RustSendFlowManager) {
+        set_coin_control_mode_with_total(manager, 10_000);
     }
 
     fn next_reconcile_message(manager: &super::RustSendFlowManager) -> super::Message {
@@ -868,6 +874,20 @@ mod tests {
         assert!(
             manager.handle_coin_control_entered_amount_changed("300".to_string(), true).is_some()
         );
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(300));
+        assert!(
+            matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
+        );
+    }
+
+    #[test]
+    fn coin_control_amount_change_preserves_amount_when_snap_threshold_unavailable() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 1_500);
+
+        assert!(manager.handle_coin_control_amount_changed(300.0).is_some());
 
         let state = manager.state.lock();
         assert_eq!(state.amount_sats, Some(300));

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -361,14 +361,18 @@ impl RustSendFlowManager {
         let fee_percentage = fee_sats as f64 / amount_sats as f64 * 100.0;
         let display_fee_percentage = format!("{fee_percentage:.0}");
 
-        if fee_percentage >= VERY_HIGH_FEE_WARNING_PERCENT && !very_high_fee_acknowledged {
-            return Some(SendFlowAlertState::Warning {
-                kind: SendFlowWarningKind::VeryHighFee,
-                title: "Very High Network Fee".to_string(),
-                message: format!(
-                    "The network fee is {display_fee_percentage}% of the amount you are sending. That is unusually high for an on-chain payment. Consider sending a larger amount, lowering the fee rate if timing allows, or using an external Lightning option for small payments."
-                ),
-            });
+        if fee_percentage >= VERY_HIGH_FEE_WARNING_PERCENT {
+            if !very_high_fee_acknowledged {
+                return Some(SendFlowAlertState::Warning {
+                    kind: SendFlowWarningKind::VeryHighFee,
+                    title: "Very High Network Fee".to_string(),
+                    message: format!(
+                        "The network fee is {display_fee_percentage}% of the amount you are sending. That is unusually high for an on-chain payment. Consider sending a larger amount, lowering the fee rate if timing allows, or using an external Lightning option for small payments."
+                    ),
+                });
+            }
+
+            return None;
         }
 
         if fee_percentage >= HIGH_FEE_WARNING_PERCENT && !high_fee_acknowledged {
@@ -836,6 +840,19 @@ mod tests {
         set_selected_fee_total(&manager, 500);
 
         assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::HighFee));
+    }
+
+    #[test]
+    fn acknowledging_very_high_fee_does_not_reveal_high_fee_for_same_fee() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 10_000);
+        set_selected_fee_total(&manager, 2_000);
+
+        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::VeryHighFee));
+
+        manager.state.lock().acknowledge_warning(super::SendFlowWarningKind::VeryHighFee);
+
+        assert_eq!(pending_warning_kind(&manager), None);
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -29,11 +29,11 @@ use crate::{
     },
 };
 use act_zero::WeakAddr;
-use alert_state::SendFlowAlertState;
+use alert_state::{SendFlowAlertState, SendFlowWarningKind};
 use amount_or_max::AmountOrMax;
 use backon::{ExponentialBuilder, Retryable};
 use btc_on_change::BtcOnChangeHandler;
-use cove_common::consts::MIN_SEND_SATS;
+use cove_common::consts::LOW_SEND_WARNING_SATS;
 use cove_types::{
     amount::Amount,
     fees::{FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee, FeeSpeed},
@@ -62,6 +62,8 @@ type SingleOrMany = deferred_sender::SingleOrMany<Message>;
 type DeferredSender = deferred_sender::DeferredSender<Message>;
 
 const LOCK_STATE_LOAD_FAILED_ERROR_ID: &str = "send_flow_lock_state_load_failed";
+const HIGH_FEE_WARNING_PERCENT: f64 = 5.0;
+const VERY_HIGH_FEE_WARNING_PERCENT: f64 = 20.0;
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
 pub enum SetAmountFocusField {
@@ -154,6 +156,7 @@ pub enum SendFlowManagerAction {
     ChangeFeeRateOptions(Arc<FeeRateOptionsWithTotalFee>),
 
     FinalizeAndGoToNextScreen,
+    AcknowledgeWarningAndFinalize(SendFlowWarningKind),
 }
 
 impl RustSendFlowManager {
@@ -232,11 +235,6 @@ impl RustSendFlowManager {
     }
 
     #[uniffi::method(default(display_alert = false))]
-    pub fn validate_fee_percentage(self: &Arc<Self>, display_alert: bool) -> bool {
-        self.validate_fee_percentage_internal(display_alert)
-    }
-
-    #[uniffi::method(default(display_alert = false))]
     pub fn validate_amount(self: &Arc<Self>, display_alert: bool) -> bool {
         self.validate_amount_internal(display_alert)
     }
@@ -256,44 +254,7 @@ impl RustSendFlowManager {
 
         true
     }
-    pub(crate) fn validate_fee_percentage_internal(self: &Arc<Self>, display_alert: bool) -> bool {
-        let Some(amount) = self.state.lock().amount_sats else { return false };
-        let Some(fee_rate) = self.selected_fee_rate() else { return false };
-        let Some(total_fee) = fee_rate.total_fee() else { return false };
 
-        let fee_sats = total_fee.as_sats();
-        let fee_percentage = fee_sats * 100 / amount;
-
-        debug!("validate_fee_percentage: {fee_sats} / {amount} = {fee_percentage} ");
-        if fee_percentage > 100 {
-            let error = SendFlowAlertState::General {
-                title: "Fee Too High!".to_string(),
-                message: "The fee is higher than the amount you are sending".to_string(),
-            };
-
-            if display_alert {
-                self.reconciler.send(Message::SetAlert(error));
-            }
-
-            return false;
-        }
-
-        if fee_percentage > 20 {
-            let error = SendFlowAlertState::General {
-                title: "Warning, High Fee!".to_string(),
-                message: "The fee is higher than 20% of the amount you are sending".to_string(),
-            };
-
-            if display_alert {
-                self.reconciler.send(Message::SetAlert(error));
-            }
-
-            // just a warning not a error
-            return true;
-        }
-
-        true
-    }
     pub(crate) fn validate_amount_internal(self: &Arc<Self>, display_alert: bool) -> bool {
         let mut sender = DeferredSender::new(self.reconciler.clone());
         let Some(amount) = self.state.lock().amount_sats else {
@@ -309,16 +270,6 @@ impl RustSendFlowManager {
 
         if amount == 0 {
             let msg = Message::SetAlert(SendFlowError::ZeroAmount.into());
-            if display_alert {
-                sender.queue(msg);
-            } else {
-                debug!("validate_amount_failed: {msg:?}");
-            }
-            return false;
-        }
-
-        if amount < MIN_SEND_SATS {
-            let msg = Message::SetAlert(SendFlowError::SendAmountToLow.into());
             if display_alert {
                 sender.queue(msg);
             } else {
@@ -367,6 +318,82 @@ impl RustSendFlowManager {
         }
 
         true
+    }
+
+    fn pending_send_warning(&self) -> Option<SendFlowAlertState> {
+        let (
+            amount_sats,
+            fee_sats,
+            small_amount_acknowledged,
+            high_fee_acknowledged,
+            very_high_fee_acknowledged,
+        ) = {
+            let state = self.state.lock();
+            let amount_sats = state.amount_sats?;
+            let fee_sats = state
+                .fee_selection
+                .as_ref()
+                .and_then(|selection| selection.selected.total_fee)
+                .map(|fee| fee.as_sats());
+
+            (
+                amount_sats,
+                fee_sats,
+                state.has_acknowledged_warning(SendFlowWarningKind::SmallAmount),
+                state.has_acknowledged_warning(SendFlowWarningKind::HighFee),
+                state.has_acknowledged_warning(SendFlowWarningKind::VeryHighFee),
+            )
+        };
+
+        if amount_sats > 0 && amount_sats < LOW_SEND_WARNING_SATS && !small_amount_acknowledged {
+            return Some(SendFlowAlertState::Warning {
+                kind: SendFlowWarningKind::SmallAmount,
+                title: "Small On-chain Payment".to_string(),
+                message: "On-chain payments always pay a network fee, so they are usually best for larger amounts. If you are making lots of small payments, Lightning may be a better fit outside Cove because it is built for fast, low-fee microtransactions.".to_string(),
+            });
+        }
+
+        let fee_sats = fee_sats?;
+        if amount_sats == 0 {
+            return None;
+        }
+
+        let fee_percentage = fee_sats as f64 / amount_sats as f64 * 100.0;
+        let display_fee_percentage = format!("{fee_percentage:.0}");
+
+        if fee_percentage >= VERY_HIGH_FEE_WARNING_PERCENT && !very_high_fee_acknowledged {
+            return Some(SendFlowAlertState::Warning {
+                kind: SendFlowWarningKind::VeryHighFee,
+                title: "Very High Network Fee".to_string(),
+                message: format!(
+                    "The network fee is {display_fee_percentage}% of the amount you are sending. That is unusually high for an on-chain payment. Consider sending a larger amount, lowering the fee rate if timing allows, or using an external Lightning option for small payments."
+                ),
+            });
+        }
+
+        if fee_percentage >= HIGH_FEE_WARNING_PERCENT && !high_fee_acknowledged {
+            return Some(SendFlowAlertState::Warning {
+                kind: SendFlowWarningKind::HighFee,
+                title: "High Network Fee".to_string(),
+                message: format!(
+                    "The network fee is {display_fee_percentage}% of the amount you are sending. On-chain fees are per transaction, so they take a bigger bite out of small payments. Consider a larger amount or an external Lightning option."
+                ),
+            });
+        }
+
+        None
+    }
+
+    fn acknowledge_warning_and_finalize(self: &Arc<Self>, kind: SendFlowWarningKind) {
+        if let Some(SendFlowAlertState::Warning { kind: pending_kind, .. }) =
+            self.pending_send_warning()
+            && pending_kind == kind
+        {
+            self.state.lock().acknowledge_warning(kind);
+        }
+
+        self.reconciler.send(Message::ClearAlert);
+        self.finalize_and_go_to_next_screen();
     }
 }
 
@@ -468,9 +495,15 @@ impl RustSendFlowManager {
             Action::NotifyPricesChanged(prices) => self.handle_prices_changed(prices),
 
             Action::FinalizeAndGoToNextScreen => self.finalize_and_go_to_next_screen(),
+            Action::AcknowledgeWarningAndFinalize(kind) => {
+                self.acknowledge_warning_and_finalize(kind);
+            }
 
             Action::NotifyAddressChanged(address) => {
                 let mut state = self.state.lock();
+                if state.address.as_ref() != Some(&address) {
+                    state.clear_warning_acknowledgements();
+                }
                 state.address = Some(address.clone());
                 state.entering_address = address.to_string();
                 state.payjoin_endpoint = None;
@@ -484,7 +517,13 @@ impl RustSendFlowManager {
 
             Action::ChangeFeeRateOptions(fee_options) => {
                 let selection = self.fee_selection_for_options(fee_options);
-                self.state.lock().fee_selection = Some(selection.clone());
+                {
+                    let mut state = self.state.lock();
+                    if state.fee_selection.as_ref() != Some(&selection) {
+                        state.clear_warning_acknowledgements();
+                    }
+                    state.fee_selection = Some(selection.clone());
+                }
                 self.reconciler.send(Message::UpdateFeeSelection(selection));
             }
 
@@ -609,6 +648,9 @@ impl RustSendFlowManager {
 
             let mut state_guard = state.lock();
             state_guard.fee_rate_options_base = Some(Arc::new(base_options));
+            if state_guard.fee_selection.as_ref() != Some(&fee_selection) {
+                state_guard.clear_warning_acknowledgements();
+            }
             state_guard.fee_selection = Some(fee_selection);
             state_guard.has_base_fees = true;
         });
@@ -659,10 +701,15 @@ impl RustSendFlowManager {
 mod tests {
     use std::sync::Arc;
 
+    use cove_types::fees::{
+        FeeRateOption, FeeRateOptionWithTotalFee, FeeRateOptionsWithTotalFee, FeeSpeed,
+    };
+
     use crate::{
         manager::{deferred_sender::SingleOrMany, wallet_manager::RustWalletManager},
-        wallet::{balance::Balance, metadata::WalletMetadata},
+        wallet::{Address, balance::Balance, metadata::WalletMetadata},
     };
+
     fn manager_for_validation() -> Arc<super::RustSendFlowManager> {
         crate::database::test_support::init_test_database();
         crate::test_support::ensure_tokio_runtime();
@@ -685,6 +732,204 @@ mod tests {
         })
     }
 
+    fn fee_rate_option_with_total_fee(
+        fee_speed: FeeSpeed,
+        total_fee_sats: u64,
+    ) -> FeeRateOptionWithTotalFee {
+        let fee_option = FeeRateOption::new(fee_speed, 1.0);
+        FeeRateOptionWithTotalFee::new(fee_option, super::Amount::from_sat(total_fee_sats))
+    }
+
+    fn set_selected_fee_total(
+        manager: &super::RustSendFlowManager,
+        total_fee_sats: u64,
+    ) -> Arc<FeeRateOptionWithTotalFee> {
+        let selected =
+            fee_rate_option_with_total_fee(FeeSpeed::Custom { duration_mins: 10 }, total_fee_sats);
+        let options = FeeRateOptionsWithTotalFee {
+            fast: fee_rate_option_with_total_fee(FeeSpeed::Fast, total_fee_sats),
+            medium: fee_rate_option_with_total_fee(FeeSpeed::Medium, total_fee_sats),
+            slow: fee_rate_option_with_total_fee(FeeSpeed::Slow, total_fee_sats),
+            custom: Some(selected),
+        };
+        let selected = Arc::new(selected);
+
+        manager.state.lock().fee_selection =
+            Some(super::FeeSelection::new(Arc::new(options), selected.clone()));
+
+        selected
+    }
+
+    fn set_selected_fee_without_total(manager: &super::RustSendFlowManager) {
+        let base_options = super::FeeRateOptions::_ffi_preview_new();
+        let selected = FeeRateOptionWithTotalFee {
+            fee_speed: FeeSpeed::Custom { duration_mins: 10 },
+            fee_rate: FeeRateOption::new(FeeSpeed::Custom { duration_mins: 10 }, 1.0).fee_rate,
+            total_fee: None,
+        };
+        let options = FeeRateOptionsWithTotalFee::without_totals(base_options);
+
+        let mut state = manager.state.lock();
+        state.fee_rate_options_base = Some(Arc::new(base_options));
+        state.fee_selection = Some(super::FeeSelection::new(Arc::new(options), Arc::new(selected)));
+    }
+
+    fn set_valid_amount_and_address(manager: &super::RustSendFlowManager, amount_sats: u64) {
+        let mut state = manager.state.lock();
+        state.amount_sats = Some(amount_sats);
+        state.unlocked_spendable_sats = Some(50_000);
+        state.address = Some(Arc::new(Address::preview_new()));
+    }
+
+    fn next_reconcile_message(manager: &super::RustSendFlowManager) -> super::Message {
+        let message = manager.reconcile_receiver.try_recv().expect("message is reconciled");
+        let SingleOrMany::Single(message) = message else {
+            panic!("expected a single reconcile message");
+        };
+
+        message
+    }
+
+    fn pending_warning_kind(
+        manager: &super::RustSendFlowManager,
+    ) -> Option<super::SendFlowWarningKind> {
+        match manager.pending_send_warning()? {
+            super::SendFlowAlertState::Warning { kind, .. } => Some(kind),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn validate_amount_allows_low_nonzero_amount() {
+        let manager = manager_for_validation();
+        {
+            let mut state = manager.state.lock();
+            state.amount_sats = Some(1_000);
+            state.unlocked_spendable_sats = Some(50_000);
+        }
+
+        assert!(manager.validate_amount(false));
+    }
+
+    #[test]
+    fn pending_warning_returns_small_amount_before_high_fee() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_total(&manager, 60);
+
+        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::SmallAmount));
+    }
+
+    #[test]
+    fn pending_warning_returns_very_high_fee_for_20_percent_or_more() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 10_000);
+        set_selected_fee_total(&manager, 2_000);
+
+        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::VeryHighFee));
+    }
+
+    #[test]
+    fn pending_warning_returns_high_fee_for_5_to_20_percent() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 10_000);
+        set_selected_fee_total(&manager, 500);
+
+        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::HighFee));
+    }
+
+    #[test]
+    fn acknowledging_small_amount_then_rerunning_finalize_reveals_high_fee() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_total(&manager, 60);
+
+        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::SmallAmount));
+
+        manager.state.lock().acknowledge_warning(super::SendFlowWarningKind::SmallAmount);
+
+        assert_eq!(pending_warning_kind(&manager), Some(super::SendFlowWarningKind::HighFee));
+    }
+
+    #[test]
+    fn stale_warning_acknowledgement_does_not_record() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_total(&manager, 60);
+
+        manager.acknowledge_warning_and_finalize(super::SendFlowWarningKind::HighFee);
+
+        let state = manager.state.lock();
+        assert!(!state.has_acknowledged_warning(super::SendFlowWarningKind::SmallAmount));
+        assert!(!state.has_acknowledged_warning(super::SendFlowWarningKind::HighFee));
+    }
+
+    #[test]
+    fn warning_acknowledgements_reset_on_amount_change() {
+        let manager = manager_for_validation();
+        manager.state.lock().acknowledge_warning(super::SendFlowWarningKind::SmallAmount);
+
+        manager.handle_amount_changed(super::Amount::from_sat(1_000));
+
+        assert!(
+            !manager.state.lock().has_acknowledged_warning(super::SendFlowWarningKind::SmallAmount)
+        );
+    }
+
+    #[test]
+    fn warning_acknowledgements_reset_on_address_change() {
+        let manager = manager_for_validation();
+        manager.state.lock().acknowledge_warning(super::SendFlowWarningKind::SmallAmount);
+
+        manager
+            .clone()
+            .dispatch(super::Action::NotifyAddressChanged(Arc::new(Address::preview_new())));
+
+        assert!(
+            !manager.state.lock().has_acknowledged_warning(super::SendFlowWarningKind::SmallAmount)
+        );
+    }
+
+    #[test]
+    fn warning_acknowledgements_reset_on_fee_change() {
+        let manager = manager_for_validation();
+        set_selected_fee_total(&manager, 500);
+        manager.state.lock().acknowledge_warning(super::SendFlowWarningKind::HighFee);
+
+        let selected = fee_rate_option_with_total_fee(FeeSpeed::Custom { duration_mins: 20 }, 750);
+        manager.selected_fee_rate_changed(Arc::new(selected));
+
+        assert!(
+            !manager.state.lock().has_acknowledged_warning(super::SendFlowWarningKind::HighFee)
+        );
+    }
+
+    #[test]
+    fn fee_greater_than_amount_hard_blocks_before_warnings() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_total(&manager, 1_001);
+
+        manager.finalize_and_go_to_next_screen();
+
+        assert!(matches!(
+            next_reconcile_message(&manager),
+            super::Message::SetAlert(super::SendFlowAlertState::General { title, .. })
+                if title == "Fee Too High!"
+        ));
+    }
+
+    #[test]
+    fn finalize_refreshes_missing_total_fee_before_warning_detection() {
+        let manager = manager_for_validation();
+        set_valid_amount_and_address(&manager, 1_000);
+        set_selected_fee_without_total(&manager);
+
+        manager.finalize_and_go_to_next_screen();
+
+        assert!(manager.reconcile_receiver.try_recv().is_err());
+    }
+
     #[test]
     fn validate_amount_blocks_send_when_lock_state_load_failed() {
         let _guard = crate::test_support::global_state_test_lock().blocking_lock();
@@ -698,8 +943,7 @@ mod tests {
 
         assert!(!manager.validate_amount(true));
 
-        let message = manager.reconcile_receiver.try_recv().expect("alert is reconciled");
-        let SingleOrMany::Single(super::Message::SetAlert(alert)) = message else {
+        let super::Message::SetAlert(alert) = next_reconcile_message(&manager) else {
             panic!("expected a single lock-state load failure alert");
         };
 

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -708,6 +708,7 @@ mod tests {
     use cove_types::fees::{
         FeeRateOption, FeeRateOptionWithTotalFee, FeeRateOptionsWithTotalFee, FeeSpeed,
     };
+    use cove_types::utxo::{UtxoList, ffi_preview::preview_new_utxo_list};
 
     use crate::{
         manager::{deferred_sender::SingleOrMany, wallet_manager::RustWalletManager},
@@ -785,6 +786,14 @@ mod tests {
         state.address = Some(Arc::new(Address::preview_new()));
     }
 
+    fn set_coin_control_mode(manager: &super::RustSendFlowManager) {
+        let utxo_list = Arc::new(UtxoList::from(preview_new_utxo_list(1, 0)));
+
+        let mut state = manager.state.lock();
+        state.metadata.selected_unit = super::BitcoinUnit::Sat;
+        state.mode = super::EnterMode::coin_control_max(utxo_list);
+    }
+
     fn next_reconcile_message(manager: &super::RustSendFlowManager) -> super::Message {
         let message = manager.reconcile_receiver.try_recv().expect("message is reconciled");
         let SingleOrMany::Single(message) = message else {
@@ -835,6 +844,36 @@ mod tests {
         }
 
         assert!(manager.validate_amount(false));
+    }
+
+    #[test]
+    fn coin_control_amount_change_preserves_below_conservative_dust_amount() {
+        let manager = manager_for_validation();
+        set_coin_control_mode(&manager);
+
+        assert!(manager.handle_coin_control_amount_changed(300.0).is_some());
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(300));
+        assert!(
+            matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
+        );
+    }
+
+    #[test]
+    fn focused_coin_control_entry_preserves_below_conservative_dust_amount() {
+        let manager = manager_for_validation();
+        set_coin_control_mode(&manager);
+
+        assert!(
+            manager.handle_coin_control_entered_amount_changed("300".to_string(), true).is_some()
+        );
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(300));
+        assert!(
+            matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
+        );
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -897,6 +897,20 @@ mod tests {
     }
 
     #[test]
+    fn coin_control_amount_change_preserves_amount_when_fallback_max_is_zero() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 900);
+
+        assert!(manager.handle_coin_control_amount_changed(600.0).is_some());
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(600));
+        assert!(
+            matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
+        );
+    }
+
+    #[test]
     fn coin_control_amount_change_snaps_to_max_when_fee_adjusted_max_exceeded() {
         let manager = manager_for_validation();
         set_coin_control_mode_with_total(&manager, 1_500);

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -904,8 +904,31 @@ mod tests {
         assert!(manager.handle_coin_control_amount_changed(600.0).is_some());
 
         let state = manager.state.lock();
-        assert_eq!(state.amount_sats, Some(1_500));
+        assert_eq!(state.amount_sats, Some(500));
         assert!(matches!(&state.mode, super::EnterMode::CoinControl(mode) if mode.is_max_selected));
+    }
+
+    #[test]
+    fn coin_control_max_snap_blocks_when_fee_exceeds_recipient_amount() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 1_500);
+        set_selected_fee_total(&manager, 1_000);
+        {
+            let mut state = manager.state.lock();
+            state.address = Some(Arc::new(Address::preview_new()));
+            state.unlocked_spendable_sats = Some(50_000);
+        }
+
+        assert!(manager.handle_coin_control_amount_changed(600.0).is_some());
+        drain_reconcile_messages(&manager);
+
+        manager.finalize_and_go_to_next_screen();
+
+        assert!(matches!(
+            next_reconcile_message(&manager),
+            super::Message::SetAlert(super::SendFlowAlertState::General { title, .. })
+                if title == "Fee Too High!"
+        ));
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -528,6 +528,7 @@ impl RustSendFlowManager {
                     }
                     state.fee_selection = Some(selection.clone());
                 }
+                self.reconcile_coin_control_amount_for_selected_fee();
                 self.reconciler.send(Message::UpdateFeeSelection(selection));
             }
 
@@ -908,6 +909,36 @@ mod tests {
         assert!(
             matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
         );
+    }
+
+    #[test]
+    fn coin_control_amount_change_caps_to_selected_total_when_fee_max_unavailable() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 900);
+
+        assert!(manager.handle_coin_control_amount_changed(1_546.0).is_some());
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(900));
+        assert!(
+            matches!(&state.mode, super::EnterMode::CoinControl(mode) if !mode.is_max_selected)
+        );
+    }
+
+    #[test]
+    fn coin_control_fee_update_caps_preserved_amount_to_real_max() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 900);
+        set_selected_fee_without_total(&manager);
+
+        assert!(manager.handle_coin_control_amount_changed(850.0).is_some());
+
+        let selected = fee_rate_option_with_total_fee(FeeSpeed::Custom { duration_mins: 20 }, 100);
+        manager.selected_fee_rate_changed(Arc::new(selected));
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(800));
+        assert!(matches!(&state.mode, super::EnterMode::CoinControl(mode) if mode.is_max_selected));
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -978,6 +978,32 @@ mod tests {
     }
 
     #[test]
+    fn coin_control_fee_update_blocks_when_fee_equals_selected_total() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 900);
+        set_selected_fee_without_total(&manager);
+        {
+            let mut state = manager.state.lock();
+            state.address = Some(Arc::new(Address::preview_new()));
+            state.unlocked_spendable_sats = Some(50_000);
+        }
+
+        assert!(manager.handle_coin_control_amount_changed(900.0).is_some());
+
+        let selected = fee_rate_option_with_total_fee(FeeSpeed::Custom { duration_mins: 20 }, 900);
+        manager.selected_fee_rate_changed(Arc::new(selected));
+        drain_reconcile_messages(&manager);
+
+        manager.finalize_and_go_to_next_screen();
+
+        assert!(matches!(
+            next_reconcile_message(&manager),
+            super::Message::SetAlert(super::SendFlowAlertState::General { title, .. })
+                if title == "Fee Too High!"
+        ));
+    }
+
+    #[test]
     fn coin_control_amount_change_snaps_to_max_when_fee_adjusted_max_exceeded() {
         let manager = manager_for_validation();
         set_coin_control_mode_with_total(&manager, 1_500);

--- a/rust/src/manager/send_flow_manager.rs
+++ b/rust/src/manager/send_flow_manager.rs
@@ -897,6 +897,18 @@ mod tests {
     }
 
     #[test]
+    fn coin_control_amount_change_snaps_to_max_when_fee_adjusted_max_exceeded() {
+        let manager = manager_for_validation();
+        set_coin_control_mode_with_total(&manager, 1_500);
+
+        assert!(manager.handle_coin_control_amount_changed(600.0).is_some());
+
+        let state = manager.state.lock();
+        assert_eq!(state.amount_sats, Some(1_500));
+        assert!(matches!(&state.mode, super::EnterMode::CoinControl(mode) if mode.is_max_selected));
+    }
+
+    #[test]
     fn pending_warning_returns_small_amount_before_high_fee() {
         let manager = manager_for_validation();
         set_valid_amount_and_address(&manager, 1_000);

--- a/rust/src/manager/send_flow_manager/address_input.rs
+++ b/rust/src/manager/send_flow_manager/address_input.rs
@@ -48,6 +48,9 @@ impl RustSendFlowManager {
         let address = parsed.map(|address_with_network| Arc::new(address_with_network.address));
         {
             let mut state = self.state.lock();
+            if state.address != address {
+                state.clear_warning_acknowledgements();
+            }
             state.address = address.clone();
             state.payjoin_endpoint = payjoin_endpoint;
         }
@@ -80,6 +83,9 @@ impl RustSendFlowManager {
     pub(crate) fn clear_send_amount(self: &Arc<Self>) {
         {
             let mut state = self.state.lock();
+            if state.amount_sats.is_some() {
+                state.clear_warning_acknowledgements();
+            }
             state.amount_sats = None;
             state.amount_fiat = None;
         }
@@ -107,6 +113,9 @@ impl RustSendFlowManager {
         let mut sender = DeferredSender::new(self.reconciler.clone());
         {
             let mut state = self.state.lock();
+            if state.address.is_some() {
+                state.clear_warning_acknowledgements();
+            }
             state.address = None;
             state.payjoin_endpoint = None;
         }
@@ -152,6 +161,9 @@ impl RustSendFlowManager {
 
         {
             let mut state = self.state.lock();
+            if state.address.as_ref() != Some(&address) {
+                state.clear_warning_acknowledgements();
+            }
             state.address = Some(address.clone());
             state.payjoin_endpoint = payjoin_endpoint;
         }

--- a/rust/src/manager/send_flow_manager/alert_state.rs
+++ b/rust/src/manager/send_flow_manager/alert_state.rs
@@ -2,10 +2,18 @@ use cove_types::address::AddressError;
 
 use super::error::SendFlowError;
 
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum SendFlowWarningKind {
+    SmallAmount,
+    HighFee,
+    VeryHighFee,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
 pub enum SendFlowAlertState {
     Error(SendFlowError),
     General { title: String, message: String },
+    Warning { kind: SendFlowWarningKind, title: String, message: String },
 }
 
 impl SendFlowAlertState {

--- a/rust/src/manager/send_flow_manager/amount_input.rs
+++ b/rust/src/manager/send_flow_manager/amount_input.rs
@@ -7,9 +7,9 @@ use cove_util::format::NumberFormatter as _;
 use tracing::{debug, trace, warn};
 
 use super::{
-    BtcOnChangeHandler, DeferredSender, EnterMode, Error, FeeSelection, FiatOnChangeHandler,
-    FiatOrBtc, Message, Result, RustSendFlowManager, SendFlowError, SetAmountFocusField, State,
-    btc_on_change, fiat_on_change,
+    BtcOnChangeHandler, DeferredSender, Error, FeeSelection, FiatOnChangeHandler, FiatOrBtc,
+    Message, Result, RustSendFlowManager, SendFlowError, SetAmountFocusField, State, btc_on_change,
+    fiat_on_change,
 };
 
 impl RustSendFlowManager {
@@ -172,6 +172,8 @@ impl RustSendFlowManager {
             sender.queue(Message::UpdateFeeSelection(selection));
         }
 
+        self.reconcile_coin_control_amount_for_selected_fee();
+
         // max was selected before, so we need to update it to match the new fee rate
         let max_selected = self.state.lock().max_selected.clone();
         if max_selected.is_some() {
@@ -182,19 +184,6 @@ impl RustSendFlowManager {
         if self.validate_amount_internal(false) && self.validate_address_internal(false) {
             self.state.lock().focus_field = None;
             sender.queue(Message::UpdateFocusField(None));
-        }
-
-        // if we are in coin control mode max mode, change the amount when fee changes
-        let mode = self.state.lock().mode.clone();
-        match mode {
-            EnterMode::CoinControl(cc) if cc.is_max_selected => {
-                if let Some(total_fee) = fee_rate.total_fee {
-                    let max_amount = cc.max_send();
-                    let amount = max_amount - total_fee;
-                    self.handle_amount_changed(amount);
-                }
-            }
-            _ => {}
         }
     }
 

--- a/rust/src/manager/send_flow_manager/amount_input.rs
+++ b/rust/src/manager/send_flow_manager/amount_input.rs
@@ -4,7 +4,6 @@ use crate::{fiat::client::PriceResponse, transaction::FeeRate, wallet::Address};
 use act_zero::call;
 use cove_types::{amount::Amount, fees::FeeRateOptionWithTotalFee, psbt::Psbt, unit::BitcoinUnit};
 use cove_util::format::NumberFormatter as _;
-use cove_util::result_ext::ResultExt as _;
 use tracing::{debug, trace, warn};
 
 use super::{
@@ -63,7 +62,13 @@ impl RustSendFlowManager {
         if let Some(amount) = amount_btc {
             let current_amount_sats = self.state.lock().amount_sats;
             let amount_sats = amount.to_sat();
-            self.state.lock().amount_sats = Some(amount_sats);
+            {
+                let mut state = self.state.lock();
+                if current_amount_sats != Some(amount_sats) {
+                    state.clear_warning_acknowledgements();
+                }
+                state.amount_sats = Some(amount_sats);
+            }
 
             if current_amount_sats != Some(amount_sats) {
                 sender.queue(Message::UpdateAmountSats(amount_sats));
@@ -128,7 +133,13 @@ impl RustSendFlowManager {
 
         if let Some(btc_amount) = btc_amount {
             let btc_amount = btc_amount.as_sats();
-            self.state.lock().amount_sats = Some(btc_amount);
+            {
+                let mut state = self.state.lock();
+                if state.amount_sats != Some(btc_amount) {
+                    state.clear_warning_acknowledgements();
+                }
+                state.amount_sats = Some(btc_amount);
+            }
             sender.queue(Message::UpdateAmountSats(btc_amount));
             self.schedule_fee_rate_update();
         }
@@ -151,7 +162,13 @@ impl RustSendFlowManager {
         let mut sender = DeferredSender::new(self.reconciler.clone());
         if let Some(options) = self.fee_rate_options() {
             let selection = FeeSelection::new(options, fee_rate.clone());
-            self.state.lock().fee_selection = Some(selection.clone());
+            {
+                let mut state = self.state.lock();
+                if state.fee_selection.as_ref() != Some(&selection) {
+                    state.clear_warning_acknowledgements();
+                }
+                state.fee_selection = Some(selection.clone());
+            }
             sender.queue(Message::UpdateFeeSelection(selection));
         }
 
@@ -179,8 +196,6 @@ impl RustSendFlowManager {
             }
             _ => {}
         }
-
-        self.validate_fee_percentage_internal(true);
     }
 
     /// When amount is changed, we will need to update the entering and fiat amounts
@@ -223,7 +238,13 @@ impl RustSendFlowManager {
 
         let old_amount_sats = self.state.lock().amount_sats;
         let amount_sats = amount.to_sat();
-        self.state.lock().amount_sats = Some(amount_sats);
+        {
+            let mut state = self.state.lock();
+            if old_amount_sats != Some(amount_sats) {
+                state.clear_warning_acknowledgements();
+            }
+            state.amount_sats = Some(amount_sats);
+        }
 
         if old_amount_sats != Some(amount_sats) {
             sender.queue(Message::UpdateAmountSats(amount_sats));
@@ -309,6 +330,9 @@ impl RustSendFlowManager {
     pub(crate) async fn select_max_send_report_error(self: &Arc<Self>) {
         match self.select_max_send().await {
             Ok(()) => {}
+            Err(SendFlowError::SendBelowDustLimit) => {
+                self.reconciler.send(Message::SetAlert(SendFlowError::SendBelowDustLimit.into()));
+            }
             Err(error) => {
                 let error = SendFlowError::UnableToGetMaxSend(error.to_string());
                 self.reconciler.send(Message::SetAlert(error.into()));
@@ -360,11 +384,8 @@ impl RustSendFlowManager {
         }
 
         let fee_rate = fee_rate.unwrap_or_else(|| FeeRate::from_sat_per_vb(50.0));
-        let psbt: Psbt = call!(wallet_actor.build_ephemeral_drain_tx(address, fee_rate))
-            .await
-            .unwrap()
-            .map_err_str(Error::UnableToGetMaxSend)?
-            .into();
+        let psbt: Psbt =
+            call!(wallet_actor.build_ephemeral_drain_tx(address, fee_rate)).await.unwrap()?.into();
 
         let total = Arc::new(psbt.output_total_amount());
         trace!("psbt: {psbt:?}, total: {total:?}, fee_rate: {fee_rate:?}");

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -82,6 +82,10 @@ impl RustSendFlowManager {
         };
 
         let max_send_sats = coin_control_mode.max_send().as_sats().saturating_sub(total_fee_sats);
+        if max_send_sats == 0 {
+            return;
+        }
+
         if coin_control_mode.is_max_selected {
             if amount_sats != Some(max_send_sats) {
                 self.handle_amount_changed(Amount::from_sat(max_send_sats));

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -25,14 +25,15 @@ impl RustSendFlowManager {
         };
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
-        if let Some(max_send_without_fees_and_small_utxo) =
-            self.max_send_minus_fees_and_small_utxo()
-            && amount >= max_send_without_fees_and_small_utxo
+        let max_send_threshold =
+            self.max_send_minus_fees_and_small_utxo().or_else(|| self.max_send_minus_fees());
+        if let Some(max_send_threshold) = max_send_threshold
+            && amount >= max_send_threshold
         {
             debug!(
                 "setting coin control to max amount close to max {} {}",
                 amount.as_sats(),
-                max_send_without_fees_and_small_utxo.as_sats()
+                max_send_threshold.as_sats()
             );
 
             let max_send = coin_control_mode.max_send();

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -25,7 +25,8 @@ impl RustSendFlowManager {
         };
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
-        let max_send_without_fees = self.max_send_minus_fees();
+        let max_send_without_fees =
+            self.max_send_minus_fees().filter(|amount| amount.as_sats() > 0);
         let max_send_threshold =
             self.max_send_minus_fees_and_small_utxo().or(max_send_without_fees);
         if let Some(max_send_threshold) = max_send_threshold

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cove_common::consts::{MIN_SEND_AMOUNT, MIN_SEND_SATS};
+use cove_common::consts::CONSERVATIVE_DUST_LIMIT_AMOUNT;
 use cove_types::{
     amount::Amount,
     unit::BitcoinUnit,
@@ -24,7 +24,7 @@ impl RustSendFlowManager {
             BitcoinUnit::Btc => Amount::from_btc(amount).ok()?,
             BitcoinUnit::Sat => Amount::from_sat(amount as u64),
         }
-        .max(MIN_SEND_AMOUNT.into());
+        .max(CONSERVATIVE_DUST_LIMIT_AMOUNT.into());
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
         let max_send_without_fees_and_small_utxo = self.max_send_minus_fees_and_small_utxo()?;
@@ -64,7 +64,14 @@ impl RustSendFlowManager {
         let amount = amount.chars().filter(|c| c.is_numeric() || *c == '.').collect::<String>();
         let amount_float = amount.parse::<f64>().ok()?;
 
-        if amount_float < MIN_SEND_SATS as f64 && is_focused {
+        let unit = self.state.lock().metadata.selected_unit;
+        let amount = match unit {
+            BitcoinUnit::Btc => Amount::from_btc(amount_float).ok()?,
+            BitcoinUnit::Sat => Amount::from_sat(amount_float as u64),
+        };
+        let dust_limit = CONSERVATIVE_DUST_LIMIT_AMOUNT.into();
+
+        if amount < dust_limit && is_focused {
             return None;
         }
 
@@ -92,6 +99,7 @@ impl RustSendFlowManager {
                 .as_ref()
                 .and_then(|selection| selection.selected.total_fee.map(|f| f.as_sats()));
 
+            state.clear_warning_acknowledgements();
             state.mode = EnterMode::coin_control_max(utxo_list.clone());
             let total_minus_fees =
                 utxo_list.total.as_sats().saturating_sub(total_fee_sats.unwrap_or(1000));
@@ -113,7 +121,11 @@ impl RustSendFlowManager {
             return;
         }
 
-        self.state.lock().mode = EnterMode::SetAmount;
+        {
+            let mut state = self.state.lock();
+            state.clear_warning_acknowledgements();
+            state.mode = EnterMode::SetAmount;
+        }
 
         let me = self.clone();
         cove_tokio::task::spawn(async move {

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -25,8 +25,9 @@ impl RustSendFlowManager {
         };
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
+        let max_send_without_fees = self.max_send_minus_fees();
         let max_send_threshold =
-            self.max_send_minus_fees_and_small_utxo().or_else(|| self.max_send_minus_fees());
+            self.max_send_minus_fees_and_small_utxo().or(max_send_without_fees);
         if let Some(max_send_threshold) = max_send_threshold
             && amount >= max_send_threshold
         {
@@ -36,11 +37,12 @@ impl RustSendFlowManager {
                 max_send_threshold.as_sats()
             );
 
-            let max_send = coin_control_mode.max_send();
+            let max_send_amount =
+                max_send_without_fees.unwrap_or_else(|| coin_control_mode.max_send());
             coin_control_mode.is_max_selected = true;
 
             self.state.lock().mode = EnterMode::CoinControl(coin_control_mode);
-            self.handle_amount_changed(max_send);
+            self.handle_amount_changed(max_send_amount);
             return Some(());
         }
 

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -23,6 +23,7 @@ impl RustSendFlowManager {
             BitcoinUnit::Btc => Amount::from_btc(amount).ok()?,
             BitcoinUnit::Sat => Amount::from_sat(amount as u64),
         };
+        let amount = amount.min(coin_control_mode.max_send());
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
         let max_send_without_fees =
@@ -56,6 +57,49 @@ impl RustSendFlowManager {
         self.handle_amount_changed(amount);
 
         Some(())
+    }
+
+    pub(crate) fn reconcile_coin_control_amount_for_selected_fee(self: &Arc<Self>) {
+        let (mut coin_control_mode, amount_sats, total_fee_sats) = {
+            let state = self.state.lock();
+            let EnterMode::CoinControl(coin_control_mode) = state.mode.clone() else {
+                return;
+            };
+
+            let total_fee_sats = state
+                .fee_selection
+                .as_ref()
+                .and_then(|selection| {
+                    selection.selected.total_fee.or(selection.options.medium.total_fee)
+                })
+                .map(|fee| fee.as_sats());
+
+            (coin_control_mode, state.amount_sats, total_fee_sats)
+        };
+
+        let Some(total_fee_sats) = total_fee_sats else {
+            return;
+        };
+
+        let max_send_sats = coin_control_mode.max_send().as_sats().saturating_sub(total_fee_sats);
+        if coin_control_mode.is_max_selected {
+            if amount_sats != Some(max_send_sats) {
+                self.handle_amount_changed(Amount::from_sat(max_send_sats));
+            }
+            return;
+        }
+
+        let Some(amount_sats) = amount_sats else {
+            return;
+        };
+
+        if amount_sats < max_send_sats {
+            return;
+        }
+
+        coin_control_mode.is_max_selected = true;
+        self.state.lock().mode = EnterMode::CoinControl(coin_control_mode);
+        self.handle_amount_changed(Amount::from_sat(max_send_sats));
     }
 
     pub(crate) fn handle_coin_control_entered_amount_changed(

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -25,9 +25,10 @@ impl RustSendFlowManager {
         };
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
-        let max_send_without_fees_and_small_utxo = self.max_send_minus_fees_and_small_utxo()?;
-
-        if amount >= max_send_without_fees_and_small_utxo {
+        if let Some(max_send_without_fees_and_small_utxo) =
+            self.max_send_minus_fees_and_small_utxo()
+            && amount >= max_send_without_fees_and_small_utxo
+        {
             debug!(
                 "setting coin control to max amount close to max {} {}",
                 amount.as_sats(),

--- a/rust/src/manager/send_flow_manager/coin_control.rs
+++ b/rust/src/manager/send_flow_manager/coin_control.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use cove_common::consts::CONSERVATIVE_DUST_LIMIT_AMOUNT;
 use cove_types::{
     amount::Amount,
     unit::BitcoinUnit,
@@ -23,8 +22,7 @@ impl RustSendFlowManager {
         let amount = match unit {
             BitcoinUnit::Btc => Amount::from_btc(amount).ok()?,
             BitcoinUnit::Sat => Amount::from_sat(amount as u64),
-        }
-        .max(CONSERVATIVE_DUST_LIMIT_AMOUNT.into());
+        };
 
         // if the amount we are selecting is within 1000 sats of the max send, then select the max send
         let max_send_without_fees_and_small_utxo = self.max_send_minus_fees_and_small_utxo()?;
@@ -58,22 +56,11 @@ impl RustSendFlowManager {
     pub(crate) fn handle_coin_control_entered_amount_changed(
         self: &Arc<Self>,
         amount: String,
-        is_focused: bool,
+        _is_focused: bool,
     ) -> Option<()> {
         debug!("handle_coin_control_entered_amount_changed: {amount}");
         let amount = amount.chars().filter(|c| c.is_numeric() || *c == '.').collect::<String>();
         let amount_float = amount.parse::<f64>().ok()?;
-
-        let unit = self.state.lock().metadata.selected_unit;
-        let amount = match unit {
-            BitcoinUnit::Btc => Amount::from_btc(amount_float).ok()?,
-            BitcoinUnit::Sat => Amount::from_sat(amount_float as u64),
-        };
-        let dust_limit = CONSERVATIVE_DUST_LIMIT_AMOUNT.into();
-
-        if amount < dust_limit && is_focused {
-            return None;
-        }
 
         self.handle_coin_control_amount_changed(amount_float)
     }

--- a/rust/src/manager/send_flow_manager/error.rs
+++ b/rust/src/manager/send_flow_manager/error.rs
@@ -29,8 +29,8 @@ pub enum SendFlowError {
     #[error("insufficient funds")]
     InsufficientFunds,
 
-    #[error("send amount to low")]
-    SendAmountToLow,
+    #[error("send amount is below the dust limit")]
+    SendBelowDustLimit,
 
     #[error("unable to get fee rate")]
     UnableToGetFeeRate,
@@ -42,10 +42,20 @@ pub enum SendFlowError {
     UnableToSaveUnsignedTransaction(String),
 
     #[error(transparent)]
-    WalletManager(#[from] WalletManagerError),
+    WalletManager(WalletManagerError),
 
     #[error("unable to get fee details: {0}")]
     UnableToGetFeeDetails(String),
+}
+
+impl From<WalletManagerError> for SendFlowError {
+    fn from(error: WalletManagerError) -> Self {
+        match error {
+            WalletManagerError::OutputBelowDustLimit => Self::SendBelowDustLimit,
+            WalletManagerError::InsufficientFunds(_) => Self::InsufficientFunds,
+            error => Self::WalletManager(error),
+        }
+    }
 }
 
 impl SendFlowError {
@@ -59,5 +69,26 @@ impl SendFlowError {
 
             _ => Self::InvalidAddress(address),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SendFlowError, WalletManagerError};
+
+    #[test]
+    fn wallet_output_below_dust_maps_to_send_below_dust() {
+        let error = SendFlowError::from(WalletManagerError::OutputBelowDustLimit);
+
+        assert!(matches!(error, SendFlowError::SendBelowDustLimit));
+    }
+
+    #[test]
+    fn wallet_insufficient_funds_maps_to_send_insufficient_funds() {
+        let error = SendFlowError::from(WalletManagerError::InsufficientFunds(
+            "not enough funds".to_string(),
+        ));
+
+        assert!(matches!(error, SendFlowError::InsufficientFunds));
     }
 }

--- a/rust/src/manager/send_flow_manager/fee_selection.rs
+++ b/rust/src/manager/send_flow_manager/fee_selection.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use act_zero::call;
-use cove_common::consts::MIN_SEND_SATS;
+use cove_common::consts::LOW_SEND_WARNING_SATS;
 use cove_util::result_ext::ResultExt as _;
 use tracing::debug;
 
@@ -136,7 +136,7 @@ impl RustSendFlowManager {
 
         let amount_sats_for_fee_calc = match &mode {
             EnterMode::CoinControl(cc) if cc.is_max_selected => cc.max_send().to_sat(),
-            _ => amount_sats.unwrap_or(MIN_SEND_SATS),
+            _ => amount_sats.unwrap_or(LOW_SEND_WARNING_SATS),
         };
 
         let amount_for_fee_calc = Amount::from_sat(amount_sats_for_fee_calc);
@@ -192,7 +192,13 @@ impl RustSendFlowManager {
             selected_fee_rate.as_ref(),
         );
         let fee_selection = FeeSelection::new(fee_rate_options_with_total_fee, selected);
-        state.lock().fee_selection = Some(fee_selection.clone());
+        {
+            let mut state = state.lock();
+            if state.fee_selection.as_ref() != Some(&fee_selection) {
+                state.clear_warning_acknowledgements();
+            }
+            state.fee_selection = Some(fee_selection.clone());
+        }
 
         match &mode {
             EnterMode::CoinControl(cc) if cc.is_max_selected => {
@@ -228,17 +234,25 @@ impl RustSendFlowManager {
             return None;
         }
 
-        let psbt = self
-            .build_psbt(Some(address), Some(amount), selected_fee_rate.fee_rate)
-            .await
-            .map_err_str(Error::UnableToGetFeeDetails);
+        let psbt =
+            match self.build_psbt(Some(address), Some(amount), selected_fee_rate.fee_rate).await {
+                Ok(psbt) => psbt,
+                Err(SendFlowError::SendBelowDustLimit) => {
+                    self.reconciler
+                        .send_async(Message::SetAlert(SendFlowError::SendBelowDustLimit.into()))
+                        .await;
+                    return None;
+                }
+                Err(error) => {
+                    let error = SendFlowError::UnableToGetMaxSend(error.to_string());
+                    self.reconciler.send_async(Message::SetAlert(error.into())).await;
+                    return None;
+                }
+            };
 
-        let total_fee = psbt.and_then(|psbt| psbt.fee().map_err_str(Error::UnableToGetFeeDetails));
-
-        let total_fee = match total_fee {
+        let total_fee = match psbt.fee().map_err_str(Error::UnableToGetFeeDetails) {
             Ok(total_fee) => total_fee,
             Err(error) => {
-                let error = SendFlowError::UnableToGetMaxSend(error.to_string());
                 self.reconciler.send_async(Message::SetAlert(error.into())).await;
                 return None;
             }

--- a/rust/src/manager/send_flow_manager/fee_selection.rs
+++ b/rust/src/manager/send_flow_manager/fee_selection.rs
@@ -200,23 +200,7 @@ impl RustSendFlowManager {
             state.fee_selection = Some(fee_selection.clone());
         }
 
-        match &mode {
-            EnterMode::CoinControl(cc) if cc.is_max_selected => {
-                let max = cc.max_send();
-                let total_fee = fee_selection
-                    .selected
-                    .total_fee
-                    .map(|fee| fee.as_sats())
-                    .or_else(|| fee_selection.options.medium.total_fee.map(|fee| fee.as_sats()))
-                    .unwrap_or(0);
-
-                let send_amount = max.as_sats() - total_fee;
-                if Some(send_amount) != amount_sats {
-                    self.handle_amount_changed(Amount::from_sat(send_amount));
-                }
-            }
-            _ => {}
-        }
+        self.reconcile_coin_control_amount_for_selected_fee();
 
         sender.queue(Message::UpdateFeeSelection(fee_selection));
     }

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
 use crate::{
-    app::AppAction, manager::deferred_dispatch::DeferredDispatch, router::RouteFactory,
-    wallet::metadata::WalletType,
+    app::AppAction,
+    manager::deferred_dispatch::DeferredDispatch,
+    router::RouteFactory,
+    wallet::{Address, metadata::WalletType},
 };
-use cove_types::amount::Amount;
+use cove_types::{amount::Amount, fees::FeeRateOptionWithTotalFee};
 
 use super::{EnterMode, Message, RustSendFlowManager, SendFlowAlertState, SendFlowError};
 
@@ -33,23 +35,52 @@ impl RustSendFlowManager {
         let Some(total_fee) = selected_fee_rate.total_fee else {
             let me = self.clone();
             let address_for_psbt = address.as_ref().clone();
+            let address_for_finalize = address.clone();
             let fee_rate = selected_fee_rate.fee_rate;
+            let selected_fee_rate_for_finalize = selected_fee_rate.clone();
             cove_tokio::task::spawn(async move {
                 me.get_or_update_fee_rate_options().await;
 
                 if me.selected_fee_rate().and_then(|fee| fee.total_fee).is_none() {
-                    if matches!(
-                        me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await,
-                        Err(SendFlowError::SendBelowDustLimit)
-                    ) {
-                        return me.send_alert_async(SendFlowError::SendBelowDustLimit).await;
-                    }
+                    match me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await {
+                        Ok(psbt) => {
+                            let total_fee = match psbt.fee() {
+                                Ok(total_fee) => total_fee,
+                                Err(error) => {
+                                    return me
+                                        .send_alert_async(SendFlowError::UnableToGetFeeDetails(
+                                            format!("selected fee total unavailable: {error}"),
+                                        ))
+                                        .await;
+                                }
+                            };
+                            let mut selected_fee_rate =
+                                Arc::unwrap_or_clone(selected_fee_rate_for_finalize);
+                            selected_fee_rate.total_fee = Some(total_fee);
 
-                    return me
-                        .send_alert_async(SendFlowError::UnableToGetFeeDetails(
-                            "selected fee total unavailable".to_string(),
-                        ))
-                        .await;
+                            me.continue_with_selected_fee(
+                                amount_sats,
+                                amount,
+                                address_for_finalize,
+                                Arc::new(selected_fee_rate),
+                                Some(total_fee),
+                            );
+                            return;
+                        }
+                        Err(
+                            error @ (SendFlowError::SendBelowDustLimit
+                            | SendFlowError::InsufficientFunds),
+                        ) => {
+                            return me.send_alert_async(error).await;
+                        }
+                        Err(error) => {
+                            return me
+                                .send_alert_async(SendFlowError::UnableToGetFeeDetails(format!(
+                                    "selected fee total unavailable: {error}"
+                                )))
+                                .await;
+                        }
+                    }
                 }
 
                 me.finalize_and_go_to_next_screen();
@@ -57,12 +88,31 @@ impl RustSendFlowManager {
             return;
         };
 
-        if total_fee.as_sats() > amount_sats {
+        self.continue_with_selected_fee(
+            amount_sats,
+            amount,
+            address,
+            selected_fee_rate,
+            Some(total_fee),
+        );
+    }
+
+    fn continue_with_selected_fee(
+        self: &Arc<Self>,
+        amount_sats: u64,
+        amount: Amount,
+        address: Arc<Address>,
+        selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
+        total_fee: Option<Amount>,
+    ) {
+        if total_fee.is_some_and(|total_fee| total_fee.as_sats() > amount_sats) {
             return self.send_alert(SendFlowAlertState::General {
                 title: "Fee Too High!".to_string(),
                 message: "The fee is higher than the amount you are sending".to_string(),
             });
         }
+
+        self.update_selected_fee_total_if_current(selected_fee_rate.clone());
 
         if let Some(warning) = self.pending_send_warning() {
             return self.reconciler.send(Message::SetAlert(warning));
@@ -134,5 +184,118 @@ impl RustSendFlowManager {
             let mut deferred = DeferredDispatch::<AppAction>::new();
             deferred.queue(AppAction::PushRoute(next_route));
         });
+    }
+
+    fn update_selected_fee_total_if_current(
+        self: &Arc<Self>,
+        selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
+    ) {
+        let Some(total_fee) = selected_fee_rate.total_fee else {
+            return;
+        };
+
+        let mut state = self.state.lock();
+        let Some(selection) = &mut state.fee_selection else {
+            return;
+        };
+
+        let current = &selection.selected;
+        if current.fee_speed == selected_fee_rate.fee_speed
+            && current.fee_rate == selected_fee_rate.fee_rate
+            && current.total_fee != Some(total_fee)
+        {
+            selection.selected = selected_fee_rate;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use cove_types::fees::{
+        FeeRateOption, FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee,
+        FeeSpeed,
+    };
+
+    use crate::{
+        manager::{deferred_sender::SingleOrMany, wallet_manager::RustWalletManager},
+        wallet::{Address, balance::Balance, metadata::WalletMetadata},
+    };
+
+    use super::super::{
+        App, DebouncedTask, FeeSelection, MessageSender, RustSendFlowManager, SendFlowAlertState,
+        SendFlowWarningKind,
+    };
+    use super::*;
+
+    fn manager_for_finalize() -> Arc<RustSendFlowManager> {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+
+        let (sender, receiver) = flume::bounded(50);
+        let balance = Arc::new(Balance::default());
+        let state = super::super::State::new(WalletMetadata::preview_new(), balance);
+        let wallet_manager = Arc::new(RustWalletManager::preview_new_wallet());
+
+        Arc::new(RustSendFlowManager {
+            app: App::global().clone(),
+            wallet_manager,
+            state: state.into_inner(),
+            reconciler: MessageSender::new(sender),
+            reconcile_receiver: Arc::new(receiver),
+            fee_check_task: DebouncedTask::new("fee_check", Duration::from_millis(200)),
+        })
+    }
+
+    fn selected_fee_without_total() -> FeeRateOptionWithTotalFee {
+        FeeRateOptionWithTotalFee {
+            fee_speed: FeeSpeed::Custom { duration_mins: 10 },
+            fee_rate: FeeRateOption::new(FeeSpeed::Custom { duration_mins: 10 }, 1.0).fee_rate,
+            total_fee: None,
+        }
+    }
+
+    #[test]
+    fn fallback_total_fee_populates_selected_fee_before_warning_detection() {
+        let manager = manager_for_finalize();
+        let address = Arc::new(Address::preview_new());
+        let selected = selected_fee_without_total();
+        {
+            let options =
+                FeeRateOptionsWithTotalFee::without_totals(FeeRateOptions::_ffi_preview_new());
+            let mut state = manager.state.lock();
+            state.amount_sats = Some(10_000);
+            state.unlocked_spendable_sats = Some(50_000);
+            state.address = Some(address.clone());
+            state.fee_selection = Some(FeeSelection::new(Arc::new(options), Arc::new(selected)));
+        }
+
+        let total_fee = Amount::from_sat(2_000);
+        let mut selected = selected_fee_without_total();
+        selected.total_fee = Some(total_fee);
+
+        manager.continue_with_selected_fee(
+            10_000,
+            Amount::from_sat(10_000),
+            address,
+            Arc::new(selected),
+            Some(total_fee),
+        );
+
+        let message = manager.reconcile_receiver.try_recv().expect("warning is reconciled");
+        let SingleOrMany::Single(message) = message else {
+            panic!("expected a single reconcile message");
+        };
+
+        assert!(matches!(
+            message,
+            super::super::SendFlowManagerReconcileMessage::SetAlert(SendFlowAlertState::Warning {
+                kind: SendFlowWarningKind::VeryHighFee,
+                ..
+            })
+        ));
+
+        assert_eq!(manager.selected_fee_rate().and_then(|fee| fee.total_fee), Some(total_fee));
     }
 }

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use cove_types::amount::Amount;
 
-use super::{EnterMode, Message, RustSendFlowManager, SendFlowError};
+use super::{EnterMode, Message, RustSendFlowManager, SendFlowAlertState, SendFlowError};
 
 impl RustSendFlowManager {
     /// Create the PSBT and everything is valid go to the next screen
@@ -29,6 +29,35 @@ impl RustSendFlowManager {
         let Some(selected_fee_rate) = self.selected_fee_rate() else {
             return self.send_alert(SendFlowError::UnableToGetFeeRate);
         };
+
+        let Some(total_fee) = selected_fee_rate.total_fee else {
+            let me = self.clone();
+            cove_tokio::task::spawn(async move {
+                me.get_or_update_fee_rate_options().await;
+
+                if me.selected_fee_rate().and_then(|fee| fee.total_fee).is_none() {
+                    return me
+                        .send_alert_async(SendFlowError::UnableToGetFeeDetails(
+                            "selected fee total unavailable".to_string(),
+                        ))
+                        .await;
+                }
+
+                me.finalize_and_go_to_next_screen();
+            });
+            return;
+        };
+
+        if total_fee.as_sats() > amount_sats {
+            return self.send_alert(SendFlowAlertState::General {
+                title: "Fee Too High!".to_string(),
+                message: "The fee is higher than the amount you are sending".to_string(),
+            });
+        }
+
+        if let Some(warning) = self.pending_send_warning() {
+            return self.reconciler.send(Message::SetAlert(warning));
+        }
 
         self.reconciler.send(Message::UpdateFocusField(None));
 
@@ -64,8 +93,7 @@ impl RustSendFlowManager {
             let details = match confirm_details {
                 Ok(details) => details,
                 Err(error) => {
-                    let error = SendFlowError::UnableToBuildTxn(error.to_string());
-                    return me.send_alert_async(error).await;
+                    return me.send_alert_async(SendFlowError::from(error)).await;
                 }
             };
 

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -58,12 +58,13 @@ impl RustSendFlowManager {
                 }
 
                 if me.selected_fee_rate().and_then(|fee| fee.total_fee).is_none() {
-                    match me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await {
-                        Ok(psbt) => {
-                            if !me.finalize_snapshot_matches(&snapshot) {
-                                return;
-                            }
+                    let psbt = me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await;
+                    if !me.finalize_snapshot_matches(&snapshot) {
+                        return;
+                    }
 
+                    match psbt {
+                        Ok(psbt) => {
                             let total_fee = match psbt.fee() {
                                 Ok(total_fee) => total_fee,
                                 Err(error) => {

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -32,10 +32,19 @@ impl RustSendFlowManager {
 
         let Some(total_fee) = selected_fee_rate.total_fee else {
             let me = self.clone();
+            let address_for_psbt = address.as_ref().clone();
+            let fee_rate = selected_fee_rate.fee_rate;
             cove_tokio::task::spawn(async move {
                 me.get_or_update_fee_rate_options().await;
 
                 if me.selected_fee_rate().and_then(|fee| fee.total_fee).is_none() {
+                    if matches!(
+                        me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await,
+                        Err(SendFlowError::SendBelowDustLimit)
+                    ) {
+                        return me.send_alert_async(SendFlowError::SendBelowDustLimit).await;
+                    }
+
                     return me
                         .send_alert_async(SendFlowError::UnableToGetFeeDetails(
                             "selected fee total unavailable".to_string(),

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -60,6 +60,10 @@ impl RustSendFlowManager {
                 if me.selected_fee_rate().and_then(|fee| fee.total_fee).is_none() {
                     match me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await {
                         Ok(psbt) => {
+                            if !me.finalize_snapshot_matches(&snapshot) {
+                                return;
+                            }
+
                             let total_fee = match psbt.fee() {
                                 Ok(total_fee) => total_fee,
                                 Err(error) => {
@@ -371,6 +375,26 @@ mod tests {
         set_finalize_snapshot_state(&manager, address, selected_fee_rate);
 
         manager.state.lock().amount_sats = Some(20_000);
+
+        assert!(!manager.finalize_snapshot_matches(&snapshot));
+    }
+
+    #[test]
+    fn finalize_snapshot_rejects_changed_fee_choice() {
+        let manager = manager_for_finalize();
+        let address = Arc::new(Address::preview_new());
+        let selected_fee_rate = Arc::new(selected_fee_without_total());
+        let snapshot = finalize_snapshot(address.clone(), selected_fee_rate.clone());
+        set_finalize_snapshot_state(&manager, address, selected_fee_rate);
+
+        let selected = Arc::new(FeeRateOptionWithTotalFee {
+            fee_speed: FeeSpeed::Custom { duration_mins: 20 },
+            fee_rate: FeeRateOption::new(FeeSpeed::Custom { duration_mins: 20 }, 2.0).fee_rate,
+            total_fee: None,
+        });
+        let options =
+            FeeRateOptionsWithTotalFee::without_totals(FeeRateOptions::_ffi_preview_new());
+        manager.state.lock().fee_selection = Some(FeeSelection::new(Arc::new(options), selected));
 
         assert!(!manager.finalize_snapshot_matches(&snapshot));
     }

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -10,6 +10,14 @@ use cove_types::{amount::Amount, fees::FeeRateOptionWithTotalFee};
 
 use super::{EnterMode, Message, RustSendFlowManager, SendFlowAlertState, SendFlowError};
 
+#[derive(Clone)]
+struct FinalizeSnapshot {
+    amount_sats: u64,
+    address: Arc<Address>,
+    selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
+    mode: EnterMode,
+}
+
 impl RustSendFlowManager {
     /// Create the PSBT and everything is valid go to the next screen
     pub(crate) fn finalize_and_go_to_next_screen(self: &Arc<Self>) {
@@ -34,12 +42,20 @@ impl RustSendFlowManager {
 
         let Some(total_fee) = selected_fee_rate.total_fee else {
             let me = self.clone();
+            let snapshot = FinalizeSnapshot {
+                amount_sats,
+                address: address.clone(),
+                selected_fee_rate: selected_fee_rate.clone(),
+                mode: self.state.lock().mode.clone(),
+            };
             let address_for_psbt = address.as_ref().clone();
-            let address_for_finalize = address.clone();
             let fee_rate = selected_fee_rate.fee_rate;
-            let selected_fee_rate_for_finalize = selected_fee_rate.clone();
             cove_tokio::task::spawn(async move {
                 me.get_or_update_fee_rate_options().await;
+
+                if !me.finalize_snapshot_matches(&snapshot) {
+                    return;
+                }
 
                 if me.selected_fee_rate().and_then(|fee| fee.total_fee).is_none() {
                     match me.build_psbt(Some(address_for_psbt), Some(amount), fee_rate).await {
@@ -55,13 +71,13 @@ impl RustSendFlowManager {
                                 }
                             };
                             let mut selected_fee_rate =
-                                Arc::unwrap_or_clone(selected_fee_rate_for_finalize);
+                                Arc::unwrap_or_clone(snapshot.selected_fee_rate.clone());
                             selected_fee_rate.total_fee = Some(total_fee);
 
                             me.continue_with_selected_fee(
-                                amount_sats,
+                                snapshot.amount_sats,
                                 amount,
-                                address_for_finalize,
+                                snapshot.address.clone(),
                                 Arc::new(selected_fee_rate),
                                 Some(total_fee),
                             );
@@ -105,10 +121,10 @@ impl RustSendFlowManager {
         selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
         total_fee: Option<Amount>,
     ) {
-        if total_fee.is_some_and(|total_fee| total_fee.as_sats() > amount_sats) {
+        if self.total_fee_blocks_send(amount_sats, total_fee) {
             return self.send_alert(SendFlowAlertState::General {
                 title: "Fee Too High!".to_string(),
-                message: "The fee is higher than the amount you are sending".to_string(),
+                message: "The fee is too high for the amount you are sending".to_string(),
             });
         }
 
@@ -186,6 +202,50 @@ impl RustSendFlowManager {
         });
     }
 
+    fn finalize_snapshot_matches(&self, snapshot: &FinalizeSnapshot) -> bool {
+        let (amount_sats, address, selected_fee_rate, mode) = {
+            let state = self.state.lock();
+            let selected_fee_rate =
+                state.fee_selection.as_ref().map(|selection| selection.selected.clone());
+
+            (state.amount_sats, state.address.clone(), selected_fee_rate, state.mode.clone())
+        };
+
+        if amount_sats != Some(snapshot.amount_sats) {
+            return false;
+        }
+
+        if address.as_deref() != Some(snapshot.address.as_ref()) {
+            return false;
+        }
+
+        if mode != snapshot.mode {
+            return false;
+        }
+
+        selected_fee_rate.as_deref().is_some_and(|current| {
+            current.fee_speed == snapshot.selected_fee_rate.fee_speed
+                && current.fee_rate == snapshot.selected_fee_rate.fee_rate
+        })
+    }
+
+    fn total_fee_blocks_send(&self, amount_sats: u64, total_fee: Option<Amount>) -> bool {
+        let Some(total_fee) = total_fee else {
+            return false;
+        };
+
+        if total_fee.as_sats() > amount_sats {
+            return true;
+        }
+
+        let mode = self.state.lock().mode.clone();
+        let EnterMode::CoinControl(coin_control) = mode else {
+            return false;
+        };
+
+        total_fee.as_sats() >= coin_control.max_send().as_sats()
+    }
+
     fn update_selected_fee_total_if_current(
         self: &Arc<Self>,
         selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
@@ -254,6 +314,65 @@ mod tests {
             fee_rate: FeeRateOption::new(FeeSpeed::Custom { duration_mins: 10 }, 1.0).fee_rate,
             total_fee: None,
         }
+    }
+
+    fn finalize_snapshot(
+        address: Arc<Address>,
+        selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
+    ) -> FinalizeSnapshot {
+        FinalizeSnapshot {
+            amount_sats: 10_000,
+            address,
+            selected_fee_rate,
+            mode: EnterMode::SetAmount,
+        }
+    }
+
+    fn set_finalize_snapshot_state(
+        manager: &RustSendFlowManager,
+        address: Arc<Address>,
+        selected_fee_rate: Arc<FeeRateOptionWithTotalFee>,
+    ) {
+        let options =
+            FeeRateOptionsWithTotalFee::without_totals(FeeRateOptions::_ffi_preview_new());
+        let mut state = manager.state.lock();
+        state.amount_sats = Some(10_000);
+        state.unlocked_spendable_sats = Some(50_000);
+        state.address = Some(address);
+        state.fee_selection = Some(FeeSelection::new(Arc::new(options), selected_fee_rate));
+    }
+
+    #[test]
+    fn finalize_snapshot_allows_selected_fee_total_to_populate() {
+        let manager = manager_for_finalize();
+        let address = Arc::new(Address::preview_new());
+        let selected_fee_rate = Arc::new(selected_fee_without_total());
+        let snapshot = finalize_snapshot(address.clone(), selected_fee_rate.clone());
+        set_finalize_snapshot_state(&manager, address, selected_fee_rate);
+
+        let mut selected_with_total = selected_fee_without_total();
+        selected_with_total.total_fee = Some(Amount::from_sat(2_000));
+        manager.state.lock().fee_selection = Some(FeeSelection::new(
+            Arc::new(
+                FeeRateOptionsWithTotalFee::without_totals(FeeRateOptions::_ffi_preview_new()),
+            ),
+            Arc::new(selected_with_total),
+        ));
+
+        assert!(manager.finalize_snapshot_matches(&snapshot));
+    }
+
+    #[test]
+    fn finalize_snapshot_rejects_changed_amount() {
+        let manager = manager_for_finalize();
+        let address = Arc::new(Address::preview_new());
+        let selected_fee_rate = Arc::new(selected_fee_without_total());
+        let snapshot = finalize_snapshot(address.clone(), selected_fee_rate.clone());
+        set_finalize_snapshot_state(&manager, address, selected_fee_rate);
+
+        manager.state.lock().amount_sats = Some(20_000);
+
+        assert!(!manager.finalize_snapshot_matches(&snapshot));
     }
 
     #[test]

--- a/rust/src/manager/send_flow_manager/state.rs
+++ b/rust/src/manager/send_flow_manager/state.rs
@@ -8,7 +8,7 @@ use cove_types::{
     utxo::UtxoList,
 };
 
-use super::SetAmountFocusField;
+use super::{SendFlowWarningKind, SetAmountFocusField};
 use crate::{
     app::App,
     database::Database,
@@ -30,6 +30,7 @@ pub struct SendFlowManagerState {
     pub(crate) wallet_balance: Option<Arc<Balance>>,
     pub(crate) unlocked_spendable_sats: Option<u64>,
     pub(crate) lock_state_load_failed: bool,
+    pub(crate) acknowledged_warnings: Vec<SendFlowWarningKind>,
     /// True once we have base fee rates (either from cache or network)
     /// UI can show immediately once this is true (total fees pending calculation)
     pub(crate) has_base_fees: bool,
@@ -147,12 +148,27 @@ impl SendFlowManagerState {
             wallet_balance: Some(balance),
             unlocked_spendable_sats: None,
             lock_state_load_failed: false,
+            acknowledged_warnings: Vec::new(),
             fee_selection: None,
             btc_price_in_fiat,
             selected_fiat_currency,
             has_base_fees: false,
             payjoin_endpoint: None,
         }
+    }
+
+    pub(crate) fn acknowledge_warning(&mut self, kind: SendFlowWarningKind) {
+        if !self.has_acknowledged_warning(kind) {
+            self.acknowledged_warnings.push(kind);
+        }
+    }
+
+    pub(crate) fn has_acknowledged_warning(&self, kind: SendFlowWarningKind) -> bool {
+        self.acknowledged_warnings.contains(&kind)
+    }
+
+    pub(crate) fn clear_warning_acknowledgements(&mut self) {
+        self.acknowledged_warnings.clear();
     }
 }
 

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -19,6 +19,7 @@ use std::{
 use act_zero::{Addr, call, send};
 use actor::WalletActor;
 pub use balance_presentation::BalancePresentation;
+use bdk_wallet::error::CreateTxError;
 use flume::Receiver;
 pub use ledger_state::WalletLedgerState;
 use parking_lot::RwLock;
@@ -352,6 +353,9 @@ pub enum WalletManagerError {
     #[error("insufficient funds: {0}")]
     InsufficientFunds(String),
 
+    #[error("send amount is below the dust limit")]
+    OutputBelowDustLimit,
+
     #[error("selected UTXOs include locked outputs")]
     LockedOutputsSelected,
 
@@ -444,6 +448,16 @@ fn unsigned_transactions_for_wallet(
         txns.into_iter().map(|txn| Arc::new(txn.into())).collect::<Vec<Arc<UnsignedTransaction>>>();
 
     Ok(txns)
+}
+
+impl From<CreateTxError> for WalletManagerError {
+    fn from(error: CreateTxError) -> Self {
+        match error {
+            CreateTxError::OutputBelowDustLimit(_) => Self::OutputBelowDustLimit,
+            CreateTxError::CoinSelection(error) => Self::InsufficientFunds(error.to_string()),
+            error => Self::BuildTxError(error.to_string()),
+        }
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -1220,10 +1234,13 @@ fn wallet_account_number(id: &WalletId) -> Option<u32> {
 mod tests {
     use std::sync::Arc;
 
+    use bdk_wallet::{coin_selection::InsufficientFunds, error::CreateTxError};
+    use bitcoin::Amount;
+
     use super::{
         Balance, BalancePresentation, Error, PREVIEW_FULL_SCAN_COMPLETED_AT, WalletLedgerState,
-        WalletLoadState, WalletScanPhase, WalletScanProgress, WalletScanStatus, WalletSnapshot,
-        initial_state_from_snapshot,
+        WalletLoadState, WalletManagerError, WalletScanPhase, WalletScanProgress, WalletScanStatus,
+        WalletSnapshot, initial_state_from_snapshot,
         initial_state_from_snapshot_with_pending_unsigned_transactions, ledger_state,
         preview_ledger_ready_metadata,
     };
@@ -1373,6 +1390,23 @@ mod tests {
 
         assert!(state.unsigned_transactions.is_empty());
         assert_eq!(state.load_state, WalletLoadState::Loading);
+    }
+
+    #[test]
+    fn create_tx_output_below_dust_maps_to_wallet_output_below_dust() {
+        let error = WalletManagerError::from(CreateTxError::OutputBelowDustLimit(0));
+
+        assert!(matches!(error, WalletManagerError::OutputBelowDustLimit));
+    }
+
+    #[test]
+    fn create_tx_coin_selection_maps_to_insufficient_funds() {
+        let error = WalletManagerError::from(CreateTxError::CoinSelection(InsufficientFunds {
+            needed: Amount::from_sat(10_000),
+            available: Amount::from_sat(1_000),
+        }));
+
+        assert!(matches!(error, WalletManagerError::InsufficientFunds(_)));
     }
 }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -1403,6 +1403,10 @@ mod tests {
         bitcoin::FeeRate::from_sat_per_vb(1).expect("fee rate")
     }
 
+    fn high_sat_vbyte_fee_rate() -> bitcoin::FeeRate {
+        bitcoin::FeeRate::from_sat_per_vb(100).expect("fee rate")
+    }
+
     #[test]
     fn progressive_scan_update_response_preserves_last_active_indices() {
         let scan_update = ScanUpdate {
@@ -1787,6 +1791,39 @@ mod tests {
             .await;
 
         actor_value(result).await.expect("manual max send above dust is allowed below 5000 sats");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn actor_manual_max_send_returns_domain_error_when_fee_shortfall_consumes_estimate() {
+        crate::database::test_support::init_test_database();
+
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([2; 32]) },
+        );
+        let spendable = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(7_500));
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        actor.db = db;
+
+        let result = actor
+            .build_manual_tx(
+                vec![spendable],
+                Amount::from_sat(7_500),
+                Address::preview_new(),
+                high_sat_vbyte_fee_rate(),
+            )
+            .await;
+        let error = actor_value(result)
+            .await
+            .expect_err("fee shortfall consuming the estimate is rejected");
+
+        assert!(matches!(error, super::Error::InsufficientFunds(_)));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -1719,7 +1719,7 @@ mod tests {
         let error =
             actor_value(result).await.expect_err("all locked outputs cannot fund transaction");
 
-        assert!(matches!(error, super::Error::BuildTxError(_)));
+        assert!(matches!(error, super::Error::InsufficientFunds(_)));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1736,7 +1736,7 @@ mod tests {
             .await
             .expect_err("all locked outputs cannot fund drain transaction");
 
-        assert!(matches!(error, super::Error::BuildTxError(_)));
+        assert!(matches!(error, super::Error::InsufficientFunds(_)));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -1760,6 +1760,36 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn actor_manual_max_send_uses_recipient_exact_dust_floor() {
+        crate::database::test_support::init_test_database();
+
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([2; 32]) },
+        );
+        let spendable = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(4_000));
+
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        actor.db = db;
+
+        let result = actor
+            .build_manual_tx(
+                vec![spendable],
+                Amount::from_sat(4_000),
+                Address::preview_new(),
+                one_sat_vbyte_fee_rate(),
+            )
+            .await;
+
+        actor_value(result).await.expect("manual max send above dust is allowed below 5000 sats");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn mnemonic_address_type_switch_restarts_wallet_scan() {
         let _guard = address_type_switch_test_lock().lock().await;
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -1776,8 +1776,10 @@ mod tests {
         let spendable = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(4_000));
 
         let (sender, _receiver) = flume::bounded(10);
+        let wallet_snapshot = test_wallet_snapshot(&wallet);
         let mut actor =
-            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+            super::WalletActor::new(wallet, sender, test_scan_status(), wallet_snapshot)
+                .expect("actor is created");
         let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
         actor.db = db;
 
@@ -1806,8 +1808,10 @@ mod tests {
         let spendable = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(7_500));
 
         let (sender, _receiver) = flume::bounded(10);
+        let wallet_snapshot = test_wallet_snapshot(&wallet);
         let mut actor =
-            super::WalletActor::new(wallet, sender, test_scan_status()).expect("actor is created");
+            super::WalletActor::new(wallet, sender, test_scan_status(), wallet_snapshot)
+                .expect("actor is created");
         let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
         actor.db = db;
 

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -14,7 +14,6 @@ use bitcoin::{
     params::Params,
 };
 use cove_bdk::coin_selection::CoveDefaultCoinSelection;
-use cove_common::consts::MIN_SEND_AMOUNT;
 use cove_types::{
     confirm::{AddressAndAmount, ConfirmDetails, ExtraItem, InputOutputDetails, SplitOutput},
     fees::{FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee},
@@ -52,7 +51,7 @@ impl WalletActor {
 
         exclude_locked_outpoints(&mut tx_builder, locked_outpoints);
         tx_builder.drain_wallet().drain_to(script_pubkey).fee_rate(fee.into());
-        let psbt = tx_builder.finish().map_err_str(Error::BuildTxError)?;
+        let psbt = tx_builder.finish().map_err(Error::from)?;
         self.wallet.unreserve_tx_change_addresses(&psbt.unsigned_tx);
 
         Ok(psbt)
@@ -81,7 +80,7 @@ impl WalletActor {
         tx_builder.add_recipient(script_pubkey, amount);
         tx_builder.fee_rate(fee_rate);
 
-        let psbt = tx_builder.finish().map_err_str(Error::BuildTxError)?;
+        let psbt = tx_builder.finish().map_err(Error::from)?;
         Ok(psbt)
     }
 
@@ -124,7 +123,7 @@ impl WalletActor {
         tx_builder.add_recipient(address.script_pubkey(), send_amount);
         tx_builder.fee_rate(fee_rate);
 
-        let psbt = tx_builder.finish().map_err_str(Error::BuildTxError)?;
+        let psbt = tx_builder.finish().map_err(Error::from)?;
         Ok(psbt)
     }
 
@@ -722,12 +721,11 @@ impl WalletActor {
                     ))
                 })?;
 
+            let recipient_dust_limit = address.script_pubkey().minimal_non_dust();
             let mut fee_psbt = None;
             while fee_psbt.is_none() {
-                if max_send_estimate < MIN_SEND_AMOUNT {
-                    return Err(Error::InsufficientFunds(format!(
-                        "no enough funds to cover the fees, total available: {total_amount}, fees: {fee_estimate}",
-                    )));
+                if max_send_estimate < recipient_dust_limit {
+                    return Err(Error::OutputBelowDustLimit);
                 }
 
                 let mut tx_builder = self.wallet.bdk.build_tx();
@@ -746,7 +744,7 @@ impl WalletActor {
                         let difference = result.needed - result.available;
                         max_send_estimate -= difference;
                     }
-                    Err(err) => return Err(Error::BuildTxError(err.to_string())),
+                    Err(err) => return Err(Error::from(err)),
                 }
             }
 

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -742,7 +742,18 @@ impl WalletActor {
                     }
                     Err(CreateTxError::CoinSelection(result)) => {
                         let difference = result.needed - result.available;
-                        max_send_estimate -= difference;
+                        let Some(reduced_estimate) = max_send_estimate.checked_sub(difference)
+                        else {
+                            return Err(Error::InsufficientFunds(format!(
+                                "not enough funds to cover the fee shortfall, total available: {utxo_total_amount}, estimate: {max_send_estimate}, shortfall: {difference}",
+                            )));
+                        };
+
+                        if reduced_estimate < recipient_dust_limit {
+                            return Err(Error::OutputBelowDustLimit);
+                        }
+
+                        max_send_estimate = reduced_estimate;
                     }
                     Err(err) => return Err(Error::from(err)),
                 }

--- a/rust/src/wallet/ffi.rs
+++ b/rust/src/wallet/ffi.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use cove_common::consts::{MIN_SEND_AMOUNT, MIN_SEND_SATS};
+use cove_common::consts::{
+    CONSERVATIVE_DUST_LIMIT_AMOUNT, CONSERVATIVE_DUST_LIMIT_SATS, LOW_SEND_WARNING_AMOUNT,
+    LOW_SEND_WARNING_SATS,
+};
 use cove_types::amount::Amount;
 
 use super::{WalletAddressType, metadata};
@@ -22,11 +25,21 @@ pub fn preview_new_wrapped_found_address() -> metadata::FoundAddress {
 }
 
 #[uniffi::export]
-pub fn ffi_min_send_sats() -> u64 {
-    MIN_SEND_SATS
+pub fn ffi_low_send_warning_sats() -> u64 {
+    LOW_SEND_WARNING_SATS
 }
 
 #[uniffi::export]
-pub fn ffi_min_send_amount() -> Arc<Amount> {
-    Arc::new(MIN_SEND_AMOUNT.into())
+pub fn ffi_low_send_warning_amount() -> Arc<Amount> {
+    Arc::new(LOW_SEND_WARNING_AMOUNT.into())
+}
+
+#[uniffi::export]
+pub fn ffi_conservative_dust_limit_sats() -> u64 {
+    CONSERVATIVE_DUST_LIMIT_SATS
+}
+
+#[uniffi::export]
+pub fn ffi_conservative_dust_limit_amount() -> Arc<Amount> {
+    Arc::new(CONSERVATIVE_DUST_LIMIT_AMOUNT.into())
 }


### PR DESCRIPTION
## Summary

Replaces Cove's 5000-sat hard send floor with finalize-time warnings for small
on-chain payments and high fee percentages.

Rust now owns the warning state, acknowledgement flow, reset behavior, and hard
validation ordering. BDK transaction construction remains authoritative for
recipient dust rejection, which is mapped to a friendly cross-platform dust
error.

iOS and Android render the new warning alerts, dispatch `Send Anyway` back to
Rust, use the conservative dust fallback for coin-control floors, and consume
regenerated UniFFI bindings.

## Verification

- `cargo test -p cove --lib send_flow_manager`
- `cargo test -p cove --lib create_tx_`
- `cargo test -p cove --lib actor_manual_max_send_uses_recipient_exact_dust_floor`
- `just fmt`
- `just clippy`
- `just build-ios`
- `just build-android`
- `just compile-ios`
- `just compile-android`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new send-flow warning dialogs for low amounts and high fees, including **Send Anyway** with warning acknowledgements.
* **Bug Fixes**
  * Updated send validation to no longer block on fee-percentage checks (warnings gate the flow instead).
  * Refined dust-limit handling across amount and coin-control screens, including slider defaults and continue-button enablement.
  * Improved warning/alert dismiss and button behavior (including “Cancel” for warnings) and updated “below dust limit” messaging.
* **Tests**
  * Added unit coverage for “fee too high” error classification used in custom fee UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->