### PR TITLE
Fix flaky UI tests

### DIFF
--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/OnboardingFlow/OnboardingBranchScreensTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/OnboardingFlow/OnboardingBranchScreensTest.kt
@@ -360,6 +360,7 @@ class OnboardingBranchScreensTest {
                 providerHint = null,
                 warningMessage = null,
                 errorMessage = null,
+                onBack = { selected = "back" },
                 onRestore = { selected = "restore" },
                 onSkip = { selected = "skip" },
             )
@@ -408,6 +409,7 @@ class OnboardingBranchScreensTest {
                 providerHint = null,
                 warningMessage = "Cloud storage may be unavailable.",
                 errorMessage = null,
+                onBack = { selected = "back-warning" },
                 onRestore = { selected = "restore-warning" },
                 onSkip = { selected = "skip-warning" },
             )
@@ -428,6 +430,7 @@ class OnboardingBranchScreensTest {
                 providerHint = null,
                 warningMessage = null,
                 errorMessage = "Passkey verification failed.",
+                onBack = { selected = "back-error" },
                 onRestore = { selected = "restore-error" },
                 onSkip = { selected = "skip-error" },
             )

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/FullLaunchRobot.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/FullLaunchRobot.kt
@@ -28,7 +28,7 @@ class FullLaunchStartupRobot(
             acceptTermsAndContinue()
         }
 
-        device.waitUntilVisible(tag("onboarding.getStarted"))
+        device.advanceUntilVisible(tag("onboarding.getStarted"))
 
         return this
     }
@@ -65,24 +65,28 @@ class FullLaunchOnboardingRobot(
             "abandon",
             "abandon",
             "about",
-        )
+    )
 
     fun tapGetStarted(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.getStarted")).click()
-        device.waitUntilVisible(text("Do you already have Bitcoin?"))
+        device.advanceUntilVisible(text("Do you already have Bitcoin?")) {
+            clickCenterIfVisible(tag("onboarding.getStarted"))
+        }
 
         return this
     }
 
     fun chooseExistingUser(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.bitcoinChoice.existing")).click()
-        device.waitUntilVisible(text("How do you store your Bitcoin?"))
+        device.advanceUntilVisible(text("How do you store your Bitcoin?")) {
+            clickCenterIfVisible(tag("onboarding.bitcoinChoice.existing"))
+        }
+
         return this
     }
 
     fun chooseNewUser(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.bitcoinChoice.new")).click()
-        device.waitUntilVisible(text("Creating your wallet"))
+        device.advanceUntilVisible(text("Creating your wallet")) {
+            clickCenterIfVisible(tag("onboarding.bitcoinChoice.new"))
+        }
         device.waitUntilVisible(textContains("Back up your wallet"), timeoutMillis = 10_000)
 
         return this
@@ -90,7 +94,7 @@ class FullLaunchOnboardingRobot(
 
     fun goBackToBitcoinChoice(): FullLaunchOnboardingRobot {
         device.waitUntilVisible(text("Back")).click()
-        device.waitUntilVisible(text("Do you already have Bitcoin?"))
+        device.advanceUntilVisible(text("Do you already have Bitcoin?"))
         device.waitUntilVisible(tag("onboarding.bitcoinChoice.new"))
         device.waitUntilVisible(tag("onboarding.bitcoinChoice.existing"))
 
@@ -99,7 +103,7 @@ class FullLaunchOnboardingRobot(
 
     fun systemBackToBitcoinChoice(): FullLaunchOnboardingRobot {
         device.pressBack()
-        device.waitUntilVisible(text("Do you already have Bitcoin?"))
+        device.advanceUntilVisible(text("Do you already have Bitcoin?"))
         device.waitUntilVisible(tag("onboarding.bitcoinChoice.new"))
         device.waitUntilVisible(tag("onboarding.bitcoinChoice.existing"))
 
@@ -107,13 +111,13 @@ class FullLaunchOnboardingRobot(
     }
 
     fun useAnotherWallet(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("How do you store your Bitcoin?"))
+        device.advanceUntilVisible(text("How do you store your Bitcoin?"))
 
         return this
     }
 
     fun assertStorageChoices(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("How do you store your Bitcoin?"))
+        device.advanceUntilVisible(text("How do you store your Bitcoin?"))
         device.waitUntilVisible(tag("onboarding.storage.exchange"))
         device.waitUntilVisible(tag("onboarding.storage.hardware"))
         device.waitUntilVisible(tag("onboarding.storage.software"))
@@ -122,30 +126,34 @@ class FullLaunchOnboardingRobot(
     }
 
     fun chooseExchange(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.storage.exchange")).click()
-        device.waitUntilVisible(text("Creating your wallet"))
+        device.advanceUntilVisible(text("Creating your wallet")) {
+            clickCenterIfVisible(tag("onboarding.storage.exchange"))
+        }
         device.waitUntilVisible(text("Back up your wallet before funding it"), timeoutMillis = 10_000)
 
         return this
     }
 
     fun chooseHardwareWallet(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.storage.hardware")).click()
-        device.waitUntilVisible(text("Import your hardware wallet"))
+        device.advanceUntilVisible(text("Import your hardware wallet")) {
+            clickCenterIfVisible(tag("onboarding.storage.hardware"))
+        }
 
         return this
     }
 
     fun chooseSoftwareWallet(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.storage.software")).click()
-        device.waitUntilVisible(text("Import your software wallet"))
+        device.advanceUntilVisible(text("Import your software wallet")) {
+            clickCenterIfVisible(tag("onboarding.storage.software"))
+        }
 
         return this
     }
 
     fun chooseSoftwareCreate(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.software.create")).click()
-        device.waitUntilVisible(text("Creating your wallet"))
+        device.advanceUntilVisible(text("Creating your wallet")) {
+            clickCenterIfVisible(tag("onboarding.software.create"))
+        }
         device.waitUntilVisible(textContains("Back up your wallet"), timeoutMillis = 10_000)
 
         return this
@@ -160,7 +168,7 @@ class FullLaunchOnboardingRobot(
     }
 
     fun viewRecoveryWords(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(tag("onboarding.secretWords")).click()
+        device.waitUntilVisible(text("Show Words")).click()
         device.waitUntilVisible(text("Your Recovery Words"))
         device.waitUntilVisible(tag("onboarding.secretWords.saved"))
 
@@ -202,7 +210,7 @@ class FullLaunchOnboardingRobot(
     }
 
     fun assertHardwareImportChoices(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Import your hardware wallet"))
+        device.advanceUntilVisible(text("Import your hardware wallet"))
         device.waitUntilVisible(text("Scan export QR"))
         device.waitUntilVisible(text("Import export file"))
         device.waitUntilVisible(text("Scan with NFC"))
@@ -211,7 +219,7 @@ class FullLaunchOnboardingRobot(
     }
 
     fun openHardwareQrScanner(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Scan export QR")).click()
+        device.clickCenter(device.advanceUntilVisible(text("Scan export QR")))
         device.waitUntilVisible(text("Scan Hardware QR"))
         assertQrScannerVisible()
 
@@ -219,7 +227,7 @@ class FullLaunchOnboardingRobot(
     }
 
     fun openHardwareNfcScanner(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Scan with NFC")).click()
+        device.clickCenter(device.advanceUntilVisible(text("Scan with NFC")))
         device.waitUntilVisible(text("Scan your hardware wallet with NFC"))
         device.waitUntilVisible(text("Start NFC Scan"))
 
@@ -227,7 +235,7 @@ class FullLaunchOnboardingRobot(
     }
 
     fun assertSoftwareImportChoices(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Import your software wallet"))
+        device.advanceUntilVisible(text("Import your software wallet"))
         device.waitUntilVisible(text("Enter recovery words"))
         device.waitUntilVisible(text("Scan QR code"))
 
@@ -235,34 +243,41 @@ class FullLaunchOnboardingRobot(
     }
 
     fun openSoftwareQrScanner(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Scan QR code")).click()
+        device.clickCenter(device.advanceUntilVisible(text("Scan QR code")))
         assertQrScannerVisible()
 
         return this
     }
 
     fun importKnownEmptyMainnetWalletWords(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Enter recovery words")).click()
-        device.waitUntilVisible(text("How many words do you have?"))
-        device.waitUntilVisible(text("12 words")).click()
-        device.waitUntilVisible(text("Import Wallet"))
+        device.advanceUntilVisible(text("How many words do you have?")) {
+            clickCenterIfVisible(text("Enter recovery words"))
+        }
+        device.advanceUntilVisible(text("Import Wallet")) {
+            clickCenterIfVisible(text("12 words"))
+        }
 
         knownEmptyMainnetMnemonic.forEachIndexed { index, word ->
             device.waitUntilVisible(tag("hotWalletImport.word.${index + 1}")).text = word
         }
 
-        device.pressEnter()
-        device.scrollUntilVisible(tag("hotWalletImport.import")).click()
-        device.waitUntilVisible(text("Protect this wallet with Cloud Backup?"), timeoutMillis = 20_000)
+        device.dismissKeyboardIfShown()
+        device.clickUntilVisible(
+            clickSelector = tag("hotWalletImport.import"),
+            targetSelector = text("Protect this wallet with Cloud Backup?"),
+            timeoutMillis = 20_000,
+        )
 
         return this
     }
 
     fun assertImportScreenBlocksScreenshots(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Enter recovery words")).click()
-        device.waitUntilVisible(text("How many words do you have?"))
-        device.waitUntilVisible(text("12 words")).click()
-        device.waitUntilVisible(text("Import Wallet"))
+        device.advanceUntilVisible(text("How many words do you have?")) {
+            clickCenterIfVisible(text("Enter recovery words"))
+        }
+        device.advanceUntilVisible(text("Import Wallet")) {
+            clickCenterIfVisible(text("12 words"))
+        }
         assertScreenshotsBlocked()
 
         return this
@@ -293,8 +308,7 @@ class FullLaunchOnboardingRobot(
     }
 
     fun assertImportedMainnetWalletHasHistoryAndNoBitcoin(): FullLaunchOnboardingRobot {
-        device.waitUntilVisible(text("Send"), timeoutMillis = 30_000).click()
-        device.waitUntilVisible(text("No funds available to send"), timeoutMillis = 10_000)
+        device.waitUntilSendShowsNoFunds()
         device.waitUntilVisible(text("Transactions"), timeoutMillis = 30_000)
 
         return this
@@ -325,7 +339,6 @@ class FullLaunchOnboardingRobot(
         device.waitUntilVisible(text("How It Works"))
         device.waitUntilVisible(text("Back"))
         device.waitUntilVisible(tag("onboarding.cloudBackup.cancel"))
-        device.waitUntilVisible(tag("onboarding.cloudBackup.enable"))
 
         return this
     }
@@ -336,10 +349,10 @@ class FullLaunchOnboardingRobot(
             "access to my Google account",
             "manually back up my 12 or 24 words",
         ).forEach { label ->
-            device.scrollUntilVisible(textContains(label)).click()
+            device.clickCheckboxBesideLabel(label)
         }
 
-        device.scrollUntilVisible(tag("onboarding.cloudBackup.enable")).click()
+        device.clickObjectUntilGoneOrSystemSheet(tag("onboarding.cloudBackup.enable"))
 
         return this
     }
@@ -409,19 +422,54 @@ class FullLaunchOnboardingRobot(
 
 fun fullLaunchDevice(): UiDevice =
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-        wakeUp()
-        executeShellCommand("wm dismiss-keyguard")
+        ensureManualFullLaunchDeviceReady()
     }
 
 fun launchFullApp() {
     val instrumentation = InstrumentationRegistry.getInstrumentation()
     val packageName = instrumentation.targetContext.packageName
+    val device = UiDevice.getInstance(instrumentation)
+
+    device.ensureManualFullLaunchDeviceReady()
+
     val output =
         instrumentation.uiAutomation.executeShellCommand(
             "am start -W -n $packageName/org.bitcoinppl.cove.MainActivity --ez org.bitcoinppl.cove.uitest.RESET_DATA true",
         )
 
     output.drainAndClose()
+    device.ensureManualFullLaunchDeviceReady()
+}
+
+private fun UiDevice.ensureManualFullLaunchDeviceReady(timeoutMillis: Long = 5_000) {
+    val deadline = System.currentTimeMillis() + timeoutMillis
+
+    while (System.currentTimeMillis() < deadline) {
+        wakeUp()
+        executeShellCommand("wm dismiss-keyguard")
+
+        if (!isDeviceLocked()) {
+            return
+        }
+
+        Thread.sleep(250)
+    }
+
+    fail(
+        "Manual full-launch tests require the connected Android device to be unlocked. " +
+            "Unlock the device and rerun just ui-manual.\n${dumpWindowHierarchy()}",
+    )
+}
+
+private fun UiDevice.isDeviceLocked(): Boolean {
+    val trustDump = executeShellCommand("dumpsys trust")
+    val currentUserLine = trustDump.lineSequence().firstOrNull { "(current)" in it }
+
+    if (currentUserLine != null) {
+        return "deviceLocked=1" in currentUserLine
+    }
+
+    return "showingAndNotOccluded=true" in executeShellCommand("dumpsys window policy")
 }
 
 private fun assertFlagSecureSet(
@@ -485,13 +533,125 @@ private fun UiDevice.waitUntilAnyVisible(
     error("Timed out waiting for ${first.description} or ${second.description}\n${dumpWindowHierarchy()}")
 }
 
+private fun UiDevice.advanceUntilVisible(
+    targetSelector: DescribedSelector,
+    timeoutMillis: Long = 20_000,
+    advance: UiDevice.() -> Boolean = { false },
+): UiObject2 {
+    val deadline = System.currentTimeMillis() + timeoutMillis
+    var didAdvance = false
+
+    while (System.currentTimeMillis() < deadline) {
+        findObject(targetSelector.value)?.let { return it }
+
+        if (continuePastCloudRestorePromptIfShown()) {
+            waitForIdle()
+            Thread.sleep(250)
+            continue
+        }
+
+        if (!didAdvance) {
+            didAdvance = advance()
+        }
+        waitForIdle()
+        Thread.sleep(250)
+    }
+
+    error("Timed out waiting for ${targetSelector.description}\n${dumpWindowHierarchy()}")
+}
+
+private fun UiDevice.continuePastCloudRestorePromptIfShown(): Boolean {
+    listOf(
+        text("Continue setup"),
+        text("Set Up as New"),
+        text("Continue Without Backup"),
+        text("Continue Without Cloud Restore"),
+    ).firstNotNullOfOrNull { selector -> findObject(selector.value) }?.let { button ->
+        clickCenter(button)
+
+        return true
+    }
+
+    if (isCloudRestorePromptVisible()) {
+        pressBack()
+        return true
+    }
+
+    return false
+}
+
 private fun UiDevice.scrollUntilVisible(selector: DescribedSelector): UiObject2 {
+    tryScrollUntilVisible(selector)?.let { return it }
+
+    return waitUntilVisible(selector)
+}
+
+private fun UiDevice.tryScrollUntilVisible(selector: DescribedSelector): UiObject2? {
     repeat(8) {
         findObject(selector.value)?.let { return it }
         swipe(displayWidth / 2, displayHeight * 3 / 4, displayWidth / 2, displayHeight / 4, 20)
     }
 
-    return waitUntilVisible(selector)
+    return findObject(selector.value)
+}
+
+private fun UiDevice.isCloudRestorePromptVisible(): Boolean =
+    findObject(text("Google Drive Backup Found").value) != null ||
+        findObject(text("Restore from Google Drive").value) != null ||
+        findObject(text("No Google Drive Backup Found").value) != null ||
+        findObject(text("You're Offline").value) != null ||
+        findObject(text("Cove backup found").value) != null
+
+private fun UiDevice.clickUntilVisible(
+    clickSelector: DescribedSelector,
+    targetSelector: DescribedSelector,
+    timeoutMillis: Long,
+) {
+    val deadline = System.currentTimeMillis() + timeoutMillis
+
+    while (System.currentTimeMillis() < deadline) {
+        findObject(targetSelector.value)?.let { return }
+
+        val clickNode = tryScrollUntilSafelyClickable(clickSelector)
+        if (clickNode?.isEnabled == true) {
+            clickCenter(clickNode)
+        }
+
+        Thread.sleep(500)
+    }
+
+    error("Timed out waiting for ${targetSelector.description}\n${dumpWindowHierarchy()}")
+}
+
+private fun UiDevice.clickObjectUntilGoneOrSystemSheet(selector: DescribedSelector) {
+    val deadline = System.currentTimeMillis() + 10_000
+    var clicked = false
+
+    while (System.currentTimeMillis() < deadline) {
+        if (findObject(textContains("Create a passkey").value) != null ||
+            findObject(textContains("Create passkey").value) != null ||
+            findObject(textContains("Save a passkey").value) != null ||
+            findObject(textContains("Save passkey").value) != null ||
+            findObject(text("Choose an account").value) != null ||
+            findObject(textContains("previous backup").value) != null ||
+            findObject(textContains("Creating your passkey").value) != null
+        ) {
+            return
+        }
+
+        val button = tryScrollUntilSafelyClickable(selector)
+            ?: if (clicked) {
+                return
+            } else {
+                error("Timed out waiting for ${selector.description}\n${dumpWindowHierarchy()}")
+            }
+        waitForIdle()
+        button.click()
+        clicked = true
+        Thread.sleep(500)
+    }
+
+    error("Timed out waiting for ${selector.description} to start an operation\n${dumpWindowHierarchy()}")
 }
 
 private fun UiDevice.acceptTerms() {
@@ -502,10 +662,117 @@ private fun UiDevice.acceptTerms() {
         "onboarding.terms.check.recovery",
         "onboarding.terms.check.agreement",
     ).forEach { tag ->
-        scrollUntilVisible(tag(tag)).click()
+        clickLeadingEdge(scrollUntilVisible(tag(tag)))
     }
 
-    scrollUntilVisible(tag("onboarding.terms.agree")).click()
+    clickSafely(tag("onboarding.terms.agree"))
+}
+
+private fun UiDevice.dismissKeyboardIfShown() {
+    clickKeyboardDoneIfShown()
+    Thread.sleep(250)
+
+    if (!isKeyboardDoneVisible()) {
+        return
+    }
+
+    pressBack()
+    Thread.sleep(250)
+}
+
+private fun UiDevice.clickKeyboardDoneIfShown(): Boolean {
+    val doneKey =
+        findObject(desc("Enter").value)
+            ?: findObject(text("Done").value)
+            ?: return false
+
+    clickCenter(doneKey)
+
+    return true
+}
+
+private fun UiDevice.isKeyboardDoneVisible(): Boolean =
+    findObject(desc("Enter").value) != null || findObject(text("Done").value) != null
+
+private fun UiDevice.clickLeadingEdge(node: UiObject2) {
+    val bounds = node.visibleBounds
+    val x = (bounds.left + 60).coerceAtMost(bounds.right - 1)
+
+    click(x, bounds.centerY())
+}
+
+private fun UiDevice.clickCheckboxBesideLabel(label: String) {
+    val labelNode = scrollUntilVisible(textContains(label))
+    clickCenter(labelNode)
+}
+
+private fun UiDevice.clickSafely(selector: DescribedSelector) {
+    clickCenter(scrollUntilSafelyClickable(selector))
+}
+
+private fun UiDevice.scrollUntilSafelyClickable(selector: DescribedSelector): UiObject2 {
+    tryScrollUntilSafelyClickable(selector)?.let { return it }
+
+    return waitUntilVisible(selector)
+}
+
+private fun UiDevice.tryScrollUntilSafelyClickable(selector: DescribedSelector): UiObject2? {
+    repeat(12) {
+        findObject(selector.value)?.let { node ->
+            if (isSafelyClickable(node)) return node
+        }
+        swipe(displayWidth / 2, displayHeight * 3 / 4, displayWidth / 2, displayHeight / 4, 20)
+    }
+
+    return findObject(selector.value)?.takeIf { isSafelyClickable(it) }
+}
+
+private fun UiDevice.isSafelyClickable(node: UiObject2): Boolean {
+    val bounds = node.visibleBounds
+    val safeBottom = displayHeight - 200
+
+    return bounds.width() > 0 &&
+        bounds.height() > 0 &&
+        bounds.centerX() in 1 until displayWidth &&
+        bounds.centerY() in 1 until safeBottom
+}
+
+private fun UiDevice.clickCenter(node: UiObject2) {
+    val bounds = node.visibleBounds
+
+    click(bounds.centerX(), bounds.centerY())
+}
+
+private fun UiDevice.clickCenterIfVisible(selector: DescribedSelector): Boolean {
+    findObject(selector.value)?.let { node ->
+        clickCenter(node)
+
+        return true
+    }
+
+    return false
+}
+
+private fun UiDevice.waitUntilSendShowsNoFunds() {
+    val noFundsSelector = text("No funds available to send")
+    val initialScanIncompleteSelector = text("Initial Scan Incomplete")
+    val deadline = System.currentTimeMillis() + 90_000
+
+    while (System.currentTimeMillis() < deadline) {
+        clickCenter(waitUntilVisible(text("Send"), timeoutMillis = 30_000))
+
+        val sendUnavailable = waitUntilAnyVisible(noFundsSelector, initialScanIncompleteSelector, timeoutMillis = 10_000)
+        if (sendUnavailable.description == noFundsSelector.description) {
+            return
+        }
+
+        waitUntilVisible(text("Can't send until initial scan completes."))
+        clickCenter(waitUntilVisible(text("OK")))
+        waitForIdle()
+        Thread.sleep(2_000)
+    }
+
+    error("Timed out waiting for Send to report no funds after scan completion\n${dumpWindowHierarchy()}")
 }
 
 private class DescribedSelector(

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/FullLaunchTestRule.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/FullLaunchTestRule.kt
@@ -1,10 +1,13 @@
 package org.bitcoinppl.cove.test
 
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import org.junit.Assume.assumeTrue
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+
+private const val STAY_AWAKE_WHILE_PLUGGED_IN = "7"
 
 class FullLaunchTestRule : TestRule {
     override fun apply(
@@ -14,7 +17,19 @@ class FullLaunchTestRule : TestRule {
         object : Statement() {
             override fun evaluate() {
                 assumeTrue("manual full-launch tests require the ManualFullLaunchTest annotation argument", isManualRun(description))
-                base.evaluate()
+
+                val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+                val previousStayAwakeSetting =
+                    device.executeShellCommand("settings get global stay_on_while_plugged_in")
+                        .trim()
+                        .ifEmpty { "0" }
+
+                try {
+                    device.executeShellCommand("settings put global stay_on_while_plugged_in $STAY_AWAKE_WHILE_PLUGGED_IN")
+                    base.evaluate()
+                } finally {
+                    restoreStayAwakeSetting(device, previousStayAwakeSetting)
+                }
             }
         }
 
@@ -27,5 +42,17 @@ class FullLaunchTestRule : TestRule {
             className.contains(ManualFullLaunchTest::class.java.name) ||
             description.getAnnotation(ManualFullLaunchTest::class.java) != null ||
             description.testClass?.isAnnotationPresent(ManualFullLaunchTest::class.java) == true
+    }
+
+    private fun restoreStayAwakeSetting(
+        device: UiDevice,
+        previousSetting: String,
+    ) {
+        if (previousSetting == "null") {
+            device.executeShellCommand("settings delete global stay_on_while_plugged_in")
+            return
+        }
+
+        device.executeShellCommand("settings put global stay_on_while_plugged_in $previousSetting")
     }
 }

--- a/justfile
+++ b/justfile
@@ -161,13 +161,22 @@ ui-manual:
 [working-directory('android')]
 android-ui-manual:
     set -e
+    STAY_AWAKE_SETTING="$(adb shell settings get global stay_on_while_plugged_in | tr -d '\r')"
 
     cleanup() {
+        if [ "$STAY_AWAKE_SETTING" = "null" ]; then
+            adb shell settings delete global stay_on_while_plugged_in >/dev/null 2>&1 || true
+        else
+            adb shell settings put global stay_on_while_plugged_in "$STAY_AWAKE_SETTING" >/dev/null 2>&1 || true
+        fi
         adb uninstall org.bitcoinppl.cove.uitest.test >/dev/null 2>&1 || true
         adb uninstall org.bitcoinppl.cove.uitest >/dev/null 2>&1 || true
     }
 
     trap cleanup EXIT
+    adb shell settings put global stay_on_while_plugged_in 7 >/dev/null
+    adb shell input keyevent KEYCODE_WAKEUP >/dev/null
+    adb shell wm dismiss-keyguard >/dev/null
 
     ./gradlew :app:connectedUiTestDebugAndroidTest \
         -Pandroid.testInstrumentationRunnerArguments.annotation=org.bitcoinppl.cove.test.ManualFullLaunchTest

--- a/rust/src/manager/cloud_backup_manager/ops/tests.rs
+++ b/rust/src/manager/cloud_backup_manager/ops/tests.rs
@@ -3074,6 +3074,7 @@ async fn disable_corrupted_persisted_state_fails_closed() {
         )
         .unwrap();
     globals.cloud.fail_list_wallet_files("disable should not inspect cloud wallets");
+    let list_wallet_files_attempt_count = globals.cloud.list_wallet_files_attempt_count();
 
     let error = manager.prepare_disable_cloud_backup().await.unwrap_err();
 
@@ -3089,7 +3090,7 @@ async fn disable_corrupted_persisted_state_fails_closed() {
         manager.current_status(),
         CloudBackupStatus::Error(message) if message == CORRUPTED_CLOUD_BACKUP_STATE_MESSAGE
     ));
-    assert_eq!(globals.cloud.list_wallet_files_attempt_count(), 0);
+    assert_eq!(globals.cloud.list_wallet_files_attempt_count(), list_wallet_files_attempt_count);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/rust/xtask/src/ios.rs
+++ b/rust/xtask/src/ios.rs
@@ -6,7 +6,7 @@ use color_eyre::{
     Result,
 };
 use colored::Colorize;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs, path::Path};
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
@@ -52,6 +52,7 @@ const IOS_CONNECTED_DEVICE_FILTER: &str = "state == \"connected\"";
 const IOS_UI_SCHEME: &str = "CoveManualUITests";
 const IOS_UI_TEST_CLASS: &str = "CoveUITests/OnboardingFullLaunchUITests";
 const IOS_UI_TEST_FILE: &str = "CoveUITests/OnboardingFullLaunchUITests.swift";
+const IOS_UI_BOOTSTRAP_RETRY_ATTEMPTS: usize = 1;
 
 #[derive(Debug, Clone, Copy)]
 pub enum IosBuildType {
@@ -810,24 +811,31 @@ fn boot_simulator(sh: &Shell, device: &str) -> Result<()> {
 }
 
 fn simulator_is_booted(sh: &Shell, device: &str) -> Result<bool> {
-    let output = cmd!(sh, "xcrun simctl list devices booted")
-        .read()
-        .wrap_err("Failed to list booted simulators")?;
+    Ok(simulator_state(sh, device)?.is_some_and(|state| state == "Booted"))
+}
 
-    Ok(output.lines().any(|line| simulator_line_matches_device(line, device)))
+fn simulator_state(sh: &Shell, device: &str) -> Result<Option<String>> {
+    let output =
+        cmd!(sh, "xcrun simctl list devices").read().wrap_err("Failed to list simulators")?;
+
+    Ok(output
+        .lines()
+        .find(|line| simulator_line_matches_device(line, device))
+        .and_then(simulator_state_from_line))
+}
+
+fn simulator_state_from_line(line: &str) -> Option<String> {
+    line.rsplit_once(" (").map(|(_, state)| state.trim().trim_end_matches(')').to_string())
 }
 
 fn simulator_line_matches_device(line: &str, device: &str) -> bool {
     let line = line.trim_start();
 
-    line.starts_with(&format!("{device} (")) && line.contains("(Booted)")
+    line.starts_with(&format!("{device} ("))
 }
 
 fn reset_simulator_state(sh: &Shell, device: &str) -> Result<()> {
-    cmd!(sh, "xcrun simctl shutdown {device}")
-        .quiet()
-        .run()
-        .wrap_err_with(|| format!("Failed to shut down simulator '{device}'"))?;
+    shutdown_simulator_for_erase(sh, device)?;
 
     cmd!(sh, "xcrun simctl erase {device}")
         .quiet()
@@ -835,6 +843,70 @@ fn reset_simulator_state(sh: &Shell, device: &str) -> Result<()> {
         .wrap_err_with(|| format!("Failed to erase simulator '{device}'"))?;
 
     Ok(())
+}
+
+fn shutdown_simulator_for_erase(sh: &Shell, device: &str) -> Result<()> {
+    if simulator_state(sh, device)?.as_deref() == Some("Shutdown") {
+        return Ok(());
+    }
+
+    let output = cmd!(sh, "xcrun simctl shutdown {device}")
+        .quiet()
+        .ignore_status()
+        .output()
+        .wrap_err_with(|| format!("Failed to shut down simulator '{device}'"))?;
+
+    if output.status.success() {
+        wait_for_simulator_shutdown(sh, device)?;
+
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8(output.stdout).wrap_err("Failed to parse simctl stdout")?;
+    let stderr = String::from_utf8(output.stderr).wrap_err("Failed to parse simctl stderr")?;
+
+    if simctl_shutdown_already_shutdown(&stdout, &stderr) {
+        wait_for_simulator_shutdown(sh, device)?;
+
+        return Ok(());
+    }
+
+    if wait_for_simulator_shutdown(sh, device).is_ok() {
+        return Ok(());
+    }
+
+    Err(eyre!("simctl shutdown exited with status {}", output.status)).with_context(|| {
+        format!(
+            "Failed to shut down simulator '{device}'\nstdout:\n{}\nstderr:\n{}",
+            non_empty_output(&stdout, "<empty>"),
+            non_empty_output(&stderr, "<empty>"),
+        )
+    })?;
+
+    Ok(())
+}
+
+fn wait_for_simulator_shutdown(sh: &Shell, device: &str) -> Result<()> {
+    let deadline = SystemTime::now() + Duration::from_secs(90);
+
+    while SystemTime::now() < deadline {
+        if simulator_state(sh, device)?.as_deref() == Some("Shutdown") {
+            return Ok(());
+        }
+
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    if simulator_state(sh, device)?.as_deref() == Some("Shutdown") {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!("Timed out waiting for simulator '{device}' to shut down");
+}
+
+fn simctl_shutdown_already_shutdown(stdout: &str, stderr: &str) -> bool {
+    stdout.contains("Unable to shutdown device in current state: Shutdown")
+        || stderr.contains("Unable to shutdown device in current state: Shutdown")
 }
 
 fn run_ios_ui_test(sh: &Shell, device: &str, test: &str, verbose: bool) -> Result<()> {
@@ -850,31 +922,85 @@ fn run_ios_ui_test(sh: &Shell, device: &str, test: &str, verbose: bool) -> Resul
 
     if verbose {
         test_cmd.run().wrap_err_with(|| format!("Failed to run iOS UI test {test}"))?;
-    } else {
+        print_success(&format!("iOS UI test passed: {test}"));
+
+        return Ok(());
+    }
+
+    for attempt in 0..=IOS_UI_BOOTSTRAP_RETRY_ATTEMPTS {
+        if attempt > 0 {
+            print_info(&format!(
+                "Retrying iOS UI test {test} after Xcode test runner bootstrap failure"
+            ));
+            reset_simulator_state(sh, device)?;
+            boot_simulator(sh, device)?;
+        }
+
+        let test_cmd = cmd!(
+            sh,
+            "xcodebuild test -project {IOS_PROJECT} -scheme {IOS_UI_SCHEME} -configuration {IOS_CONFIGURATION_DEBUG} -destination {destination} -parallel-testing-enabled NO {only_testing}"
+        );
+
         let output = test_cmd
             .quiet()
             .ignore_status()
             .output()
             .wrap_err_with(|| format!("Failed to run iOS UI test {test}"))?;
 
-        if !output.status.success() {
-            let stdout =
-                String::from_utf8(output.stdout).wrap_err("Failed to parse xcodebuild stdout")?;
-            let stderr =
-                String::from_utf8(output.stderr).wrap_err("Failed to parse xcodebuild stderr")?;
+        if output.status.success() {
+            print_success(&format!("iOS UI test passed: {test}"));
 
-            Err(eyre!("xcodebuild exited with status {}", output.status)).with_context(|| {
-                format!(
-                    "Failed to run iOS UI test {test}\nstdout:\n{}\nstderr:\n{}",
-                    non_empty_output(&stdout, "<empty>"),
-                    non_empty_output(&stderr, "<empty>"),
-                )
-            })?;
+            return Ok(());
         }
+
+        let failure = XcodebuildFailure::from_output(output)?;
+
+        if failure.is_test_runner_bootstrap_failure() && attempt < IOS_UI_BOOTSTRAP_RETRY_ATTEMPTS {
+            continue;
+        }
+
+        return fail_ios_ui_test(test, failure);
     }
 
-    print_success(&format!("iOS UI test passed: {test}"));
-    Ok(())
+    unreachable!("iOS UI test retry loop should return from every branch")
+}
+
+struct XcodebuildFailure {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+impl XcodebuildFailure {
+    fn from_output(output: std::process::Output) -> Result<Self> {
+        Ok(Self {
+            status: output.status,
+            stdout: String::from_utf8(output.stdout)
+                .wrap_err("Failed to parse xcodebuild stdout")?,
+            stderr: String::from_utf8(output.stderr)
+                .wrap_err("Failed to parse xcodebuild stderr")?,
+        })
+    }
+
+    fn is_test_runner_bootstrap_failure(&self) -> bool {
+        xcodebuild_test_runner_bootstrap_failed(&self.stdout)
+            || xcodebuild_test_runner_bootstrap_failed(&self.stderr)
+    }
+}
+
+fn xcodebuild_test_runner_bootstrap_failed(output: &str) -> bool {
+    output.contains("Early unexpected exit, operation never finished bootstrapping")
+        && output.contains("while preparing to run tests")
+}
+
+fn fail_ios_ui_test(test: &str, failure: XcodebuildFailure) -> Result<()> {
+    Err(eyre!("xcodebuild exited with status {}", failure.status)).with_context(|| {
+        format!(
+            "Failed to run iOS UI test {test}\nstdout:\n{}\nstderr:\n{}",
+            non_empty_output(&failure.stdout, "<empty>"),
+            non_empty_output(&failure.stderr, "<empty>"),
+        )
+    })
 }
 
 fn non_empty_output<'a>(output: &'a str, fallback: &'a str) -> &'a str {
@@ -1078,6 +1204,7 @@ fn parse_device_detail(output: &str, prefix: &str) -> Result<String> {
 mod tests {
     use super::{
         ensure_aasa_webcredentials_app, normalize_pem_text, simulator_line_matches_device,
+        simulator_state_from_line,
     };
 
     const VALID_PEM: &str = "\
@@ -1103,11 +1230,22 @@ ABC123
     }
 
     #[test]
-    fn simulator_line_does_not_match_shutdown_device() {
-        assert!(!simulator_line_matches_device(
+    fn simulator_line_matches_exact_shutdown_device_name() {
+        assert!(simulator_line_matches_device(
             "    iPhone 17 (F4E2B0AD-2E89-4E34-8B69-879F4C580475) (Shutdown)",
             "iPhone 17",
         ));
+    }
+
+    #[test]
+    fn simulator_state_from_line_trims_shutdown_state() {
+        assert_eq!(
+            simulator_state_from_line(
+                "    iPhone 17 (F4E2B0AD-2E89-4E34-8B69-879F4C580475) (Shutdown) "
+            )
+            .as_deref(),
+            Some("Shutdown"),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep Android manual UI runs awake and unlock-ready while preserving the prior stay-awake setting
- harden the Android full-launch robot around scrolling, keyboard dismissal, restore prompts, and system sheets
- make iOS manual UI harness cleanup idempotent and retry Xcode test-runner bootstrap flakes once

## Validation

- just fmt
- just clippy
- git diff --check
- just ui-manual
  - Android: 18/18 passed
  - iOS: all manual onboarding UI cases passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding and restore flows to handle back navigation and restore prompts more reliably.
  * Made app launch and setup more resilient on Android devices, including better handling of locked devices and startup prompts.
  * Fixed manual test setup so device power/lock settings are restored after runs.
  * Improved iOS UI test reliability by retrying when simulator startup issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->