### PR TITLE
Cutoff layout issues

### DIFF
--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/AndroidCompactLayoutAuditTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/AndroidCompactLayoutAuditTest.kt
@@ -1,0 +1,393 @@
+package org.bitcoinppl.cove.flows
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.test.platform.app.InstrumentationRegistry
+import org.bitcoinppl.cove.AppManager
+import org.bitcoinppl.cove.ImportWalletManager
+import org.bitcoinppl.cove.WalletManager
+import org.bitcoinppl.cove.flows.NewWalletFlow.NewWalletSelectScreen
+import org.bitcoinppl.cove.flows.NewWalletFlow.hot_wallet.HotWalletImportScreen
+import org.bitcoinppl.cove.flows.NewWalletFlow.hot_wallet.HotWalletSelectScreen
+import org.bitcoinppl.cove.flows.NewWalletFlow.hot_wallet.VerificationCompleteScreen
+import org.bitcoinppl.cove.flows.NewWalletFlow.hot_wallet.VerifyWordsScreen
+import org.bitcoinppl.cove.flows.SendFlow.SendFlowConfirmScreen
+import org.bitcoinppl.cove.flows.SendFlow.SendFlowManager
+import org.bitcoinppl.cove.flows.SendFlow.SendFlowPresenter
+import org.bitcoinppl.cove.flows.SendFlow.SendState
+import org.bitcoinppl.cove.flows.TapSignerFlow.TapSignerAdvancedChainCode
+import org.bitcoinppl.cove.flows.TapSignerFlow.TapSignerChooseChainCode
+import org.bitcoinppl.cove.flows.TapSignerFlow.TapSignerManager
+import org.bitcoinppl.cove.test.AndroidDeviceStayAwakeRule
+import org.bitcoinppl.cove.test.LayoutRegressionTest
+import org.bitcoinppl.cove.test.bootstrapRustRuntimeForUiTest
+import org.bitcoinppl.cove.test.saveNodeScreenshotToLayoutAudit
+import org.bitcoinppl.cove.ui.theme.CoveTheme
+import org.bitcoinppl.cove.views.NumberPadPinView
+import org.bitcoinppl.cove_core.ImportType
+import org.bitcoinppl.cove_core.NumberOfBip39Words
+import org.bitcoinppl.cove_core.TapSignerRoute
+import org.bitcoinppl.cove_core.WordValidator
+import org.bitcoinppl.cove_core.WordVerifyStateMachine
+import org.bitcoinppl.cove_core.tapcard.TapSigner
+import org.bitcoinppl.cove_core.tapcard.tapSignerPreviewNew
+import org.bitcoinppl.cove_core.types.confirmDetailsPreviewNew
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+
+@LayoutRegressionTest
+class AndroidCompactLayoutAuditTest {
+    private val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @get:Rule
+    val rules: RuleChain =
+        RuleChain
+            .outerRule(AndroidDeviceStayAwakeRule())
+            .around(compose)
+
+    private var importWalletManager: ImportWalletManager? = null
+    private var wordValidator: WordValidator? = null
+    private var wordVerifyStateMachine: WordVerifyStateMachine? = null
+    private val sendFlowManagers = mutableListOf<SendFlowManager>()
+    private val walletManagers = mutableListOf<WalletManager>()
+    private val tapSignerManagers = mutableListOf<TapSignerManager>()
+    private val tapSigners = mutableListOf<TapSigner>()
+
+    @Before
+    fun bootstrapRustRuntime() {
+        bootstrapRustRuntimeForUiTest()
+    }
+
+    @After
+    fun closeManagers() {
+        tapSignerManagers.forEach { it.close() }
+        tapSignerManagers.clear()
+        tapSigners.forEach { it.close() }
+        tapSigners.clear()
+        wordVerifyStateMachine?.close()
+        wordVerifyStateMachine = null
+        wordValidator?.close()
+        wordValidator = null
+        importWalletManager?.close()
+        importWalletManager = null
+        sendFlowManagers.forEach { it.close() }
+        sendFlowManagers.clear()
+        walletManagers.forEach { it.close() }
+        walletManagers.clear()
+    }
+
+    @Test
+    fun newWalletSelectCompactSnapshot() {
+        val screenName = "new-wallet-select"
+
+        renderCompact(screenName) {
+            NewWalletSelectScreen(
+                app = remember { AppManager.getInstance() },
+                onBack = {},
+                canGoBack = true,
+                onOpenNewHotWallet = {},
+                onOpenQrScan = {},
+                onOpenNfcScan = {},
+                snackbarHostState = remember { SnackbarHostState() },
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "newWalletSelect.hardwareWallet")
+        assertNodeInsideViewport(screenName, "newWalletSelect.onThisDevice")
+    }
+
+    @Test
+    fun hotWalletSelectCompactSnapshot() {
+        val screenName = "hot-wallet-select"
+
+        renderCompact(screenName) {
+            HotWalletSelectScreen(
+                app = remember { AppManager.getInstance() },
+                snackbarHostState = remember { SnackbarHostState() },
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "hotWalletSelect.createWallet")
+        assertNodeInsideViewport(screenName, "hotWalletSelect.importWallet")
+    }
+
+    @Test
+    fun hotWalletImportCompactSnapshot() {
+        val screenName = "hot-wallet-import"
+        val manager = ImportWalletManager()
+        importWalletManager = manager
+
+        renderCompact(screenName) {
+            HotWalletImportScreen(
+                app = remember { AppManager.getInstance() },
+                manager = manager,
+                numberOfWords = NumberOfBip39Words.TWELVE,
+                importType = ImportType.MANUAL,
+                snackbarHostState = remember { SnackbarHostState() },
+                showNfcAction = false,
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "hotWalletImport.import")
+    }
+
+    @Test
+    fun verifyWordsCompactSnapshot() {
+        val screenName = "verify-words"
+        val validator = WordValidator.preview(true, NumberOfBip39Words.TWELVE)
+        val stateMachine = WordVerifyStateMachine(validator, 1u)
+        wordValidator = validator
+        wordVerifyStateMachine = stateMachine
+
+        renderCompact(screenName) {
+            VerifyWordsScreen(
+                onBack = {},
+                onShowWords = {},
+                onSkip = {},
+                stateMachine = stateMachine,
+                snackbarHostState = remember { SnackbarHostState() },
+            )
+        }
+
+        assertNodeInsideViewport(screenName, "verifyWords.target", minBottomPadding = 0.dp)
+
+        if (isAfterScreenshot()) {
+            compose
+                .onNodeWithTag("verifyWords.bottomPadding")
+                .performScrollTo()
+        }
+
+        saveAuditScreenshot(screenName)
+
+        compose
+            .onNodeWithTag("verifyWords.bottomPadding")
+            .performScrollTo()
+
+        assertNodeInsideViewport(screenName, "verifyWords.showWords")
+        assertNodeInsideViewport(screenName, "verifyWords.skip")
+    }
+
+    @Test
+    fun verificationCompleteCompactSnapshot() {
+        val screenName = "verification-complete"
+
+        renderCompact(screenName) {
+            VerificationCompleteScreen(
+                app = remember { AppManager.getInstance() },
+                manager = null,
+                snackbarHostState = remember { SnackbarHostState() },
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "verificationComplete.goToWallet")
+    }
+
+    @Test
+    fun tapSignerChooseChainCodeCompactSnapshot() {
+        val screenName = "tap-signer-choose-chain-code"
+        val tapSigner = previewTapSigner()
+        val manager = TapSignerManager(TapSignerRoute.InitSelect(tapSigner))
+        tapSignerManagers.add(manager)
+
+        renderCompact(screenName, darkTheme = false) {
+            TapSignerChooseChainCode(
+                app = remember { AppManager.getInstance() },
+                manager = manager,
+                tapSigner = tapSigner,
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "tapSignerChoose.automaticSetup")
+        assertNodeInsideViewport(screenName, "tapSignerChoose.advancedSetup")
+    }
+
+    @Test
+    fun tapSignerAdvancedChainCodeCompactSnapshot() {
+        val screenName = "tap-signer-advanced-chain-code"
+        val tapSigner = previewTapSigner()
+        val manager = TapSignerManager(TapSignerRoute.InitAdvanced(tapSigner))
+        tapSignerManagers.add(manager)
+
+        renderCompact(screenName, darkTheme = false) {
+            TapSignerAdvancedChainCode(
+                app = remember { AppManager.getInstance() },
+                manager = manager,
+                tapSigner = tapSigner,
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "tapSignerAdvanced.continue")
+    }
+
+    @Test
+    fun numberPadPinCompactSnapshot() {
+        val screenName = "number-pad-pin"
+
+        renderCompact(screenName) {
+            NumberPadPinView(
+                title = "Enter Pin",
+                isPinCorrect = { it == "123456" },
+                backAction = {},
+            )
+        }
+
+        saveBeforeScreenshot(screenName)
+        assertNodeInsideViewport(screenName, "numberPadPin.digit.0")
+        assertNodeInsideViewport(screenName, "numberPadPin.delete")
+    }
+
+    @Test
+    fun sendFlowConfirmCompactSnapshot() {
+        val screenName = "send-flow-confirm"
+        val app = AppManager.getInstance()
+        val walletManager = WalletManager.previewNew()
+        walletManagers.add(walletManager)
+        val sendFlowManager =
+            SendFlowManager(
+                walletManager.newSendFlowManager(walletManager.balance),
+                SendFlowPresenter(app, walletManager),
+            )
+        sendFlowManagers.add(sendFlowManager)
+        val details = confirmDetailsPreviewNew()
+
+        renderCompact(screenName) {
+            SendFlowConfirmScreen(
+                app = app,
+                walletManager = walletManager,
+                sendFlowManager = sendFlowManager,
+                details = details,
+                sendState = SendState.Idle,
+                onBack = {},
+                onSwipeToSend = {},
+            )
+        }
+
+        if (isAfterScreenshot()) {
+            compose
+                .onNodeWithTag("sendFlowConfirm.bottomPadding")
+                .performScrollTo()
+        }
+
+        saveAuditScreenshot(screenName)
+
+        compose
+            .onNodeWithTag("sendFlowConfirm.bottomPadding")
+            .performScrollTo()
+
+        assertNodeInsideViewport(screenName, "sendFlowConfirm.swipeToSend")
+    }
+
+    private fun renderCompact(
+        screenName: String,
+        darkTheme: Boolean = true,
+        content: @Composable () -> Unit,
+    ) {
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        compose.setContent {
+            CoveTheme(darkTheme = darkTheme) {
+                Box(
+                    modifier =
+                        Modifier
+                            .width(auditViewportWidth())
+                            .height(auditViewportHeight())
+                            .testTag(viewportTag(screenName)),
+                ) {
+                    content()
+                }
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    private fun saveBeforeScreenshot(screenName: String) {
+        saveAuditScreenshot(screenName)
+    }
+
+    private fun saveAuditScreenshot(screenName: String) {
+        compose.saveNodeScreenshotToLayoutAudit(
+            tag = viewportTag(screenName),
+            name = "$screenName-${screenshotSuffix()}.png",
+        )
+    }
+
+    private fun screenshotSuffix(): String =
+        InstrumentationRegistry
+            .getArguments()
+            .getString("layoutScreenshotSuffix")
+            ?: "before"
+
+    private fun isAfterScreenshot(): Boolean = screenshotSuffix().endsWith("after")
+
+    private fun auditViewportWidth(): Dp =
+        InstrumentationRegistry
+            .getArguments()
+            .getString("layoutViewportWidthDp")
+            ?.toIntOrNull()
+            ?.dp
+            ?: 360.dp
+
+    private fun auditViewportHeight(): Dp =
+        InstrumentationRegistry
+            .getArguments()
+            .getString("layoutViewportHeightDp")
+            ?.toIntOrNull()
+            ?.dp
+            ?: 640.dp
+
+    private fun assertNodeInsideViewport(
+        screenName: String,
+        nodeTag: String,
+        minBottomPadding: Dp = 16.dp,
+    ) {
+        compose
+            .onNodeWithTag(nodeTag)
+            .assertIsDisplayed()
+
+        val viewportBounds =
+            compose
+                .onNodeWithTag(viewportTag(screenName))
+                .getUnclippedBoundsInRoot()
+        val nodeBounds =
+            compose
+                .onNodeWithTag(nodeTag)
+                .getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "$nodeTag should fit inside the compact viewport",
+            nodeBounds.left >= viewportBounds.left &&
+                nodeBounds.right <= viewportBounds.right &&
+                nodeBounds.top >= viewportBounds.top &&
+                nodeBounds.bottom <= viewportBounds.bottom - minBottomPadding,
+        )
+    }
+
+    private fun viewportTag(screenName: String): String = "androidCompactAudit.$screenName.viewport"
+
+    private fun previewTapSigner(): TapSigner =
+        tapSignerPreviewNew(true).also { tapSigners.add(it) }
+}

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreenTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreenTest.kt
@@ -1,10 +1,5 @@
 package org.bitcoinppl.cove.flows.NewWalletFlow.hot_wallet
 
-import android.content.ContentValues
-import android.content.Context
-import android.graphics.Bitmap
-import android.os.Environment
-import android.provider.MediaStore
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -14,12 +9,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.test.platform.app.InstrumentationRegistry
@@ -28,6 +22,7 @@ import org.bitcoinppl.cove.PendingWalletManager
 import org.bitcoinppl.cove.test.AndroidDeviceStayAwakeRule
 import org.bitcoinppl.cove.test.LayoutRegressionTest
 import org.bitcoinppl.cove.test.bootstrapRustRuntimeForUiTest
+import org.bitcoinppl.cove.test.saveNodeScreenshotToLayoutAudit
 import org.bitcoinppl.cove.ui.theme.CoveTheme
 import org.bitcoinppl.cove_core.NumberOfBip39Words
 import org.junit.After
@@ -36,8 +31,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import java.io.File
-import java.io.FileOutputStream
 
 @LayoutRegressionTest
 class HotWalletCreateScreenTest {
@@ -63,7 +56,7 @@ class HotWalletCreateScreenTest {
     }
 
     @Test
-    fun primaryActionCanScrollFullyIntoCompactViewport() {
+    fun primaryActionFitsCompactViewportWithBottomPadding() {
         val manager = PendingWalletManager(NumberOfBip39Words.TWELVE)
         pendingWalletManager = manager
 
@@ -73,8 +66,8 @@ class HotWalletCreateScreenTest {
                 Box(
                     modifier =
                         Modifier
-                            .width(360.dp)
-                            .height(640.dp)
+                            .width(auditViewportWidth())
+                            .height(auditViewportHeight())
                             .testTag("hotWalletCreate.viewport"),
                 ) {
                     HotWalletCreateScreen(
@@ -92,8 +85,11 @@ class HotWalletCreateScreenTest {
         }
 
         compose
-            .onNodeWithTag("hotWalletCreate.primaryAction")
+            .onNodeWithTag("hotWalletCreate.bottomPadding")
             .performScrollTo()
+
+        compose
+            .onNodeWithTag("hotWalletCreate.primaryAction")
             .assertIsDisplayed()
 
         if (screenshotMode() == "after-scroll") {
@@ -108,13 +104,14 @@ class HotWalletCreateScreenTest {
             compose
                 .onNodeWithTag("hotWalletCreate.primaryAction")
                 .getUnclippedBoundsInRoot()
+        val minimumBottomPadding = 40.dp
 
         assertTrue(
-            "primary action should fit within compact viewport after scrolling",
+            "primary action should fit within compact viewport with bottom padding after scrolling",
             actionBounds.left >= viewportBounds.left &&
                 actionBounds.right <= viewportBounds.right &&
                 actionBounds.top >= viewportBounds.top &&
-            actionBounds.bottom <= viewportBounds.bottom,
+                actionBounds.bottom <= viewportBounds.bottom - minimumBottomPadding,
         )
     }
 
@@ -129,43 +126,22 @@ class HotWalletCreateScreenTest {
                 .getArguments()
                 .getString("layoutScreenshotName")
                 ?: return
-        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val screenshotDir = File(targetContext.getExternalFilesDir(null), "layout-screenshots")
-        screenshotDir.mkdirs()
-
-        val screenshotFile = File(screenshotDir, name)
-        val bitmap =
-            compose
-                .onNodeWithTag("hotWalletCreate.viewport")
-                .captureToImage()
-                .asAndroidBitmap()
-
-        FileOutputStream(screenshotFile).use { output ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
-        }
-
-        saveBitmapToDownloads(targetContext, name, bitmap)
+        compose.saveNodeScreenshotToLayoutAudit("hotWalletCreate.viewport", name)
     }
 
-    private fun saveBitmapToDownloads(context: Context, name: String, bitmap: Bitmap) {
-        val values =
-            ContentValues().apply {
-                put(MediaStore.Images.Media.DISPLAY_NAME, name)
-                put(MediaStore.Images.Media.MIME_TYPE, "image/png")
-                put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/cove-layout-screenshots")
-                put(MediaStore.Images.Media.IS_PENDING, 1)
-            }
-        val resolver = context.contentResolver
-        val uri =
-            resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
-                ?: return
+    private fun auditViewportWidth(): Dp =
+        InstrumentationRegistry
+            .getArguments()
+            .getString("layoutViewportWidthDp")
+            ?.toIntOrNull()
+            ?.dp
+            ?: 360.dp
 
-        resolver.openOutputStream(uri)?.use { output ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
-        }
-
-        values.clear()
-        values.put(MediaStore.Images.Media.IS_PENDING, 0)
-        resolver.update(uri, values, null, null)
-    }
+    private fun auditViewportHeight(): Dp =
+        InstrumentationRegistry
+            .getArguments()
+            .getString("layoutViewportHeightDp")
+            ?.toIntOrNull()
+            ?.dp
+            ?: 640.dp
 }

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreenTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreenTest.kt
@@ -1,0 +1,171 @@
+package org.bitcoinppl.cove.flows.NewWalletFlow.hot_wallet
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.test.platform.app.InstrumentationRegistry
+import org.bitcoinppl.cove.AppManager
+import org.bitcoinppl.cove.PendingWalletManager
+import org.bitcoinppl.cove.test.AndroidDeviceStayAwakeRule
+import org.bitcoinppl.cove.test.LayoutRegressionTest
+import org.bitcoinppl.cove.test.bootstrapRustRuntimeForUiTest
+import org.bitcoinppl.cove.ui.theme.CoveTheme
+import org.bitcoinppl.cove_core.NumberOfBip39Words
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import java.io.File
+import java.io.FileOutputStream
+
+@LayoutRegressionTest
+class HotWalletCreateScreenTest {
+    private val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @get:Rule
+    val rules: RuleChain =
+        RuleChain
+            .outerRule(AndroidDeviceStayAwakeRule())
+            .around(compose)
+
+    private var pendingWalletManager: PendingWalletManager? = null
+
+    @Before
+    fun bootstrapRustRuntime() {
+        bootstrapRustRuntimeForUiTest()
+    }
+
+    @After
+    fun closePendingWalletManager() {
+        pendingWalletManager?.close()
+        pendingWalletManager = null
+    }
+
+    @Test
+    fun primaryActionCanScrollFullyIntoCompactViewport() {
+        val manager = PendingWalletManager(NumberOfBip39Words.TWELVE)
+        pendingWalletManager = manager
+
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        compose.setContent {
+            CoveTheme(darkTheme = true) {
+                Box(
+                    modifier =
+                        Modifier
+                            .width(360.dp)
+                            .height(640.dp)
+                            .testTag("hotWalletCreate.viewport"),
+                ) {
+                    HotWalletCreateScreen(
+                        app = remember { AppManager.getInstance() },
+                        manager = manager,
+                        snackbarHostState = remember { SnackbarHostState() },
+                    )
+                }
+            }
+        }
+
+        if (screenshotMode() == "initial") {
+            saveViewportScreenshot()
+            return
+        }
+
+        compose
+            .onNodeWithTag("hotWalletCreate.primaryAction")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        if (screenshotMode() == "after-scroll") {
+            saveViewportScreenshot()
+        }
+
+        val viewportBounds =
+            compose
+                .onNodeWithTag("hotWalletCreate.viewport")
+                .getUnclippedBoundsInRoot()
+        val actionBounds =
+            compose
+                .onNodeWithTag("hotWalletCreate.primaryAction")
+                .getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "primary action should fit within compact viewport after scrolling",
+            actionBounds.left >= viewportBounds.left &&
+                actionBounds.right <= viewportBounds.right &&
+                actionBounds.top >= viewportBounds.top &&
+            actionBounds.bottom <= viewportBounds.bottom,
+        )
+    }
+
+    private fun screenshotMode(): String? =
+        InstrumentationRegistry
+            .getArguments()
+            .getString("layoutScreenshotMode")
+
+    private fun saveViewportScreenshot() {
+        val name =
+            InstrumentationRegistry
+                .getArguments()
+                .getString("layoutScreenshotName")
+                ?: return
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val screenshotDir = File(targetContext.getExternalFilesDir(null), "layout-screenshots")
+        screenshotDir.mkdirs()
+
+        val screenshotFile = File(screenshotDir, name)
+        val bitmap =
+            compose
+                .onNodeWithTag("hotWalletCreate.viewport")
+                .captureToImage()
+                .asAndroidBitmap()
+
+        FileOutputStream(screenshotFile).use { output ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        }
+
+        saveBitmapToDownloads(targetContext, name, bitmap)
+    }
+
+    private fun saveBitmapToDownloads(context: Context, name: String, bitmap: Bitmap) {
+        val values =
+            ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, name)
+                put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+                put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/cove-layout-screenshots")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        val resolver = context.contentResolver
+        val uri =
+            resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+                ?: return
+
+        resolver.openOutputStream(uri)?.use { output ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        }
+
+        values.clear()
+        values.put(MediaStore.Images.Media.IS_PENDING, 0)
+        resolver.update(uri, values, null, null)
+    }
+}

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
@@ -7,6 +7,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 private const val STAY_AWAKE_WHILE_PLUGGED_IN = "7"
+private const val STAY_AWAKE_SCREEN_OFF_TIMEOUT_MS = "1800000"
 
 class AndroidDeviceStayAwakeRule : TestRule {
     override fun apply(
@@ -26,15 +27,21 @@ internal fun UiDevice.withStayAwake(block: () -> Unit) {
         executeShellCommand("settings get global stay_on_while_plugged_in")
             .trim()
             .ifEmpty { "0" }
+    val previousScreenOffTimeout =
+        executeShellCommand("settings get system screen_off_timeout")
+            .trim()
+            .ifEmpty { "30000" }
 
     try {
         executeShellCommand("settings put global stay_on_while_plugged_in $STAY_AWAKE_WHILE_PLUGGED_IN")
+        executeShellCommand("settings put system screen_off_timeout $STAY_AWAKE_SCREEN_OFF_TIMEOUT_MS")
         wakeUp()
         executeShellCommand("wm dismiss-keyguard")
 
         block()
     } finally {
         restoreStayAwakeSetting(previousStayAwakeSetting)
+        restoreScreenOffTimeout(previousScreenOffTimeout)
     }
 }
 
@@ -45,4 +52,13 @@ private fun UiDevice.restoreStayAwakeSetting(previousSetting: String) {
     }
 
     executeShellCommand("settings put global stay_on_while_plugged_in $previousSetting")
+}
+
+private fun UiDevice.restoreScreenOffTimeout(previousSetting: String) {
+    if (previousSetting == "null") {
+        executeShellCommand("settings delete system screen_off_timeout")
+        return
+    }
+
+    executeShellCommand("settings put system screen_off_timeout $previousSetting")
 }

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
@@ -35,6 +35,7 @@ internal fun UiDevice.withStayAwake(block: () -> Unit) {
     try {
         executeShellCommand("settings put global stay_on_while_plugged_in $STAY_AWAKE_WHILE_PLUGGED_IN")
         executeShellCommand("settings put system screen_off_timeout $STAY_AWAKE_SCREEN_OFF_TIMEOUT_MS")
+        executeShellCommand("svc power stayon true")
         wakeUp()
         executeShellCommand("wm dismiss-keyguard")
 

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
@@ -1,0 +1,48 @@
+package org.bitcoinppl.cove.test
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+private const val STAY_AWAKE_WHILE_PLUGGED_IN = "7"
+
+class AndroidDeviceStayAwakeRule : TestRule {
+    override fun apply(
+        base: Statement,
+        description: Description,
+    ): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+                device.withStayAwake { base.evaluate() }
+            }
+        }
+}
+
+internal fun UiDevice.withStayAwake(block: () -> Unit) {
+    val previousStayAwakeSetting =
+        executeShellCommand("settings get global stay_on_while_plugged_in")
+            .trim()
+            .ifEmpty { "0" }
+
+    try {
+        executeShellCommand("settings put global stay_on_while_plugged_in $STAY_AWAKE_WHILE_PLUGGED_IN")
+        wakeUp()
+        executeShellCommand("wm dismiss-keyguard")
+
+        block()
+    } finally {
+        restoreStayAwakeSetting(previousStayAwakeSetting)
+    }
+}
+
+private fun UiDevice.restoreStayAwakeSetting(previousSetting: String) {
+    if (previousSetting == "null") {
+        executeShellCommand("settings delete global stay_on_while_plugged_in")
+        return
+    }
+
+    executeShellCommand("settings put global stay_on_while_plugged_in $previousSetting")
+}

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/AndroidDeviceStayAwakeRule.kt
@@ -41,9 +41,14 @@ internal fun UiDevice.withStayAwake(block: () -> Unit) {
 
         block()
     } finally {
+        restoreStayOnService(previousStayAwakeSetting)
         restoreStayAwakeSetting(previousStayAwakeSetting)
         restoreScreenOffTimeout(previousScreenOffTimeout)
     }
+}
+
+private fun UiDevice.restoreStayOnService(previousSetting: String) {
+    executeShellCommand("svc power stayon ${previousSetting.toStayOnServiceArgument()}")
 }
 
 private fun UiDevice.restoreStayAwakeSetting(previousSetting: String) {
@@ -63,3 +68,13 @@ private fun UiDevice.restoreScreenOffTimeout(previousSetting: String) {
 
     executeShellCommand("settings put system screen_off_timeout $previousSetting")
 }
+
+private fun String.toStayOnServiceArgument(): String =
+    when (toIntOrNull() ?: 0) {
+        0 -> "false"
+        1 -> "ac"
+        2 -> "usb"
+        4 -> "wireless"
+        8 -> "dock"
+        else -> "true"
+    }

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/FullLaunchTestRule.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/FullLaunchTestRule.kt
@@ -7,8 +7,6 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-private const val STAY_AWAKE_WHILE_PLUGGED_IN = "7"
-
 class FullLaunchTestRule : TestRule {
     override fun apply(
         base: Statement,
@@ -19,17 +17,7 @@ class FullLaunchTestRule : TestRule {
                 assumeTrue("manual full-launch tests require the ManualFullLaunchTest annotation argument", isManualRun(description))
 
                 val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-                val previousStayAwakeSetting =
-                    device.executeShellCommand("settings get global stay_on_while_plugged_in")
-                        .trim()
-                        .ifEmpty { "0" }
-
-                try {
-                    device.executeShellCommand("settings put global stay_on_while_plugged_in $STAY_AWAKE_WHILE_PLUGGED_IN")
-                    base.evaluate()
-                } finally {
-                    restoreStayAwakeSetting(device, previousStayAwakeSetting)
-                }
+                device.withStayAwake { base.evaluate() }
             }
         }
 
@@ -42,17 +30,5 @@ class FullLaunchTestRule : TestRule {
             className.contains(ManualFullLaunchTest::class.java.name) ||
             description.getAnnotation(ManualFullLaunchTest::class.java) != null ||
             description.testClass?.isAnnotationPresent(ManualFullLaunchTest::class.java) == true
-    }
-
-    private fun restoreStayAwakeSetting(
-        device: UiDevice,
-        previousSetting: String,
-    ) {
-        if (previousSetting == "null") {
-            device.executeShellCommand("settings delete global stay_on_while_plugged_in")
-            return
-        }
-
-        device.executeShellCommand("settings put global stay_on_while_plugged_in $previousSetting")
     }
 }

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/LayoutRegressionTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/LayoutRegressionTest.kt
@@ -1,0 +1,5 @@
+package org.bitcoinppl.cove.test
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LayoutRegressionTest

--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/test/LayoutScreenshot.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/test/LayoutScreenshot.kt
@@ -1,0 +1,61 @@
+package org.bitcoinppl.cove.test
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import java.io.FileOutputStream
+
+fun ComposeContentTestRule.saveNodeScreenshotToLayoutAudit(
+    tag: String,
+    name: String,
+) {
+    val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+    val screenshotDir = File(targetContext.getExternalFilesDir(null), "layout-screenshots")
+    screenshotDir.mkdirs()
+
+    val screenshotFile = File(screenshotDir, name)
+    val bitmap =
+        onNodeWithTag(tag)
+            .captureToImage()
+            .asAndroidBitmap()
+
+    FileOutputStream(screenshotFile).use { output ->
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+    }
+
+    saveBitmapToPictures(targetContext, name, bitmap)
+}
+
+private fun saveBitmapToPictures(
+    context: Context,
+    name: String,
+    bitmap: Bitmap,
+) {
+    val values =
+        ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, name)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/cove-layout-screenshots")
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+    val resolver = context.contentResolver
+    val uri =
+        resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+            ?: return
+
+    resolver.openOutputStream(uri)?.use { output ->
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+    }
+
+    values.clear()
+    values.put(MediaStore.Images.Media.IS_PENDING, 0)
+    resolver.update(uri, values, null, null)
+}

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/NewWalletSelectScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/NewWalletSelectScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -219,9 +220,10 @@ fun NewWalletSelectScreen(
 
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(padding),
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .testTag("newWalletSelect.viewport"),
         ) {
             Image(
                 painter = painterResource(id = R.drawable.image_chain_code_pattern_horizontal),
@@ -284,7 +286,7 @@ fun NewWalletSelectScreen(
                                     containerColor = CoveColor.btnPrimary,
                                     contentColor = CoveColor.midnightBlue,
                                 ),
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier.weight(1f).testTag("newWalletSelect.hardwareWallet"),
                         )
 
                         ImageButton(
@@ -296,7 +298,7 @@ fun NewWalletSelectScreen(
                                     containerColor = CoveColor.btnPrimary,
                                     contentColor = CoveColor.midnightBlue,
                                 ),
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier.weight(1f).testTag("newWalletSelect.onThisDevice"),
                         )
                     }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -216,7 +217,7 @@ fun HotWalletCreateScreen(
                             .fillMaxWidth()
                             .heightIn(min = maxHeight)
                             .verticalScroll(rememberScrollState())
-                            .padding(vertical = 20.dp),
+                            .padding(top = 20.dp, bottom = 32.dp),
                     verticalArrangement = Arrangement.SpaceBetween,
                 ) {
                     // pager for word groups
@@ -323,6 +324,12 @@ fun HotWalletCreateScreen(
                                 Modifier
                                     .fillMaxWidth()
                                     .testTag("hotWalletCreate.primaryAction"),
+                        )
+
+                        Spacer(
+                            Modifier
+                                .height(16.dp)
+                                .testTag("hotWalletCreate.bottomPadding"),
                         )
                     }
                 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
@@ -5,15 +5,20 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -45,6 +50,7 @@ import android.view.WindowManager
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -199,116 +205,126 @@ fun HotWalletCreateScreen(
                 alpha = 0.5f,
             )
 
-            Column(
+            BoxWithConstraints(
                 modifier =
                     Modifier
-                        .fillMaxSize()
-                        .padding(vertical = 20.dp),
-                verticalArrangement = Arrangement.SpaceBetween,
+                        .fillMaxSize(),
             ) {
-                // pager for word groups
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) { page ->
-                        WordCardView(
-                            words = groupedWords[page],
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 20.dp),
-                        )
-                    }
-
-                    // page indicator
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center,
-                    ) {
-                        DotMenuViewCircle(
-                            count = groupedWords.size,
-                            currentIndex = currentPage,
-                        )
-                    }
-                }
-
-                Spacer(Modifier.weight(1f))
-
-                // bottom section
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(24.dp),
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 20.dp),
+                            .heightIn(min = maxHeight)
+                            .verticalScroll(rememberScrollState())
+                            .padding(vertical = 20.dp),
+                    verticalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
+                    // pager for word groups
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
                     ) {
-                        DotMenuView(
-                            count = 5,
-                            currentIndex = 2,
-                        )
-                        Spacer(Modifier.weight(1f))
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { page ->
+                            WordCardView(
+                                words = groupedWords[page],
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 20.dp),
+                            )
+                        }
+
+                        // page indicator
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            DotMenuViewCircle(
+                                count = groupedWords.size,
+                                currentIndex = currentPage,
+                            )
+                        }
                     }
 
-                    Text(
-                        text = stringResource(R.string.label_recovery_words_title),
-                        color = Color.White,
-                        fontSize = 38.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        lineHeight = 42.sp,
-                    )
+                    // bottom section
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(24.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .navigationBarsPadding()
+                                .padding(horizontal = 20.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            DotMenuView(
+                                count = 5,
+                                currentIndex = 2,
+                            )
+                            Spacer(Modifier.weight(1f))
+                        }
 
-                    Text(
-                        text = stringResource(R.string.label_recovery_words_body),
-                        color = CoveColor.coveLightGray,
-                        fontSize = 15.sp,
-                        lineHeight = 20.sp,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                        Text(
+                            text = stringResource(R.string.label_recovery_words_title),
+                            color = Color.White,
+                            fontSize = 38.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            lineHeight = 42.sp,
+                        )
 
-                    Text(
-                        text = stringResource(R.string.label_recovery_words_secure_note),
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 15.sp,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                        Text(
+                            text = stringResource(R.string.label_recovery_words_body),
+                            color = CoveColor.coveLightGray,
+                            fontSize = 15.sp,
+                            lineHeight = 20.sp,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                    HorizontalDivider(
-                        color = CoveColor.coveLightGray.copy(alpha = 0.50f),
-                        thickness = 1.dp,
-                    )
+                        Text(
+                            text = stringResource(R.string.label_recovery_words_secure_note),
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 15.sp,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                    ImageButton(
-                        text =
-                            if (isLastPage) {
-                                stringResource(R.string.btn_save_wallet)
-                            } else {
-                                stringResource(R.string.btn_next)
-                            },
-                        onClick = {
-                            if (isLastPage) {
-                                handleSaveWallet()
-                            } else {
-                                scope.launch {
-                                    pagerState.animateScrollToPage(currentPage + 1)
+                        HorizontalDivider(
+                            color = CoveColor.coveLightGray.copy(alpha = 0.50f),
+                            thickness = 1.dp,
+                        )
+
+                        ImageButton(
+                            text =
+                                if (isLastPage) {
+                                    stringResource(R.string.btn_save_wallet)
+                                } else {
+                                    stringResource(R.string.btn_next)
+                                },
+                            onClick = {
+                                if (isLastPage) {
+                                    handleSaveWallet()
+                                } else {
+                                    scope.launch {
+                                        pagerState.animateScrollToPage(currentPage + 1)
+                                    }
                                 }
-                            }
-                        },
-                        enabled = !isSaving,
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = CoveColor.btnPrimary,
-                                contentColor = CoveColor.midnightBlue,
-                            ),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                            },
+                            enabled = !isSaving,
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = CoveColor.btnPrimary,
+                                    contentColor = CoveColor.midnightBlue,
+                                ),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .testTag("hotWalletCreate.primaryAction"),
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletImportScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletImportScreen.kt
@@ -362,9 +362,10 @@ fun HotWalletImportScreen(
     ) { padding ->
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(padding),
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .testTag("hotWalletImport.viewport"),
         ) {
             Image(
                 painter = painterResource(id = R.drawable.image_chain_code_pattern_horizontal),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletSelectScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletSelectScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -128,9 +129,10 @@ fun HotWalletSelectScreen(
     ) { padding ->
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(padding),
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .testTag("hotWalletSelect.viewport"),
         ) {
             Image(
                 painter = painterResource(id = R.drawable.image_chain_code_pattern_horizontal),
@@ -193,7 +195,7 @@ fun HotWalletSelectScreen(
                                     containerColor = CoveColor.btnPrimary,
                                     contentColor = CoveColor.midnightBlue,
                                 ),
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier.fillMaxWidth().testTag("hotWalletSelect.createWallet"),
                         )
 
                         Text(
@@ -205,6 +207,7 @@ fun HotWalletSelectScreen(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
+                                    .testTag("hotWalletSelect.importWallet")
                                     .clickable {
                                         showSheet = true
                                         nextScreen = NextScreenDialog.Import

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/VerificationCompleteScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/VerificationCompleteScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -81,9 +82,10 @@ fun VerificationCompleteScreen(
     ) { padding ->
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(padding),
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .testTag("verificationComplete.viewport"),
         ) {
             Image(
                 painter = painterResource(id = R.drawable.image_chain_code_pattern_horizontal),
@@ -167,7 +169,7 @@ fun VerificationCompleteScreen(
                                 containerColor = CoveColor.btnPrimary,
                                 contentColor = CoveColor.midnightBlue,
                             ),
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().testTag("verificationComplete.goToWallet"),
                         fontSize = 13.sp,
                     )
                 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/VerifyWordsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/VerifyWordsScreen.kt
@@ -17,12 +17,16 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -55,6 +59,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -269,6 +274,7 @@ fun VerifyWordsScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(padding)
+                    .testTag("verifyWords.viewport")
                     .onGloballyPositioned { coords ->
                         val pos = coords.positionInRoot()
                         rootOffset = Offset(pos.x, pos.y)
@@ -284,143 +290,147 @@ fun VerifyWordsScreen(
                         .align(Alignment.TopCenter),
             )
 
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(vertical = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(24.dp),
-            ) {
+            BoxWithConstraints(Modifier.fillMaxSize()) {
                 Column(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 20.dp),
-                    verticalArrangement = Arrangement.Top,
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                            .heightIn(min = maxHeight)
+                            .verticalScroll(rememberScrollState())
+                            .padding(top = 20.dp, bottom = 32.dp),
+                    verticalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    Spacer(Modifier.height(12.dp))
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp),
+                        verticalArrangement = Arrangement.Top,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Spacer(Modifier.height(12.dp))
 
-                    Text(
-                        text = stringResource(R.string.label_what_is_word_n, wordNumber),
-                        color = Color.White,
-                        fontSize = 22.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-
-                    Spacer(Modifier.height(24.dp))
-
-                    // target position for chip animation
-                    BoxWithConstraints(Modifier.fillMaxWidth()) {
-                        val cellWidth = (maxWidth - 12.dp * 3) / 4
-                        Box(
+                        Text(
+                            text = stringResource(R.string.label_what_is_word_n, wordNumber),
+                            color = Color.White,
+                            fontSize = 22.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            textAlign = TextAlign.Center,
                             modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center,
-                        ) {
+                        )
+
+                        Spacer(Modifier.height(24.dp))
+
+                        // target position for chip animation
+                        BoxWithConstraints(Modifier.fillMaxWidth()) {
+                            val cellWidth = (maxWidth - 12.dp * 3) / 4
                             Box(
-                                modifier =
-                                    Modifier
-                                        .width(cellWidth)
-                                        .height(chipHeight)
-                                        .onGloballyPositioned { coordinates ->
-                                            val pos = coordinates.positionInRoot()
-                                            targetPosition =
-                                                Offset(
-                                                    pos.x - rootOffset.x,
-                                                    pos.y - rootOffset.y,
-                                                )
-                                        },
-                            ) { }
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .width(cellWidth)
+                                            .height(chipHeight)
+                                            .testTag("verifyWords.target")
+                                            .onGloballyPositioned { coordinates ->
+                                                val pos = coordinates.positionInRoot()
+                                                targetPosition =
+                                                    Offset(
+                                                        pos.x - rootOffset.x,
+                                                        pos.y - rootOffset.y,
+                                                    )
+                                            },
+                                ) { }
+                            }
                         }
-                    }
 
-                    Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(12.dp))
 
-                    HorizontalDivider(
-                        color = Color.White,
-                        thickness = 1.dp,
-                        modifier = Modifier.width(160.dp),
-                    )
+                        HorizontalDivider(
+                            color = Color.White,
+                            thickness = 1.dp,
+                            modifier = Modifier.width(160.dp),
+                        )
 
-                    Spacer(Modifier.height(24.dp))
+                        Spacer(Modifier.height(24.dp))
 
-                    // word options grid
-                    BoxWithConstraints(Modifier.fillMaxWidth()) {
-                        val cellWidth = (maxWidth - 12.dp * 3) / 4
-                        actualChipWidth = cellWidth
+                        // word options grid
+                        BoxWithConstraints(Modifier.fillMaxWidth()) {
+                            val cellWidth = (maxWidth - 12.dp * 3) / 4
+                            actualChipWidth = cellWidth
 
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            possibleWords.chunked(4).forEach { rowItems ->
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
-                                    rowItems.forEach { word ->
-                                        Box(modifier = Modifier.weight(1f)) {
-                                            val isAnimating =
-                                                checkState.let {
-                                                    when (it) {
-                                                        is WordCheckState.Checking -> it.word == word
-                                                        is WordCheckState.Correct -> it.word == word
-                                                        is WordCheckState.Incorrect -> it.word == word
-                                                        is WordCheckState.Returning -> it.word == word
-                                                        WordCheckState.None -> false
-                                                    }
-                                                }
-
-                                            if (isAnimating) {
-                                                // placeholder while animating
-                                                Box(
-                                                    modifier =
-                                                        Modifier
-                                                            .fillMaxWidth()
-                                                            .height(46.dp),
-                                                ) { }
-                                            } else {
-                                                OptionChip(
-                                                    text = word,
-                                                    selected = false,
-                                                    onClick = {
-                                                        if (checkState == WordCheckState.None) {
-                                                            val transition = stateMachine.selectWord(word)
-                                                            checkState = transition.newState
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(12.dp),
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                possibleWords.chunked(4).forEach { rowItems ->
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                        modifier = Modifier.fillMaxWidth(),
+                                    ) {
+                                        rowItems.forEach { word ->
+                                            Box(modifier = Modifier.weight(1f)) {
+                                                val isAnimating =
+                                                    checkState.let {
+                                                        when (it) {
+                                                            is WordCheckState.Checking -> it.word == word
+                                                            is WordCheckState.Correct -> it.word == word
+                                                            is WordCheckState.Incorrect -> it.word == word
+                                                            is WordCheckState.Returning -> it.word == word
+                                                            WordCheckState.None -> false
                                                         }
-                                                    },
-                                                    onPositionCaptured = { position ->
-                                                        wordPositions = wordPositions + (
-                                                            word to
-                                                                Offset(
-                                                                    position.x - rootOffset.x,
-                                                                    position.y - rootOffset.y,
-                                                                )
-                                                        )
-                                                    },
-                                                )
+                                                    }
+
+                                                if (isAnimating) {
+                                                    // placeholder while animating
+                                                    Box(
+                                                        modifier =
+                                                            Modifier
+                                                                .fillMaxWidth()
+                                                                .height(46.dp),
+                                                    ) { }
+                                                } else {
+                                                    OptionChip(
+                                                        text = word,
+                                                        selected = false,
+                                                        onClick = {
+                                                            if (checkState == WordCheckState.None) {
+                                                                val transition = stateMachine.selectWord(word)
+                                                                checkState = transition.newState
+                                                            }
+                                                        },
+                                                        onPositionCaptured = { position ->
+                                                            wordPositions = wordPositions + (
+                                                                word to
+                                                                    Offset(
+                                                                        position.x - rootOffset.x,
+                                                                        position.y - rootOffset.y,
+                                                                    )
+                                                            )
+                                                        },
+                                                    )
+                                                }
                                             }
                                         }
-                                    }
-                                    repeat(4 - rowItems.size) {
-                                        Spacer(modifier = Modifier.weight(1f))
+                                        repeat(4 - rowItems.size) {
+                                            Spacer(modifier = Modifier.weight(1f))
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
 
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
-                            .padding(horizontal = 20.dp),
-                ) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .navigationBarsPadding()
+                                .padding(horizontal = 20.dp),
+                    ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         DotMenuView(
                             count = 4,
@@ -444,8 +454,6 @@ fun VerifyWordsScreen(
                         lineHeight = 18.sp,
                     )
 
-                    Spacer(Modifier.weight(1f))
-
                     HorizontalDivider(color = Color.White.copy(alpha = 0.35f), thickness = 1.dp)
 
                     Button(
@@ -457,7 +465,7 @@ fun VerifyWordsScreen(
                                 contentColor = CoveColor.midnightBlue,
                             ),
                         contentPadding = PaddingValues(vertical = 20.dp, horizontal = 10.dp),
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().testTag("verifyWords.showWords"),
                     ) {
                         Text(
                             text = stringResource(R.string.btn_show_words),
@@ -477,8 +485,16 @@ fun VerifyWordsScreen(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
+                                .testTag("verifyWords.skip")
                                 .clickable { showSkipAlert = true },
                     )
+
+                    Spacer(
+                        Modifier
+                            .height(1.dp)
+                            .testTag("verifyWords.bottomPadding"),
+                    )
+                    }
                 }
             }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/OnboardingFlow/OnboardingCloudRestorePromptViews.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/OnboardingFlow/OnboardingCloudRestorePromptViews.kt
@@ -368,6 +368,8 @@ private fun CloudRestoreProviderHint.passkeyDisplayName(): String =
 
 @Composable
 private fun OnboardingCloudSearchHero() {
+    val innerRingSize = 68.dp
+
     Box(
         modifier = Modifier.size(118.dp),
         contentAlignment = Alignment.Center,
@@ -389,7 +391,7 @@ private fun OnboardingCloudSearchHero() {
         Box(
             modifier =
                 Modifier
-                    .size(58.dp)
+                    .size(innerRingSize)
                     .border(1.5.dp, OnboardingGradientLight.copy(alpha = 0.88f), CircleShape),
         )
 
@@ -399,6 +401,23 @@ private fun OnboardingCloudSearchHero() {
             tint = OnboardingGradientLight,
             modifier = Modifier.size(34.dp),
         )
+    }
+}
+
+@Preview(
+    name = "Onboarding Cloud Search Hero",
+    showBackground = true,
+    backgroundColor = 0xFF1C2536,
+    widthDp = 160,
+    heightDp = 160,
+)
+@Composable
+private fun OnboardingCloudSearchHeroPreview() {
+    Box(
+        modifier = Modifier.size(160.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        OnboardingCloudSearchHero()
     }
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/OnboardingFlow/OnboardingTheme.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/OnboardingFlow/OnboardingTheme.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -55,6 +56,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -249,7 +251,8 @@ internal fun OnboardingStatusHero(
                 .wrapContentHeight(Alignment.CenterVertically),
         contentAlignment = Alignment.Center,
     ) {
-        val ringSizes = remember { listOf(118.dp, 86.dp, 58.dp) }
+        val innerBadgeSize = 68.dp
+        val ringSizes = remember { listOf(118.dp, 86.dp, innerBadgeSize) }
         val ringAlphas = remember { listOf(0.15f, 0.22f, 0.34f) }
 
         ringSizes.zip(ringAlphas).forEach { (size, alpha) ->
@@ -265,7 +268,7 @@ internal fun OnboardingStatusHero(
         Box(
             modifier =
                 Modifier
-                    .size(58.dp)
+                    .size(innerBadgeSize)
                     .clip(CircleShape)
                     .background(fillColor)
                     .border(1.3.dp, tint.copy(alpha = 0.72f), CircleShape),
@@ -278,6 +281,23 @@ internal fun OnboardingStatusHero(
                 modifier = Modifier.size(24.dp),
             )
         }
+    }
+}
+
+@Preview(
+    name = "Onboarding Status Hero - Cloud",
+    showBackground = true,
+    backgroundColor = 0xFF1C2536,
+    widthDp = 160,
+    heightDp = 160,
+)
+@Composable
+private fun OnboardingStatusHeroCloudPreview() {
+    Box(
+        modifier = Modifier.size(160.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        OnboardingStatusHero(icon = Icons.Default.Cloud)
     }
 }
 

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
@@ -175,44 +175,49 @@ fun SendFlowConfirmScreen(
                                 .fillMaxWidth()
                                 .heightIn(min = maxHeight)
                                 .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.SpaceBetween,
                     ) {
-                        AmountWidget(
-                            amount = sendingAmount,
-                            denomination = sendingAmountDenomination,
-                            dollarText = dollarEquivalentText,
-                            accountShort = accountShort,
-                        )
-                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
-                        SummaryWidget(
-                            address = address,
-                            networkFee = networkFee,
-                            willReceive = willReceive,
-                            willPay = willPay,
-                            onAddressClick = { sheetState = SheetState.AdvancedDetails },
-                        )
-                        Spacer(Modifier.weight(1f))
-                        SwipeToSendStub(
-                            text = stringResource(R.string.action_swipe_to_send),
-                            sendState = sendState,
-                            onComplete = onSwipeToSend,
-                            containerColor = MaterialTheme.coveColors.swipeTrackBg,
-                            targetContainerColor = MaterialTheme.coveColors.midnightBtn,
-                            knobColor = MaterialTheme.coveColors.midnightBtn,
-                            textColor = MaterialTheme.colorScheme.onSurface,
-                            targetTextColor = SWIPE_BUTTON_TEXT_COLOR_TARGET,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .navigationBarsPadding()
-                                    .padding(bottom = 24.dp)
-                                    .testTag("sendFlowConfirm.swipeToSend"),
-                        )
+                        Column {
+                            AmountWidget(
+                                amount = sendingAmount,
+                                denomination = sendingAmountDenomination,
+                                dollarText = dollarEquivalentText,
+                                accountShort = accountShort,
+                            )
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
+                            SummaryWidget(
+                                address = address,
+                                networkFee = networkFee,
+                                willReceive = willReceive,
+                                willPay = willPay,
+                                onAddressClick = { sheetState = SheetState.AdvancedDetails },
+                            )
+                        }
 
-                        Spacer(
-                            Modifier
-                                .height(1.dp)
-                                .testTag("sendFlowConfirm.bottomPadding"),
-                        )
+                        Column {
+                            SwipeToSendStub(
+                                text = stringResource(R.string.action_swipe_to_send),
+                                sendState = sendState,
+                                onComplete = onSwipeToSend,
+                                containerColor = MaterialTheme.coveColors.swipeTrackBg,
+                                targetContainerColor = MaterialTheme.coveColors.midnightBtn,
+                                knobColor = MaterialTheme.coveColors.midnightBtn,
+                                textColor = MaterialTheme.colorScheme.onSurface,
+                                targetTextColor = SWIPE_BUTTON_TEXT_COLOR_TARGET,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .navigationBarsPadding()
+                                        .padding(bottom = 24.dp)
+                                        .testTag("sendFlowConfirm.swipeToSend"),
+                            )
+
+                            Spacer(
+                                Modifier
+                                    .height(1.dp)
+                                    .testTag("sendFlowConfirm.bottomPadding"),
+                            )
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -38,6 +40,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -159,42 +162,58 @@ fun SendFlowConfirmScreen(
                         walletManager.dispatch(WalletManagerAction.ToggleSensitiveVisibility)
                     },
                 )
-                Column(
+                BoxWithConstraints(
                     modifier =
                         Modifier
                             .fillMaxHeight()
                             .background(MaterialTheme.colorScheme.surface)
                             .padding(horizontal = 16.dp),
                 ) {
-                    AmountWidget(
-                        amount = sendingAmount,
-                        denomination = sendingAmountDenomination,
-                        dollarText = dollarEquivalentText,
-                        accountShort = accountShort,
-                    )
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
-                    SummaryWidget(
-                        address = address,
-                        networkFee = networkFee,
-                        willReceive = willReceive,
-                        willPay = willPay,
-                        onAddressClick = { sheetState = SheetState.AdvancedDetails },
-                    )
-                    Spacer(Modifier.weight(1f))
-                    SwipeToSendStub(
-                        text = stringResource(R.string.action_swipe_to_send),
-                        sendState = sendState,
-                        onComplete = onSwipeToSend,
-                        containerColor = MaterialTheme.coveColors.swipeTrackBg,
-                        targetContainerColor = MaterialTheme.coveColors.midnightBtn,
-                        knobColor = MaterialTheme.coveColors.midnightBtn,
-                        textColor = MaterialTheme.colorScheme.onSurface,
-                        targetTextColor = SWIPE_BUTTON_TEXT_COLOR_TARGET,
+                    Column(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .padding(bottom = 24.dp),
-                    )
+                                .heightIn(min = maxHeight)
+                                .verticalScroll(rememberScrollState()),
+                    ) {
+                        AmountWidget(
+                            amount = sendingAmount,
+                            denomination = sendingAmountDenomination,
+                            dollarText = dollarEquivalentText,
+                            accountShort = accountShort,
+                        )
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
+                        SummaryWidget(
+                            address = address,
+                            networkFee = networkFee,
+                            willReceive = willReceive,
+                            willPay = willPay,
+                            onAddressClick = { sheetState = SheetState.AdvancedDetails },
+                        )
+                        Spacer(Modifier.weight(1f))
+                        SwipeToSendStub(
+                            text = stringResource(R.string.action_swipe_to_send),
+                            sendState = sendState,
+                            onComplete = onSwipeToSend,
+                            containerColor = MaterialTheme.coveColors.swipeTrackBg,
+                            targetContainerColor = MaterialTheme.coveColors.midnightBtn,
+                            knobColor = MaterialTheme.coveColors.midnightBtn,
+                            textColor = MaterialTheme.colorScheme.onSurface,
+                            targetTextColor = SWIPE_BUTTON_TEXT_COLOR_TARGET,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .navigationBarsPadding()
+                                    .padding(bottom = 24.dp)
+                                    .testTag("sendFlowConfirm.swipeToSend"),
+                        )
+
+                        Spacer(
+                            Modifier
+                                .height(1.dp)
+                                .testTag("sendFlowConfirm.bottomPadding"),
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerAdvancedChainCode.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerAdvancedChainCode.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -152,7 +153,8 @@ fun TapSignerAdvancedChainCode(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 30.dp),
+                        .padding(horizontal = 16.dp, vertical = 30.dp)
+                        .testTag("tapSignerAdvanced.continue"),
                 colors =
                     ButtonDefaults.buttonColors(
                         disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerChooseChainCode.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/TapSignerFlow/TapSignerChooseChainCode.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -105,7 +106,8 @@ fun TapSignerChooseChainCode(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 20.dp, vertical = 50.dp),
+                            .padding(horizontal = 20.dp, vertical = 50.dp)
+                            .testTag("tapSignerChoose.automaticSetup"),
                     shape = RoundedCornerShape(10.dp),
                     color = MaterialTheme.colorScheme.surfaceVariant,
                 ) {
@@ -148,7 +150,7 @@ fun TapSignerChooseChainCode(
                     onClick = {
                         manager.navigate(TapSignerRoute.InitAdvanced(tapSigner))
                     },
-                    modifier = Modifier.padding(bottom = 30.dp),
+                    modifier = Modifier.padding(bottom = 30.dp).testTag("tapSignerChoose.advancedSetup"),
                 ) {
                     Text(
                         text = "Advanced Setup",

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/NumberPadPinView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/NumberPadPinView.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -85,7 +86,8 @@ fun NumberPadPinView(
             Modifier
                 .fillMaxSize()
                 .background(CoveColor.midnightBlue)
-                .padding(16.dp),
+                .padding(16.dp)
+                .testTag("numberPadPin.viewport"),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         // cancel button header (matches iOS CancelView pattern)
@@ -195,6 +197,7 @@ fun NumberPadPinView(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
+                                .testTag("numberPadPin.cancel")
                                 .clickable { backAction() }
                                 .padding(vertical = 20.dp),
                         contentAlignment = Alignment.Center,
@@ -242,6 +245,7 @@ fun NumberPadPinView(
                     modifier =
                         Modifier
                             .fillMaxWidth()
+                            .testTag("numberPadPin.delete")
                             .clickable(
                                 onClick = { if (pin.isNotEmpty()) pin = pin.dropLast(1) },
                                 indication = null,
@@ -270,6 +274,7 @@ private fun NumberButton(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .testTag("numberPadPin.digit.$text")
                 .clickable(
                     onClick = onClick,
                     indication = null,

--- a/android/app/src/screenshotTest/java/org/bitcoinppl/cove/screenshots/PreviewScreenshotTests.kt
+++ b/android/app/src/screenshotTest/java/org/bitcoinppl/cove/screenshots/PreviewScreenshotTests.kt
@@ -1,12 +1,20 @@
 package org.bitcoinppl.cove.screenshots
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.android.tools.screenshot.PreviewTest
 import org.bitcoinppl.cove.cloudbackup.CloudBackupVerificationPromptFailurePreviewContent
 import org.bitcoinppl.cove.cloudbackup.CloudBackupVerificationPromptPreviewContent
 import org.bitcoinppl.cove.cloudbackup.CloudBackupVerificationPromptRunningPreviewContent
 import org.bitcoinppl.cove.cloudbackup.CloudOnlyWalletActionSheetPreviewContent
+import org.bitcoinppl.cove.flows.OnboardingFlow.OnboardingStatusHero
 import org.bitcoinppl.cove.flows.SettingsFlow.AboutSettingsPreviewContent
 import org.bitcoinppl.cove.views.ChoiceAlertDialogNoCancelPreviewContent
 import org.bitcoinppl.cove.views.ChoiceAlertDialogPreviewContent
@@ -93,4 +101,22 @@ fun ChoiceAlertDialogNoCancelScreenshot() {
 @Composable
 fun CloudOnlyWalletActionSheetScreenshot() {
     CloudOnlyWalletActionSheetPreviewContent()
+}
+
+@PreviewTest
+@Preview(
+    name = "Onboarding Status Hero Cloud",
+    showBackground = true,
+    backgroundColor = 0xFF1C2536,
+    widthDp = 160,
+    heightDp = 160,
+)
+@Composable
+fun OnboardingStatusHeroCloudPreviewScreenshot() {
+    Box(
+        modifier = Modifier.size(160.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        OnboardingStatusHero(icon = Icons.Default.Cloud)
+    }
 }

--- a/android/detekt.yml
+++ b/android/detekt.yml
@@ -12,6 +12,14 @@ exceptions:
   TooGenericExceptionCaught:
     active: true
 
+naming:
+  FunctionNaming:
+    active: false
+
 potential-bugs:
   UnsafeCallOnNullableType:
     active: true
+
+style:
+  UnusedPrivateFunction:
+    allowedNames: '.*Preview.*'

--- a/ios/Cove.xcodeproj/project.pbxproj
+++ b/ios/Cove.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C0B000182F00000000000001 /* ICloudDriveHelperDecompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000192F00000000000001 /* ICloudDriveHelperDecompositionTests.swift */; };
 		C0B000192F10000000000001 /* AmountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000182F10000000000001 /* AmountFormatterTests.swift */; };
 		C0B0001B2F10000000000001 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B0001A2F10000000000001 /* NavigationCoordinatorTests.swift */; };
+		C0B0001C2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B0001D2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,7 @@
 		C0B000192F00000000000001 /* ICloudDriveHelperDecompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudDriveHelperDecompositionTests.swift; sourceTree = "<group>"; };
 		C0B000182F10000000000001 /* AmountFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountFormatterTests.swift; sourceTree = "<group>"; };
 		C0B0001A2F10000000000001 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
+		C0B0001D2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotWalletCreateScreenLayoutTests.swift; sourceTree = "<group>"; };
 		D0245F4C2C0F7B4E0042B447 /* Cove.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cove.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -129,6 +131,7 @@
 				C0B000182F10000000000001 /* AmountFormatterTests.swift */,
 				C0B000112F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift */,
 				C0B000172F00000000000001 /* CustomFeeRateErrorTests.swift */,
+				C0B0001D2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift */,
 				C0B000192F00000000000001 /* ICloudDriveHelperDecompositionTests.swift */,
 				C0B0001A2F10000000000001 /* NavigationCoordinatorTests.swift */,
 				C0B000152F00000000000001 /* OnboardingBackupViewsTests.swift */,
@@ -318,6 +321,7 @@
 				C0B000192F10000000000001 /* AmountFormatterTests.swift in Sources */,
 				C0B000102F00000000000001 /* CloudBackupPresentationCoordinatorTests.swift in Sources */,
 				C0B000162F00000000000001 /* CustomFeeRateErrorTests.swift in Sources */,
+				C0B0001C2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift in Sources */,
 				C0B000182F00000000000001 /* ICloudDriveHelperDecompositionTests.swift in Sources */,
 				C0B0001B2F10000000000001 /* NavigationCoordinatorTests.swift in Sources */,
 				C0B000142F00000000000001 /* OnboardingBackupViewsTests.swift in Sources */,

--- a/ios/Cove/Constants.swift
+++ b/ios/Cove/Constants.swift
@@ -19,7 +19,12 @@ let screenHeight = UIScreen.main.bounds.height
 let screenWidth = UIScreen.main.bounds.width
 
 let isMiniDevice = screenHeight <= 812
+let compactLayoutHeightThreshold: CGFloat = 812
 
 func isMiniDeviceOrLargeText(_ sizeCategory: ContentSizeCategory) -> Bool {
     isMiniDevice || sizeCategory >= .extraExtraLarge
+}
+
+func usesCompactLayout(sizeCategory: ContentSizeCategory, availableHeight: CGFloat) -> Bool {
+    sizeCategory >= .extraExtraLarge || availableHeight <= compactLayoutHeightThreshold
 }

--- a/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
+++ b/ios/Cove/Flows/CoinControlFlow/UtxoListScreen.swift
@@ -110,157 +110,136 @@ struct UtxoListScreen: View {
 
     /// ─── Body ────────────────────────────────────────────────
     var body: some View {
-        VStack(spacing: 24) {
-            VStack(spacing: 16) {
-                // ─ Search bar ─
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                    TextField("Search UTXOs", text: manager.searchBinding)
-                        .focused($isFocused)
-                        .autocorrectionDisabled()
-                        .autocapitalization(.none)
-
-                    if !manager.search.isEmpty {
-                        Button(action: { manager.dispatch(.clearSearch) }) {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(.gray)
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .transition(.scale)
-                    }
-                }
-                .padding(8)
-                .background(Color.systemGray5)
-                .cornerRadius(10)
-                .padding(.horizontal)
-
-                // ─ Sort buttons ─
-                if !isFocused {
+        VStack(spacing: 0) {
+            VStack(spacing: 24) {
+                VStack(spacing: 16) {
+                    // ─ Search bar ─
                     HStack {
-                        sortButton(for: .date)
-                        Spacer()
-                        sortButton(for: .name)
-                        Spacer()
-                        sortButton(for: .amount)
-                        Spacer()
-                        sortButton(for: .change)
-                    }
-                    .padding(.horizontal)
-                }
-            }
+                        Image(systemName: "magnifyingglass")
+                        TextField("Search UTXOs", text: manager.searchBinding)
+                            .focused($isFocused)
+                            .autocorrectionDisabled()
+                            .autocapitalization(.none)
 
-            VStack(spacing: 8) {
-                // ─ Section header ─
-                HStack {
-                    Text("LIST OF UTXOS")
-                        .font(.caption)
-                        .fontWeight(.regular)
-                        .foregroundColor(.primary.opacity(0.6))
-                    Spacer()
-
-                    Group {
-                        if manager.selected.isEmpty {
-                            Text("Select All")
-                        } else {
-                            Text("Deselect All")
+                        if !manager.search.isEmpty {
+                            Button(action: { manager.dispatch(.clearSearch) }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.gray)
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                            .transition(.scale)
                         }
                     }
-                    .font(.caption)
-                    .fontWeight(.medium)
-                    .foregroundStyle(.link)
-                    .contentShape(
-                        Rectangle().inset(
-                            by:
-                            EdgeInsets(
-                                top: -15,
-                                leading: -35,
-                                bottom: -10,
-                                trailing: -35
+                    .padding(8)
+                    .background(Color.systemGray5)
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+
+                    // ─ Sort buttons ─
+                    if !isFocused {
+                        HStack {
+                            sortButton(for: .date)
+                            Spacer()
+                            sortButton(for: .name)
+                            Spacer()
+                            sortButton(for: .amount)
+                            Spacer()
+                            sortButton(for: .change)
+                        }
+                        .padding(.horizontal)
+                    }
+                }
+
+                VStack(spacing: 8) {
+                    // ─ Section header ─
+                    HStack {
+                        Text("LIST OF UTXOS")
+                            .font(.caption)
+                            .fontWeight(.regular)
+                            .foregroundColor(.primary.opacity(0.6))
+                        Spacer()
+
+                        Group {
+                            if manager.selected.isEmpty {
+                                Text("Select All")
+                            } else {
+                                Text("Deselect All")
+                            }
+                        }
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.link)
+                        .contentShape(
+                            Rectangle().inset(
+                                by:
+                                EdgeInsets(
+                                    top: -15,
+                                    leading: -35,
+                                    bottom: -10,
+                                    trailing: -35
+                                )
                             )
                         )
-                    )
-                    .onTapGesture { manager.dispatch(.toggleSelectAll) }
-                }
-                .padding(.horizontal)
-                .padding(.horizontal)
-                .zIndex(1)
-
-                // ─ UTXO list ─
-                VStack(spacing: 8) {
-                    UtxoList()
-                    if manager.lockStateLoadFailed {
-                        Text("Unable to read UTXO lock state. UTXOs are shown locked for safety.")
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.red)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal)
+                        .onTapGesture { manager.dispatch(.toggleSelectAll) }
                     }
+                    .padding(.horizontal)
+                    .padding(.horizontal)
+                    .zIndex(1)
 
-                    Text(manager.totalSelectedAmount)
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .opacity(manager.selected.isEmpty ? 0 : 0.8)
-                        .contentTransition(.numericText())
-                        .animation(.easeInOut(duration: 0.1), value: manager.totalSelectedAmount)
-                }
-            }
+                    // ─ UTXO list ─
+                    VStack(spacing: 8) {
+                        UtxoList()
+                        if manager.lockStateLoadFailed {
+                            Text("Unable to read UTXO lock state. UTXOs are shown locked for safety.")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundStyle(.red)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal)
+                        }
 
-            Spacer()
-
-            if !isFocused {
-                // ─ Footer notes ─
-                VStack(spacing: 16) {
-                    HStack {
-                        Text(
-                            "Select UTXOs to manage or send. Unspent outputs will remain in your wallet for future use."
-                        )
-                        .font(.caption)
-                        .fontWeight(.regular)
-
-                        Spacer()
+                        Text(manager.totalSelectedAmount)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .opacity(manager.selected.isEmpty ? 0 : 0.8)
+                            .contentTransition(.numericText())
+                            .animation(.easeInOut(duration: 0.1), value: manager.totalSelectedAmount)
                     }
+                }
 
-                    HStack(spacing: 4) {
-                        Image(systemName: "circlebadge.2")
-                            .font(.footnote)
+                Spacer()
 
-                        Text("Denotes UTXO change")
+                if !isFocused {
+                    // ─ Footer notes ─
+                    VStack(spacing: 16) {
+                        HStack {
+                            Text(
+                                "Select UTXOs to manage or send. Unspent outputs will remain in your wallet for future use."
+                            )
                             .font(.caption)
                             .fontWeight(.regular)
 
-                        Spacer()
-                    }
-                }
-                .foregroundStyle(.secondary)
-                .padding(.horizontal)
-                .padding(.horizontal)
+                            Spacer()
+                        }
 
-                // ─ Action buttons ─
-                Button(continueText) {
-                    manager.continuePressed()
-                    navigate(
-                        RouteFactory()
-                            .coinControlSend(
-                                id: manager.id,
-                                utxos: manager.selectedUtxos()
-                            )
-                    )
+                        HStack(spacing: 4) {
+                            Image(systemName: "circlebadge.2")
+                                .font(.footnote)
+
+                            Text("Denotes UTXO change")
+                                .font(.caption)
+                                .fontWeight(.regular)
+
+                            Spacer()
+                        }
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+                    .padding(.horizontal)
                 }
-                .buttonStyle(
-                    canContinue
-                        ? DarkButtonStyle()
-                        : DarkButtonStyle(
-                            backgroundColor: .systemGray4, foregroundColor: .secondary
-                        )
-                )
-                .controlSize(.large)
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal)
-                .padding(.bottom, 4)
-                .disabled(!canContinue)
-                .contentTransition(.interpolate)
             }
+            .frame(maxHeight: .infinity)
+            .padding(.bottom, isFocused ? 0 : 112)
         }
         .navigationTitle("Manage UTXOs")
         .navigationBarTitleDisplayMode(isFocused ? .inline : .automatic)
@@ -292,6 +271,13 @@ struct UtxoListScreen: View {
             Color(.systemGroupedBackground)
                 .ignoresSafeArea()
         )
+        .overlay(alignment: .bottom) {
+            if !isFocused {
+                continueButton
+                    .padding(.horizontal)
+                    .padding(.bottom, 32)
+            }
+        }
         .alert("UTXO Locked", isPresented: $showLockedSelectionAlert) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -312,6 +298,30 @@ struct UtxoListScreen: View {
     }
 
     // MARK: - Helpers
+
+    private var continueButton: some View {
+        Button(continueText) {
+            manager.continuePressed()
+            navigate(
+                RouteFactory()
+                    .coinControlSend(
+                        id: manager.id,
+                        utxos: manager.selectedUtxos()
+                    )
+            )
+        }
+        .buttonStyle(
+            canContinue
+                ? DarkButtonStyle()
+                : DarkButtonStyle(
+                    backgroundColor: .systemGray4, foregroundColor: .secondary
+                )
+        )
+        .controlSize(.large)
+        .frame(maxWidth: .infinity)
+        .disabled(!canContinue)
+        .contentTransition(.interpolate)
+    }
 
     private func sortButton(for key: CoinControlListSortKey) -> some View {
         let _ = manager.sort

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
@@ -45,33 +45,39 @@ struct WordsView: View {
     }
 
     var body: some View {
-        if sizeCategory >= .extraExtraLarge || isMiniDevice {
-            ScrollView {
-                RecoveryWordsContent(
-                    groupedWords: groupedWords,
-                    tabIndex: $tabIndex,
-                    lastIndex: lastIndex,
-                    showConfirmationAlert: $showConfirmationAlert,
-                    saveWallet: saveWallet,
-                    dismiss: { dismiss() }
-                )
-                .frame(minHeight: screenHeight, maxHeight: .infinity)
-            }
-            .background(
-                Color.midnightBlue
-                    .ignoresSafeArea(.all)
-            )
-
-        } else {
-            RecoveryWordsContent(
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let content = RecoveryWordsContent(
                 groupedWords: groupedWords,
                 tabIndex: $tabIndex,
                 lastIndex: lastIndex,
                 showConfirmationAlert: $showConfirmationAlert,
+                compactHeight: scrollableLayout,
                 saveWallet: saveWallet,
                 dismiss: { dismiss() }
             )
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        content
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity)
+                            .padding(.bottom, 48)
+                    }
+                    .background(
+                        Color.midnightBlue
+                            .ignoresSafeArea(.all)
+                    )
+
+                } else {
+                    content
+                }
+            }
         }
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 
     private func saveWallet() {
@@ -89,12 +95,13 @@ struct RecoveryWordsContent: View {
     @Binding var tabIndex: Int
     let lastIndex: Int
     @Binding var showConfirmationAlert: Bool
+    let compactHeight: Bool
     let saveWallet: () -> Void
     let dismiss: () -> Void
 
     var body: some View {
         VStack(spacing: 24) {
-            StyledWordCard(tabIndex: $tabIndex) {
+            StyledWordCard(tabIndex: $tabIndex, compactHeight: compactHeight) {
                 ForEach(Array(groupedWords.enumerated()), id: \.offset) { index, wordGroup in
                     WordCardView(words: wordGroup).tag(index)
                 }
@@ -265,6 +272,7 @@ struct WordCardView: View {
 
 struct StyledWordCard<Content: View>: View {
     @Binding var tabIndex: Int
+    let compactHeight: Bool
     @ViewBuilder var content: Content
 
     var body: some View {
@@ -272,7 +280,7 @@ struct StyledWordCard<Content: View>: View {
             content.padding(.bottom, 40)
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
-        .frame(minHeight: isMiniDevice ? 350 : nil)
+        .frame(minHeight: compactHeight ? 350 : nil)
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
@@ -44,7 +44,10 @@ struct WordsView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -74,10 +77,6 @@ struct WordsView: View {
                 }
             }
         }
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 
     private func recoveryWordsContent(compactHeight: Bool, includesPrimaryAction: Bool) -> some View {

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
@@ -19,9 +19,6 @@ struct HotWalletCreateScreen: View {
     }
 }
 
-private let columns =
-    Array(repeating: GridItem(.flexible()), count: 3)
-
 struct WordsView: View {
     @Environment(\.sizeCategory) var sizeCategory
 
@@ -35,9 +32,10 @@ struct WordsView: View {
     @Environment(\.navigate) private var navigate
     @Environment(AppManager.self) private var app
 
-    init(manager: PendingWalletManager) {
+    init(manager: PendingWalletManager, initialTabIndex: Int = 0) {
         self.manager = manager
         self.groupedWords = manager.rust.bip39WordsGrouped()
+        self.tabIndex = initialTabIndex
     }
 
     var lastIndex: Int {
@@ -47,30 +45,32 @@ struct WordsView: View {
     var body: some View {
         GeometryReader { proxy in
             let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
-            let content = RecoveryWordsContent(
-                groupedWords: groupedWords,
-                tabIndex: $tabIndex,
-                lastIndex: lastIndex,
-                showConfirmationAlert: $showConfirmationAlert,
-                compactHeight: scrollableLayout,
-                saveWallet: saveWallet,
-                dismiss: { dismiss() }
-            )
 
             Group {
                 if scrollableLayout {
-                    ScrollView {
-                        content
-                            .frame(minHeight: proxy.size.height, maxHeight: .infinity)
-                            .padding(.bottom, 48)
+                    VStack(spacing: 0) {
+                        ScrollView {
+                            recoveryWordsContent(
+                                compactHeight: scrollableLayout,
+                                includesPrimaryAction: false
+                            )
+                            .padding(.bottom, 24)
+                        }
+                        .scrollIndicators(.hidden)
+
+                        compactBottomAction
                     }
+                    .frame(width: proxy.size.width, height: proxy.size.height)
                     .background(
                         Color.midnightBlue
                             .ignoresSafeArea(.all)
                     )
 
                 } else {
-                    content
+                    recoveryWordsContent(
+                        compactHeight: scrollableLayout,
+                        includesPrimaryAction: true
+                    )
                 }
             }
         }
@@ -78,6 +78,36 @@ struct WordsView: View {
 
     private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
         sizeCategory >= .extraExtraLarge || availableHeight <= 812
+    }
+
+    private func recoveryWordsContent(compactHeight: Bool, includesPrimaryAction: Bool) -> some View {
+        RecoveryWordsContent(
+            groupedWords: groupedWords,
+            tabIndex: $tabIndex,
+            lastIndex: lastIndex,
+            showConfirmationAlert: $showConfirmationAlert,
+            compactHeight: compactHeight,
+            includesPrimaryAction: includesPrimaryAction,
+            saveWallet: saveWallet,
+            dismiss: { dismiss() }
+        )
+    }
+
+    private var compactBottomAction: some View {
+        VStack(spacing: 16) {
+            Divider()
+                .overlay(.coveLightGray.opacity(0.50))
+
+            RecoveryWordsPrimaryActionButton(
+                tabIndex: $tabIndex,
+                lastIndex: lastIndex,
+                saveWallet: saveWallet
+            )
+        }
+        .padding(.horizontal)
+        .padding(.top, 12)
+        .padding(.bottom, 56)
+        .background(Color.midnightBlue)
     }
 
     private func saveWallet() {
@@ -96,6 +126,7 @@ struct RecoveryWordsContent: View {
     let lastIndex: Int
     @Binding var showConfirmationAlert: Bool
     let compactHeight: Bool
+    let includesPrimaryAction: Bool
     let saveWallet: () -> Void
     let dismiss: () -> Void
 
@@ -107,7 +138,9 @@ struct RecoveryWordsContent: View {
                 }
             }
 
-            Spacer()
+            if !compactHeight {
+                Spacer()
+            }
 
             HStack {
                 DotMenuView(selected: 2, size: 5)
@@ -147,46 +180,21 @@ struct RecoveryWordsContent: View {
                 Spacer()
             }
 
-            Divider()
-                .overlay(.coveLightGray.opacity(0.50))
+            if includesPrimaryAction {
+                Divider()
+                    .overlay(.coveLightGray.opacity(0.50))
 
-            VStack(spacing: 24) {
-                Group {
-                    if tabIndex == lastIndex {
-                        Button(action: saveWallet) {
-                            Text("Save Wallet")
-                                .font(.subheadline)
-                                .fontWeight(.medium)
-                                .frame(maxWidth: .infinity)
-                                .contentShape(Rectangle())
-                                .padding(.vertical, 20)
-                                .padding(.horizontal, 10)
-                                .background(Color.btnPrimary)
-                                .foregroundColor(.midnightBlue)
-                                .cornerRadius(10)
-                        }
-                    } else {
-                        Button(action: {
-                            withAnimation { tabIndex += 1 }
-                        }) {
-                            Text("Next")
-                                .font(.subheadline)
-                                .fontWeight(.medium)
-                                .frame(maxWidth: .infinity)
-                                .contentShape(Rectangle())
-                                .padding(.vertical, 20)
-                                .padding(.horizontal, 10)
-                                .background(Color.btnPrimary)
-                                .foregroundColor(.midnightBlue)
-                                .cornerRadius(10)
-                        }
-                    }
+                VStack(spacing: 24) {
+                    primaryActionButton
                 }
             }
         }
         .padding()
         .navigationBarTitleDisplayMode(.inline)
         .adaptiveToolbarStyle()
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbarBackground(Color.midnightBlue, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .frame(maxHeight: .infinity)
         .background(
             Image(.newWalletPattern)
@@ -224,63 +232,126 @@ struct RecoveryWordsContent: View {
         }
         .navigationBarBackButtonHidden(true)
     }
+
+    private var primaryActionButton: some View {
+        RecoveryWordsPrimaryActionButton(
+            tabIndex: $tabIndex,
+            lastIndex: lastIndex,
+            saveWallet: saveWallet
+        )
+    }
+}
+
+struct RecoveryWordsPrimaryActionButton: View {
+    @Binding var tabIndex: Int
+    let lastIndex: Int
+    let saveWallet: () -> Void
+
+    var body: some View {
+        if tabIndex == lastIndex {
+            Button(action: saveWallet) {
+                primaryActionLabel("Save Wallet")
+            }
+        } else {
+            Button(action: {
+                withAnimation { tabIndex += 1 }
+            }) {
+                primaryActionLabel("Next")
+            }
+        }
+    }
+
+    private func primaryActionLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.subheadline)
+            .fontWeight(.medium)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .padding(.vertical, 20)
+            .padding(.horizontal, 10)
+            .background(Color.btnPrimary)
+            .foregroundColor(.midnightBlue)
+            .cornerRadius(10)
+    }
 }
 
 struct WordCardView: View {
     @Environment(\.sizeCategory) var sizeCategory
     let words: [GroupedWord]
 
+    private let columnCount = 3
+    private let columnSpacing: CGFloat = 12
+
     var body: some View {
-        ColumnMajorGrid(items: words) { _, group in
-            HStack(spacing: 0) {
-                Text("\(String(format: "%d", group.number)). ")
-                    .fontWeight(.medium)
-                    .foregroundColor(.black.opacity(0.5))
-                    .multilineTextAlignment(.leading)
-                    .frame(alignment: .leading)
-                    .minimumScaleFactor(0.8)
-                    .lineLimit(sizeCategory >= .extraExtraLarge ? 3 : 1)
-                    .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .caption)
-
-                Spacer()
-
-                Text(group.word)
-                    .fontWeight(.medium)
-                    .foregroundStyle(.midnightBlue)
-                    .multilineTextAlignment(.center)
-                    .frame(alignment: .leading)
-                    .minimumScaleFactor(0.2)
-                    .lineLimit(sizeCategory >= .extraExtraLarge ? 5 : 1)
-                    .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .footnote)
-
-                Spacer()
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 12)
-            .frame(width: (screenWidth * 0.33) - 20)
-            .background(Color.btnPrimary)
-            .cornerRadius(10)
-            .contextMenu {
-                isMiniDeviceOrLargeText(sizeCategory)
-                    ? Button(action: {}) {
-                        Text("\(String(format: "%d", group.number)). \(group.word)")
-                    } : nil
+        GeometryReader { proxy in
+            ColumnMajorGrid(items: words, numberOfColumns: columnCount, spacing: columnSpacing) { _, group in
+                wordCard(group, width: wordCardWidth(availableWidth: proxy.size.width))
             }
         }
+    }
+
+    private func wordCard(_ group: GroupedWord, width: CGFloat) -> some View {
+        HStack(spacing: 0) {
+            Text("\(String(format: "%d", group.number)). ")
+                .fontWeight(.medium)
+                .foregroundColor(.black.opacity(0.5))
+                .multilineTextAlignment(.leading)
+                .frame(alignment: .leading)
+                .minimumScaleFactor(0.8)
+                .lineLimit(sizeCategory >= .extraExtraLarge ? 3 : 1)
+                .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .caption)
+
+            Spacer(minLength: 4)
+
+            Text(group.word)
+                .fontWeight(.medium)
+                .foregroundStyle(.midnightBlue)
+                .multilineTextAlignment(.center)
+                .frame(alignment: .leading)
+                .minimumScaleFactor(0.2)
+                .lineLimit(sizeCategory >= .extraExtraLarge ? 5 : 1)
+                .font(isMiniDeviceOrLargeText(sizeCategory) ? .caption2 : .footnote)
+
+            Spacer(minLength: 4)
+        }
+        .padding(.horizontal, isMiniDeviceOrLargeText(sizeCategory) ? 8 : 10)
+        .padding(.vertical, 12)
+        .frame(width: width)
+        .background(Color.btnPrimary)
+        .cornerRadius(10)
+        .contextMenu {
+            isMiniDeviceOrLargeText(sizeCategory)
+                ? Button(action: {}) {
+                    Text("\(String(format: "%d", group.number)). \(group.word)")
+                } : nil
+        }
+    }
+
+    private func wordCardWidth(availableWidth: CGFloat) -> CGFloat {
+        let totalColumnSpacing = columnSpacing * CGFloat(columnCount - 1)
+
+        return max((availableWidth - totalColumnSpacing) / CGFloat(columnCount), 0)
     }
 }
 
 struct StyledWordCard<Content: View>: View {
+    @Environment(\.sizeCategory) var sizeCategory
+
     @Binding var tabIndex: Int
     let compactHeight: Bool
     @ViewBuilder var content: Content
 
     var body: some View {
-        TabView(selection: $tabIndex) {
+        let tabView = TabView(selection: $tabIndex) {
             content.padding(.bottom, 40)
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
-        .frame(minHeight: compactHeight ? 350 : nil)
+
+        if compactHeight {
+            tabView.frame(height: isMiniDeviceOrLargeText(sizeCategory) ? 320 : 260)
+        } else {
+            tabView
+        }
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletSelectScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletSelectScreen.swift
@@ -29,7 +29,10 @@ struct HotWalletSelectScreen: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -158,10 +161,6 @@ struct HotWalletSelectScreen: View {
                 Text("24 Words")
             }
         }
-    }
-
-    private func usesScrollableLayout(availableHeight _: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletSelectScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletSelectScreen.swift
@@ -13,6 +13,8 @@ enum NextScreenDialog {
 }
 
 struct HotWalletSelectScreen: View {
+    @Environment(\.sizeCategory) private var sizeCategory
+
     @State private var isSheetShown = false
     @State private var nextScreen: NextScreenDialog = .create
 
@@ -26,9 +28,75 @@ struct HotWalletSelectScreen: View {
     }
 
     var body: some View {
-        VStack(spacing: 28) {
-            Spacer()
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
 
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleTopSpacer: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .bottom)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    bottomActionLayout()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                }
+            }
+        }
+        .background(
+            Image(.newWalletPattern)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(height: screenHeight * 0.75, alignment: .topTrailing)
+                .frame(maxWidth: .infinity)
+                .brightness(0.05)
+        )
+        .background(Color.midnightBlue)
+        .navigationTitle("Add New Wallet")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    private func mainContent(usesFlexibleTopSpacer: Bool) -> some View {
+        VStack(spacing: 28) {
+            if usesFlexibleTopSpacer {
+                Spacer()
+            }
+
+            promptContent
+
+            Divider()
+                .overlay(.coveLightGray.opacity(0.50))
+
+            walletChoiceActions
+        }
+        .padding()
+        .frame(maxHeight: .infinity)
+    }
+
+    private func bottomActionLayout() -> some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            promptContent
+                .padding(.horizontal)
+                .padding(.bottom, 28)
+
+            VStack(spacing: 28) {
+                Divider()
+                    .overlay(.coveLightGray.opacity(0.50))
+
+                walletChoiceActions
+            }
+            .padding(.horizontal)
+            .padding(.top, 16)
+            .padding(.bottom, 56)
+        }
+    }
+
+    private var promptContent: some View {
+        VStack(spacing: 28) {
             HStack {
                 DotMenuView(selected: 1, size: 5)
                 Spacer()
@@ -42,69 +110,58 @@ struct HotWalletSelectScreen: View {
 
                 Spacer()
             }
+        }
+    }
 
-            Divider()
-                .overlay(.coveLightGray.opacity(0.50))
-
-            VStack(spacing: 24) {
-                Button(action: {
-                    isSheetShown = true
-                    nextScreen = .create
-                }) {
-                    Text("Create new wallet")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 20)
-                        .padding(.horizontal, 10)
-                        .background(Color.btnPrimary)
-                        .foregroundColor(.midnightBlue)
-                        .cornerRadius(10)
-                }
-
-                Button(action: {
-                    isSheetShown = true
-                    nextScreen = .import_
-                }) {
-                    Text("Import existing wallet")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .frame(maxWidth: .infinity)
-                        .foregroundColor(.white)
-                }
+    private var walletChoiceActions: some View {
+        VStack(spacing: 24) {
+            Button(action: {
+                isSheetShown = true
+                nextScreen = .create
+            }) {
+                Text("Create new wallet")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+                    .padding(.horizontal, 10)
+                    .background(Color.btnPrimary)
+                    .foregroundColor(.midnightBlue)
+                    .cornerRadius(10)
             }
-            .confirmationDialog("Select Number of Words", isPresented: $isSheetShown) {
-                if nextScreen == .import_ {
-                    NavigationLink(value: route(.twentyFour, importType: .qr)) {
-                        Text("Scan QR")
-                    }
 
-                    NavigationLink(value: route(.twentyFour, importType: .nfc)) {
-                        Text("NFC")
-                    }
-                }
-                NavigationLink(value: route(.twelve)) {
-                    Text("12 Words")
-                }
-                NavigationLink(value: route(.twentyFour)) {
-                    Text("24 Words")
-                }
+            Button(action: {
+                isSheetShown = true
+                nextScreen = .import_
+            }) {
+                Text("Import existing wallet")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .frame(maxWidth: .infinity)
+                    .foregroundColor(.white)
             }
         }
-        .padding()
-        .frame(maxHeight: .infinity)
-        .background(
-            Image(.newWalletPattern)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(height: screenHeight * 0.75, alignment: .topTrailing)
-                .frame(maxWidth: .infinity)
-                .brightness(0.05)
-        )
-        .background(Color.midnightBlue)
-        .navigationTitle("Add New Wallet")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
+        .confirmationDialog("Select Number of Words", isPresented: $isSheetShown) {
+            if nextScreen == .import_ {
+                NavigationLink(value: route(.twentyFour, importType: .qr)) {
+                    Text("Scan QR")
+                }
+
+                NavigationLink(value: route(.twentyFour, importType: .nfc)) {
+                    Text("NFC")
+                }
+            }
+            NavigationLink(value: route(.twelve)) {
+                Text("12 Words")
+            }
+            NavigationLink(value: route(.twentyFour)) {
+                Text("24 Words")
+            }
+        }
+    }
+
+    private func usesScrollableLayout(availableHeight _: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerificationCompleteScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerificationCompleteScreen.swift
@@ -23,7 +23,10 @@ struct VerificationCompleteScreen: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -112,10 +115,6 @@ struct VerificationCompleteScreen: View {
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerificationCompleteScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerificationCompleteScreen.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 
 struct VerificationCompleteScreen: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) var app
 
     /// args
@@ -21,9 +22,39 @@ struct VerificationCompleteScreen: View {
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .background(
+            Image(.newWalletPattern)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(height: screenHeight * 0.75, alignment: .topTrailing)
+                .frame(maxWidth: .infinity)
+                .opacity(0.75)
+        )
+        .background(Color.midnightBlue)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack(spacing: 24) {
-            Spacer()
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+                Spacer()
+            }
 
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: screenWidth * 0.46))
@@ -31,9 +62,11 @@ struct VerificationCompleteScreen: View {
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(.midnightBlue, Color.lightGreen)
 
-            Spacer()
-            Spacer()
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+                Spacer()
+                Spacer()
+            }
 
             HStack {
                 DotMenuView(selected: 3, size: 5)
@@ -79,15 +112,10 @@ struct VerificationCompleteScreen: View {
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            Image(.newWalletPattern)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(height: screenHeight * 0.75, alignment: .topTrailing)
-                .frame(maxWidth: .infinity)
-                .opacity(0.75)
-        )
-        .background(Color.midnightBlue)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerifyWordsScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerifyWordsScreen.swift
@@ -156,6 +156,7 @@ private struct VerifyWordsLoadedView: View {
 // MARK: Screen
 
 struct VerifyWordsScreen: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(\.navigate) private var navigate
     @Environment(AppManager.self) private var app
 
@@ -344,6 +345,39 @@ struct VerifyWordsScreen: View {
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    VStack(spacing: 0) {
+                        ScrollView {
+                            mainContent(usesFlexibleMiddleSpacer: false, includesActions: false)
+                                .padding(.bottom, 24)
+                        }
+                        .scrollIndicators(.hidden)
+
+                        compactBottomActions
+                    }
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+                } else {
+                    mainContent(usesFlexibleMiddleSpacer: true, includesActions: true)
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                }
+            }
+        }
+        .background(
+            Image(.newWalletPattern)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(height: screenHeight * 0.75, alignment: .topTrailing)
+                .frame(maxWidth: .infinity)
+                .opacity(0.5)
+        )
+        .background(Color.midnightBlue)
+    }
+
+    private func mainContent(usesFlexibleMiddleSpacer: Bool, includesActions: Bool) -> some View {
         VStack(spacing: 24) {
             Text("What is word #\(wordNumber)?")
                 .foregroundStyle(.white)
@@ -412,7 +446,9 @@ struct VerifyWordsScreen: View {
             }
             .padding(.vertical)
 
-            Spacer()
+            if usesFlexibleMiddleSpacer {
+                Spacer()
+            }
 
             HStack {
                 DotMenuView(selected: 3, size: 5)
@@ -443,37 +479,51 @@ struct VerifyWordsScreen: View {
 
             if !isMiniDevice { Spacer() }
 
-            Divider()
-                .overlay(.coveLightGray.opacity(0.50))
+            if includesActions {
+                Divider()
+                    .overlay(.coveLightGray.opacity(0.50))
 
-            VStack(spacing: 16) {
-                Button(action: { activeAlert = .words }) {
-                    Text("Show Words")
-                }
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(action: { activeAlert = .skip }) {
-                    Text("Skip Verification")
-                        .foregroundStyle(.white)
-                        .font(.caption)
-                        .fontWeight(.medium)
-                }
+                actionButtons
+                    .safeAreaPadding(.bottom, 30)
             }
-            .safeAreaPadding(.bottom, 30)
         }
         .padding()
         .alert(item: $activeAlert) { alertType in
             DisplayAlert(for: alertType)
         }
-        .background(
-            Image(.newWalletPattern)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(height: screenHeight * 0.75, alignment: .topTrailing)
-                .frame(maxWidth: .infinity)
-                .opacity(0.5)
-        )
+    }
+
+    private var actionButtons: some View {
+        VStack(spacing: 16) {
+            Button(action: { activeAlert = .words }) {
+                Text("Show Words")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(action: { activeAlert = .skip }) {
+                Text("Skip Verification")
+                    .foregroundStyle(.white)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+        }
+    }
+
+    private var compactBottomActions: some View {
+        VStack(spacing: 16) {
+            Divider()
+                .overlay(.coveLightGray.opacity(0.50))
+
+            actionButtons
+        }
+        .padding(.horizontal)
+        .padding(.top, 12)
+        .padding(.bottom, 56)
         .background(Color.midnightBlue)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 
     private var isReturning: Bool {

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerifyWordsScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/VerifyWords/VerifyWordsScreen.swift
@@ -346,7 +346,10 @@ struct VerifyWordsScreen: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -520,10 +523,6 @@ struct VerifyWordsScreen: View {
         .padding(.top, 12)
         .padding(.bottom, 56)
         .background(Color.midnightBlue)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 
     private var isReturning: Bool {

--- a/ios/Cove/Flows/NewWalletFlow/NewWalletSelectScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/NewWalletSelectScreen.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct NewWalletSelectScreen: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) var app
     @Environment(\.dismiss) private var dismiss
 
@@ -34,89 +35,22 @@ struct NewWalletSelectScreen: View {
     }
 
     var body: some View {
-        VStack(spacing: 28) {
-            Spacer()
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
 
-            HStack {
-                DotMenuView(selected: 0, size: 5)
-                Spacer()
-            }
-
-            HStack {
-                Text("How do you want to secure your Bitcoin?")
-                    .font(.system(size: 38, weight: .semibold))
-                    .lineSpacing(1.2)
-                    .foregroundColor(.white)
-
-                Spacer()
-            }
-
-            Divider()
-                .overlay(.coveLightGray.opacity(0.50))
-
-            HStack(spacing: 14) {
-                Button(action: { showSelectDialog = true }) {
-                    HStack {
-                        BitcoinShieldIcon(width: 15, color: .midnightBlue)
-
-                        Text("Hardware Wallet")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleTopSpacer: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .bottom)
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 20)
-                    .padding(.horizontal, 10)
-                    .background(Color.btnPrimary)
-                    .foregroundColor(.midnightBlue)
-                    .cornerRadius(10)
+                    .scrollIndicators(.hidden)
+                } else {
+                    bottomActionLayout()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
                 }
-
-                NavigationLink(value: RouteFactory().newHotWallet()) {
-                    HStack {
-                        Image(systemName: "iphone")
-                            .font(.subheadline)
-                            .symbolRenderingMode(.monochrome)
-
-                        Text("On This Device")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 20)
-                    .padding(.horizontal, 10)
-                    .background(Color.btnPrimary)
-                    .foregroundColor(.midnightBlue)
-                    .cornerRadius(10)
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-            .confirmationDialog(
-                "Import hardware wallet using",
-                isPresented: $showSelectDialog,
-                titleVisibility: .visible
-            ) {
-                NewWalletSelectConfirmationDialogContent(
-                    qrRoute: routeFactory.qrImport(),
-                    importFile: { isImporting = true },
-                    scanNfc: scanNfc,
-                    pasteWallet: pasteWallet
-                )
-            }
-
-            if nfcCalled {
-                Button(action: {
-                    sheetState = TaggedItem(.nfcHelp)
-                }) {
-                    HStack {
-                        Image(systemName: "wave.3.right")
-                        Text("NFC Help")
-                            .font(.subheadline)
-                    }
-                }
-                .foregroundColor(.white)
             }
         }
-        .padding()
         .fileImporter(
             isPresented: $isImporting,
             allowedContentTypes: [.plainText, .json]
@@ -141,7 +75,6 @@ struct NewWalletSelectScreen: View {
             )
         }
         .sheet(item: $sheetState, content: SheetContent)
-        .frame(maxHeight: .infinity)
         .background(
             Image(.newWalletPattern)
                 .resizable()
@@ -169,6 +102,138 @@ struct NewWalletSelectScreen: View {
                 }
             }
         }
+    }
+
+    private func mainContent(usesFlexibleTopSpacer: Bool) -> some View {
+        VStack(spacing: 28) {
+            if usesFlexibleTopSpacer {
+                Spacer()
+            }
+
+            promptContent
+
+            Divider()
+                .overlay(.coveLightGray.opacity(0.50))
+
+            walletTypeActions
+        }
+        .padding()
+        .frame(maxHeight: .infinity)
+    }
+
+    private func bottomActionLayout() -> some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            promptContent
+                .padding(.horizontal)
+                .padding(.bottom, 28)
+
+            VStack(spacing: 28) {
+                Divider()
+                    .overlay(.coveLightGray.opacity(0.50))
+
+                walletTypeActions
+            }
+            .padding(.horizontal)
+            .padding(.top, 16)
+            .padding(.bottom, 56)
+        }
+    }
+
+    private var promptContent: some View {
+        VStack(spacing: 28) {
+            HStack {
+                DotMenuView(selected: 0, size: 5)
+                Spacer()
+            }
+
+            HStack {
+                Text("How do you want to secure your Bitcoin?")
+                    .font(.system(size: 38, weight: .semibold))
+                    .lineSpacing(1.2)
+                    .foregroundColor(.white)
+
+                Spacer()
+            }
+        }
+    }
+
+    private var walletTypeActions: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 14) {
+                hardwareWalletButton
+                hotWalletButton
+            }
+            .confirmationDialog(
+                "Import hardware wallet using",
+                isPresented: $showSelectDialog,
+                titleVisibility: .visible
+            ) {
+                NewWalletSelectConfirmationDialogContent(
+                    qrRoute: routeFactory.qrImport(),
+                    importFile: { isImporting = true },
+                    scanNfc: scanNfc,
+                    pasteWallet: pasteWallet
+                )
+            }
+
+            if nfcCalled {
+                Button(action: {
+                    sheetState = TaggedItem(.nfcHelp)
+                }) {
+                    HStack {
+                        Image(systemName: "wave.3.right")
+                        Text("NFC Help")
+                            .font(.subheadline)
+                    }
+                }
+                .foregroundColor(.white)
+            }
+        }
+    }
+
+    private var hardwareWalletButton: some View {
+        Button(action: { showSelectDialog = true }) {
+            HStack {
+                BitcoinShieldIcon(width: 15, color: .midnightBlue)
+
+                Text("Hardware Wallet")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .padding(.horizontal, 10)
+            .background(Color.btnPrimary)
+            .foregroundColor(.midnightBlue)
+            .cornerRadius(10)
+        }
+    }
+
+    private var hotWalletButton: some View {
+        NavigationLink(value: RouteFactory().newHotWallet()) {
+            HStack {
+                Image(systemName: "iphone")
+                    .font(.subheadline)
+                    .symbolRenderingMode(.monochrome)
+
+                Text("On This Device")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .padding(.horizontal, 10)
+            .background(Color.btnPrimary)
+            .foregroundColor(.midnightBlue)
+            .cornerRadius(10)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private func usesScrollableLayout(availableHeight _: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge
     }
 
     private func newWalletFromXpub(_ xpub: String) {

--- a/ios/Cove/Flows/NewWalletFlow/NewWalletSelectScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/NewWalletSelectScreen.swift
@@ -36,7 +36,10 @@ struct NewWalletSelectScreen: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -230,10 +233,6 @@ struct NewWalletSelectScreen: View {
             .cornerRadius(10)
         }
         .buttonStyle(PlainButtonStyle())
-    }
-
-    private func usesScrollableLayout(availableHeight _: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge
     }
 
     private func newWalletFromXpub(_ xpub: String) {

--- a/ios/Cove/Flows/Onboarding/OnboardingBackupViews.swift
+++ b/ios/Cove/Flows/Onboarding/OnboardingBackupViews.swift
@@ -125,55 +125,53 @@ struct OnboardingSecretWordsView: View {
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 2)
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button("Back", action: onBack)
-                    .foregroundStyle(.white)
-                    .font(.headline)
-                Spacer()
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 20)
+        GeometryReader { proxy in
+            ZStack(alignment: .bottom) {
+                ScrollView {
+                    VStack(spacing: 24) {
+                        HStack {
+                            Button("Back", action: onBack)
+                                .foregroundStyle(.white)
+                                .font(.headline)
+                            Spacer()
+                        }
+                        .padding(.top, 20)
 
-            ScrollView {
-                VStack(spacing: 24) {
-                    VStack(spacing: 12) {
-                        Text("Your Recovery Words")
-                            .font(.system(size: 34, weight: .semibold))
-                            .foregroundStyle(.white)
+                        VStack(spacing: 12) {
+                            Text("Your Recovery Words")
+                                .font(.system(size: 34, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                            Text(
+                                "Write these down exactly in order and keep them offline. Anyone with these words can control your Bitcoin."
+                            )
+                            .font(.footnote)
+                            .foregroundStyle(.coveLightGray.opacity(0.74))
                             .frame(maxWidth: .infinity, alignment: .leading)
+                        }
 
-                        Text(
-                            "Write these down exactly in order and keep them offline. Anyone with these words can control your Bitcoin."
-                        )
-                        .font(.footnote)
-                        .foregroundStyle(.coveLightGray.opacity(0.74))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+                        let wordCards = onboardingWordsInTwoColumnVisualOrder(words)
 
-                    let wordCards = onboardingWordsInTwoColumnVisualOrder(words)
-
-                    LazyVGrid(columns: columns, spacing: 12) {
-                        ForEach(wordCards) { wordCard in
-                            OnboardingWordCard(index: wordCard.index, word: wordCard.word)
+                        LazyVGrid(columns: columns, spacing: 12) {
+                            ForEach(wordCards) { wordCard in
+                                OnboardingWordCard(index: wordCard.index, word: wordCard.word)
+                            }
                         }
                     }
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 140)
                 }
-                .padding(.horizontal, 24)
-                .padding(.top, 32)
-                .padding(.bottom, 120)
+
+                Button("I Saved These Words", action: onSaved)
+                    .buttonStyle(OnboardingPrimaryButtonStyle())
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 56)
             }
+            .frame(width: proxy.size.width, height: proxy.size.height)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onboardingRecoveryBackground()
-        .safeAreaInset(edge: .bottom) {
-            Button("I Saved These Words", action: onSaved)
-                .buttonStyle(OnboardingPrimaryButtonStyle())
-                .padding(.horizontal, 24)
-                .padding(.top, 12)
-                .padding(.bottom, 24)
-                .background(.clear)
-        }
     }
 }
 

--- a/ios/Cove/Flows/Onboarding/StartupRecovery/DeviceRestoreView.swift
+++ b/ios/Cove/Flows/Onboarding/StartupRecovery/DeviceRestoreView.swift
@@ -90,8 +90,11 @@ private struct DeviceRestoreContent: View {
     @ViewBuilder
     private var heroIcon: some View {
         switch restoreState {
-        case .idle, .restoring:
-            restoringHeroIcon
+        case .idle:
+            restoringHeroIcon(pulse: false)
+
+        case .restoring:
+            restoringHeroIcon(pulse: true)
 
         case .complete:
             OnboardingStatusHero(
@@ -118,8 +121,8 @@ private struct DeviceRestoreContent: View {
         }
     }
 
-    private var restoringHeroIcon: some View {
-        OnboardingStatusHero(systemImage: "icloud.and.arrow.down", iconSize: 22)
+    private func restoringHeroIcon(pulse: Bool) -> some View {
+        OnboardingStatusHero(systemImage: "icloud.and.arrow.down", pulse: pulse, iconSize: 22)
     }
 
     @ViewBuilder

--- a/ios/Cove/Flows/Onboarding/StartupRecovery/DeviceRestoreView.swift
+++ b/ios/Cove/Flows/Onboarding/StartupRecovery/DeviceRestoreView.swift
@@ -119,32 +119,7 @@ private struct DeviceRestoreContent: View {
     }
 
     private var restoringHeroIcon: some View {
-        ZStack {
-            Circle()
-                .stroke(Color.btnGradientLight.opacity(0.12), lineWidth: 1)
-                .frame(width: 118, height: 118)
-
-            Circle()
-                .stroke(Color.btnGradientLight.opacity(0.18), lineWidth: 1)
-                .frame(width: 86, height: 86)
-
-            Circle()
-                .stroke(Color.btnGradientLight.opacity(0.34), lineWidth: 1)
-                .frame(width: 58, height: 58)
-
-            Circle()
-                .fill(Color.duskBlue.opacity(0.42))
-                .frame(width: 58, height: 58)
-
-            Circle()
-                .stroke(Color.btnGradientLight.opacity(0.7), lineWidth: 1.3)
-                .frame(width: 58, height: 58)
-
-            Image(systemName: "icloud.and.arrow.down")
-                .font(.system(size: 22, weight: .semibold))
-                .foregroundStyle(Color.btnGradientLight)
-        }
-        .frame(width: 118, height: 118)
+        OnboardingStatusHero(systemImage: "icloud.and.arrow.down", iconSize: 22)
     }
 
     @ViewBuilder

--- a/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SecretWordsScreen: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) private var app
     @Environment(AuthManager.self) private var auth
 
@@ -44,80 +45,22 @@ struct SecretWordsScreen: View {
     }
 
     var body: some View {
-        VStack {
-            Spacer()
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
 
             Group {
-                if let words {
-                    GroupBox {
-                        ColumnMajorGrid(items: words.allWords()) { _, word in
-                            HStack {
-                                Text("\(word.number).")
-                                    .fontWeight(.medium)
-                                    .foregroundStyle(.secondary)
-                                    .fontDesign(.monospaced)
-                                    .multilineTextAlignment(.leading)
-                                    .minimumScaleFactor(0.5)
-
-                                Text(word.word)
-                                    .fontWeight(.bold)
-                                    .fontDesign(.monospaced)
-                                    .multilineTextAlignment(.leading)
-                                    .minimumScaleFactor(0.75)
-                                    .lineLimit(1)
-                                    .fixedSize()
-
-                                Spacer()
-                            }
-                        }
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
                     }
-                    .frame(maxHeight: rowHeight * CGFloat(numberOfRows) + 32)
-                    .frame(width: screenWidth * 0.9)
-                    .font(.caption)
+                    .scrollIndicators(.hidden)
                 } else {
-                    Text(errorMessage ?? "Loading...")
-                }
-
-                Spacer()
-                Spacer()
-                Spacer()
-
-                VStack(spacing: 12) {
-                    HStack {
-                        Text("Recovery Words")
-                            .font(.system(size: 36, weight: .semibold))
-                            .foregroundColor(.white)
-                            .multilineTextAlignment(.leading)
-
-                        Spacer()
-                    }
-
-                    HStack {
-                        Text(
-                            "Your secret recovery words are the only way to recover your wallet if you lose your phone or switch to a different wallet. Whoever has your recovery words, controls your Bitcoin."
-                        )
-                        .multilineTextAlignment(.leading)
-                        .font(.footnote)
-                        .foregroundStyle(.coveLightGray.opacity(0.75))
-                        .fixedSize(horizontal: false, vertical: true)
-
-                        Spacer()
-                    }
-
-                    HStack {
-                        Text("Please save these words in a secure location.")
-                            .font(.subheadline)
-                            .multilineTextAlignment(.leading)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.white)
-                            .opacity(0.9)
-
-                        Spacer()
-                    }
+                    mainContent(usesFlexibleSpacing: true)
                 }
             }
         }
-        .padding()
         .onAppear {
             auth.lock()
             guard words == nil else { return }
@@ -156,6 +99,91 @@ struct SecretWordsScreen: View {
                 .opacity(0.5)
         )
         .background(Color.midnightBlue)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
+        VStack {
+            if usesFlexibleSpacing {
+                Spacer()
+            }
+
+            Group {
+                if let words {
+                    GroupBox {
+                        ColumnMajorGrid(items: words.allWords()) { _, word in
+                            HStack {
+                                Text("\(word.number).")
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(.secondary)
+                                    .fontDesign(.monospaced)
+                                    .multilineTextAlignment(.leading)
+                                    .minimumScaleFactor(0.5)
+
+                                Text(word.word)
+                                    .fontWeight(.bold)
+                                    .fontDesign(.monospaced)
+                                    .multilineTextAlignment(.leading)
+                                    .minimumScaleFactor(0.75)
+                                    .lineLimit(1)
+                                    .fixedSize()
+
+                                Spacer()
+                            }
+                        }
+                    }
+                    .frame(maxHeight: rowHeight * CGFloat(numberOfRows) + 32)
+                    .frame(width: screenWidth * 0.9)
+                    .font(.caption)
+                } else {
+                    Text(errorMessage ?? "Loading...")
+                }
+
+                if usesFlexibleSpacing {
+                    Spacer()
+                    Spacer()
+                    Spacer()
+                }
+
+                VStack(spacing: 12) {
+                    HStack {
+                        Text("Recovery Words")
+                            .font(.system(size: 36, weight: .semibold))
+                            .foregroundColor(.white)
+                            .multilineTextAlignment(.leading)
+
+                        Spacer()
+                    }
+
+                    HStack {
+                        Text(
+                            "Your secret recovery words are the only way to recover your wallet if you lose your phone or switch to a different wallet. Whoever has your recovery words, controls your Bitcoin."
+                        )
+                        .multilineTextAlignment(.leading)
+                        .font(.footnote)
+                        .foregroundStyle(.coveLightGray.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                        Spacer()
+                    }
+
+                    HStack {
+                        Text("Please save these words in a secure location.")
+                            .font(.subheadline)
+                            .multilineTextAlignment(.leading)
+                            .fontWeight(.bold)
+                            .foregroundStyle(.white)
+                            .opacity(0.9)
+
+                        Spacer()
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
@@ -46,7 +46,10 @@ struct SecretWordsScreen: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -180,10 +183,6 @@ struct SecretWordsScreen: View {
             }
         }
         .padding()
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
+++ b/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
@@ -7,6 +7,9 @@
 import Foundation
 import SwiftUI
 
+private let minimumSwipeToSendControlHeight: CGFloat = 70
+private let swipeToSendVerticalTextPadding: CGFloat = 48
+
 enum SendState: Hashable, Equatable {
     case idle
     case sending
@@ -25,17 +28,23 @@ struct SwipeToSendView: View {
     @State var offset: CGFloat = 0
     @State var isDragging = false
     @State var containerWidth = screenWidth
+    @State private var measuredTextHeight: CGFloat = 0
 
     var maxOffset: CGFloat {
-        containerWidth - 70
+        max(0, containerWidth - circleSize)
     }
 
-    var height: CGFloat = 70
+    var height: CGFloat {
+        max(minimumSwipeToSendControlHeight, measuredTextHeight + swipeToSendVerticalTextPadding)
+    }
+
     var circleSize: CGFloat {
         height
     }
 
     var fontOpacity: Double {
+        guard maxOffset > 0 else { return 1 }
+
         let percentDragged = offset / maxOffset
 
         if percentDragged == 0 {
@@ -75,7 +84,9 @@ struct SwipeToSendView: View {
                 Text("Swipe to Send")
                     .foregroundColor(colorScheme == .dark ? .white : .midnightBtn)
                     .fontWeight(.medium)
+                    .fixedSize(horizontal: false, vertical: true)
                     .opacity(fontOpacity)
+                    .recordSwipeToSendTextHeight()
 
                 Spacer()
             }
@@ -91,7 +102,7 @@ struct SwipeToSendView: View {
                         }
                     }
                 )
-                .offset(x: -containerWidth / 2 + 35 + offset)
+                .offset(x: -containerWidth / 2 + circleSize / 2 + offset)
                 .gesture(
                     DragGesture()
                         .onChanged { value in
@@ -101,7 +112,7 @@ struct SwipeToSendView: View {
                         .onEnded { _ in
                             isDragging = false
                             if offset > maxOffset * 0.8 {
-                                // Trigger send action
+                                // trigger send action
                                 withAnimation {
                                     offset = maxOffset
                                 }
@@ -121,15 +132,18 @@ struct SwipeToSendView: View {
                 case .idle: EmptyView()
                 case .sending: HStack(spacing: 16) {
                         Text("sending")
+                            .recordSwipeToSendTextHeight()
                         ThreeDotsAnimation()
                     }
                 case .sent: HStack(spacing: 12) {
                         Text("sent")
+                            .recordSwipeToSendTextHeight()
                         Image(systemName: "checkmark")
                             .foregroundColor(.green)
                     }
                 case .error: HStack(spacing: 10) {
                         Text("error")
+                            .recordSwipeToSendTextHeight()
                         Image(systemName: "xmark")
                             .foregroundColor(.red)
                             .onAppear {
@@ -143,10 +157,34 @@ struct SwipeToSendView: View {
         }
         .frame(height: height)
         .onChange(of: sendState, initial: true, onChangeSendState)
+        .onPreferenceChange(SwipeToSendTextHeightPreferenceKey.self) { height in
+            measuredTextHeight = height
+        }
         .onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: .global)
         } action: { frame in
             containerWidth = frame.width
+        }
+    }
+}
+
+private struct SwipeToSendTextHeightPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private extension View {
+    func recordSwipeToSendTextHeight() -> some View {
+        background {
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: SwipeToSendTextHeightPreferenceKey.self,
+                    value: proxy.size.height
+                )
+            }
         }
     }
 }

--- a/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
+++ b/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
@@ -7,7 +7,6 @@
 import Foundation
 import SwiftUI
 
-private let minimumSwipeToSendControlHeight: CGFloat = 70
 private let swipeToSendVerticalTextPadding: CGFloat = 48
 
 enum SendState: Hashable, Equatable {
@@ -18,6 +17,8 @@ enum SendState: Hashable, Equatable {
 }
 
 struct SwipeToSendView: View {
+    static let minimumControlHeight: CGFloat = 70
+
     @Environment(\.colorScheme) var colorScheme
 
     // args
@@ -35,7 +36,7 @@ struct SwipeToSendView: View {
     }
 
     var height: CGFloat {
-        max(minimumSwipeToSendControlHeight, measuredTextHeight + swipeToSendVerticalTextPadding)
+        max(Self.minimumControlHeight, measuredTextHeight + swipeToSendVerticalTextPadding)
     }
 
     var circleSize: CGFloat {

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -10,9 +10,6 @@ import SwiftUI
 
 private let sendConfirmationActionTopPadding: CGFloat = 20
 private let sendConfirmationActionBottomPadding: CGFloat = 24
-private let sendConfirmationActionReservedHeight: CGFloat = 70
-    + sendConfirmationActionTopPadding
-    + sendConfirmationActionBottomPadding
 
 struct SendFlowConfirmScreen: View {
     @Environment(AppManager.self) private var app
@@ -171,10 +168,8 @@ struct SendFlowConfirmScreen: View {
                         }
                         .scrollIndicators(.hidden)
                         .padding(.horizontal)
-                        .frame(
-                            width: geometry.size.width,
-                            height: max(0, geometry.size.height - sendConfirmationActionReservedHeight)
-                        )
+                        .frame(width: geometry.size.width)
+                        .frame(maxHeight: .infinity)
                         .background(Color.coveBg)
 
                         SwipeToSendView(sendState: $sendState) {
@@ -221,7 +216,6 @@ struct SendFlowConfirmScreen: View {
                             }
                         }
                         .frame(maxWidth: .infinity)
-                        .offset(y: -sendConfirmationActionBottomPadding)
                         .padding(.horizontal)
                         .padding(.top, sendConfirmationActionTopPadding)
                         .padding(.bottom, sendConfirmationActionBottomPadding)

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -8,6 +8,12 @@
 import Foundation
 import SwiftUI
 
+private let sendConfirmationActionTopPadding: CGFloat = 20
+private let sendConfirmationActionBottomPadding: CGFloat = 24
+private let sendConfirmationActionReservedHeight: CGFloat = 70
+    + sendConfirmationActionTopPadding
+    + sendConfirmationActionBottomPadding
+
 struct SendFlowConfirmScreen: View {
     @Environment(AppManager.self) private var app
     @Environment(AuthManager.self) private var auth
@@ -70,159 +76,171 @@ struct SendFlowConfirmScreen: View {
 
                 // MARK: CONTENT
 
-                ScrollView {
-                    VStack(spacing: 24) {
-                        // set amount
-                        VStack(spacing: 8) {
-                            HStack {
-                                Text("You're sending")
-                                    .font(.headline)
-                                    .fontWeight(.bold)
-
-                                Spacer()
-                            }
-                            .padding(.top, 6)
-
-                            HStack {
-                                Text("The amount they will receive")
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary.opacity(0.80))
-                                    .fontWeight(.medium)
-                                Spacer()
-                            }
-                        }
-                        .padding(.top, 10)
-
-                        // the amount in sats or btc
-                        VStack(spacing: 8) {
-                            HStack(alignment: .bottom) {
-                                Spacer()
-
-                                Text(manager.amountFmt(details.sendingAmount()))
-                                    .frame(minWidth: screenWidth / 2)
-                                    .font(.system(size: 48, weight: .bold))
-                                    .minimumScaleFactor(0.01)
-                                    .lineLimit(1)
-                                    .multilineTextAlignment(.center)
-
-                                Button(action: { showingMenu.toggle() }) {
-                                    HStack(spacing: 0) {
-                                        Text(metadata.selectedUnit == .sat ? "sats" : "btc")
-
-                                        Image(systemName: "chevron.down")
-                                            .font(.caption)
+                GeometryReader { geometry in
+                    VStack(spacing: 0) {
+                        ScrollView {
+                            VStack(spacing: 24) {
+                                // set amount
+                                VStack(spacing: 8) {
+                                    HStack {
+                                        Text("You're sending")
+                                            .font(.headline)
                                             .fontWeight(.bold)
-                                            .padding(.top, 2)
-                                            .padding(.leading, 4)
-                                    }
-                                    .frame(alignment: .trailing)
-                                }
-                                .foregroundStyle(.primary)
-                                .padding(.vertical, 10)
-                                .padding(.leading, 16)
-                                .popover(isPresented: $showingMenu) {
-                                    VStack(alignment: .center, spacing: 0) {
-                                        Button("sats") {
-                                            manager.dispatch(action: .updateUnit(.sat))
-                                            showingMenu = false
-                                        }
-                                        .padding(12)
-                                        .buttonStyle(.plain)
 
-                                        Divider()
-
-                                        Button("btc") {
-                                            manager.dispatch(action: .updateUnit(.btc))
-                                            showingMenu = false
-                                        }
-                                        .padding(12)
-                                        .buttonStyle(.plain)
+                                        Spacer()
                                     }
-                                    .padding(.vertical, 8)
-                                    .padding(.horizontal, 12)
-                                    .frame(minWidth: 120, maxWidth: 200)
-                                    .presentationCompactAdaptation(.popover)
-                                    .foregroundStyle(.primary.opacity(0.8))
+                                    .padding(.top, 6)
+
+                                    HStack {
+                                        Text("The amount they will receive")
+                                            .font(.footnote)
+                                            .foregroundStyle(.secondary.opacity(0.80))
+                                            .fontWeight(.medium)
+                                        Spacer()
+                                    }
                                 }
+                                .padding(.top, 10)
+
+                                // the amount in sats or btc
+                                VStack(spacing: 8) {
+                                    HStack(alignment: .bottom) {
+                                        Spacer()
+
+                                        Text(manager.amountFmt(details.sendingAmount()))
+                                            .frame(minWidth: screenWidth / 2)
+                                            .font(.system(size: 48, weight: .bold))
+                                            .minimumScaleFactor(0.01)
+                                            .lineLimit(1)
+                                            .multilineTextAlignment(.center)
+
+                                        Button(action: { showingMenu.toggle() }) {
+                                            HStack(spacing: 0) {
+                                                Text(metadata.selectedUnit == .sat ? "sats" : "btc")
+
+                                                Image(systemName: "chevron.down")
+                                                    .font(.caption)
+                                                    .fontWeight(.bold)
+                                                    .padding(.top, 2)
+                                                    .padding(.leading, 4)
+                                            }
+                                            .frame(alignment: .trailing)
+                                        }
+                                        .foregroundStyle(.primary)
+                                        .padding(.vertical, 10)
+                                        .padding(.leading, 16)
+                                        .popover(isPresented: $showingMenu) {
+                                            VStack(alignment: .center, spacing: 0) {
+                                                Button("sats") {
+                                                    manager.dispatch(action: .updateUnit(.sat))
+                                                    showingMenu = false
+                                                }
+                                                .padding(12)
+                                                .buttonStyle(.plain)
+
+                                                Divider()
+
+                                                Button("btc") {
+                                                    manager.dispatch(action: .updateUnit(.btc))
+                                                    showingMenu = false
+                                                }
+                                                .padding(12)
+                                                .buttonStyle(.plain)
+                                            }
+                                            .padding(.vertical, 8)
+                                            .padding(.horizontal, 12)
+                                            .frame(minWidth: 120, maxWidth: 200)
+                                            .presentationCompactAdaptation(.popover)
+                                            .foregroundStyle(.primary.opacity(0.8))
+                                        }
+                                    }
+                                    .frame(alignment: .center)
+
+                                    Text(fiatAmount)
+                                        .font(.title3)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.top, 8)
+
+                                SendFlowAccountSection(manager: manager)
+                                    .padding(.top)
+
+                                Divider()
+
+                                SendFlowDetailsView(manager: manager, details: details, prices: prices)
                             }
-                            .frame(alignment: .center)
-
-                            Text(fiatAmount)
-                                .font(.title3)
-                                .foregroundColor(.secondary)
                         }
-                        .padding(.top, 8)
+                        .scrollIndicators(.hidden)
+                        .padding(.horizontal)
+                        .frame(
+                            width: geometry.size.width,
+                            height: max(0, geometry.size.height - sendConfirmationActionReservedHeight)
+                        )
+                        .background(Color.coveBg)
 
-                        SendFlowAccountSection(manager: manager)
-                            .padding(.top)
-
-                        Divider()
-
-                        SendFlowDetailsView(manager: manager, details: details, prices: prices)
-                    }
-                }
-                .scrollIndicators(.hidden)
-                .padding(.horizontal)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.coveBg)
-
-                SwipeToSendView(sendState: $sendState) {
-                    sendState = .sending
-                    Task {
-                        do {
-                            switch input {
-                            case let .signedTransaction(txn):
-                                _ = try await manager.rust.broadcastTransaction(
-                                    signedTransaction: txn
-                                )
-                            case .signedPsbt:
-                                guard let finalizedTransaction else {
-                                    throw SendConfirmationError.unfinalizedSignedPsbt
-                                }
-                                _ = try await manager.rust.broadcastTransaction(
-                                    signedTransaction: finalizedTransaction
-                                )
-                            case .unsigned:
-                                _ = try await manager.rust.initiatePayment(
-                                    psbt: details.psbt(),
-                                    payjoinEndpoint: payjoinEndpoint
-                                )
-                                // for payjoin, stay in .sending — PayjoinTxBroadcast reconcile fires sendState = .sent
-                                if payjoinEndpoint == nil {
+                        SwipeToSendView(sendState: $sendState) {
+                            sendState = .sending
+                            Task {
+                                do {
+                                    switch input {
+                                    case let .signedTransaction(txn):
+                                        _ = try await manager.rust.broadcastTransaction(
+                                            signedTransaction: txn
+                                        )
+                                    case .signedPsbt:
+                                        guard let finalizedTransaction else {
+                                            throw SendConfirmationError.unfinalizedSignedPsbt
+                                        }
+                                        _ = try await manager.rust.broadcastTransaction(
+                                            signedTransaction: finalizedTransaction
+                                        )
+                                    case .unsigned:
+                                        _ = try await manager.rust.initiatePayment(
+                                            psbt: details.psbt(),
+                                            payjoinEndpoint: payjoinEndpoint
+                                        )
+                                        // for payjoin, stay in .sending — PayjoinTxBroadcast reconcile fires sendState = .sent
+                                        if payjoinEndpoint == nil {
+                                            sendState = .sent
+                                            presenter.confirmationAlertState = .init(.sent(id))
+                                            auth.unlock()
+                                        }
+                                        return
+                                    }
                                     sendState = .sent
                                     presenter.confirmationAlertState = .init(.sent(id))
                                     auth.unlock()
+                                } catch let error as WalletManagerError {
+                                    sendState = .error(error.description)
+                                    presenter.confirmationAlertState = .init(.broadcastError(error.description))
+                                } catch {
+                                    sendState = .error(error.localizedDescription)
+                                    presenter.confirmationAlertState = .init(
+                                        .broadcastError(error.localizedDescription)
+                                    )
                                 }
-                                return
                             }
-                            sendState = .sent
-                            presenter.confirmationAlertState = .init(.sent(id))
-                            auth.unlock()
-                        } catch let error as WalletManagerError {
-                            sendState = .error(error.description)
-                            presenter.confirmationAlertState = .init(.broadcastError(error.description))
-                        } catch {
-                            sendState = .error(error.localizedDescription)
-                            presenter.confirmationAlertState = .init(
-                                .broadcastError(error.localizedDescription)
-                            )
+                        }
+                        .frame(maxWidth: .infinity)
+                        .offset(y: -sendConfirmationActionBottomPadding)
+                        .padding(.horizontal)
+                        .padding(.top, sendConfirmationActionTopPadding)
+                        .padding(.bottom, sendConfirmationActionBottomPadding)
+                        .background(Color.coveBg)
+                        .onAppear {
+                            lockingTask = Task {
+                                try? await Task.sleep(for: .milliseconds(50))
+                                if Task.isCancelled { return }
+
+                                if metadata.walletType == .hot { auth.lock() }
+                            }
                         }
                     }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal)
-                .padding(.bottom, 6)
-                .padding(.top, 20)
-                .background(Color.coveBg)
-                .onAppear {
-                    lockingTask = Task {
-                        try? await Task.sleep(for: .milliseconds(50))
-                        if Task.isCancelled { return }
-
-                        if metadata.walletType == .hot { auth.lock() }
-                    }
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .background(Color.coveBg)
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.coveBg)
             .onDisappear {
                 lockingTask?.cancel()
                 guard let lockedAt = auth.lockedAt else { return }

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -10,6 +10,10 @@ import SwiftUI
 
 private let sendConfirmationActionTopPadding: CGFloat = 20
 private let sendConfirmationActionBottomPadding: CGFloat = 24
+private let sendConfirmationActionReservedHeight =
+    SwipeToSendView.minimumControlHeight +
+    sendConfirmationActionTopPadding +
+    sendConfirmationActionBottomPadding
 
 struct SendFlowConfirmScreen: View {
     @Environment(AppManager.self) private var app
@@ -74,152 +78,156 @@ struct SendFlowConfirmScreen: View {
                 // MARK: CONTENT
 
                 GeometryReader { geometry in
-                    VStack(spacing: 0) {
-                        ScrollView {
-                            VStack(spacing: 24) {
-                                // set amount
-                                VStack(spacing: 8) {
-                                    HStack {
-                                        Text("You're sending")
-                                            .font(.headline)
-                                            .fontWeight(.bold)
+                    ScrollView {
+                        VStack(spacing: 24) {
+                            // set amount
+                            VStack(spacing: 8) {
+                                HStack {
+                                    Text("You're sending")
+                                        .font(.headline)
+                                        .fontWeight(.bold)
 
-                                        Spacer()
-                                    }
-                                    .padding(.top, 6)
-
-                                    HStack {
-                                        Text("The amount they will receive")
-                                            .font(.footnote)
-                                            .foregroundStyle(.secondary.opacity(0.80))
-                                            .fontWeight(.medium)
-                                        Spacer()
-                                    }
+                                    Spacer()
                                 }
-                                .padding(.top, 10)
+                                .padding(.top, 6)
 
-                                // the amount in sats or btc
-                                VStack(spacing: 8) {
-                                    HStack(alignment: .bottom) {
-                                        Spacer()
-
-                                        Text(manager.amountFmt(details.sendingAmount()))
-                                            .frame(minWidth: screenWidth / 2)
-                                            .font(.system(size: 48, weight: .bold))
-                                            .minimumScaleFactor(0.01)
-                                            .lineLimit(1)
-                                            .multilineTextAlignment(.center)
-
-                                        Button(action: { showingMenu.toggle() }) {
-                                            HStack(spacing: 0) {
-                                                Text(metadata.selectedUnit == .sat ? "sats" : "btc")
-
-                                                Image(systemName: "chevron.down")
-                                                    .font(.caption)
-                                                    .fontWeight(.bold)
-                                                    .padding(.top, 2)
-                                                    .padding(.leading, 4)
-                                            }
-                                            .frame(alignment: .trailing)
-                                        }
-                                        .foregroundStyle(.primary)
-                                        .padding(.vertical, 10)
-                                        .padding(.leading, 16)
-                                        .popover(isPresented: $showingMenu) {
-                                            VStack(alignment: .center, spacing: 0) {
-                                                Button("sats") {
-                                                    manager.dispatch(action: .updateUnit(.sat))
-                                                    showingMenu = false
-                                                }
-                                                .padding(12)
-                                                .buttonStyle(.plain)
-
-                                                Divider()
-
-                                                Button("btc") {
-                                                    manager.dispatch(action: .updateUnit(.btc))
-                                                    showingMenu = false
-                                                }
-                                                .padding(12)
-                                                .buttonStyle(.plain)
-                                            }
-                                            .padding(.vertical, 8)
-                                            .padding(.horizontal, 12)
-                                            .frame(minWidth: 120, maxWidth: 200)
-                                            .presentationCompactAdaptation(.popover)
-                                            .foregroundStyle(.primary.opacity(0.8))
-                                        }
-                                    }
-                                    .frame(alignment: .center)
-
-                                    Text(fiatAmount)
-                                        .font(.title3)
-                                        .foregroundColor(.secondary)
+                                HStack {
+                                    Text("The amount they will receive")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary.opacity(0.80))
+                                        .fontWeight(.medium)
+                                    Spacer()
                                 }
-                                .padding(.top, 8)
-
-                                SendFlowAccountSection(manager: manager)
-                                    .padding(.top)
-
-                                Divider()
-
-                                SendFlowDetailsView(manager: manager, details: details, prices: prices)
                             }
+                            .padding(.top, 10)
+
+                            // the amount in sats or btc
+                            VStack(spacing: 8) {
+                                HStack(alignment: .bottom) {
+                                    Spacer()
+
+                                    Text(manager.amountFmt(details.sendingAmount()))
+                                        .frame(minWidth: screenWidth / 2)
+                                        .font(.system(size: 48, weight: .bold))
+                                        .minimumScaleFactor(0.01)
+                                        .lineLimit(1)
+                                        .multilineTextAlignment(.center)
+
+                                    Button(action: { showingMenu.toggle() }) {
+                                        HStack(spacing: 0) {
+                                            Text(metadata.selectedUnit == .sat ? "sats" : "btc")
+
+                                            Image(systemName: "chevron.down")
+                                                .font(.caption)
+                                                .fontWeight(.bold)
+                                                .padding(.top, 2)
+                                                .padding(.leading, 4)
+                                        }
+                                        .frame(alignment: .trailing)
+                                    }
+                                    .foregroundStyle(.primary)
+                                    .padding(.vertical, 10)
+                                    .padding(.leading, 16)
+                                    .popover(isPresented: $showingMenu) {
+                                        VStack(alignment: .center, spacing: 0) {
+                                            Button("sats") {
+                                                manager.dispatch(action: .updateUnit(.sat))
+                                                showingMenu = false
+                                            }
+                                            .padding(12)
+                                            .buttonStyle(.plain)
+
+                                            Divider()
+
+                                            Button("btc") {
+                                                manager.dispatch(action: .updateUnit(.btc))
+                                                showingMenu = false
+                                            }
+                                            .padding(12)
+                                            .buttonStyle(.plain)
+                                        }
+                                        .padding(.vertical, 8)
+                                        .padding(.horizontal, 12)
+                                        .frame(minWidth: 120, maxWidth: 200)
+                                        .presentationCompactAdaptation(.popover)
+                                        .foregroundStyle(.primary.opacity(0.8))
+                                    }
+                                }
+                                .frame(alignment: .center)
+
+                                Text(fiatAmount)
+                                    .font(.title3)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.top, 8)
+
+                            SendFlowAccountSection(manager: manager)
+                                .padding(.top)
+
+                            Divider()
+
+                            SendFlowDetailsView(manager: manager, details: details, prices: prices)
                         }
-                        .scrollIndicators(.hidden)
-                        .padding(.horizontal)
-                        .frame(width: geometry.size.width)
-                        .frame(maxHeight: .infinity)
-                        .background(Color.coveBg)
-
-                        SwipeToSendView(sendState: $sendState) {
-                            sendState = .sending
-                            Task {
-                                do {
-                                    switch input {
-                                    case let .signedTransaction(txn):
-                                        _ = try await manager.rust.broadcastTransaction(
-                                            signedTransaction: txn
-                                        )
-                                    case .signedPsbt:
-                                        guard let finalizedTransaction else {
-                                            throw SendConfirmationError.unfinalizedSignedPsbt
+                        .padding(.bottom, sendConfirmationActionReservedHeight)
+                    }
+                    .scrollIndicators(.hidden)
+                    .padding(.horizontal)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .background(Color.coveBg)
+                    .overlay(alignment: .bottom) {
+                        VStack(spacing: 0) {
+                            SwipeToSendView(sendState: $sendState) {
+                                sendState = .sending
+                                Task {
+                                    do {
+                                        switch input {
+                                        case let .signedTransaction(txn):
+                                            _ = try await manager.rust.broadcastTransaction(
+                                                signedTransaction: txn
+                                            )
+                                        case .signedPsbt:
+                                            guard let finalizedTransaction else {
+                                                throw SendConfirmationError.unfinalizedSignedPsbt
+                                            }
+                                            _ = try await manager.rust.broadcastTransaction(
+                                                signedTransaction: finalizedTransaction
+                                            )
+                                        case .unsigned:
+                                            _ = try await manager.rust.initiatePayment(
+                                                psbt: details.psbt(),
+                                                payjoinEndpoint: payjoinEndpoint
+                                            )
+                                            // for payjoin, stay in .sending — PayjoinTxBroadcast reconcile fires sendState = .sent
+                                            if payjoinEndpoint == nil {
+                                                sendState = .sent
+                                                presenter.confirmationAlertState = .init(.sent(id))
+                                                auth.unlock()
+                                            }
+                                            return
                                         }
-                                        _ = try await manager.rust.broadcastTransaction(
-                                            signedTransaction: finalizedTransaction
+                                        sendState = .sent
+                                        presenter.confirmationAlertState = .init(.sent(id))
+                                        auth.unlock()
+                                    } catch let error as WalletManagerError {
+                                        sendState = .error(error.description)
+                                        presenter.confirmationAlertState = .init(.broadcastError(error.description))
+                                    } catch {
+                                        sendState = .error(error.localizedDescription)
+                                        presenter.confirmationAlertState = .init(
+                                            .broadcastError(error.localizedDescription)
                                         )
-                                    case .unsigned:
-                                        _ = try await manager.rust.initiatePayment(
-                                            psbt: details.psbt(),
-                                            payjoinEndpoint: payjoinEndpoint
-                                        )
-                                        // for payjoin, stay in .sending — PayjoinTxBroadcast reconcile fires sendState = .sent
-                                        if payjoinEndpoint == nil {
-                                            sendState = .sent
-                                            presenter.confirmationAlertState = .init(.sent(id))
-                                            auth.unlock()
-                                        }
-                                        return
                                     }
-                                    sendState = .sent
-                                    presenter.confirmationAlertState = .init(.sent(id))
-                                    auth.unlock()
-                                } catch let error as WalletManagerError {
-                                    sendState = .error(error.description)
-                                    presenter.confirmationAlertState = .init(.broadcastError(error.description))
-                                } catch {
-                                    sendState = .error(error.localizedDescription)
-                                    presenter.confirmationAlertState = .init(
-                                        .broadcastError(error.localizedDescription)
-                                    )
                                 }
                             }
+
+                            Color.clear
+                                .frame(height: sendConfirmationActionBottomPadding)
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.horizontal)
                         .padding(.top, sendConfirmationActionTopPadding)
-                        .padding(.bottom, sendConfirmationActionBottomPadding)
                         .background(Color.coveBg)
+                        .offset(y: -sendConfirmationActionBottomPadding)
                         .onAppear {
                             lockingTask = Task {
                                 try? await Task.sleep(for: .milliseconds(50))
@@ -229,8 +237,6 @@ struct SendFlowConfirmScreen: View {
                             }
                         }
                     }
-                    .frame(width: geometry.size.width, height: geometry.size.height)
-                    .background(Color.coveBg)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerAdvancedChainCode.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerAdvancedChainCode.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct TapSignerAdvancedChainCode: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) var app
     @Environment(TapSignerManager.self) var manager
 
@@ -21,8 +22,29 @@ struct TapSignerAdvancedChainCode: View {
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .contentTransition(.opacity)
+        .background(backgroundView)
+        .navigationBarHidden(true)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack(spacing: 20) {
-            // Top Back Button
             HStack {
                 Button(action: { manager.popRoute() }) {
                     Image(systemName: "chevron.left")
@@ -36,7 +58,9 @@ struct TapSignerAdvancedChainCode: View {
             .foregroundStyle(.primary)
             .fontWeight(.semibold)
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack {
                 Text("Advanced Setup")
@@ -45,7 +69,6 @@ struct TapSignerAdvancedChainCode: View {
                     .padding(.bottom, 5)
             }
 
-            // Description Text
             VStack(spacing: 12) {
                 Group {
                     Text("Enter your custom 32-byte chain code below. If you’re unsure, select automatic on the previous screen.")
@@ -79,7 +102,7 @@ struct TapSignerAdvancedChainCode: View {
                     .padding(.bottom, 30)
             }
             .contentShape(Rectangle())
-            .padding(.bottom, screenHeight * 0.1)
+            .padding(.bottom, usesFlexibleSpacing ? screenHeight * 0.1 : 0)
 
             Button("Continue") {
                 manager.navigate(to: .startingPin(tapSigner: tapSigner, chainCode: chainCode))
@@ -94,21 +117,23 @@ struct TapSignerAdvancedChainCode: View {
             .padding(.bottom, 30)
             .disabled(isButtonDisabled)
         }
-        .contentTransition(.opacity)
-        .edgesIgnoringSafeArea(.all)
-        .background(
-            VStack {
-                Image(.chainCodePattern)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .ignoresSafeArea(edges: .all)
-                    .padding(.top, 5)
+    }
 
-                Spacer()
-            }
-            .opacity(0.8)
-        )
-        .navigationBarHidden(true)
+    private var backgroundView: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
+        }
+        .opacity(0.8)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerAdvancedChainCode.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerAdvancedChainCode.swift
@@ -23,7 +23,10 @@ struct TapSignerAdvancedChainCode: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -39,7 +42,7 @@ struct TapSignerAdvancedChainCode: View {
             }
         }
         .contentTransition(.opacity)
-        .background(backgroundView)
+        .background(TapSignerResultBackground())
         .navigationBarHidden(true)
     }
 
@@ -117,23 +120,6 @@ struct TapSignerAdvancedChainCode: View {
             .padding(.bottom, 30)
             .disabled(isButtonDisabled)
         }
-    }
-
-    private var backgroundView: some View {
-        VStack {
-            Image(.chainCodePattern)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .ignoresSafeArea(edges: .all)
-                .padding(.top, 5)
-
-            Spacer()
-        }
-        .opacity(0.8)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerChooseChainCode.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerChooseChainCode.swift
@@ -16,7 +16,10 @@ struct TapSignerChooseChainCode: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -32,7 +35,7 @@ struct TapSignerChooseChainCode: View {
             }
         }
         .contentTransition(.opacity)
-        .background(backgroundView)
+        .background(TapSignerResultBackground())
         .navigationBarHidden(true)
     }
 
@@ -120,23 +123,6 @@ struct TapSignerChooseChainCode: View {
             }
             .contentShape(Rectangle())
         }
-    }
-
-    private var backgroundView: some View {
-        VStack {
-            Image(.chainCodePattern)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .ignoresSafeArea(edges: .all)
-                .padding(.top, 5)
-
-            Spacer()
-        }
-        .opacity(0.8)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerChooseChainCode.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerChooseChainCode.swift
@@ -8,14 +8,36 @@
 import SwiftUI
 
 struct TapSignerChooseChainCode: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) var app
     @Environment(TapSignerManager.self) var manager
 
     let tapSigner: TapSigner
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .contentTransition(.opacity)
+        .background(backgroundView)
+        .navigationBarHidden(true)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack {
-            // Top Cancel Button
             HStack {
                 Button(action: { app.sheetState = .none }) {
                     Text("Cancel")
@@ -27,9 +49,10 @@ struct TapSignerChooseChainCode: View {
             .foregroundStyle(.primary)
             .fontWeight(.semibold)
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
-            // Title with Underline
             VStack {
                 Text("Setup Chain Code")
                     .font(.largeTitle)
@@ -37,7 +60,6 @@ struct TapSignerChooseChainCode: View {
                     .padding(.bottom, 5)
             }
 
-            // Description Text
             VStack(spacing: 12) {
                 Group {
                     Text("A chain code works with your private key to generate Bitcoin addresses")
@@ -84,9 +106,10 @@ struct TapSignerChooseChainCode: View {
             .foregroundStyle(.primary)
             .padding(.top, 50)
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
-            // Advanced Setup Link
             Button(action: {
                 manager.navigate(to: .initAdvanced(tapSigner))
             }) {
@@ -97,21 +120,23 @@ struct TapSignerChooseChainCode: View {
             }
             .contentShape(Rectangle())
         }
-        .contentTransition(.opacity)
-        .edgesIgnoringSafeArea(.all)
-        .background(
-            VStack {
-                Image(.chainCodePattern)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .ignoresSafeArea(edges: .all)
-                    .padding(.top, 5)
+    }
 
-                Spacer()
-            }
-            .opacity(0.8)
-        )
-        .navigationBarHidden(true)
+    private var backgroundView: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
+        }
+        .opacity(0.8)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerContainer.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerContainer.swift
@@ -129,6 +129,21 @@ struct TapSignerContainer: View {
     }
 }
 
+struct TapSignerResultBackground: View {
+    var body: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
+        }
+        .opacity(0.8)
+    }
+}
+
 #Preview {
     TapSignerContainer(route: .initSelect(tapSignerPreviewNew(preview: true)))
 }

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerImportRetryView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerImportRetryView.swift
@@ -17,7 +17,10 @@ struct TapSignerImportRetry: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -32,7 +35,7 @@ struct TapSignerImportRetry: View {
                 }
             }
         }
-        .background(backgroundView)
+        .background(TapSignerResultBackground())
         .scrollIndicators(.hidden)
         .navigationBarHidden(true)
     }
@@ -103,23 +106,6 @@ struct TapSignerImportRetry: View {
                 .padding(.horizontal)
             }
         }
-    }
-
-    private var backgroundView: some View {
-        VStack {
-            Image(.chainCodePattern)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .ignoresSafeArea(edges: .all)
-                .padding(.top, 5)
-
-            Spacer()
-        }
-        .opacity(0.8)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerImportRetryView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerImportRetryView.swift
@@ -9,12 +9,35 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct TapSignerImportRetry: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) private var app
     @Environment(TapSignerManager.self) private var manager
 
     let tapSigner: TapSigner
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .background(backgroundView)
+        .scrollIndicators(.hidden)
+        .navigationBarHidden(true)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack(spacing: 40) {
             VStack {
                 HStack {
@@ -30,7 +53,9 @@ struct TapSignerImportRetry: View {
                 .fontWeight(.semibold)
             }
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 20) {
                 Image(systemName: "x.circle.fill")
@@ -52,7 +77,9 @@ struct TapSignerImportRetry: View {
             }
             .padding(.horizontal)
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 14) {
                 Button("Retry") {
@@ -76,20 +103,23 @@ struct TapSignerImportRetry: View {
                 .padding(.horizontal)
             }
         }
-        .background(
-            VStack {
-                Image(.chainCodePattern)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .ignoresSafeArea(edges: .all)
-                    .padding(.top, 5)
+    }
 
-                Spacer()
-            }
-            .opacity(0.8)
-        )
-        .scrollIndicators(.hidden)
-        .navigationBarHidden(true)
+    private var backgroundView: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
+        }
+        .opacity(0.8)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerImportSuccessView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerImportSuccessView.swift
@@ -30,7 +30,10 @@ struct TapSignerImportSuccess: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -48,7 +51,7 @@ struct TapSignerImportSuccess: View {
         .onAppear {
             saveWallet()
         }
-        .background(backgroundView)
+        .background(TapSignerResultBackground())
         .scrollIndicators(.hidden)
         .navigationBarHidden(true)
     }
@@ -104,23 +107,6 @@ struct TapSignerImportSuccess: View {
             }
         }
         .padding(.horizontal)
-    }
-
-    private var backgroundView: some View {
-        VStack {
-            Image(.chainCodePattern)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .ignoresSafeArea(edges: .all)
-                .padding(.top, 5)
-
-            Spacer()
-        }
-        .opacity(0.8)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerImportSuccessView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerImportSuccessView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct TapSignerImportSuccess: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) private var app
     @Environment(TapSignerManager.self) private var manager
 
@@ -28,6 +29,31 @@ struct TapSignerImportSuccess: View {
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .onAppear {
+            saveWallet()
+        }
+        .background(backgroundView)
+        .scrollIndicators(.hidden)
+        .navigationBarHidden(true)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack(spacing: 40) {
             VStack {
                 HStack {
@@ -43,7 +69,9 @@ struct TapSignerImportSuccess: View {
                 .fontWeight(.semibold)
             }
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 20) {
                 Image(systemName: "checkmark.circle.fill")
@@ -62,7 +90,9 @@ struct TapSignerImportSuccess: View {
                 }
             }
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 14) {
                 Button("Continue") {
@@ -74,23 +104,23 @@ struct TapSignerImportSuccess: View {
             }
         }
         .padding(.horizontal)
-        .onAppear {
-            saveWallet()
-        }
-        .background(
-            VStack {
-                Image(.chainCodePattern)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .ignoresSafeArea(edges: .all)
-                    .padding(.top, 5)
+    }
 
-                Spacer()
-            }
-            .opacity(0.8)
-        )
-        .scrollIndicators(.hidden)
-        .navigationBarHidden(true)
+    private var backgroundView: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
+        }
+        .opacity(0.8)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerSetupRetryView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerSetupRetryView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct TapSignerSetupRetry: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) private var app
     @Environment(TapSignerManager.self) private var manager
 
@@ -16,6 +17,28 @@ struct TapSignerSetupRetry: View {
     let response: SetupCmdResponse
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .background(backgroundView)
+        .scrollIndicators(.hidden)
+        .navigationBarHidden(true)
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack(spacing: 40) {
             VStack {
                 HStack {
@@ -31,7 +54,9 @@ struct TapSignerSetupRetry: View {
                 .fontWeight(.semibold)
             }
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 20) {
                 Image(systemName: "x.circle.fill")
@@ -53,7 +78,9 @@ struct TapSignerSetupRetry: View {
             }
             .padding(.horizontal)
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 14) {
                 Button("Retry") {
@@ -80,20 +107,23 @@ struct TapSignerSetupRetry: View {
                 .padding(.horizontal)
             }
         }
-        .background(
-            VStack {
-                Image(.chainCodePattern)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .ignoresSafeArea(edges: .all)
-                    .padding(.top, 5)
+    }
 
-                Spacer()
-            }
-            .opacity(0.8)
-        )
-        .scrollIndicators(.hidden)
-        .navigationBarHidden(true)
+    private var backgroundView: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
+        }
+        .opacity(0.8)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerSetupRetryView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerSetupRetryView.swift
@@ -18,7 +18,10 @@ struct TapSignerSetupRetry: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -33,7 +36,7 @@ struct TapSignerSetupRetry: View {
                 }
             }
         }
-        .background(backgroundView)
+        .background(TapSignerResultBackground())
         .scrollIndicators(.hidden)
         .navigationBarHidden(true)
     }
@@ -107,23 +110,6 @@ struct TapSignerSetupRetry: View {
                 .padding(.horizontal)
             }
         }
-    }
-
-    private var backgroundView: some View {
-        VStack {
-            Image(.chainCodePattern)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .ignoresSafeArea(edges: .all)
-                .padding(.top, 5)
-
-            Spacer()
-        }
-        .opacity(0.8)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerSetupSuccessView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerSetupSuccessView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct TapSignerSetupSuccess: View {
+    @Environment(\.sizeCategory) private var sizeCategory
     @Environment(AppManager.self) private var app
     @Environment(TapSignerManager.self) private var manager
 
@@ -33,6 +34,31 @@ struct TapSignerSetupSuccess: View {
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+
+            Group {
+                if scrollableLayout {
+                    ScrollView {
+                        mainContent(usesFlexibleSpacing: false)
+                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
+                            .safeAreaPadding(.bottom, 24)
+                    }
+                    .scrollIndicators(.hidden)
+                } else {
+                    mainContent(usesFlexibleSpacing: true)
+                }
+            }
+        }
+        .background(backgroundView)
+        .scrollIndicators(.hidden)
+        .navigationBarHidden(true)
+        .onAppear {
+            saveWallet()
+        }
+    }
+
+    private func mainContent(usesFlexibleSpacing: Bool) -> some View {
         VStack(spacing: 40) {
             VStack {
                 HStack {
@@ -48,7 +74,9 @@ struct TapSignerSetupSuccess: View {
                 .fontWeight(.semibold)
             }
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 20) {
                 Image(systemName: "checkmark.circle.fill")
@@ -111,7 +139,9 @@ struct TapSignerSetupSuccess: View {
             .font(.footnote)
             .fontWeight(.semibold)
 
-            Spacer()
+            if usesFlexibleSpacing {
+                Spacer()
+            }
 
             VStack(spacing: 14) {
                 Button("Continue") {
@@ -123,23 +153,23 @@ struct TapSignerSetupSuccess: View {
             }
         }
         .padding(.horizontal)
-        .background(
-            VStack {
-                Image(.chainCodePattern)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .ignoresSafeArea(edges: .all)
-                    .padding(.top, 5)
+    }
 
-                Spacer()
-            }
-            .opacity(0.8)
-        )
-        .scrollIndicators(.hidden)
-        .navigationBarHidden(true)
-        .onAppear {
-            saveWallet()
+    private var backgroundView: some View {
+        VStack {
+            Image(.chainCodePattern)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .ignoresSafeArea(edges: .all)
+                .padding(.top, 5)
+
+            Spacer()
         }
+        .opacity(0.8)
+    }
+
+    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
+        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Flows/TapSignerFlow/TapSignerSetupSuccessView.swift
+++ b/ios/Cove/Flows/TapSignerFlow/TapSignerSetupSuccessView.swift
@@ -35,7 +35,10 @@ struct TapSignerSetupSuccess: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesScrollableLayout(availableHeight: proxy.size.height)
+            let scrollableLayout = usesCompactLayout(
+                sizeCategory: sizeCategory,
+                availableHeight: proxy.size.height
+            )
 
             Group {
                 if scrollableLayout {
@@ -50,7 +53,7 @@ struct TapSignerSetupSuccess: View {
                 }
             }
         }
-        .background(backgroundView)
+        .background(TapSignerResultBackground())
         .scrollIndicators(.hidden)
         .navigationBarHidden(true)
         .onAppear {
@@ -153,23 +156,6 @@ struct TapSignerSetupSuccess: View {
             }
         }
         .padding(.horizontal)
-    }
-
-    private var backgroundView: some View {
-        VStack {
-            Image(.chainCodePattern)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .ignoresSafeArea(edges: .all)
-                .padding(.top, 5)
-
-            Spacer()
-        }
-        .opacity(0.8)
-    }
-
-    private func usesScrollableLayout(availableHeight: CGFloat) -> Bool {
-        sizeCategory >= .extraExtraLarge || availableHeight <= 812
     }
 }
 

--- a/ios/Cove/Views/OnboardingRecoveryTheme.swift
+++ b/ios/Cove/Views/OnboardingRecoveryTheme.swift
@@ -41,7 +41,8 @@ struct OnboardingStatusHero: View {
     var fillColor: Color = .duskBlue.opacity(0.42)
     var pulse = false
     var iconSize: CGFloat = 24
-    var ringSizes: [CGFloat] = [118, 86, 58]
+    var innerBadgeSize: CGFloat = 68
+    var ringSizes: [CGFloat] = [118, 86, 68]
 
     var body: some View {
         Group {
@@ -69,11 +70,11 @@ struct OnboardingStatusHero: View {
 
             Circle()
                 .fill(fillColor)
-                .frame(width: 58, height: 58)
+                .frame(width: innerBadgeSize, height: innerBadgeSize)
 
             Circle()
                 .stroke(tint.opacity(pulse ? 0.88 : 0.7), lineWidth: 1.3)
-                .frame(width: 58, height: 58)
+                .frame(width: innerBadgeSize, height: innerBadgeSize)
 
             Image(systemName: systemImage)
                 .font(.system(size: iconSize, weight: .semibold))
@@ -110,6 +111,16 @@ struct OnboardingStatusHero: View {
         default: 0.04
         }
     }
+}
+
+#Preview("Onboarding Status Hero - Cloud") {
+    ZStack {
+        Color.midnightBlue
+            .ignoresSafeArea()
+
+        OnboardingStatusHero(systemImage: "icloud")
+    }
+    .frame(width: 160, height: 160)
 }
 
 struct OnboardingThinProgressBar: View {

--- a/ios/CoveTests/AmountFormatterTests.swift
+++ b/ios/CoveTests/AmountFormatterTests.swift
@@ -73,7 +73,8 @@ final class AmountFormatterTests: XCTestCase {
     }
 
     func testSentAndReceivedFormattingMatchesExistingHelpers() {
-        let metadata = walletMetadataPreview()
+        var metadata = walletMetadataPreview()
+        metadata.sensitiveVisible = false
         let transaction = transactionsPreviewNew(confirmed: 0, unconfirmed: 1)[0]
         let sentAndReceived = transaction.sentAndReceived()
         let formatter = AmountFormatter(metadata: metadata)

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -409,6 +409,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         try saveScreenshotIfRequested(image)
         try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-create-after.png")
         try assertNavigationChromeDoesNotShowWordCardBackground(in: image)
+        try assertRecoveryWordCardsStayInsideHorizontalViewport(in: image)
         try assertPrimaryActionIsNotClippedAtBottom(in: image)
 
         let recognizedText = try normalizedRecognizedText(in: image)
@@ -420,6 +421,34 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         XCTAssertTrue(
             recognizedText.contains("recovery words"),
             "expected compact recovery words screen to keep the word-copy context visible, got:\n\(recognizedText)"
+        )
+    }
+
+    func testLargeRecoveryWordsLayoutKeepsWordCardsInsideViewport() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 430, height: 932)
+        let manager = PendingWalletManager(numberOfWords: .twelve)
+        let view = NavigationStack {
+            WordsView(
+                manager: manager,
+                initialTabIndex: manager.rust.bip39WordsGrouped().count - 1
+            )
+            .environment(AppManager.shared)
+        }
+        .frame(width: size.width, height: size.height)
+        let image = render(view: view, size: size)
+        addScreenshotAttachment(image, name: "large-recovery-words-final-page")
+        try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-create-large-after.png")
+        try assertNavigationChromeDoesNotShowWordCardBackground(in: image)
+        try assertRecoveryWordCardsStayInsideHorizontalViewport(in: image)
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("save wallet"),
+            "expected large recovery words screen to show Save Wallet, got:\n\(recognizedText)"
         )
     }
 
@@ -712,6 +741,57 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             file: file,
             line: line
         )
+    }
+
+    private func assertRecoveryWordCardsStayInsideHorizontalViewport(
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let scale = CGFloat(cgImage.width) / image.size.width
+        let edgeWidth = max(Int(8 * scale), 1)
+        let bandTop = max(Int(110 * scale), 0)
+        let bandHeight = min(Int(300 * scale), cgImage.height - bandTop)
+        let leftEdge = CGRect(x: 0, y: bandTop, width: edgeWidth, height: bandHeight)
+        let rightEdge = CGRect(
+            x: cgImage.width - edgeWidth,
+            y: bandTop,
+            width: edgeWidth,
+            height: bandHeight
+        )
+        let leftCardPixels = try lightWordCardPixelCount(in: cgImage, rect: leftEdge)
+        let rightCardPixels = try lightWordCardPixelCount(in: cgImage, rect: rightEdge)
+        let maximumAllowedEdgePixels = max(1, edgeWidth * bandHeight / 25)
+
+        XCTAssertLessThan(
+            leftCardPixels,
+            maximumAllowedEdgePixels,
+            "expected recovery word cards to stay inside the left viewport edge",
+            file: file,
+            line: line
+        )
+        XCTAssertLessThan(
+            rightCardPixels,
+            maximumAllowedEdgePixels,
+            "expected recovery word cards to stay inside the right viewport edge",
+            file: file,
+            line: line
+        )
+    }
+
+    private func lightWordCardPixelCount(in image: CGImage, rect: CGRect) throws -> Int {
+        let croppedImage = try XCTUnwrap(image.cropping(to: rect))
+        let pixels = try rgbaPixels(in: croppedImage)
+
+        return stride(from: 0, to: pixels.count, by: 4).count { offset in
+            pixels[offset] > 190 &&
+                pixels[offset] < 245 &&
+                pixels[offset + 1] > 195 &&
+                pixels[offset + 1] < 245 &&
+                pixels[offset + 2] > 200 &&
+                pixels[offset + 2] < 245
+        }
     }
 
     private func rgbaPixels(in image: CGImage) throws -> [UInt8] {

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -1,0 +1,203 @@
+@testable import Cove
+import CoveCore
+import SwiftUI
+import Vision
+import XCTest
+
+@MainActor
+final class HotWalletCreateScreenLayoutTests: XCTestCase {
+    func testCompactRecoveryWordsLayoutCanScrollToPrimaryAction() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let manager = PendingWalletManager(numberOfWords: .twelve)
+        let view = NavigationStack {
+            WordsView(manager: manager)
+                .environment(AppManager.shared)
+        }
+        .frame(width: size.width, height: size.height)
+
+        let hostingController = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        hostingController.view.bounds = window.bounds
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
+
+        if screenshotMode() == "initial" {
+            let image = render(hostingController: hostingController, size: size)
+            addScreenshotAttachment(image, name: "compact-recovery-words-initial")
+            try saveScreenshotIfRequested(image)
+            return
+        }
+
+        let scrollView = try XCTUnwrap(findVerticallyScrollableView(in: hostingController.view))
+        let maxOffsetY = max(
+            scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom,
+            -scrollView.adjustedContentInset.top
+        )
+        scrollView.setContentOffset(
+            CGPoint(x: 0, y: maxOffsetY),
+            animated: false
+        )
+        hostingController.view.layoutIfNeeded()
+
+        let image = render(hostingController: hostingController, size: size)
+        addScreenshotAttachment(image, name: "compact-recovery-words-after-scroll")
+        try saveScreenshotIfRequested(image)
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("save wallet"),
+            "expected compact recovery words screen to scroll to Save Wallet, got:\n\(recognizedText)"
+        )
+    }
+
+    private func bootstrapIfNeeded() async throws {
+        do {
+            _ = try await bootstrap()
+        } catch AppInitError.AlreadyCalled(_) {}
+    }
+
+    private func findVerticallyScrollableView(in view: UIView) -> UIScrollView? {
+        if let scrollView = view as? UIScrollView,
+           scrollView.contentSize.height > scrollView.bounds.height + 1
+        {
+            return scrollView
+        }
+
+        for subview in view.subviews {
+            if let scrollView = findVerticallyScrollableView(in: subview) {
+                return scrollView
+            }
+        }
+
+        return nil
+    }
+
+    private func render(
+        hostingController: UIHostingController<some View>,
+        size: CGSize
+    ) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 3
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+
+        return renderer.image { _ in
+            hostingController.view.drawHierarchy(in: hostingController.view.bounds, afterScreenUpdates: true)
+        }
+    }
+
+    private func normalizedRecognizedText(in image: UIImage) throws -> String {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = false
+
+        let handler = VNImageRequestHandler(cgImage: cgImage)
+        try handler.perform([request])
+
+        return request.results?
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: "\n")
+            .lowercased()
+            .replacingOccurrences(of: "\n", with: " ") ?? ""
+    }
+
+    private func assertPrimaryActionIsNotClippedAtBottom(
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let sampleHeight = min(16, cgImage.height)
+        let bottomRect = CGRect(
+            x: 0,
+            y: cgImage.height - sampleHeight,
+            width: cgImage.width,
+            height: sampleHeight
+        )
+        let bottomEdge = try XCTUnwrap(cgImage.cropping(to: bottomRect))
+        let pixels = try rgbaPixels(in: bottomEdge)
+        let brightPixelCount = stride(from: 0, to: pixels.count, by: 4).count(where: { offset in
+            pixels[offset] > 210 &&
+                pixels[offset + 1] > 210 &&
+                pixels[offset + 2] > 210
+        })
+        let maximumAllowedBrightPixels = max(1, bottomEdge.width * bottomEdge.height / 20)
+
+        XCTAssertLessThan(
+            brightPixelCount,
+            maximumAllowedBrightPixels,
+            "expected dark padding below the primary action; bright pixels at the bottom edge indicate the button is clipped",
+            file: file,
+            line: line
+        )
+    }
+
+    private func rgbaPixels(in image: CGImage) throws -> [UInt8] {
+        let bytesPerPixel = 4
+        let bytesPerRow = image.width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: image.height * bytesPerRow)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        let context = try XCTUnwrap(
+            CGContext(
+                data: &pixels,
+                width: image.width,
+                height: image.height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo
+            )
+        )
+
+        context.draw(
+            image,
+            in: CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        )
+
+        return pixels
+    }
+
+    private func addScreenshotAttachment(_ image: UIImage, name: String) {
+        let attachment = XCTAttachment(image: image)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func screenshotMode() -> String? {
+        screenshotEnvironmentValue("COVE_LAYOUT_SCREENSHOT_MODE")
+    }
+
+    private func saveScreenshotIfRequested(_ image: UIImage) throws {
+        guard let name = screenshotEnvironmentValue("COVE_LAYOUT_SCREENSHOT_NAME") else {
+            return
+        }
+
+        let documentsDirectory = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let screenshotDirectory = documentsDirectory.appendingPathComponent("layout-screenshots")
+        try FileManager.default.createDirectory(at: screenshotDirectory, withIntermediateDirectories: true)
+
+        let screenshotUrl = screenshotDirectory.appendingPathComponent(name)
+        try XCTUnwrap(image.pngData()).write(to: screenshotUrl)
+    }
+
+    private func screenshotEnvironmentValue(_ key: String) -> String? {
+        let environment = ProcessInfo.processInfo.environment
+
+        return environment[key] ?? environment["TEST_RUNNER_\(key)"]
+    }
+}

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -758,14 +758,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         )
         let croppedBand = try XCTUnwrap(cgImage.cropping(to: navBand))
         let pixels = try rgbaPixels(in: croppedBand)
-        let lightWordCardPixelCount = stride(from: 0, to: pixels.count, by: 4).count { offset in
-            pixels[offset] > 190 &&
-                pixels[offset] < 245 &&
-                pixels[offset + 1] > 195 &&
-                pixels[offset + 1] < 245 &&
-                pixels[offset + 2] > 200 &&
-                pixels[offset + 2] < 245
-        }
+        let lightWordCardPixelCount = lightWordCardPixelCount(in: pixels)
         let maximumAllowedLightPixels = max(1, croppedBand.width * croppedBand.height / 25)
 
         XCTAssertLessThan(
@@ -818,14 +811,39 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         let croppedImage = try XCTUnwrap(image.cropping(to: rect))
         let pixels = try rgbaPixels(in: croppedImage)
 
-        return stride(from: 0, to: pixels.count, by: 4).count { offset in
-            pixels[offset] > 190 &&
-                pixels[offset] < 245 &&
-                pixels[offset + 1] > 195 &&
-                pixels[offset + 1] < 245 &&
-                pixels[offset + 2] > 200 &&
-                pixels[offset + 2] < 245
+        return lightWordCardPixelCount(in: pixels)
+    }
+
+    private func lightWordCardPixelCount(in pixels: [UInt8]) -> Int {
+        var count = 0
+        var offset = 0
+
+        while offset + 2 < pixels.count {
+            if isLightWordCardPixel(
+                red: pixels[offset],
+                green: pixels[offset + 1],
+                blue: pixels[offset + 2]
+            ) {
+                count += 1
+            }
+
+            offset += 4
         }
+
+        return count
+    }
+
+    private func isLightWordCardPixel(red: UInt8, green: UInt8, blue: UInt8) -> Bool {
+        let red = Int(red)
+        let green = Int(green)
+        let blue = Int(blue)
+
+        return red > 190 &&
+            red < 245 &&
+            green > 195 &&
+            green < 245 &&
+            blue > 200 &&
+            blue < 245
     }
 
     private func rgbaPixels(in image: CGImage) throws -> [UInt8] {

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -6,13 +6,383 @@ import XCTest
 
 @MainActor
 final class HotWalletCreateScreenLayoutTests: XCTestCase {
+    func testCompactNewWalletSelectActionsAreVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: NavigationStack { NewWalletSelectScreen() }
+                .environment(AppManager.shared)
+                .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-new-wallet-select")
+        try saveAuditScreenshotIfDirectoryRequested(image, name: "new-wallet-select-after.png")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("hardware wallet"),
+            "expected compact new wallet select screen to show Hardware Wallet, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("on this device"),
+            "expected compact new wallet select screen to show On This Device, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactHotWalletSelectActionsAreVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: NavigationStack { HotWalletSelectScreen() }
+                .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-hot-wallet-select")
+        try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-select-after.png")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("create new wallet"),
+            "expected compact hot wallet select screen to show Create new wallet, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("import existing wallet"),
+            "expected compact hot wallet select screen to show Import existing wallet, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactVerificationCompleteActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: NavigationStack {
+                VerificationCompleteScreen(
+                    manager: WalletManager(preview: "preview_only"),
+                    onVerified: {}
+                )
+            }
+            .environment(AppManager.shared)
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-verification-complete")
+        try saveAuditScreenshotIfDirectoryRequested(image, name: "verification-complete-after.png")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("go to wallet"),
+            "expected compact verification complete screen to show Go To Wallet, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactTapSignerSetupSuccessActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: TapSignerContainer(
+                route: .setupSuccess(
+                    tapSignerPreviewNew(preview: true),
+                    tapSignerSetupCompleteNew(preview: true)
+                )
+            )
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-tap-signer-setup-success")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "tap-signer-setup-success")
+        try assertLightScreenBottomEdgeIsClear(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("continue"),
+            "expected compact TapSigner setup success screen to show Continue, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactTapSignerImportSuccessActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let setup = tapSignerSetupCompleteNew(preview: true)
+        let image = render(
+            view: TapSignerContainer(
+                route: .importSuccess(
+                    tapSignerPreviewNew(preview: true),
+                    setup.deriveInfo
+                )
+            )
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-tap-signer-import-success")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "tap-signer-import-success")
+        try assertLightScreenBottomEdgeIsClear(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("continue"),
+            "expected compact TapSigner import success screen to show Continue, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactTapSignerRetryActionsAreVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        try assertTapSignerRoute(
+            .importRetry(tapSignerPreviewNew(preview: true)),
+            screenName: "tap-signer-import-retry",
+            expectedText: "retry"
+        )
+        try assertTapSignerRoute(
+            .setupRetry(
+                tapSignerPreviewNew(preview: true),
+                tapSignerSetupRetryContinueCmd(preview: true)
+            ),
+            screenName: "tap-signer-setup-retry",
+            expectedText: "retry"
+        )
+    }
+
+    func testCompactTapSignerChainCodeActionsAreVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        try assertTapSignerRoute(
+            .initSelect(tapSignerPreviewNew(preview: true)),
+            screenName: "tap-signer-choose-chain-code",
+            expectedText: "advanced setup"
+        )
+        try assertTapSignerRoute(
+            .initAdvanced(tapSignerPreviewNew(preview: true)),
+            screenName: "tap-signer-advanced-chain-code",
+            expectedText: "generate new string for me",
+            requiresBottomButtonBand: true
+        )
+    }
+
+    func testCompactOnboardingSecretWordsActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: OnboardingSecretWordsView(
+                words: (1 ... 12).map { "word-\($0)" },
+                onBack: {},
+                onSaved: {}
+            )
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-onboarding-secret-words")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "onboarding-backup-views")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+        try assertBluePrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("i saved these words"),
+            "expected compact onboarding secret words screen to show I Saved These Words, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactCloudBackupEnableCanScrollToAction() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let view = CloudBackupEnableOnboardingView(
+            onEnable: {},
+            onCancel: {},
+            message: nil,
+            isBusy: false
+        )
+        .frame(width: size.width, height: size.height)
+        let image = try renderAfterScrollingToBottom(view: view, size: size)
+        addScreenshotAttachment(image, name: "compact-cloud-backup-enable-onboarding")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "cloud-backup-enable-onboarding")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("enable cloud backup"),
+            "expected compact cloud backup onboarding screen to show Enable Cloud Backup after scrolling, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactFeeRateSheetActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let feeOptions = FeeRateOptionsWithTotalFee.previewNew()
+        let image = render(
+            view: SendFlowSelectFeeRateView(
+                manager: WalletManager(preview: "preview_only"),
+                feeOptions: .constant(feeOptions),
+                selectedOption: .constant(feeOptions.medium()),
+                selectedPresentationDetent: .constant(.large)
+            )
+            .environment(AppManager.shared)
+            .frame(height: 440)
+            .frame(width: size.width, height: size.height, alignment: .top)
+            .background(Color.coveBg),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-fee-rate-sheet")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "send-flow-select-fee-rate")
+        try assertLightScreenBottomEdgeIsClear(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("customize fee"),
+            "expected compact fee-rate sheet to show Customize Fee, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactHotWalletImportActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: NavigationStack {
+                HotWalletImportScreen(numberOfWords: .twelve)
+                    .environment(AppManager.shared)
+            }
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-hot-wallet-import")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "hot-wallet-import")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("import wallet"),
+            "expected compact hot wallet import screen to show Import Wallet, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactVerifyWordsActionsAreVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let view = NavigationStack {
+            VerifyWordsScreen(
+                manager: WalletManager(preview: "preview_only"),
+                stateMachine: WordVerifyStateMachine(
+                    validator: WordValidator.preview(preview: true),
+                    startingWordNumber: 1
+                ),
+                verificationComplete: .constant(false)
+            )
+            .environment(AppManager.shared)
+        }
+        .frame(width: size.width, height: size.height)
+        let image = render(view: view, size: size)
+        addScreenshotAttachment(image, name: "compact-verify-words")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "verify-words")
+        try assertPrimaryActionIsNotClippedAtBottom(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("show words"),
+            "expected compact verify words screen to show Show Words, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("skip verification"),
+            "expected compact verify words screen to show Skip Verification, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("what is word"),
+            "expected compact verify words screen to keep the answer prompt visible, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactSecretWordsContentIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: NavigationStack {
+                SecretWordsScreen(
+                    id: WalletId(),
+                    words: Mnemonic.preview(numberOfBip39Words: .twentyFour)
+                )
+                .environment(AppManager.shared)
+                .environment(AuthManager.shared)
+            }
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-secret-words")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "secret-words")
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("recovery words"),
+            "expected compact secret words screen to show Recovery Words, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("please save these words"),
+            "expected compact secret words screen to show the save guidance, got:\n\(recognizedText)"
+        )
+    }
+
+    func testCompactUtxoListActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: NavigationStack {
+                UtxoListScreen(
+                    manager: CoinControlManager(RustCoinControlManager.previewNew())
+                )
+                .environment(WalletManager(preview: "preview_only"))
+            }
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-utxo-list")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "utxo-list")
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("manage utxos"),
+            "expected compact UTXO list screen to render Manage UTXOs, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("continue"),
+            "expected compact UTXO list screen to show Continue, got:\n\(recognizedText)"
+        )
+    }
+
     func testCompactRecoveryWordsLayoutCanScrollToPrimaryAction() async throws {
         try await bootstrapIfNeeded()
 
         let size = CGSize(width: 375, height: 667)
         let manager = PendingWalletManager(numberOfWords: .twelve)
+        let initialTabIndex =
+            screenshotMode() == "initial"
+                ? 0
+                : manager.rust.bip39WordsGrouped().count - 1
         let view = NavigationStack {
-            WordsView(manager: manager)
+            WordsView(manager: manager, initialTabIndex: initialTabIndex)
                 .environment(AppManager.shared)
         }
         .frame(width: size.width, height: size.height)
@@ -34,27 +404,22 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             return
         }
 
-        let scrollView = try XCTUnwrap(findVerticallyScrollableView(in: hostingController.view))
-        let maxOffsetY = max(
-            scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom,
-            -scrollView.adjustedContentInset.top
-        )
-        scrollView.setContentOffset(
-            CGPoint(x: 0, y: maxOffsetY),
-            animated: false
-        )
-        hostingController.view.layoutIfNeeded()
-
         let image = render(hostingController: hostingController, size: size)
-        addScreenshotAttachment(image, name: "compact-recovery-words-after-scroll")
+        addScreenshotAttachment(image, name: "compact-recovery-words-final-page")
         try saveScreenshotIfRequested(image)
+        try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-create-after.png")
+        try assertNavigationChromeDoesNotShowWordCardBackground(in: image)
         try assertPrimaryActionIsNotClippedAtBottom(in: image)
 
         let recognizedText = try normalizedRecognizedText(in: image)
 
         XCTAssertTrue(
             recognizedText.contains("save wallet"),
-            "expected compact recovery words screen to scroll to Save Wallet, got:\n\(recognizedText)"
+            "expected compact recovery words screen to show Save Wallet, got:\n\(recognizedText)"
+        )
+        XCTAssertTrue(
+            recognizedText.contains("recovery words"),
+            "expected compact recovery words screen to keep the word-copy context visible, got:\n\(recognizedText)"
         )
     }
 
@@ -80,6 +445,33 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         return nil
     }
 
+    private func assertTapSignerRoute(
+        _ route: TapSignerRoute,
+        screenName: String,
+        expectedText: String,
+        requiresBottomButtonBand: Bool = false
+    ) throws {
+        let size = CGSize(width: 375, height: 667)
+        let image = render(
+            view: TapSignerContainer(route: route)
+                .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-\(screenName)")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: screenName)
+        try assertLightScreenBottomEdgeIsClear(in: image)
+        if requiresBottomButtonBand {
+            try assertLightScreenBottomButtonBandIsVisible(in: image)
+        }
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains(expectedText),
+            "expected compact \(screenName) screen to show \(expectedText), got:\n\(recognizedText)"
+        )
+    }
+
     private func render(
         hostingController: UIHostingController<some View>,
         size: CGSize
@@ -91,6 +483,42 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         return renderer.image { _ in
             hostingController.view.drawHierarchy(in: hostingController.view.bounds, afterScreenUpdates: true)
         }
+    }
+
+    private func render(view: some View, size: CGSize) -> UIImage {
+        let hostingController = hostingController(rootView: view, size: size)
+
+        return render(hostingController: hostingController, size: size)
+    }
+
+    private func renderAfterScrollingToBottom(view: some View, size: CGSize) throws -> UIImage {
+        let hostingController = hostingController(rootView: view, size: size)
+        let scrollView = try XCTUnwrap(findVerticallyScrollableView(in: hostingController.view))
+        let maxOffsetY = max(
+            scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom,
+            -scrollView.adjustedContentInset.top
+        )
+        scrollView.setContentOffset(
+            CGPoint(x: 0, y: maxOffsetY),
+            animated: false
+        )
+        hostingController.view.layoutIfNeeded()
+
+        return render(hostingController: hostingController, size: size)
+    }
+
+    private func hostingController(rootView: some View, size: CGSize) -> UIHostingController<some View> {
+        let hostingController = UIHostingController(rootView: rootView)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        hostingController.view.bounds = window.bounds
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
+
+        return hostingController
     }
 
     private func normalizedRecognizedText(in image: UIImage) throws -> String {
@@ -140,6 +568,152 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         )
     }
 
+    private func assertBluePrimaryActionIsNotClippedAtBottom(
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let scale = CGFloat(cgImage.width) / image.size.width
+        let sampleHeight = min(Int(16 * scale), cgImage.height)
+        let bottomRect = CGRect(
+            x: 0,
+            y: cgImage.height - sampleHeight,
+            width: cgImage.width,
+            height: sampleHeight
+        )
+        let bottomEdge = try XCTUnwrap(cgImage.cropping(to: bottomRect))
+        let pixels = try rgbaPixels(in: bottomEdge)
+        let blueButtonPixelCount = stride(from: 0, to: pixels.count, by: 4).count { offset in
+            isPrimaryBluePixel(
+                red: pixels[offset],
+                green: pixels[offset + 1],
+                blue: pixels[offset + 2]
+            )
+        }
+        let maximumAllowedBluePixels = max(1, bottomEdge.width * bottomEdge.height / 80)
+
+        XCTAssertLessThan(
+            blueButtonPixelCount,
+            maximumAllowedBluePixels,
+            "expected dark padding below the blue primary action; blue pixels at the bottom edge indicate the button is clipped",
+            file: file,
+            line: line
+        )
+    }
+
+    private func isPrimaryBluePixel(red: UInt8, green: UInt8, blue: UInt8) -> Bool {
+        Int(blue) > 145 &&
+            Int(blue) > Int(red) + 45 &&
+            Int(blue) > Int(green) + 20 &&
+            Int(green) > 45
+    }
+
+    private func assertLightScreenBottomEdgeIsClear(
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let sampleHeight = min(16, cgImage.height)
+        let bottomRect = CGRect(
+            x: 0,
+            y: cgImage.height - sampleHeight,
+            width: cgImage.width,
+            height: sampleHeight
+        )
+        let bottomEdge = try XCTUnwrap(cgImage.cropping(to: bottomRect))
+        let pixels = try rgbaPixels(in: bottomEdge)
+        let nonLightPixelCount = stride(from: 0, to: pixels.count, by: 4).count(where: { offset in
+            pixels[offset] < 235 ||
+                pixels[offset + 1] < 235 ||
+                pixels[offset + 2] < 235
+        })
+        let maximumAllowedNonLightPixels = max(1, bottomEdge.width * bottomEdge.height / 20)
+
+        XCTAssertLessThan(
+            nonLightPixelCount,
+            maximumAllowedNonLightPixels,
+            "expected clear light padding below the primary action; dark or colored pixels at the bottom edge indicate clipped content",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertLightScreenBottomButtonBandIsVisible(
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let scale = CGFloat(cgImage.width) / image.size.width
+        let bandRect = CGRect(
+            x: Int(16 * scale),
+            y: Int((image.size.height - 150) * scale),
+            width: Int((image.size.width - 32) * scale),
+            height: Int(95 * scale)
+        )
+        let actionBand = try XCTUnwrap(cgImage.cropping(to: bandRect))
+        let pixels = try rgbaPixels(in: actionBand)
+        let neutralButtonPixelCount = stride(from: 0, to: pixels.count, by: 4).count { offset in
+            let red = Int(pixels[offset])
+            let green = Int(pixels[offset + 1])
+            let blue = Int(pixels[offset + 2])
+            let channelSpread = max(red, green, blue) - min(red, green, blue)
+
+            return red > 165 &&
+                red < 230 &&
+                green > 165 &&
+                green < 230 &&
+                blue > 165 &&
+                blue < 235 &&
+                channelSpread < 18
+        }
+        let minimumButtonPixels = actionBand.width * actionBand.height / 5
+
+        XCTAssertGreaterThan(
+            neutralButtonPixelCount,
+            minimumButtonPixels,
+            "expected the disabled bottom action band to be visible in the compact viewport",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertNavigationChromeDoesNotShowWordCardBackground(
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let scale = CGFloat(cgImage.width) / image.size.width
+        let navBand = CGRect(
+            x: 0,
+            y: Int(64 * scale),
+            width: cgImage.width,
+            height: Int(56 * scale)
+        )
+        let croppedBand = try XCTUnwrap(cgImage.cropping(to: navBand))
+        let pixels = try rgbaPixels(in: croppedBand)
+        let lightWordCardPixelCount = stride(from: 0, to: pixels.count, by: 4).count { offset in
+            pixels[offset] > 190 &&
+                pixels[offset] < 245 &&
+                pixels[offset + 1] > 195 &&
+                pixels[offset + 1] < 245 &&
+                pixels[offset + 2] > 200 &&
+                pixels[offset + 2] < 245
+        }
+        let maximumAllowedLightPixels = max(1, croppedBand.width * croppedBand.height / 25)
+
+        XCTAssertLessThan(
+            lightWordCardPixelCount,
+            maximumAllowedLightPixels,
+            "expected solid navigation chrome; light recovery word card pixels in the nav band indicate content is scrolling under the title/back button",
+            file: file,
+            line: line
+        )
+    }
+
     private func rgbaPixels(in image: CGImage) throws -> [UInt8] {
         let bytesPerPixel = 4
         let bytesPerRow = image.width * bytesPerPixel
@@ -182,13 +756,39 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             return
         }
 
-        let documentsDirectory = try FileManager.default.url(
-            for: .documentDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        let screenshotDirectory = documentsDirectory.appendingPathComponent("layout-screenshots")
+        try saveAuditScreenshot(image, name: name)
+    }
+
+    private func saveAuditScreenshotIfDirectoryRequested(_ image: UIImage, name: String) throws {
+        guard screenshotEnvironmentValue("COVE_LAYOUT_SCREENSHOT_DIR") != nil else {
+            return
+        }
+
+        try saveAuditScreenshot(image, name: name)
+    }
+
+    private func saveAuditScreenshotIfDirectoryRequested(_ image: UIImage, screenName: String) throws {
+        guard screenshotEnvironmentValue("COVE_LAYOUT_SCREENSHOT_DIR") != nil else {
+            return
+        }
+
+        let phase = screenshotEnvironmentValue("COVE_LAYOUT_SCREENSHOT_PHASE") ?? "after"
+        try saveAuditScreenshot(image, name: "\(screenName)-\(phase).png")
+    }
+
+    private func saveAuditScreenshot(_ image: UIImage, name: String) throws {
+        let screenshotDirectory: URL
+        if let directoryPath = screenshotEnvironmentValue("COVE_LAYOUT_SCREENSHOT_DIR") {
+            screenshotDirectory = URL(fileURLWithPath: directoryPath)
+        } else {
+            let documentsDirectory = try FileManager.default.url(
+                for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            screenshotDirectory = documentsDirectory.appendingPathComponent("layout-screenshots")
+        }
         try FileManager.default.createDirectory(at: screenshotDirectory, withIntermediateDirectories: true)
 
         let screenshotUrl = screenshotDirectory.appendingPathComponent(name)

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -251,6 +251,40 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         )
     }
 
+    func testCompactSendFlowConfirmActionIsVisible() async throws {
+        try await bootstrapIfNeeded()
+
+        let size = CGSize(width: 375, height: 667)
+        let manager = WalletManager(preview: "preview_only")
+        let presenter = SendFlowPresenter(app: AppManager.shared, manager: manager)
+        let image = render(
+            view: NavigationStack {
+                SendFlowConfirmScreen(
+                    id: WalletId(),
+                    manager: manager,
+                    details: confirmDetailsPreviewNew(),
+                    input: .unsigned,
+                    payjoinEndpoint: nil
+                )
+                .environment(AppManager.shared)
+                .environment(AuthManager.shared)
+                .environment(presenter)
+            }
+            .frame(width: size.width, height: size.height),
+            size: size
+        )
+        addScreenshotAttachment(image, name: "compact-send-flow-confirm")
+        try saveAuditScreenshotIfDirectoryRequested(image, screenName: "send-flow-confirm")
+        try assertLightScreenBottomEdgeIsClear(in: image)
+
+        let recognizedText = try normalizedRecognizedText(in: image)
+
+        XCTAssertTrue(
+            recognizedText.contains("swipe to send"),
+            "expected compact send confirmation screen to show Swipe to Send, got:\n\(recognizedText)"
+        )
+    }
+
     func testCompactHotWalletImportActionIsVisible() async throws {
         try await bootstrapIfNeeded()
 

--- a/ios/CoveTests/NavigationCoordinatorTests.swift
+++ b/ios/CoveTests/NavigationCoordinatorTests.swift
@@ -20,9 +20,7 @@ final class NavigationCoordinatorTests: XCTestCase {
 
         await sleeper.waitForSleepCount(1)
         sleeper.resumeNext()
-        await Task.yield()
-
-        XCTAssertTrue(coordinator.isNavigationSettled)
+        await waitForNavigationSettled(coordinator)
     }
 
     func testOlderGenerationCannotSettleAfterNewGenerationAdvances() async {
@@ -48,8 +46,7 @@ final class NavigationCoordinatorTests: XCTestCase {
         XCTAssertFalse(coordinator.isNavigationSettled)
 
         sleeper.resumeNext()
-        await Task.yield()
-        XCTAssertTrue(coordinator.isNavigationSettled)
+        await waitForNavigationSettled(coordinator)
     }
 
     func testRapidSidebarNavigationOnlyRunsLatestAction() async {
@@ -83,10 +80,37 @@ final class NavigationCoordinatorTests: XCTestCase {
         XCTAssertTrue(actions.isEmpty)
 
         sleeper.resumeFirstSleep(duration: .milliseconds(250))
-        await Task.yield()
+        await waitForActions(["second"], currentActions: { actions })
         XCTAssertEqual(actions, ["second"])
 
         sleeper.resumeAll()
+    }
+
+    private func waitForNavigationSettled(
+        _ coordinator: NavigationCoordinator,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0 ..< 50 {
+            if coordinator.isNavigationSettled { break }
+            await Task.yield()
+        }
+
+        XCTAssertTrue(coordinator.isNavigationSettled, file: file, line: line)
+    }
+
+    private func waitForActions(
+        _ expectedActions: [String],
+        currentActions: @MainActor () -> [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0 ..< 50 {
+            if currentActions() == expectedActions { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(currentActions(), expectedActions, file: file, line: line)
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -189,8 +189,6 @@ ui-manual:
 #
 # Focused instrumentation tests should use AndroidDeviceStayAwakeRule when the
 # stay-awake behavior belongs in the test itself.
-#
-# Run an Android device command from android/ with stay-awake enabled.
 [group('test')]
 android-stay-awake *command:
     just xtask android-stay-awake -- {{ command }}

--- a/justfile
+++ b/justfile
@@ -182,31 +182,23 @@ compile-android:
 ui-manual:
     just android-ui-manual && just ios-ui-background
 
-# Run manual Android full-launch onboarding UI tests
+# Run an Android device command from android/ with stay-awake enabled.
+#
+# Use this for ad hoc device UI testing:
+#   just android-stay-awake ./gradlew :app:connectedUiTestDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=org.bitcoinppl.cove.test.LayoutRegressionTest
+#
+# Focused instrumentation tests should use AndroidDeviceStayAwakeRule when the
+# stay-awake behavior belongs in the test itself.
+#
+# Run an Android device command from android/ with stay-awake enabled.
 [group('test')]
-[script('bash')]
-[working-directory('android')]
+android-stay-awake *command:
+    just xtask android-stay-awake -- {{ command }}
+
+# Run manual Android full-launch onboarding UI tests.
+[group('test')]
 android-ui-manual:
-    set -e
-    STAY_AWAKE_SETTING="$(adb shell settings get global stay_on_while_plugged_in | tr -d '\r')"
-
-    cleanup() {
-        if [ "$STAY_AWAKE_SETTING" = "null" ]; then
-            adb shell settings delete global stay_on_while_plugged_in >/dev/null 2>&1 || true
-        else
-            adb shell settings put global stay_on_while_plugged_in "$STAY_AWAKE_SETTING" >/dev/null 2>&1 || true
-        fi
-        adb uninstall org.bitcoinppl.cove.uitest.test >/dev/null 2>&1 || true
-        adb uninstall org.bitcoinppl.cove.uitest >/dev/null 2>&1 || true
-    }
-
-    trap cleanup EXIT
-    adb shell settings put global stay_on_while_plugged_in 7 >/dev/null
-    adb shell input keyevent KEYCODE_WAKEUP >/dev/null
-    adb shell wm dismiss-keyguard >/dev/null
-
-    ./gradlew :app:connectedUiTestDebugAndroidTest \
-        -Pandroid.testInstrumentationRunnerArguments.annotation=org.bitcoinppl.cove.test.ManualFullLaunchTest
+    just xtask android-ui-manual
 
 alias aum := android-ui-manual
 

--- a/rust/xtask/src/android.rs
+++ b/rust/xtask/src/android.rs
@@ -3,7 +3,7 @@ use crate::common::{
     trim_generated_trailing_whitespace,
 };
 use color_eyre::{
-    eyre::{Context, ContextCompat},
+    eyre::{bail, Context, ContextCompat},
     Result,
 };
 use colored::Colorize;
@@ -34,6 +34,11 @@ const APK_PATH_DEBUG: &str = "app/build/outputs/apk/dev/debug/app-dev-debug.apk"
 const APK_PATH_RELEASE: &str = "app/build/outputs/apk/dev/release/app-dev-release.apk";
 const ANDROID_SCREENSHOT_DIRS: &[&str] =
     &["/sdcard/Pictures/Screenshots", "/sdcard/DCIM/Screenshots"];
+const ANDROID_PROJECT_DIR: &str = "../android";
+const STAY_AWAKE_SETTING: &str = "stay_on_while_plugged_in";
+const STAY_AWAKE_WHILE_PLUGGED_IN: &str = "7";
+const UI_TEST_PACKAGE_NAME: &str = "org.bitcoinppl.cove.uitest";
+const UI_TEST_RUNNER_PACKAGE_NAME: &str = "org.bitcoinppl.cove.uitest.test";
 
 // Android bundle constants (store flavor for Play Store)
 const AAB_OUTPUT_PATH: &str = "app/build/outputs/bundle/storeRelease/app-store-release.aab";
@@ -633,6 +638,128 @@ fn remote_shell_quote(value: &str) -> String {
 
     quoted.push('\'');
     quoted
+}
+
+pub fn run_with_stay_awake(command: &[String]) -> Result<()> {
+    if command.is_empty() {
+        bail!("Command is required after --");
+    }
+
+    if !command_exists("adb") {
+        print_error("adb not found. Please install Android SDK platform-tools");
+        bail!("adb command not found");
+    }
+
+    let previous_setting = read_stay_awake_setting()?;
+    let _guard = AndroidStayAwakeGuard::new(previous_setting);
+
+    adb_status(
+        &["shell", "settings", "put", "global", STAY_AWAKE_SETTING, STAY_AWAKE_WHILE_PLUGGED_IN],
+        "Failed to enable Android stay-awake setting",
+    )?;
+    adb_status(&["shell", "input", "keyevent", "KEYCODE_WAKEUP"], "Failed to wake Android device")?;
+
+    if let Err(error) =
+        adb_status(&["shell", "wm", "dismiss-keyguard"], "Failed to dismiss Android keyguard")
+    {
+        print_warning(&format!("{error}"));
+    }
+
+    print_info(&format!("Running Android command: {}", command.join(" ")));
+    let status = Command::new(&command[0])
+        .args(&command[1..])
+        .current_dir(ANDROID_PROJECT_DIR)
+        .status()
+        .wrap_err_with(|| format!("Failed to run Android command {}", command[0]))?;
+
+    if !status.success() {
+        bail!("Android command failed with status {status}");
+    }
+
+    Ok(())
+}
+
+pub fn run_manual_ui_tests() -> Result<()> {
+    let _guard = AndroidUiPackageCleanupGuard;
+    let command = [
+        "./gradlew",
+        ":app:connectedUiTestDebugAndroidTest",
+        "-Pandroid.testInstrumentationRunnerArguments.annotation=org.bitcoinppl.cove.test.ManualFullLaunchTest",
+    ]
+    .map(String::from);
+
+    run_with_stay_awake(&command)
+}
+
+struct AndroidStayAwakeGuard {
+    previous_setting: String,
+}
+
+impl AndroidStayAwakeGuard {
+    fn new(previous_setting: String) -> Self {
+        Self { previous_setting }
+    }
+}
+
+impl Drop for AndroidStayAwakeGuard {
+    fn drop(&mut self) {
+        if let Err(error) = restore_stay_awake_setting(&self.previous_setting) {
+            print_warning(&format!("{error}"));
+        }
+    }
+}
+
+struct AndroidUiPackageCleanupGuard;
+
+impl Drop for AndroidUiPackageCleanupGuard {
+    fn drop(&mut self) {
+        uninstall_android_package(UI_TEST_RUNNER_PACKAGE_NAME);
+        uninstall_android_package(UI_TEST_PACKAGE_NAME);
+    }
+}
+
+fn read_stay_awake_setting() -> Result<String> {
+    let output = Command::new("adb")
+        .args(["shell", "settings", "get", "global", STAY_AWAKE_SETTING])
+        .output()
+        .wrap_err("Failed to read Android stay-awake setting")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to read Android stay-awake setting: {}", stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn restore_stay_awake_setting(previous_setting: &str) -> Result<()> {
+    if previous_setting == "null" {
+        return adb_status(
+            &["shell", "settings", "delete", "global", STAY_AWAKE_SETTING],
+            "Failed to restore Android stay-awake setting",
+        );
+    }
+
+    adb_status(
+        &["shell", "settings", "put", "global", STAY_AWAKE_SETTING, previous_setting],
+        "Failed to restore Android stay-awake setting",
+    )
+}
+
+fn adb_status(args: &[&str], context: &str) -> Result<()> {
+    let status = Command::new("adb").args(args).status().wrap_err_with(|| context.to_string())?;
+
+    if !status.success() {
+        bail!("{context}: adb exited with status {status}");
+    }
+
+    Ok(())
+}
+
+fn uninstall_android_package(package_name: &str) {
+    if let Err(error) = Command::new("adb").args(["uninstall", package_name]).status() {
+        print_warning(&format!("Failed to run adb uninstall for {package_name}: {error}"));
+    }
 }
 
 fn extract_version_name(content: &str) -> Option<String> {

--- a/rust/xtask/src/android.rs
+++ b/rust/xtask/src/android.rs
@@ -723,6 +723,9 @@ impl AndroidStayAwakeGuard {
 
 impl Drop for AndroidStayAwakeGuard {
     fn drop(&mut self) {
+        if let Err(error) = restore_stayon_service_state(&self.previous_stay_awake_setting) {
+            print_warning(&format!("{error}"));
+        }
         if let Err(error) = restore_stay_awake_setting(&self.previous_stay_awake_setting) {
             print_warning(&format!("{error}"));
         }
@@ -789,6 +792,26 @@ fn restore_screen_off_timeout_setting(previous_setting: &str) -> Result<()> {
         &["shell", "settings", "put", "system", SCREEN_OFF_TIMEOUT_SETTING, previous_setting],
         "Failed to restore Android screen-off timeout",
     )
+}
+
+fn restore_stayon_service_state(previous_setting: &str) -> Result<()> {
+    let stayon_arg = stayon_service_arg(previous_setting);
+
+    adb_status(
+        &["shell", "svc", "power", "stayon", stayon_arg],
+        "Failed to restore Android svc stayon",
+    )
+}
+
+fn stayon_service_arg(previous_setting: &str) -> &'static str {
+    match previous_setting.parse::<u32>().unwrap_or(0) {
+        0 => "false",
+        1 => "ac",
+        2 => "usb",
+        4 => "wireless",
+        8 => "dock",
+        _ => "true",
+    }
 }
 
 fn adb_status(args: &[&str], context: &str) -> Result<()> {

--- a/rust/xtask/src/android.rs
+++ b/rust/xtask/src/android.rs
@@ -37,6 +37,8 @@ const ANDROID_SCREENSHOT_DIRS: &[&str] =
 const ANDROID_PROJECT_DIR: &str = "../android";
 const STAY_AWAKE_SETTING: &str = "stay_on_while_plugged_in";
 const STAY_AWAKE_WHILE_PLUGGED_IN: &str = "7";
+const SCREEN_OFF_TIMEOUT_SETTING: &str = "screen_off_timeout";
+const STAY_AWAKE_SCREEN_OFF_TIMEOUT_MS: &str = "1800000";
 const UI_TEST_PACKAGE_NAME: &str = "org.bitcoinppl.cove.uitest";
 const UI_TEST_RUNNER_PACKAGE_NAME: &str = "org.bitcoinppl.cove.uitest.test";
 
@@ -650,12 +652,25 @@ pub fn run_with_stay_awake(command: &[String]) -> Result<()> {
         bail!("adb command not found");
     }
 
-    let previous_setting = read_stay_awake_setting()?;
-    let _guard = AndroidStayAwakeGuard::new(previous_setting);
+    let previous_stay_awake_setting = read_stay_awake_setting()?;
+    let previous_screen_off_timeout = read_screen_off_timeout_setting()?;
+    let _guard =
+        AndroidStayAwakeGuard::new(previous_stay_awake_setting, previous_screen_off_timeout);
 
     adb_status(
         &["shell", "settings", "put", "global", STAY_AWAKE_SETTING, STAY_AWAKE_WHILE_PLUGGED_IN],
         "Failed to enable Android stay-awake setting",
+    )?;
+    adb_status(
+        &[
+            "shell",
+            "settings",
+            "put",
+            "system",
+            SCREEN_OFF_TIMEOUT_SETTING,
+            STAY_AWAKE_SCREEN_OFF_TIMEOUT_MS,
+        ],
+        "Failed to increase Android screen-off timeout",
     )?;
     adb_status(&["shell", "input", "keyevent", "KEYCODE_WAKEUP"], "Failed to wake Android device")?;
 
@@ -692,18 +707,22 @@ pub fn run_manual_ui_tests() -> Result<()> {
 }
 
 struct AndroidStayAwakeGuard {
-    previous_setting: String,
+    previous_stay_awake_setting: String,
+    previous_screen_off_timeout: String,
 }
 
 impl AndroidStayAwakeGuard {
-    fn new(previous_setting: String) -> Self {
-        Self { previous_setting }
+    fn new(previous_stay_awake_setting: String, previous_screen_off_timeout: String) -> Self {
+        Self { previous_stay_awake_setting, previous_screen_off_timeout }
     }
 }
 
 impl Drop for AndroidStayAwakeGuard {
     fn drop(&mut self) {
-        if let Err(error) = restore_stay_awake_setting(&self.previous_setting) {
+        if let Err(error) = restore_stay_awake_setting(&self.previous_stay_awake_setting) {
+            print_warning(&format!("{error}"));
+        }
+        if let Err(error) = restore_screen_off_timeout_setting(&self.previous_screen_off_timeout) {
             print_warning(&format!("{error}"));
         }
     }
@@ -719,14 +738,22 @@ impl Drop for AndroidUiPackageCleanupGuard {
 }
 
 fn read_stay_awake_setting() -> Result<String> {
+    read_android_setting("global", STAY_AWAKE_SETTING, "Android stay-awake setting")
+}
+
+fn read_screen_off_timeout_setting() -> Result<String> {
+    read_android_setting("system", SCREEN_OFF_TIMEOUT_SETTING, "Android screen-off timeout")
+}
+
+fn read_android_setting(namespace: &str, setting: &str, label: &str) -> Result<String> {
     let output = Command::new("adb")
-        .args(["shell", "settings", "get", "global", STAY_AWAKE_SETTING])
+        .args(["shell", "settings", "get", namespace, setting])
         .output()
-        .wrap_err("Failed to read Android stay-awake setting")?;
+        .wrap_err_with(|| format!("Failed to read {label}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("Failed to read Android stay-awake setting: {}", stderr.trim());
+        bail!("Failed to read {label}: {}", stderr.trim());
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -743,6 +770,20 @@ fn restore_stay_awake_setting(previous_setting: &str) -> Result<()> {
     adb_status(
         &["shell", "settings", "put", "global", STAY_AWAKE_SETTING, previous_setting],
         "Failed to restore Android stay-awake setting",
+    )
+}
+
+fn restore_screen_off_timeout_setting(previous_setting: &str) -> Result<()> {
+    if previous_setting == "null" {
+        return adb_status(
+            &["shell", "settings", "delete", "system", SCREEN_OFF_TIMEOUT_SETTING],
+            "Failed to restore Android screen-off timeout",
+        );
+    }
+
+    adb_status(
+        &["shell", "settings", "put", "system", SCREEN_OFF_TIMEOUT_SETTING, previous_setting],
+        "Failed to restore Android screen-off timeout",
     )
 }
 

--- a/rust/xtask/src/android.rs
+++ b/rust/xtask/src/android.rs
@@ -672,6 +672,10 @@ pub fn run_with_stay_awake(command: &[String]) -> Result<()> {
         ],
         "Failed to increase Android screen-off timeout",
     )?;
+    adb_status(
+        &["shell", "svc", "power", "stayon", "true"],
+        "Failed to enable Android svc stayon",
+    )?;
     adb_status(&["shell", "input", "keyevent", "KEYCODE_WAKEUP"], "Failed to wake Android device")?;
 
     if let Err(error) =

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -63,6 +63,18 @@ enum Commands {
     #[command(name = "download-android-screenshots")]
     DownloadAndroidScreenshots,
 
+    /// Run an Android command from android/ while keeping the device awake
+    #[command(name = "android-stay-awake")]
+    AndroidStayAwake {
+        /// Command and arguments to run after --
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+
+    /// Run manual Android full-launch onboarding UI tests
+    #[command(name = "android-ui-manual")]
+    AndroidUiManual,
+
     /// Build iOS library and generate Swift bindings
     #[command(name = "build-ios")]
     BuildIos {
@@ -269,6 +281,10 @@ fn main() -> Result<()> {
         Commands::BundleAndroid => android::bundle_android(cli.verbose),
 
         Commands::DownloadAndroidScreenshots => android::download_android_screenshots(),
+
+        Commands::AndroidStayAwake { command } => android::run_with_stay_awake(&command),
+
+        Commands::AndroidUiManual => android::run_manual_ui_tests(),
 
         Commands::BuildIos { build_type, device, sign } => {
             let ios_build_type = ios::IosBuildType::from_str(&build_type);


### PR DESCRIPTION
## Summary

Fix compact-screen layout cutoff issues across Android and iOS send, wallet setup, recovery-word, TapSigner, and onboarding restore flows.

Address review feedback by restoring Android `svc power stayon` state after stay-awake test helpers run, removing an invalid weighted spacer from a scrollable Compose column, centralizing iOS compact-layout threshold logic, sharing the TapSigner background view, restoring the active iCloud restore pulse animation, and allowing the iOS swipe-to-send control to grow with Dynamic Type.

## Testing

- `just fmt`
- `just clippy`
- `just compile-ios`
- `just compile-android`
- `just lint-swift`
- `just lint-android`

### Manual Device Coverage

Use one small and one large form factor per platform. On each screen, verify primary actions are visible or reachable, bottom actions are not clipped by safe areas/navigation bars, scrolling still works where needed, and horizontal content stays within the viewport.

#### iOS

- [ ] Small iOS device/simulator
- [ ] Large iOS device/simulator

Screens to cover:

- New wallet select
- Hot wallet select
- Hot wallet create / recovery words pager
- Hot wallet import
- Verify recovery words
- Verification complete
- Onboarding secret words
- Onboarding cloud backup enable
- Startup device restore
- Send confirmation / swipe to send
- Send fee-rate sheet
- Wallet secret words
- Coin control UTXO list
- TapSigner choose chain code
- TapSigner advanced chain code
- TapSigner setup success
- TapSigner import success
- TapSigner setup retry
- TapSigner import retry

#### Android

- [ ] Small Android device/emulator
- [ ] Large Android device/emulator

Screens to cover:

- New wallet select
- Hot wallet select
- Hot wallet create / recovery words pager
- Hot wallet import
- Verify recovery words
- Verification complete
- Onboarding cloud restore offer/prompt
- Send confirmation / swipe to send
- TapSigner choose chain code
- TapSigner advanced chain code
- Number-pad PIN entry

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [ ] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact-layout support across key onboarding, wallet setup, TapSigner, and send screens so content fits better on smaller displays and with larger text.
  * Improved screenshot-based layout auditing for Android and iOS to catch clipped or inaccessible UI before release.

* **Bug Fixes**
  * Adjusted spacing, scrolling, and bottom actions on several screens to keep primary actions visible and usable.
  * Prevented test runs from sleeping the device, improving reliability of UI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
