### PR TITLE
Preserve cloud-only rows after wallet ops

### DIFF
--- a/rust/src/manager/cloud_backup_manager/actors/supervisor.rs
+++ b/rust/src/manager/cloud_backup_manager/actors/supervisor.rs
@@ -154,6 +154,22 @@ fn apply_refresh_detail_result(manager: &RustCloudBackupManager, result: &CloudB
     }
 }
 
+fn apply_cloud_only_operation_refresh_detail_result(
+    manager: &RustCloudBackupManager,
+    result: &CloudBackupDetailResult,
+) {
+    match result {
+        CloudBackupDetailResult::Success(detail) => {
+            manager.apply_detail_outcome_preserving_cloud_only_if_consistent(
+                CloudBackupDetailOutcome::Refreshed(detail.clone()),
+            );
+        }
+        CloudBackupDetailResult::AccessError(error) => {
+            error!("Failed to refresh detail: {error}");
+        }
+    }
+}
+
 fn refresh_detail_needs_connectivity_retry(
     manager: &RustCloudBackupManager,
     attempt: DetailRefreshAttempt,
@@ -655,7 +671,15 @@ impl CloudBackupSupervisor {
         };
 
         if let Some(result) = result {
-            apply_refresh_detail_result(&manager, &result);
+            if matches!(
+                claim.operation(),
+                CloudBackupExclusiveOperation::RestoreCloudWallet
+                    | CloudBackupExclusiveOperation::DeleteCloudWallet
+            ) {
+                apply_cloud_only_operation_refresh_detail_result(&manager, &result);
+            } else {
+                apply_refresh_detail_result(&manager, &result);
+            }
         }
 
         self.active_operation = None;

--- a/rust/src/manager/cloud_backup_manager/detail.rs
+++ b/rust/src/manager/cloud_backup_manager/detail.rs
@@ -607,6 +607,7 @@ fn cloud_only_wallets_match_detail(
     wallets: &[CloudBackupWalletItem],
     detail: &CloudBackupDetail,
 ) -> bool {
+    // detail carries only a cloud-only count, so identity consistency is limited to local overlap
     wallets.len() as u32 == detail.cloud_only_count
         && wallets.iter().all(|cloud_wallet| {
             detail
@@ -707,6 +708,27 @@ mod tests {
             manager.state.read().cloud_only(),
             CloudOnlyState::Loaded { wallets: vec![wallet_b] }
         );
+    }
+
+    #[test]
+    fn detail_refresh_preserves_empty_loaded_cloud_only_cache_after_restore_when_count_matches() {
+        let _guard = test_lock().lock();
+        let manager = init_manager();
+        let wallet = cloud_backup_wallet_item("wallet-a");
+
+        manager.apply_detail_outcome(CloudBackupDetailOutcome::Refreshed(cloud_backup_detail(1)));
+        manager.apply_cloud_only_fetch_outcome(CloudBackupCloudOnlyFetchOutcome::Loaded(vec![
+            wallet.clone(),
+        ]));
+        manager.apply_cloud_only_wallet_outcome(CloudBackupCloudOnlyWalletOutcome::Restored {
+            record_id: wallet.record_id,
+            warning: None,
+        });
+        manager.apply_detail_outcome_preserving_cloud_only_if_consistent(
+            CloudBackupDetailOutcome::Refreshed(cloud_backup_detail(0)),
+        );
+
+        assert_eq!(manager.state.read().cloud_only(), CloudOnlyState::Loaded { wallets: vec![] });
     }
 
     #[test]

--- a/rust/src/manager/cloud_backup_manager/detail.rs
+++ b/rust/src/manager/cloud_backup_manager/detail.rs
@@ -435,20 +435,47 @@ impl RustCloudBackupManager {
 
 impl RustCloudBackupManager {
     pub(crate) fn apply_detail_outcome(&self, outcome: CloudBackupDetailOutcome) {
+        self.apply_detail_outcome_with_cloud_only_policy(
+            outcome,
+            CloudOnlyRefreshPolicy::ResetIfStale,
+        );
+    }
+
+    pub(crate) fn apply_detail_outcome_preserving_cloud_only_if_consistent(
+        &self,
+        outcome: CloudBackupDetailOutcome,
+    ) {
+        self.apply_detail_outcome_with_cloud_only_policy(
+            outcome,
+            CloudOnlyRefreshPolicy::PreserveLoadedIfConsistent,
+        );
+    }
+
+    fn apply_detail_outcome_with_cloud_only_policy(
+        &self,
+        outcome: CloudBackupDetailOutcome,
+        cloud_only_policy: CloudOnlyRefreshPolicy,
+    ) {
         let detail = match outcome {
             CloudBackupDetailOutcome::Cleared => None,
             CloudBackupDetailOutcome::Refreshed(detail) => Some(detail),
         };
         let detail_snapshot = self.cloud_only_detail_snapshot.read().clone();
-        let reset_cloud_only = {
-            let state = self.state.read();
-            detail.as_ref().is_some_and(|detail| {
-                cloud_only_cache_is_stale(&state.cloud_only(), detail, detail_snapshot.as_ref())
-            })
-        };
+        let cloud_only = self.state.read().cloud_only();
+        let preserve_cloud_only = detail.as_ref().is_some_and(|detail| {
+            cloud_only_policy == CloudOnlyRefreshPolicy::PreserveLoadedIfConsistent
+                && loaded_cloud_only_matches_detail(&cloud_only, detail)
+        });
+        let reset_cloud_only = detail.as_ref().is_some_and(|detail| {
+            !preserve_cloud_only
+                && cloud_only_cache_is_stale(&cloud_only, detail, detail_snapshot.as_ref())
+        });
 
         if reset_cloud_only {
             *self.cloud_only_detail_snapshot.write() = None;
+        }
+        if preserve_cloud_only && let Some(detail) = detail.as_ref() {
+            *self.cloud_only_detail_snapshot.write() = Some(detail.clone());
         }
 
         self.apply_model_event(CloudBackupStateReducerEvent::DetailRefreshApplied {
@@ -543,6 +570,12 @@ impl RustCloudBackupManager {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloudOnlyRefreshPolicy {
+    ResetIfStale,
+    PreserveLoadedIfConsistent,
+}
+
 fn cloud_only_cache_is_stale(
     cloud_only: &CloudOnlyState,
     detail: &CloudBackupDetail,
@@ -556,17 +589,32 @@ fn cloud_only_cache_is_stale(
         return true;
     }
 
-    if wallets.len() as u32 != detail.cloud_only_count {
-        return true;
-    }
+    !cloud_only_wallets_match_detail(wallets, detail)
+}
 
-    wallets.iter().any(|cloud_wallet| {
-        detail
-            .up_to_date
-            .iter()
-            .chain(detail.needs_sync.iter())
-            .any(|local_wallet| local_wallet.record_id == cloud_wallet.record_id)
-    })
+fn loaded_cloud_only_matches_detail(
+    cloud_only: &CloudOnlyState,
+    detail: &CloudBackupDetail,
+) -> bool {
+    let CloudOnlyState::Loaded { wallets } = cloud_only else {
+        return false;
+    };
+
+    cloud_only_wallets_match_detail(wallets, detail)
+}
+
+fn cloud_only_wallets_match_detail(
+    wallets: &[CloudBackupWalletItem],
+    detail: &CloudBackupDetail,
+) -> bool {
+    wallets.len() as u32 == detail.cloud_only_count
+        && wallets.iter().all(|cloud_wallet| {
+            detail
+                .up_to_date
+                .iter()
+                .chain(detail.needs_sync.iter())
+                .all(|local_wallet| local_wallet.record_id != cloud_wallet.record_id)
+        })
 }
 
 #[cfg(test)]
@@ -634,6 +682,31 @@ mod tests {
         manager.apply_detail_outcome(CloudBackupDetailOutcome::Refreshed(cloud_backup_detail(0)));
 
         assert!(matches!(manager.state.read().cloud_only(), CloudOnlyState::NotFetched));
+    }
+
+    #[test]
+    fn detail_refresh_preserves_loaded_cloud_only_cache_after_delete_when_count_matches() {
+        let _guard = test_lock().lock();
+        let manager = init_manager();
+        let wallet_a = cloud_backup_wallet_item("wallet-a");
+        let wallet_b = cloud_backup_wallet_item("wallet-b");
+
+        manager.apply_detail_outcome(CloudBackupDetailOutcome::Refreshed(cloud_backup_detail(2)));
+        manager.apply_cloud_only_fetch_outcome(CloudBackupCloudOnlyFetchOutcome::Loaded(vec![
+            wallet_a.clone(),
+            wallet_b.clone(),
+        ]));
+        manager.apply_cloud_only_wallet_outcome(CloudBackupCloudOnlyWalletOutcome::Deleted {
+            record_id: wallet_a.record_id,
+        });
+        manager.apply_detail_outcome_preserving_cloud_only_if_consistent(
+            CloudBackupDetailOutcome::Refreshed(cloud_backup_detail(1)),
+        );
+
+        assert_eq!(
+            manager.state.read().cloud_only(),
+            CloudOnlyState::Loaded { wallets: vec![wallet_b] }
+        );
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud backup details now update more reliably after restore or delete actions, preserving existing cloud-only wallet data when it remains consistent.
  * Improved handling of detail refreshes so the app no longer clears refreshed cloud-only state unnecessarily.
  * Access errors continue to be reported as before.

* **Tests**
  * Added coverage for cloud-only wallet refresh behavior after restore and delete flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->