### PR TITLE
Add mobile artifact xtask workflow

### DIFF
--- a/.github/workflows/mobile-artifacts.yml
+++ b/.github/workflows/mobile-artifacts.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
@@ -114,7 +114,7 @@ jobs:
           PY
 
       - name: Upload Android artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cove-android-dev-debug
           retention-days: 2
@@ -129,7 +129,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
@@ -193,7 +193,7 @@ jobs:
           PY
 
       - name: Upload iOS CoveCore artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cove-ios-core-debug-device
           retention-days: 2

--- a/.github/workflows/mobile-artifacts.yml
+++ b/.github/workflows/mobile-artifacts.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -133,6 +134,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/mobile-artifacts.yml
+++ b/.github/workflows/mobile-artifacts.yml
@@ -1,0 +1,203 @@
+name: Mobile Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Mobile artifact platform to build
+        required: true
+        type: choice
+        default: both
+        options:
+          - android
+          - ios-core
+          - both
+      profile:
+        description: Build profile
+        required: true
+        type: choice
+        default: debug
+        options:
+          - debug
+      label:
+        description: Optional display label
+        required: false
+        type: string
+
+concurrency:
+  group: mobile-artifacts-${{ github.ref_name }}-${{ inputs.platform }}
+  cancel-in-progress: false
+
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "10"
+
+jobs:
+  android:
+    if: ${{ inputs.platform == 'android' || inputs.platform == 'both' }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+          cache-bin: false
+          prefix-key: v1-rust
+
+      - name: Set up just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install build dependencies
+        run: cd rust && cargo xtask install-deps
+
+      - name: Build Rust FFI and generate Kotlin bindings
+        run: just build-android
+
+      - name: Assemble Android dev debug APK
+        run: cd android && ./gradlew assembleDevDebug
+
+      - name: Stage Android artifact
+        shell: bash
+        env:
+          ARTIFACT_NAME: cove-android-dev-debug
+          PLATFORM: android
+          PROFILE: ${{ inputs.profile }}
+          LABEL: ${{ inputs.label }}
+        run: |
+          set -euo pipefail
+          mkdir -p mobile-artifact/android
+          cp android/app/build/outputs/apk/dev/debug/app-dev-debug.apk mobile-artifact/android/app-dev-debug.apk
+          cp android/app/build/outputs/apk/dev/debug/output-metadata.json mobile-artifact/android/output-metadata.json
+
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from datetime import datetime, timezone
+
+          manifest = {
+              "schema_version": 1,
+              "platform": os.environ["PLATFORM"],
+              "profile": os.environ["PROFILE"],
+              "git_ref": os.environ["GITHUB_REF_NAME"],
+              "git_sha": os.environ["GITHUB_SHA"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+              "artifact_name": os.environ["ARTIFACT_NAME"],
+              "rustc_version": subprocess.check_output(["rustc", "--version"], text=True).strip(),
+              "runner_os": os.environ["RUNNER_OS"],
+          }
+          label = os.environ.get("LABEL", "").strip()
+          if label:
+              manifest["label"] = label
+          with open("mobile-artifact/manifest.json", "w", encoding="utf-8") as manifest_file:
+              json.dump(manifest, manifest_file, indent=2)
+              manifest_file.write("\n")
+          PY
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cove-android-dev-debug
+          retention-days: 2
+          path: |
+            mobile-artifact/manifest.json
+            mobile-artifact/android/app-dev-debug.apk
+            mobile-artifact/android/output-metadata.json
+
+  ios-core:
+    if: ${{ inputs.platform == 'ios-core' || inputs.platform == 'both' }}
+    runs-on: macos-26
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+          cache-bin: false
+          prefix-key: v1-rust
+
+      - name: Set up just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Build iOS debug device CoveCore inputs
+        run: just build-ios debug --device
+
+      - name: Stage iOS CoveCore artifact
+        shell: bash
+        env:
+          ARTIFACT_NAME: cove-ios-core-debug-device
+          PLATFORM: ios-core
+          PROFILE: ${{ inputs.profile }}
+          LABEL: ${{ inputs.label }}
+        run: |
+          set -euo pipefail
+          mkdir -p mobile-artifact/ios/CoveCore/Sources/CoveCore
+          cp -R ios/CoveCore/Sources/cove_core_ffi.xcframework mobile-artifact/ios/CoveCore/Sources/
+          cp -R ios/CoveCore/Sources/CoveCore/generated mobile-artifact/ios/CoveCore/Sources/CoveCore/generated
+
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from datetime import datetime, timezone
+
+          manifest = {
+              "schema_version": 1,
+              "platform": os.environ["PLATFORM"],
+              "profile": os.environ["PROFILE"],
+              "git_ref": os.environ["GITHUB_REF_NAME"],
+              "git_sha": os.environ["GITHUB_SHA"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+              "artifact_name": os.environ["ARTIFACT_NAME"],
+              "rustc_version": subprocess.check_output(["rustc", "--version"], text=True).strip(),
+              "runner_os": os.environ["RUNNER_OS"],
+              "xcodebuild_version": subprocess.check_output(["xcodebuild", "-version"], text=True).strip(),
+          }
+          label = os.environ.get("LABEL", "").strip()
+          if label:
+              manifest["label"] = label
+          with open("mobile-artifact/manifest.json", "w", encoding="utf-8") as manifest_file:
+              json.dump(manifest, manifest_file, indent=2)
+              manifest_file.write("\n")
+          PY
+
+      - name: Upload iOS CoveCore artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cove-ios-core-debug-device
+          retention-days: 2
+          path: |
+            mobile-artifact/manifest.json
+            mobile-artifact/ios/CoveCore/Sources/cove_core_ffi.xcframework
+            mobile-artifact/ios/CoveCore/Sources/CoveCore/generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _docs/
 _plans
+/_artifacts/
 
 *~.swift
 **/**/UserInterfaceState.xcuserstate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - never manually edit generated files
 - use `cove_util::ResultExt::map_err_str` and `..map_err_prefix` instead of `.map_err(|e| Error::Variant(e.to_string()))`, and `.map_err(|e| Error::Variant(format!("context: {e}")))`
 - for local UniFFI updates use `just build-ios`/`just build-android`; `just rb` runs GitHub Actions for committed branch changes
+- to install and launch iOS from the CLI without Xcode, use `just build-run-ios --udid <device-udid>` and keep the phone unlocked
 - no mod.rs files use the other format module_name.rs module_name/new_module.rs
 - data structures and UniFFI-derived Rust types may change when they directly serve the requested work; update generated bindings and affected Swift/Kotlin call sites when exported APIs change
 - don't mix test-only code into production code; `#[cfg(test)]` helpers should live in `mod tests` or dedicated `test_support` modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,9 @@ The `COVE_KEYSTORE_*` variables in `.envrc.example` are only needed for signed A
 2. Build the Rust library and bindings:
    - iOS: `just build-ios` (`just bi`) for simulator or `just build-ios-debug-device` (`just bidd`) for device
    - Android: `just build-android` (`just ba`)
-3. Open in Xcode (`ios/Cove.xcodeproj`) or Android Studio (`android/`)
-4. Build and run
+3. Build and run on a device:
+   - iOS: `just build-run-ios --udid <device-udid>` or set `IOS_DEVICE_UDID` and run `just build-run-ios`
+   - Android: open Android Studio (`android/`) or use the Android run/install recipes
 
 ## Release Builds
 
@@ -59,9 +60,12 @@ Then build a signed APK/AAB via Android Studio (Build → Generate Signed Bundle
 - **Rust-only changes**: Use `just bacon` or `just bcheck` for continuous feedback
 - **UI changes (no Rust API changes)**: Use `just compile-ios` or `just compile-android` for faster iteration
 - **Rust API or UniFFI changes**: Run `just build-ios` or `just build-android` to rebuild Rust and regenerate bindings
+- **Run iOS on a physical device**: Use `just build-run-ios --udid <device-udid>` when bindings may be stale, or `just run-ios --udid <device-udid>` when generated bindings are already current
 - **Tests**: Run `just watch-test` (`just wtest`) in a separate terminal for continuous test feedback
 
 `just build-ios` and `just build-android` rebuild the Rust core, regenerate UniFFI bindings, and update the mobile projects. `just compile-ios` and `just compile-android` only rebuild the native apps, so use them when Rust exports have not changed.
+
+`just build-run-ios` rebuilds the debug iOS bindings, builds the Xcode app with checkout-specific DerivedData, installs it with `devicectl`, and launches it without opening Xcode. It targets the first available paired iOS device by default; pass `--udid <device-udid>`, `--device-name <device-name>`, or set `IOS_DEVICE_UDID` / `IOS_DEVICE_NAME` to choose a specific phone. The phone must be connected, paired, in Developer Mode, and unlocked before launch.
 
 ### Common Commands
 
@@ -72,6 +76,8 @@ Then build a signed APK/AAB via Android Studio (Build → Generate Signed Bundle
 | `just build-ios` | `just bi` | Build iOS debug simulator |
 | `just build-ios-debug-device` | `just bidd` | Build iOS debug device |
 | `just build-ios-release` | `just bir` | Build iOS release |
+| `just build-run-ios` | `just bri` | Rebuild iOS bindings, install, and run on device or simulator |
+| `just run-ios` | `just ri` | Install and run iOS using existing generated bindings |
 | `just compile-ios` | - | Compile iOS without regenerating bindings |
 | `just compile-android` | - | Compile Android without regenerating bindings |
 | `just test` | - | Run the Rust test suite with nextest |

--- a/justfile
+++ b/justfile
@@ -73,6 +73,26 @@ regenerate-bindings:
 
 alias rb := regenerate-bindings
 
+# Run mobile artifact producer or consumer commands
+[group('ci')]
+mobile-artifact *args:
+    just xtask mobile-artifact {{ args }}
+
+# Trigger Android and iOS mobile artifacts for a pushed ref
+[group('ci')]
+mobile-artifact-trigger ref platform="both":
+    just mobile-artifact trigger --platform "{{ platform }}" --ref "{{ ref }}"
+
+# Install latest matching Android mobile artifact
+[group('ci')]
+mobile-artifact-install-android ref:
+    just mobile-artifact install-android --ref "{{ ref }}"
+
+# Fetch latest matching iOS CoveCore mobile artifact
+[group('ci')]
+mobile-artifact-fetch-ios-core ref:
+    just mobile-artifact fetch-ios-core --ref "{{ ref }}"
+
 # ------------------------------------------------------------------------------
 # build
 # ------------------------------------------------------------------------------

--- a/justfile
+++ b/justfile
@@ -481,16 +481,17 @@ install-android-clean:
 
 alias iac := install-android-clean
 
-# Run iOS app
+# Run iOS app with existing generated bindings
 [group('util')]
 run-ios *args:
     just xtask run-ios {{ args }} && just notf "done run ios"
 
 alias ri := run-ios
 
+# Rebuild iOS bindings, then install and run the iOS app
 [group('util')]
-build-run-ios:
-    just bidd && just ri
+build-run-ios *args:
+    just xtask build-run-ios {{ args }} && just notf "done build run ios"
 
 alias bri := build-run-ios
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4786,6 +4786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,8 +5732,11 @@ dependencies = [
  "hex",
  "image",
  "qrcode",
+ "serde",
  "serde_json",
+ "tempfile",
  "xshell",
+ "zip",
 ]
 
 [[package]]
@@ -5860,6 +5869,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5870,6 +5893,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 color-eyre = "0.6.5"
 xshell = "0.2.7"
 colored = "3.1.1"
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 # for util sign-psbt
@@ -23,3 +24,7 @@ gif = "0.14.2"
 bbqr = { version = "0.3.5", default-features = false }
 foundation-ur = { version = "0.4.0", default-features = false, features = ["std"] }
 hex = "0.4.3"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/rust/xtask/src/ios.rs
+++ b/rust/xtask/src/ios.rs
@@ -44,8 +44,9 @@ const IOS_REQUIRED_SIGNED_ENTITLEMENTS: [&str; 4] = [
 ];
 const IOS_SIMULATOR_DESTINATION: &str = "platform=iOS Simulator,name=iPhone 15 Pro,OS=latest";
 const XCODE_DERIVED_DATA_PATH: &str = "Library/Developer/Xcode/DerivedData";
-const IOS_SIMULATOR_DERIVED_DATA_DIR: &str = "Cove-simulator-run";
-const IOS_DEVICE_DERIVED_DATA_DIR: &str = "Cove-device-run";
+const COVE_BUILD_SLOT_ENV: &str = "COVE_BUILD_SLOT";
+const IOS_SIMULATOR_DERIVED_DATA_SUFFIX: &str = "simulator-run";
+const IOS_DEVICE_DERIVED_DATA_SUFFIX: &str = "device-run";
 const IOS_SIMULATOR_PRODUCTS_DIR: &str = "Debug-iphonesimulator";
 const IOS_DEVICE_PRODUCTS_DIR: &str = "Debug-iphoneos";
 const IOS_CONNECTED_DEVICE_FILTER: &str = "state == \"connected\"";
@@ -1048,7 +1049,7 @@ fn normalize_arg(value: String) -> Option<String> {
 }
 
 fn run_ios_simulator(sh: &Shell, verbose: bool) -> Result<()> {
-    let derived_data_path = derived_data_path(IOS_SIMULATOR_DERIVED_DATA_DIR)?;
+    let derived_data_path = derived_data_path(IOS_SIMULATOR_DERIVED_DATA_SUFFIX)?;
     let app_path = build_ios_app(
         sh,
         IOS_SIMULATOR_DESTINATION,
@@ -1077,7 +1078,7 @@ fn run_ios_device(sh: &Shell, selector: &DeviceSelector, verbose: bool) -> Resul
     let device_identifier = device.device_identifier.clone();
     print_info(&format!("Running iOS app on {}", device.description));
 
-    let derived_data_path = derived_data_path(IOS_DEVICE_DERIVED_DATA_DIR)?;
+    let derived_data_path = derived_data_path(IOS_DEVICE_DERIVED_DATA_SUFFIX)?;
     let app_path = build_ios_app(
         sh,
         &device.destination,
@@ -1134,9 +1135,59 @@ fn build_ios_app(
     Ok(app_path)
 }
 
-fn derived_data_path(dir_name: &str) -> Result<String> {
+fn derived_data_path(target_suffix: &str) -> Result<String> {
     let home_dir = std::env::var("HOME").wrap_err("Failed to get HOME environment variable")?;
+    let dir_name = derived_data_dir_name(target_suffix)?;
+
     Ok(format!("{home_dir}/{XCODE_DERIVED_DATA_PATH}/{dir_name}"))
+}
+
+fn derived_data_dir_name(target_suffix: &str) -> Result<String> {
+    Ok(derived_data_dir_name_for_slot(target_suffix, &ios_build_slot()?))
+}
+
+fn derived_data_dir_name_for_slot(target_suffix: &str, slot: &str) -> String {
+    format!("Cove-{}-{target_suffix}", sanitize_build_slot(slot))
+}
+
+fn ios_build_slot() -> Result<String> {
+    if let Some(slot) = std::env::var_os(COVE_BUILD_SLOT_ENV).filter(|slot| !slot.is_empty()) {
+        return Ok(sanitize_build_slot(&slot.to_string_lossy()));
+    }
+
+    let current_dir = std::env::current_dir().wrap_err("Failed to get current directory")?;
+
+    Ok(default_build_slot_from_cwd(&current_dir))
+}
+
+fn default_build_slot_from_cwd(cwd: &Path) -> String {
+    let workspace_dir = if cwd.file_name().is_some_and(|name| name == "rust") {
+        cwd.parent().unwrap_or(cwd)
+    } else {
+        cwd
+    };
+
+    let slot = workspace_dir
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "workspace".into());
+
+    sanitize_build_slot(&slot)
+}
+
+fn sanitize_build_slot(slot: &str) -> String {
+    let sanitized = slot
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+
+    if sanitized.is_empty() {
+        "workspace".to_string()
+    } else {
+        sanitized
+    }
 }
 
 fn resolve_connected_device(sh: &Shell, selector: &str) -> Result<ResolvedDevice> {

--- a/rust/xtask/src/ios.rs
+++ b/rust/xtask/src/ios.rs
@@ -6,8 +6,12 @@ use color_eyre::{
     Result,
 };
 use colored::Colorize;
+use serde::Deserialize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 use xshell::{cmd, Shell};
@@ -49,7 +53,6 @@ const IOS_SIMULATOR_DERIVED_DATA_SUFFIX: &str = "simulator-run";
 const IOS_DEVICE_DERIVED_DATA_SUFFIX: &str = "device-run";
 const IOS_SIMULATOR_PRODUCTS_DIR: &str = "Debug-iphonesimulator";
 const IOS_DEVICE_PRODUCTS_DIR: &str = "Debug-iphoneos";
-const IOS_CONNECTED_DEVICE_FILTER: &str = "state == \"connected\"";
 const IOS_UI_SCHEME: &str = "CoveManualUITests";
 const IOS_UI_TEST_CLASS: &str = "CoveUITests/OnboardingFullLaunchUITests";
 const IOS_UI_TEST_FILE: &str = "CoveUITests/OnboardingFullLaunchUITests.swift";
@@ -105,7 +108,7 @@ impl IosRunOptions {
         }
     }
 
-    fn target(&self) -> Result<IosRunTarget> {
+    fn target(&self, sh: &Shell) -> Result<IosRunTarget> {
         if self.simulator && (self.device_name.is_some() || self.udid.is_some()) {
             color_eyre::eyre::bail!("--simulator cannot be combined with --device-name or --udid");
         }
@@ -114,7 +117,9 @@ impl IosRunOptions {
             return Ok(IosRunTarget::Simulator);
         }
 
-        Ok(IosRunTarget::Device(DeviceSelector::new(self.device_name.clone(), self.udid.clone())))
+        let selector = DeviceSelector::new(self.device_name.clone(), self.udid.clone());
+
+        Ok(IosRunTarget::Device(selector.resolve(sh)?))
     }
 }
 
@@ -151,7 +156,7 @@ impl TestflightUploadOptions {
 #[derive(Debug, Clone)]
 enum IosRunTarget {
     Simulator,
-    Device(DeviceSelector),
+    Device(ResolvedDevice),
 }
 
 #[derive(Debug, Clone)]
@@ -177,21 +182,22 @@ impl DeviceSelector {
     fn resolve(&self, sh: &Shell) -> Result<ResolvedDevice> {
         match self {
             Self::Auto => {
-                print_error(
-                    "No simulator or device passed via arg or env. Falling back to the first connected iOS device",
+                print_info(
+                    "No simulator or device passed via arg or env. Using the first available iOS device",
                 );
 
-                let device_name = first_connected_device_name(sh)?;
-                resolve_connected_device(sh, &device_name)
+                first_available_ios_device(sh)
             }
-            Self::Name(device_name) => resolve_connected_device(sh, device_name),
-            Self::Udid(udid) => resolve_connected_device_by_udid(sh, udid),
+            Self::Name(device_name) => resolve_available_ios_device_by_name(sh, device_name),
+            Self::Udid(udid) => resolve_available_ios_device_by_udid(sh, udid),
         }
     }
 }
 
 #[derive(Debug, Clone)]
 struct ResolvedDevice {
+    name: String,
+    udid: String,
     destination: String,
     device_identifier: String,
     description: String,
@@ -200,11 +206,49 @@ struct ResolvedDevice {
 impl ResolvedDevice {
     fn new(name: String, device_identifier: String, udid: String) -> Self {
         Self {
+            name: name.clone(),
+            udid: udid.clone(),
             destination: format!("platform=iOS,id={udid}"),
             device_identifier,
-            description: format!("device '{name}'"),
+            description: format!("device '{name}' ({udid})"),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicectlListDevicesOutput {
+    result: DevicectlListDevicesResult,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicectlListDevicesResult {
+    devices: Vec<DevicectlDevice>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DevicectlDevice {
+    identifier: String,
+    connection_properties: DevicectlConnectionProperties,
+    device_properties: DevicectlDeviceProperties,
+    hardware_properties: DevicectlHardwareProperties,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DevicectlConnectionProperties {
+    tunnel_state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicectlDeviceProperties {
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicectlHardwareProperties {
+    platform: Option<String>,
+    udid: Option<String>,
 }
 
 pub fn build_ios(build_type: IosBuildType, device: bool, _sign: bool, verbose: bool) -> Result<()> {
@@ -355,9 +399,26 @@ pub fn build_ios(build_type: IosBuildType, device: bool, _sign: bool, verbose: b
 }
 
 pub fn run_ios(options: IosRunOptions, verbose: bool) -> Result<()> {
-    let sh = Shell::new()?;
-    let run_target = options.target()?;
+    ensure_ios_run_commands()?;
 
+    let sh = Shell::new()?;
+    let run_target = options.target(&sh)?;
+
+    run_ios_target(&sh, run_target, verbose)
+}
+
+pub fn build_run_ios(options: IosRunOptions, verbose: bool) -> Result<()> {
+    ensure_ios_run_commands()?;
+
+    let sh = Shell::new()?;
+    let run_target = options.target(&sh)?;
+    let build_for_device = matches!(run_target, IosRunTarget::Device(_));
+
+    build_ios(IosBuildType::Debug, build_for_device, false, verbose)?;
+    run_ios_target(&sh, run_target, verbose)
+}
+
+fn ensure_ios_run_commands() -> Result<()> {
     if !command_exists("xcodebuild") {
         print_error("xcodebuild not found. Please install Xcode");
         color_eyre::eyre::bail!("xcodebuild command not found");
@@ -368,11 +429,15 @@ pub fn run_ios(options: IosRunOptions, verbose: bool) -> Result<()> {
         color_eyre::eyre::bail!("xcrun command not found");
     }
 
+    Ok(())
+}
+
+fn run_ios_target(sh: &Shell, run_target: IosRunTarget, verbose: bool) -> Result<()> {
     sh.change_dir("../ios");
 
     match run_target {
-        IosRunTarget::Simulator => run_ios_simulator(&sh, verbose),
-        IosRunTarget::Device(selector) => run_ios_device(&sh, &selector, verbose),
+        IosRunTarget::Simulator => run_ios_simulator(sh, verbose),
+        IosRunTarget::Device(device) => run_ios_device(sh, &device, verbose),
     }
 }
 
@@ -1073,8 +1138,7 @@ fn run_ios_simulator(sh: &Shell, verbose: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_ios_device(sh: &Shell, selector: &DeviceSelector, verbose: bool) -> Result<()> {
-    let device = selector.resolve(sh)?;
+fn run_ios_device(sh: &Shell, device: &ResolvedDevice, verbose: bool) -> Result<()> {
     let device_identifier = device.device_identifier.clone();
     print_info(&format!("Running iOS app on {}", device.description));
 
@@ -1190,72 +1254,104 @@ fn sanitize_build_slot(slot: &str) -> String {
     }
 }
 
-fn resolve_connected_device(sh: &Shell, selector: &str) -> Result<ResolvedDevice> {
-    let output = cmd!(sh, "xcrun devicectl device info details --device {selector}")
-        .read()
-        .wrap_err_with(|| format!("Failed to load iOS device details for {selector}"))?;
-
-    parse_device_details(&output)
-}
-
-fn resolve_connected_device_by_udid(sh: &Shell, udid: &str) -> Result<ResolvedDevice> {
-    let device_names = connected_device_names(sh)?;
-
-    for device_name in device_names {
-        let device = resolve_connected_device(sh, &device_name)?;
-        if device.destination == format!("platform=iOS,id={udid}") {
-            return Ok(device);
-        }
-    }
-
-    color_eyre::eyre::bail!("No connected iOS device found for udid={udid}");
-}
-
-fn first_connected_device_name(sh: &Shell) -> Result<String> {
-    connected_device_names(sh)?
+fn first_available_ios_device(sh: &Shell) -> Result<ResolvedDevice> {
+    available_ios_devices(sh)?
         .into_iter()
         .next()
-        .ok_or_else(|| eyre!("No connected iOS device found"))
+        .ok_or_else(|| eyre!("No available paired iOS device found"))
 }
 
-fn connected_device_names(sh: &Shell) -> Result<Vec<String>> {
-    let output = cmd!(
-        sh,
-        "xcrun devicectl list devices --filter {IOS_CONNECTED_DEVICE_FILTER} --columns name --hide-default-columns --hide-headers"
-    )
-    .read()
-    .wrap_err("Failed to list connected iOS devices")?;
+fn resolve_available_ios_device_by_name(sh: &Shell, device_name: &str) -> Result<ResolvedDevice> {
+    let devices = available_ios_devices(sh)?;
 
-    Ok(output
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(ToOwned::to_owned)
-        .collect())
+    devices
+        .iter()
+        .find(|device| device.name == device_name)
+        .cloned()
+        .ok_or_else(|| eyre!("No available paired iOS device named '{device_name}' found"))
+        .with_context(|| available_device_context(&devices))
 }
 
-fn parse_device_details(output: &str) -> Result<ResolvedDevice> {
-    let identifier = parse_device_detail(output, "• identifier: ")?;
-    let name = parse_device_detail(output, "• name: ")?;
-    let udid = parse_device_detail(output, "• udid: ")?;
+fn resolve_available_ios_device_by_udid(sh: &Shell, udid: &str) -> Result<ResolvedDevice> {
+    let devices = available_ios_devices(sh)?;
 
-    Ok(ResolvedDevice::new(name, identifier, udid))
+    devices
+        .iter()
+        .find(|device| device.udid == udid)
+        .cloned()
+        .ok_or_else(|| eyre!("No available paired iOS device found for udid={udid}"))
+        .with_context(|| available_device_context(&devices))
 }
 
-fn parse_device_detail(output: &str, prefix: &str) -> Result<String> {
-    output
-        .lines()
-        .map(str::trim)
-        .find_map(|line| line.strip_prefix(prefix))
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| eyre!("Missing `{prefix}` in devicectl device details"))
+fn available_ios_devices(sh: &Shell) -> Result<Vec<ResolvedDevice>> {
+    let output_path = devicectl_json_output_path()?;
+
+    let result = (|| -> Result<Vec<ResolvedDevice>> {
+        cmd!(sh, "xcrun devicectl list devices --quiet --json-output {output_path}")
+            .quiet()
+            .run()
+            .wrap_err("Failed to list iOS devices")?;
+
+        let output = sh
+            .read_file(&output_path)
+            .wrap_err_with(|| format!("Failed to read {}", output_path.display()))?;
+        let list = serde_json::from_str::<DevicectlListDevicesOutput>(&output)
+            .wrap_err("Failed to parse devicectl device list JSON")?;
+
+        Ok(list.result.devices.into_iter().filter_map(resolved_available_ios_device).collect())
+    })();
+
+    let _ = fs::remove_file(&output_path);
+
+    result
+}
+
+fn resolved_available_ios_device(device: DevicectlDevice) -> Option<ResolvedDevice> {
+    if !devicectl_device_is_available_ios(&device) {
+        return None;
+    }
+
+    let name = device.device_properties.name?;
+    let udid = device.hardware_properties.udid?;
+
+    Some(ResolvedDevice::new(name, device.identifier, udid))
+}
+
+fn devicectl_device_is_available_ios(device: &DevicectlDevice) -> bool {
+    device.hardware_properties.platform.as_deref() == Some("iOS")
+        && device.connection_properties.tunnel_state.as_deref() == Some("connected")
+}
+
+fn devicectl_json_output_path() -> Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .wrap_err("System clock is before UNIX epoch")?
+        .as_nanos();
+
+    Ok(std::env::temp_dir()
+        .join(format!("cove-devicectl-devices-{}-{timestamp}.json", std::process::id())))
+}
+
+fn available_device_context(devices: &[ResolvedDevice]) -> String {
+    if devices.is_empty() {
+        return "No available paired iOS devices found".to_string();
+    }
+
+    let devices = devices
+        .iter()
+        .map(|device| format!("{} ({})", device.name, device.udid))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!("Available paired iOS devices: {devices}")
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ensure_aasa_webcredentials_app, normalize_pem_text, simulator_line_matches_device,
-        simulator_state_from_line,
+        devicectl_device_is_available_ios, ensure_aasa_webcredentials_app, normalize_pem_text,
+        simulator_line_matches_device, simulator_state_from_line, DevicectlConnectionProperties,
+        DevicectlDevice, DevicectlDeviceProperties, DevicectlHardwareProperties,
     };
 
     const VALID_PEM: &str = "\
@@ -1297,6 +1393,27 @@ ABC123
             .as_deref(),
             Some("Shutdown"),
         );
+    }
+
+    #[test]
+    fn devicectl_device_is_available_ios_accepts_connected_ios_device() {
+        let device = devicectl_device("iOS", "connected");
+
+        assert!(devicectl_device_is_available_ios(&device));
+    }
+
+    #[test]
+    fn devicectl_device_is_available_ios_rejects_unavailable_ios_device() {
+        let device = devicectl_device("iOS", "unavailable");
+
+        assert!(!devicectl_device_is_available_ios(&device));
+    }
+
+    #[test]
+    fn devicectl_device_is_available_ios_rejects_non_ios_device() {
+        let device = devicectl_device("macOS", "connected");
+
+        assert!(!devicectl_device_is_available_ios(&device));
     }
 
     #[test]
@@ -1389,5 +1506,21 @@ ABC123
         let body = r#"{"applinks": {"apps": []}}"#;
 
         assert!(ensure_aasa_webcredentials_app(body, "Q8UP8C53Y8.org.bitcoinppl.cove").is_err());
+    }
+
+    fn devicectl_device(platform: &str, tunnel_state: &str) -> DevicectlDevice {
+        DevicectlDevice {
+            identifier: "device-id".to_string(),
+            connection_properties: DevicectlConnectionProperties {
+                tunnel_state: Some(tunnel_state.to_string()),
+            },
+            device_properties: DevicectlDeviceProperties {
+                name: Some("Praveens iPhone 15".to_string()),
+            },
+            hardware_properties: DevicectlHardwareProperties {
+                platform: Some(platform.to_string()),
+                udid: Some("00008120-0006243420214032".to_string()),
+            },
+        }
     }
 }

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -5,6 +5,7 @@ mod android;
 mod common;
 mod github;
 mod ios;
+mod mobile_artifact;
 mod rebase;
 mod util;
 mod version;
@@ -142,6 +143,13 @@ enum Commands {
     #[command(name = "regenerate-bindings")]
     RegenerateBindings,
 
+    /// Build, download, validate, install, and clean mobile artifacts
+    #[command(name = "mobile-artifact")]
+    MobileArtifact {
+        #[command(subcommand)]
+        command: mobile_artifact::MobileArtifactCommand,
+    },
+
     /// Rebase the current branch onto a new base after choosing the old base
     #[command(name = "rebase")]
     Rebase {
@@ -260,6 +268,8 @@ fn main() -> Result<()> {
         Commands::InstallDeps => install_deps(cli.verbose),
 
         Commands::RegenerateBindings => github::regenerate_bindings(),
+
+        Commands::MobileArtifact { command } => mobile_artifact::run(command, cli.verbose),
 
         Commands::Rebase { new_base } => rebase::rebase(&new_base),
 

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -87,6 +87,22 @@ enum Commands {
         udid: Option<String>,
     },
 
+    /// Rebuild iOS bindings, then build, install, and run the iOS app
+    #[command(name = "build-run-ios")]
+    BuildRunIos {
+        /// Run in the iOS simulator instead of on a physical device
+        #[arg(long)]
+        simulator: bool,
+
+        /// Physical device name to target
+        #[arg(long, env = "IOS_DEVICE_NAME")]
+        device_name: Option<String>,
+
+        /// Physical device UDID to target
+        #[arg(long, env = "IOS_DEVICE_UDID")]
+        udid: Option<String>,
+    },
+
     /// Run manual iOS full-launch UI tests
     #[command(name = "ios-ui")]
     IosUi {
@@ -246,6 +262,11 @@ fn main() -> Result<()> {
         Commands::RunIos { simulator, device_name, udid } => {
             let options = ios::IosRunOptions::new(simulator, device_name, udid);
             ios::run_ios(options, cli.verbose)
+        }
+
+        Commands::BuildRunIos { simulator, device_name, udid } => {
+            let options = ios::IosRunOptions::new(simulator, device_name, udid);
+            ios::build_run_ios(options, cli.verbose)
         }
 
         Commands::IosUi { device, test, foreground } => {

--- a/rust/xtask/src/mobile_artifact.rs
+++ b/rust/xtask/src/mobile_artifact.rs
@@ -700,7 +700,7 @@ fn validate_and_extract_zip(zip_path: &Path, dest: &Path) -> Result<()> {
             .ok_or_else(|| eyre!("Artifact ZIP entry is unsafe: {}", file.name()))?;
 
         validate_zip_entry_path(&enclosed_name)?;
-        reject_zip_link_entry(file.name(), file.unix_mode())?;
+        reject_zip_unsafe_entry_type(file.name(), file.unix_mode())?;
     }
 
     recreate_dir(dest)?;
@@ -730,6 +730,7 @@ fn validate_and_extract_zip(zip_path: &Path, dest: &Path) -> Result<()> {
             .wrap_err_with(|| format!("Failed to create {}", out_path.display()))?;
         io::copy(&mut file, &mut output)
             .wrap_err_with(|| format!("Failed to extract {}", out_path.display()))?;
+        apply_zip_file_permissions(&out_path, file.unix_mode())?;
     }
 
     Ok(())
@@ -740,16 +741,17 @@ fn validate_zip_entry_path(path: &Path) -> Result<()> {
     validate_artifact_top_level(path)
 }
 
-fn reject_zip_link_entry(name: &str, unix_mode: Option<u32>) -> Result<()> {
+fn reject_zip_unsafe_entry_type(name: &str, unix_mode: Option<u32>) -> Result<()> {
     let Some(unix_mode) = unix_mode else {
         return Ok(());
     };
-    let file_type = unix_mode & 0o170000;
-    if matches!(file_type, 0o120000 | 0o10000) {
-        color_eyre::eyre::bail!("Artifact ZIP entry is a link: {name}");
-    }
 
-    Ok(())
+    let file_type = unix_mode & 0o170000;
+    match file_type {
+        0o120000 => color_eyre::eyre::bail!("Artifact ZIP entry is a symlink: {name}"),
+        0o010000 => color_eyre::eyre::bail!("Artifact ZIP entry is a FIFO: {name}"),
+        _ => Ok(()),
+    }
 }
 
 fn validate_tree_safety(root: &Path) -> Result<()> {
@@ -845,6 +847,29 @@ fn reject_hardlink(path: &Path, metadata: &fs::Metadata) -> Result<()> {
 
 #[cfg(not(unix))]
 fn reject_hardlink(_path: &Path, _metadata: &fs::Metadata) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_zip_file_permissions(path: &Path, unix_mode: Option<u32>) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(unix_mode) = unix_mode else {
+        return Ok(());
+    };
+
+    let permission_bits = unix_mode & 0o777;
+    if permission_bits == 0 {
+        return Ok(());
+    }
+
+    let permissions = fs::Permissions::from_mode(permission_bits);
+    fs::set_permissions(path, permissions)
+        .wrap_err_with(|| format!("Failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn apply_zip_file_permissions(_path: &Path, _unix_mode: Option<u32>) -> Result<()> {
     Ok(())
 }
 
@@ -1076,7 +1101,14 @@ fn ensure_clean_ios_targets() -> Result<()> {
 }
 
 fn git_status_paths(paths: &[&str]) -> Result<String> {
+    let root = repo_root()?;
+
+    git_status_paths_at(&root, paths)
+}
+
+fn git_status_paths_at(root: &Path, paths: &[&str]) -> Result<String> {
     let output = Command::new("git")
+        .current_dir(root)
         .args(["status", "--porcelain", "--untracked-files=all", "--"])
         .args(paths)
         .output()
@@ -1453,10 +1485,52 @@ mod tests {
     }
 
     #[test]
-    fn rejects_zip_link_modes() {
-        assert!(reject_zip_link_entry("link", Some(0o120777)).is_err());
-        assert!(reject_zip_link_entry("hardlink", Some(0o010777)).is_err());
-        assert!(reject_zip_link_entry("file", Some(0o100644)).is_ok());
+    fn rejects_zip_unsafe_entry_types() {
+        assert!(reject_zip_unsafe_entry_type("link", Some(0o120777)).is_err());
+        assert!(reject_zip_unsafe_entry_type("fifo", Some(0o010777)).is_err());
+        assert!(reject_zip_unsafe_entry_type("file", Some(0o100644)).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_zip_preserves_unix_file_permissions() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        use zip::write::SimpleFileOptions;
+
+        let root = tempfile::tempdir().unwrap();
+        let zip_path = root.path().join("artifact.zip");
+        let zip_file = File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(zip_file);
+        let options = SimpleFileOptions::default().unix_permissions(0o755);
+
+        zip.start_file(ANDROID_APK_PATH, options).unwrap();
+        zip.write_all(b"apk").unwrap();
+        zip.finish().unwrap();
+
+        let dest = root.path().join("dest");
+        validate_and_extract_zip(&zip_path, &dest).unwrap();
+
+        let mode = fs::metadata(dest.join(ANDROID_APK_PATH)).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+    }
+
+    #[test]
+    fn git_status_paths_at_uses_repo_root_relative_pathspecs() {
+        let root = tempfile::tempdir().unwrap();
+        let repo_root = root.path();
+
+        let status =
+            Command::new("git").current_dir(repo_root).args(["init", "--quiet"]).status().unwrap();
+        assert!(status.success());
+
+        let dirty_path = repo_root.join(IOS_GENERATED_PATH).join("dirty.swift");
+        fs::create_dir_all(dirty_path.parent().unwrap()).unwrap();
+        fs::write(&dirty_path, "dirty").unwrap();
+
+        let dirty = git_status_paths_at(repo_root, &[IOS_GENERATED_PATH]).unwrap();
+
+        assert!(dirty.contains("ios/CoveCore/Sources/CoveCore/generated/dirty.swift"));
     }
 
     #[test]

--- a/rust/xtask/src/mobile_artifact.rs
+++ b/rust/xtask/src/mobile_artifact.rs
@@ -404,6 +404,8 @@ fn download_validate_and_stage(
     expected_ref: Option<&str>,
     allow_mismatch: bool,
 ) -> Result<SelectedArtifact> {
+    validate_run_id(run_id)?;
+
     let artifact_name = platform.artifact_name();
     let tmp_dir = repo_root.join(ARTIFACT_ROOT).join("tmp").join(unique_tmp_name(run_id));
     let artifact_tmp = tmp_dir.join(artifact_name);
@@ -614,6 +616,14 @@ fn validate_sha(sha: &str) -> Result<()> {
     }
 
     color_eyre::eyre::bail!("Manifest git_sha is not a 40-character SHA: {sha}");
+}
+
+fn validate_run_id(run_id: &str) -> Result<()> {
+    if !run_id.is_empty() && run_id.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!("Workflow run_id must be numeric: {run_id}");
 }
 
 fn validate_required_text(field: &str, value: &str) -> Result<()> {
@@ -1068,6 +1078,10 @@ fn rollback_ios_core_inputs(
         let backup = backup_root.join(relative);
         let target = repo_root.join(relative);
         if backup.exists() {
+            if target.exists() {
+                remove_path(&target)?;
+            }
+
             move_path(&backup, &target)?;
         }
     }
@@ -1554,6 +1568,14 @@ mod tests {
     }
 
     #[test]
+    fn validates_run_id_shape() {
+        assert!(validate_run_id("123").is_ok());
+        assert!(validate_run_id("").is_err());
+        assert!(validate_run_id("../123").is_err());
+        assert!(validate_run_id("12/3").is_err());
+    }
+
+    #[test]
     fn missing_expected_path_is_rejected() {
         let root = tempfile::tempdir().unwrap();
         fs::write(root.path().join(MANIFEST_PATH), "{}").unwrap();
@@ -1642,6 +1664,31 @@ mod tests {
         rollback_ios_core_inputs(&repo_root, &backup_root, &IosReplacement::default()).unwrap();
 
         assert_eq!(fs::read_to_string(original).unwrap(), "old swift");
+    }
+
+    #[test]
+    fn ios_rollback_removes_partial_target_before_restoring_backup() {
+        let root = tempfile::tempdir().unwrap();
+        let repo_root = root.path().join("repo");
+        let backup_root = root.path().join("backup");
+        let backup_file = backup_root.join(IOS_XCFRAMEWORK_PATH).join("old.txt");
+        let partial_file = repo_root.join(IOS_XCFRAMEWORK_PATH).join("new.txt");
+
+        fs::create_dir_all(backup_file.parent().unwrap()).unwrap();
+        fs::create_dir_all(partial_file.parent().unwrap()).unwrap();
+        fs::write(&backup_file, "old framework").unwrap();
+        fs::write(&partial_file, "partial framework").unwrap();
+
+        let replacement = IosReplacement {
+            moved_targets: vec![IOS_XCFRAMEWORK_PATH.to_string()],
+            copied_targets: Vec::new(),
+        };
+
+        rollback_ios_core_inputs(&repo_root, &backup_root, &replacement).unwrap();
+
+        let restored_file = repo_root.join(IOS_XCFRAMEWORK_PATH).join("old.txt");
+        assert_eq!(fs::read_to_string(restored_file).unwrap(), "old framework");
+        assert!(!partial_file.exists());
     }
 
     #[test]

--- a/rust/xtask/src/mobile_artifact.rs
+++ b/rust/xtask/src/mobile_artifact.rs
@@ -1,0 +1,1584 @@
+use crate::common::{command_exists, print_info, print_success, print_warning};
+use clap::{Args, Subcommand, ValueEnum};
+use color_eyre::{
+    eyre::{eyre, Context, ContextCompat},
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{self, File},
+    io,
+    path::{Component, Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use zip::ZipArchive;
+
+const WORKFLOW_FILE: &str = "mobile-artifacts.yml";
+const GITHUB_REPO: &str = "bitcoinppl/cove";
+const SCHEMA_VERSION: u32 = 1;
+const DEBUG_PROFILE: &str = "debug";
+const ANDROID_ARTIFACT_NAME: &str = "cove-android-dev-debug";
+const IOS_CORE_ARTIFACT_NAME: &str = "cove-ios-core-debug-device";
+const ARTIFACT_ROOT: &str = "_artifacts/mobile";
+const ANDROID_APK_PATH: &str = "android/app-dev-debug.apk";
+const ANDROID_OUTPUT_METADATA_PATH: &str = "android/output-metadata.json";
+const MANIFEST_PATH: &str = "manifest.json";
+const ANDROID_PACKAGE_NAME: &str = "org.bitcoinppl.cove.dev";
+const ANDROID_ACTIVITY_NAME: &str = "org.bitcoinppl.cove.MainActivity";
+const IOS_XCFRAMEWORK_PATH: &str = "ios/CoveCore/Sources/cove_core_ffi.xcframework";
+const IOS_GENERATED_PATH: &str = "ios/CoveCore/Sources/CoveCore/generated";
+const IOS_TARGET_DIRS: &[&str] = &[IOS_XCFRAMEWORK_PATH, IOS_GENERATED_PATH];
+const DIRTY_WARNING_PATHS: &[&str] = &[
+    "rust",
+    "rust/bindings",
+    "android",
+    "android/app/src/main/java/org/bitcoinppl/cove_core",
+    "ios",
+    "ios/CoveCore/Sources/CoveCore/generated",
+];
+
+#[derive(Subcommand)]
+pub enum MobileArtifactCommand {
+    /// Trigger the mobile artifact workflow for a pushed ref
+    Trigger(TriggerArgs),
+
+    /// List completed matching mobile artifact runs and locally valid artifacts
+    List(ListArgs),
+
+    /// Download, validate, install, and launch an Android artifact
+    #[command(name = "install-android")]
+    InstallAndroid(InstallAndroidArgs),
+
+    /// Download, validate, and replace local iOS CoveCore generated inputs
+    #[command(name = "fetch-ios-core")]
+    FetchIosCore(FetchIosCoreArgs),
+
+    /// Clean local mobile artifact cache entries
+    Clean(CleanArgs),
+}
+
+#[derive(Args)]
+pub struct TriggerArgs {
+    #[arg(long, value_enum)]
+    platform: TriggerPlatform,
+
+    #[arg(long = "ref")]
+    git_ref: String,
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    #[arg(long = "ref")]
+    git_ref: Option<String>,
+}
+
+#[derive(Args)]
+pub struct InstallAndroidArgs {
+    #[arg(long = "ref")]
+    git_ref: Option<String>,
+
+    #[arg(long)]
+    run_id: Option<String>,
+
+    #[arg(long)]
+    allow_mismatch: bool,
+
+    #[arg(long)]
+    reset: bool,
+}
+
+#[derive(Args)]
+pub struct FetchIosCoreArgs {
+    #[arg(long = "ref")]
+    git_ref: Option<String>,
+
+    #[arg(long)]
+    run_id: Option<String>,
+
+    #[arg(long)]
+    allow_mismatch: bool,
+}
+
+#[derive(Args)]
+pub struct CleanArgs {
+    #[arg(long, default_value_t = 7)]
+    older_than_days: u64,
+
+    #[arg(long)]
+    include_derived_data: bool,
+
+    #[arg(long)]
+    include_rust_targets: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum TriggerPlatform {
+    Android,
+    #[value(name = "ios-core")]
+    IosCore,
+    Both,
+}
+
+impl TriggerPlatform {
+    fn workflow_value(self) -> &'static str {
+        match self {
+            Self::Android => "android",
+            Self::IosCore => "ios-core",
+            Self::Both => "both",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum ArtifactPlatform {
+    Android,
+    IosCore,
+}
+
+impl ArtifactPlatform {
+    fn artifact_name(self) -> &'static str {
+        match self {
+            Self::Android => ANDROID_ARTIFACT_NAME,
+            Self::IosCore => IOS_CORE_ARTIFACT_NAME,
+        }
+    }
+
+    fn display(self) -> &'static str {
+        match self {
+            Self::Android => "android",
+            Self::IosCore => "ios-core",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ArtifactManifest {
+    schema_version: u32,
+    platform: ArtifactPlatform,
+    profile: String,
+    git_ref: String,
+    git_sha: String,
+    workflow_run_id: String,
+    created_at: String,
+    artifact_name: String,
+    rustc_version: String,
+    runner_os: String,
+    #[serde(default)]
+    xcodebuild_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowRun {
+    #[serde(rename = "databaseId")]
+    database_id: u64,
+    #[serde(rename = "headBranch")]
+    head_branch: Option<String>,
+    #[serde(rename = "headSha")]
+    head_sha: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    status: String,
+    conclusion: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ArtifactsResponse {
+    artifacts: Vec<GitHubArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubArtifact {
+    id: u64,
+    name: String,
+    expired: bool,
+}
+
+#[derive(Debug)]
+struct SelectedArtifact {
+    run_id: String,
+    artifact_dir: PathBuf,
+    manifest: ArtifactManifest,
+}
+
+pub fn run(command: MobileArtifactCommand, _verbose: bool) -> Result<()> {
+    match command {
+        MobileArtifactCommand::Trigger(args) => trigger(args),
+        MobileArtifactCommand::List(args) => list(args),
+        MobileArtifactCommand::InstallAndroid(args) => install_android(args),
+        MobileArtifactCommand::FetchIosCore(args) => fetch_ios_core(args),
+        MobileArtifactCommand::Clean(args) => clean(args),
+    }
+}
+
+fn trigger(args: TriggerArgs) -> Result<()> {
+    ensure_command("gh")?;
+
+    let status = Command::new("gh")
+        .args([
+            "workflow",
+            "run",
+            WORKFLOW_FILE,
+            "--ref",
+            &args.git_ref,
+            "--repo",
+            GITHUB_REPO,
+            "-f",
+            &format!("platform={}", args.platform.workflow_value()),
+            "-f",
+            "profile=debug",
+        ])
+        .status()
+        .wrap_err("Failed to trigger mobile artifacts workflow through gh")?;
+
+    if !status.success() {
+        color_eyre::eyre::bail!("gh workflow run failed");
+    }
+
+    print_success(&format!(
+        "Triggered {WORKFLOW_FILE} for ref {} platform {}",
+        args.git_ref,
+        args.platform.workflow_value()
+    ));
+
+    Ok(())
+}
+
+fn list(args: ListArgs) -> Result<()> {
+    let git_ref = args.git_ref.map(Ok).unwrap_or_else(current_branch)?;
+    let repo_root = repo_root()?;
+    let runs = successful_runs(&git_ref)?;
+
+    if runs.is_empty() {
+        print_warning(&format!("No completed successful {WORKFLOW_FILE} runs found for {git_ref}"));
+        return Ok(());
+    }
+
+    for run in runs {
+        println!(
+            "run={} ref={} sha={} created={} url={}",
+            run.database_id,
+            run.head_branch.as_deref().unwrap_or("<unknown>"),
+            run.head_sha,
+            run.created_at,
+            run.url
+        );
+
+        for platform in [ArtifactPlatform::Android, ArtifactPlatform::IosCore] {
+            let result = download_validate_and_stage(
+                &repo_root,
+                &run.database_id.to_string(),
+                platform,
+                Some(&git_ref),
+                true,
+            );
+
+            match result {
+                Ok(artifact) => println!(
+                    "  {} artifact={} manifest_sha={} staged={}",
+                    platform.display(),
+                    artifact.manifest.artifact_name,
+                    artifact.manifest.git_sha,
+                    artifact.artifact_dir.display()
+                ),
+                Err(error) => println!("  {} unavailable: {error:#}", platform.display()),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn install_android(args: InstallAndroidArgs) -> Result<()> {
+    ensure_command("adb")?;
+    warn_on_dirty_artifact_inputs()?;
+
+    let repo_root = repo_root()?;
+    let artifact = select_artifact(
+        &repo_root,
+        ArtifactPlatform::Android,
+        args.git_ref.as_deref(),
+        args.run_id.as_deref(),
+        args.allow_mismatch,
+    )?;
+    let apk_path = artifact.artifact_dir.join(ANDROID_APK_PATH);
+
+    validate_android_apk_identity(&apk_path)?;
+    install_apk(&apk_path, args.reset)?;
+
+    println!(
+        "Installed Android artifact {} from run {}",
+        artifact.manifest.artifact_name, artifact.run_id
+    );
+
+    Ok(())
+}
+
+fn fetch_ios_core(args: FetchIosCoreArgs) -> Result<()> {
+    warn_on_dirty_artifact_inputs()?;
+    ensure_clean_ios_targets()?;
+
+    let repo_root = repo_root()?;
+    let artifact = select_artifact(
+        &repo_root,
+        ArtifactPlatform::IosCore,
+        args.git_ref.as_deref(),
+        args.run_id.as_deref(),
+        args.allow_mismatch,
+    )?;
+
+    replace_ios_core_inputs(&repo_root, &artifact.artifact_dir)?;
+    println!(
+        "Fetched iOS CoveCore artifact {} from run {}",
+        artifact.manifest.artifact_name, artifact.run_id
+    );
+
+    Ok(())
+}
+
+fn clean(args: CleanArgs) -> Result<()> {
+    let repo_root = repo_root()?;
+    let cutoff = cutoff_time(args.older_than_days)?;
+    let artifact_root = repo_root.join(ARTIFACT_ROOT);
+
+    remove_old_children(&artifact_root.join("tmp"), cutoff, true)?;
+    remove_old_children(&artifact_root.join("runs"), cutoff, false)?;
+
+    if args.include_derived_data {
+        let derived_data = derived_data_root()?;
+        remove_allowlisted_children(&derived_data, cutoff, |name| name.starts_with("Cove-"))?;
+    }
+
+    if args.include_rust_targets {
+        remove_allowlisted_path(&repo_root.join("rust/target"), cutoff)?;
+    }
+
+    print_success("Mobile artifact cleanup completed");
+    Ok(())
+}
+
+fn select_artifact(
+    repo_root: &Path,
+    platform: ArtifactPlatform,
+    git_ref: Option<&str>,
+    run_id: Option<&str>,
+    allow_mismatch: bool,
+) -> Result<SelectedArtifact> {
+    if let Some(run_id) = run_id {
+        return download_validate_and_stage(repo_root, run_id, platform, git_ref, allow_mismatch);
+    }
+
+    let git_ref = match git_ref {
+        Some(git_ref) => git_ref.to_string(),
+        None => current_branch()?,
+    };
+
+    for run in successful_runs(&git_ref)? {
+        let run_id = run.database_id.to_string();
+        match download_validate_and_stage(
+            repo_root,
+            &run_id,
+            platform,
+            Some(&git_ref),
+            allow_mismatch,
+        ) {
+            Ok(artifact) => return Ok(artifact),
+            Err(error) => {
+                print_warning(&format!(
+                    "Skipping run {run_id} for {}: {error:#}",
+                    platform.display()
+                ));
+            }
+        }
+    }
+
+    color_eyre::eyre::bail!("No valid {} artifact found for ref {git_ref}", platform.display());
+}
+
+fn download_validate_and_stage(
+    repo_root: &Path,
+    run_id: &str,
+    platform: ArtifactPlatform,
+    expected_ref: Option<&str>,
+    allow_mismatch: bool,
+) -> Result<SelectedArtifact> {
+    let artifact_name = platform.artifact_name();
+    let tmp_dir = repo_root.join(ARTIFACT_ROOT).join("tmp").join(unique_tmp_name(run_id));
+    let artifact_tmp = tmp_dir.join(artifact_name);
+    let archive_path = tmp_dir.join(format!("{artifact_name}.zip"));
+    let staged_dir = repo_root.join(ARTIFACT_ROOT).join("runs").join(run_id).join(artifact_name);
+
+    recreate_dir(&tmp_dir)?;
+    gh_download(run_id, artifact_name, &archive_path)?;
+    validate_and_extract_zip(&archive_path, &artifact_tmp)?;
+    validate_tree_safety(&artifact_tmp)?;
+
+    let manifest = read_manifest(&artifact_tmp)?;
+    validate_manifest(&manifest, platform, artifact_name, expected_ref, run_id)?;
+    validate_expected_paths(&artifact_tmp, platform)?;
+    validate_head_match(&manifest, allow_mismatch)?;
+
+    if staged_dir.exists() {
+        fs::remove_dir_all(&staged_dir).wrap_err_with(|| {
+            format!("Failed to remove old staged artifact {}", staged_dir.display())
+        })?;
+    }
+
+    let staged_parent =
+        staged_dir.parent().ok_or_else(|| eyre!("staged artifact path has no parent"))?;
+    fs::create_dir_all(staged_parent)
+        .wrap_err_with(|| format!("Failed to create {}", staged_parent.display()))?;
+    fs::rename(&artifact_tmp, &staged_dir)
+        .or_else(|_| copy_dir_replace(&artifact_tmp, &staged_dir))
+        .wrap_err_with(|| format!("Failed to stage artifact at {}", staged_dir.display()))?;
+    let _ = fs::remove_dir_all(&tmp_dir);
+
+    Ok(SelectedArtifact { run_id: run_id.to_string(), artifact_dir: staged_dir, manifest })
+}
+
+fn gh_download(run_id: &str, artifact_name: &str, dest: &Path) -> Result<()> {
+    ensure_command("gh")?;
+
+    let artifact = github_artifact(run_id, artifact_name)?;
+    let output =
+        File::create(dest).wrap_err_with(|| format!("Failed to create {}", dest.display()))?;
+    let status = Command::new("gh")
+        .args([
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            &format!("/repos/{GITHUB_REPO}/actions/artifacts/{}/zip", artifact.id),
+        ])
+        .stdout(Stdio::from(output))
+        .status()
+        .wrap_err_with(|| {
+            format!("Failed to download artifact {artifact_name} from run {run_id}")
+        })?;
+
+    if !status.success() {
+        color_eyre::eyre::bail!(
+            "gh artifact download failed for run {run_id} artifact {artifact_name}"
+        );
+    }
+
+    Ok(())
+}
+
+fn github_artifact(run_id: &str, artifact_name: &str) -> Result<GitHubArtifact> {
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            &format!("/repos/{GITHUB_REPO}/actions/runs/{run_id}/artifacts"),
+        ])
+        .output()
+        .wrap_err_with(|| format!("Failed to list artifacts for run {run_id}"))?;
+
+    if !output.status.success() {
+        color_eyre::eyre::bail!("gh api artifact listing failed for run {run_id}");
+    }
+
+    let response: ArtifactsResponse =
+        serde_json::from_slice(&output.stdout).wrap_err("Failed to parse GitHub artifact list")?;
+    response
+        .artifacts
+        .into_iter()
+        .find(|artifact| artifact.name == artifact_name && !artifact.expired)
+        .ok_or_else(|| eyre!("Run {run_id} does not have non-expired artifact {artifact_name}"))
+}
+
+fn successful_runs(git_ref: &str) -> Result<Vec<WorkflowRun>> {
+    ensure_command("gh")?;
+
+    let output = Command::new("gh")
+        .args([
+            "run",
+            "list",
+            "--repo",
+            GITHUB_REPO,
+            "--workflow",
+            WORKFLOW_FILE,
+            "--branch",
+            git_ref,
+            "--status",
+            "success",
+            "--limit",
+            "20",
+            "--json",
+            "databaseId,headBranch,headSha,createdAt,status,conclusion,url",
+        ])
+        .output()
+        .wrap_err("Failed to list mobile artifact workflow runs through gh")?;
+
+    if !output.status.success() {
+        color_eyre::eyre::bail!("gh run list failed");
+    }
+
+    let runs: Vec<WorkflowRun> = serde_json::from_slice(&output.stdout)
+        .wrap_err("Failed to parse gh run list JSON for mobile artifacts")?;
+
+    Ok(runs
+        .into_iter()
+        .filter(|run| run.status == "completed" && run.conclusion == "success")
+        .collect())
+}
+
+fn read_manifest(artifact_dir: &Path) -> Result<ArtifactManifest> {
+    let manifest_path = artifact_dir.join(MANIFEST_PATH);
+    let manifest = fs::read_to_string(&manifest_path)
+        .wrap_err_with(|| format!("Failed to read {}", manifest_path.display()))?;
+
+    serde_json::from_str(&manifest)
+        .wrap_err_with(|| format!("Failed to parse {}", manifest_path.display()))
+}
+
+fn validate_manifest(
+    manifest: &ArtifactManifest,
+    platform: ArtifactPlatform,
+    artifact_name: &str,
+    expected_ref: Option<&str>,
+    run_id: &str,
+) -> Result<()> {
+    if manifest.schema_version != SCHEMA_VERSION {
+        color_eyre::eyre::bail!(
+            "Unknown mobile artifact manifest schema_version {}",
+            manifest.schema_version
+        );
+    }
+
+    if manifest.platform != platform {
+        color_eyre::eyre::bail!(
+            "Manifest platform {} does not match requested {}",
+            manifest.platform.display(),
+            platform.display()
+        );
+    }
+
+    if manifest.profile != DEBUG_PROFILE {
+        color_eyre::eyre::bail!("Refusing non-debug mobile artifact profile {}", manifest.profile);
+    }
+
+    if manifest.git_ref.trim().is_empty() {
+        color_eyre::eyre::bail!("Manifest git_ref is empty");
+    }
+
+    if manifest.artifact_name != artifact_name {
+        color_eyre::eyre::bail!(
+            "Manifest artifact_name {} does not match expected {artifact_name}",
+            manifest.artifact_name
+        );
+    }
+
+    if !manifest.workflow_run_id.chars().all(|c| c.is_ascii_digit()) {
+        color_eyre::eyre::bail!(
+            "Manifest workflow_run_id is not numeric: {}",
+            manifest.workflow_run_id
+        );
+    }
+
+    if manifest.workflow_run_id != run_id {
+        color_eyre::eyre::bail!(
+            "Manifest workflow_run_id {} does not match selected run {run_id}",
+            manifest.workflow_run_id
+        );
+    }
+
+    if expected_ref.is_some_and(|expected_ref| manifest.git_ref != expected_ref) {
+        let expected_ref = expected_ref.unwrap();
+        color_eyre::eyre::bail!(
+            "Manifest git_ref {} does not match requested ref {expected_ref}",
+            manifest.git_ref
+        );
+    }
+
+    validate_sha(&manifest.git_sha)?;
+    validate_created_at(&manifest.created_at)?;
+    validate_required_text("rustc_version", &manifest.rustc_version)?;
+    validate_required_text("runner_os", &manifest.runner_os)?;
+    if platform == ArtifactPlatform::IosCore {
+        validate_required_text(
+            "xcodebuild_version",
+            manifest.xcodebuild_version.as_deref().unwrap_or_default(),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_sha(sha: &str) -> Result<()> {
+    if sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!("Manifest git_sha is not a 40-character SHA: {sha}");
+}
+
+fn validate_required_text(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        color_eyre::eyre::bail!("Manifest {field} is empty");
+    }
+
+    Ok(())
+}
+
+fn validate_created_at(value: &str) -> Result<()> {
+    validate_required_text("created_at", value)?;
+
+    if value.contains('T') && value.ends_with('Z') {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!("Manifest created_at is not an expected UTC timestamp: {value}");
+}
+
+fn validate_head_match(manifest: &ArtifactManifest, allow_mismatch: bool) -> Result<()> {
+    let head = current_head_sha()?;
+    let comparison = head_mismatch(&head, &manifest.git_sha);
+
+    if comparison == HeadComparison::Matches || allow_mismatch {
+        if comparison == HeadComparison::Mismatches {
+            print_warning(&format!(
+                "Using artifact for git_sha {} while workspace HEAD is {}",
+                manifest.git_sha, head
+            ));
+        }
+
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!(
+        "Workspace HEAD {head} differs from artifact git_sha {}; pass --allow-mismatch to use it deliberately",
+        manifest.git_sha
+    );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeadComparison {
+    Matches,
+    Mismatches,
+}
+
+fn head_mismatch(head: &str, manifest_sha: &str) -> HeadComparison {
+    if head == manifest_sha {
+        HeadComparison::Matches
+    } else {
+        HeadComparison::Mismatches
+    }
+}
+
+fn validate_expected_paths(artifact_dir: &Path, platform: ArtifactPlatform) -> Result<()> {
+    let expected = match platform {
+        ArtifactPlatform::Android => {
+            vec![MANIFEST_PATH, ANDROID_APK_PATH, ANDROID_OUTPUT_METADATA_PATH]
+        }
+        ArtifactPlatform::IosCore => vec![MANIFEST_PATH, IOS_XCFRAMEWORK_PATH, IOS_GENERATED_PATH],
+    };
+
+    for relative in expected {
+        let path = artifact_dir.join(relative);
+        if !path.exists() {
+            color_eyre::eyre::bail!("Artifact is missing expected path {}", path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_and_extract_zip(zip_path: &Path, dest: &Path) -> Result<()> {
+    let zip_file =
+        File::open(zip_path).wrap_err_with(|| format!("Failed to open {}", zip_path.display()))?;
+    let mut archive = ZipArchive::new(zip_file)
+        .wrap_err_with(|| format!("Failed to read artifact ZIP {}", zip_path.display()))?;
+
+    for index in 0..archive.len() {
+        let file = archive.by_index(index).wrap_err("Failed to inspect artifact ZIP entry")?;
+        let enclosed_name = file
+            .enclosed_name()
+            .ok_or_else(|| eyre!("Artifact ZIP entry is unsafe: {}", file.name()))?;
+
+        validate_zip_entry_path(&enclosed_name)?;
+        reject_zip_link_entry(file.name(), file.unix_mode())?;
+    }
+
+    recreate_dir(dest)?;
+
+    let zip_file =
+        File::open(zip_path).wrap_err_with(|| format!("Failed to open {}", zip_path.display()))?;
+    let mut archive = ZipArchive::new(zip_file)
+        .wrap_err_with(|| format!("Failed to read artifact ZIP {}", zip_path.display()))?;
+
+    for index in 0..archive.len() {
+        let mut file = archive.by_index(index).wrap_err("Failed to extract artifact ZIP entry")?;
+        let relative = file
+            .enclosed_name()
+            .ok_or_else(|| eyre!("Artifact ZIP entry is unsafe: {}", file.name()))?;
+        let out_path = dest.join(&relative);
+
+        if file.is_dir() {
+            fs::create_dir_all(&out_path)
+                .wrap_err_with(|| format!("Failed to create {}", out_path.display()))?;
+            continue;
+        }
+
+        let parent = out_path.parent().wrap_err("ZIP output path has no parent")?;
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("Failed to create {}", parent.display()))?;
+        let mut output = File::create(&out_path)
+            .wrap_err_with(|| format!("Failed to create {}", out_path.display()))?;
+        io::copy(&mut file, &mut output)
+            .wrap_err_with(|| format!("Failed to extract {}", out_path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn validate_zip_entry_path(path: &Path) -> Result<()> {
+    validate_relative_path(path)?;
+    validate_artifact_top_level(path)
+}
+
+fn reject_zip_link_entry(name: &str, unix_mode: Option<u32>) -> Result<()> {
+    let Some(unix_mode) = unix_mode else {
+        return Ok(());
+    };
+    let file_type = unix_mode & 0o170000;
+    if matches!(file_type, 0o120000 | 0o10000) {
+        color_eyre::eyre::bail!("Artifact ZIP entry is a link: {name}");
+    }
+
+    Ok(())
+}
+
+fn validate_tree_safety(root: &Path) -> Result<()> {
+    let canonical_root =
+        root.canonicalize().wrap_err_with(|| format!("Failed to resolve {}", root.display()))?;
+
+    validate_tree_safety_inner(root, root, &canonical_root)
+}
+
+fn validate_tree_safety_inner(root: &Path, current: &Path, canonical_root: &Path) -> Result<()> {
+    for entry in fs::read_dir(current)
+        .wrap_err_with(|| format!("Failed to read artifact directory {}", current.display()))?
+    {
+        let entry = entry.wrap_err("Failed to read artifact directory entry")?;
+        let path = entry.path();
+        let relative = path
+            .strip_prefix(root)
+            .wrap_err_with(|| format!("Artifact path escaped root: {}", path.display()))?;
+
+        validate_relative_path(relative)?;
+        validate_artifact_top_level(relative)?;
+
+        let metadata = fs::symlink_metadata(&path)
+            .wrap_err_with(|| format!("Failed to inspect {}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            color_eyre::eyre::bail!("Artifact contains symlink {}", path.display());
+        }
+
+        reject_hardlink(&path, &metadata)?;
+
+        let canonical = path
+            .canonicalize()
+            .wrap_err_with(|| format!("Failed to resolve {}", path.display()))?;
+        if !canonical.starts_with(canonical_root) {
+            color_eyre::eyre::bail!("Artifact path escapes staging root: {}", path.display());
+        }
+
+        if metadata.is_dir() {
+            validate_tree_safety_inner(root, &path, canonical_root)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        color_eyre::eyre::bail!("Artifact path is absolute: {}", path.display());
+    }
+
+    for component in path.components() {
+        if matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_)) {
+            color_eyre::eyre::bail!("Artifact path is unsafe: {}", path.display());
+        }
+
+        if matches!(&component, Component::Normal(value) if value.to_string_lossy().contains('\\'))
+        {
+            color_eyre::eyre::bail!(
+                "Artifact path contains a Windows separator: {}",
+                path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_artifact_top_level(path: &Path) -> Result<()> {
+    let Some(top_level) = path.components().next().and_then(|component| match component {
+        Component::Normal(value) => Some(value),
+        _ => None,
+    }) else {
+        return Ok(());
+    };
+
+    if matches!(top_level.to_str(), Some("manifest.json" | "android" | "ios")) {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!("Artifact contains unexpected top-level path {}", path.display());
+}
+
+#[cfg(unix)]
+fn reject_hardlink(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    if metadata.is_file() && metadata.nlink() > 1 {
+        color_eyre::eyre::bail!("Artifact contains hardlink {}", path.display());
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_hardlink(_path: &Path, _metadata: &fs::Metadata) -> Result<()> {
+    Ok(())
+}
+
+fn validate_android_apk_identity(apk_path: &Path) -> Result<()> {
+    let package = read_apk_package_name(apk_path)?;
+
+    if package == ANDROID_PACKAGE_NAME {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!(
+        "APK package name {package} does not match expected {ANDROID_PACKAGE_NAME}"
+    );
+}
+
+fn read_apk_package_name(apk_path: &Path) -> Result<String> {
+    if let Some(aapt) = find_android_tool("aapt") {
+        let output = Command::new(aapt)
+            .args(["dump", "badging"])
+            .arg(apk_path)
+            .output()
+            .wrap_err("Failed to inspect APK with aapt")?;
+
+        if output.status.success() {
+            let stdout = String::from_utf8(output.stdout)
+                .wrap_err("aapt output for APK identity was not valid UTF-8")?;
+
+            return parse_aapt_package_name(&stdout)
+                .ok_or_else(|| eyre!("aapt output did not include package name"));
+        }
+    }
+
+    if let Some(apkanalyzer) = find_android_tool("apkanalyzer") {
+        let output = Command::new(apkanalyzer)
+            .args(["manifest", "application-id"])
+            .arg(apk_path)
+            .output()
+            .wrap_err("Failed to inspect APK with apkanalyzer")?;
+
+        if output.status.success() {
+            let package = String::from_utf8(output.stdout)
+                .wrap_err("apkanalyzer output for APK identity was not valid UTF-8")?
+                .trim()
+                .to_string();
+
+            if !package.is_empty() {
+                return Ok(package);
+            }
+        }
+    }
+
+    color_eyre::eyre::bail!(
+        "Unable to inspect APK identity; install Android SDK build-tools with aapt or apkanalyzer"
+    );
+}
+
+fn parse_aapt_package_name(output: &str) -> Option<String> {
+    let line = output.lines().find(|line| line.starts_with("package: "))?;
+    let name_start = line.find("name='")? + "name='".len();
+    let rest = &line[name_start..];
+    let name_end = rest.find('\'')?;
+
+    Some(rest[..name_end].to_string())
+}
+
+fn find_android_tool(name: &str) -> Option<PathBuf> {
+    if command_exists(name) {
+        return Some(PathBuf::from(name));
+    }
+
+    for env_name in ["ANDROID_HOME", "ANDROID_SDK_ROOT"] {
+        let Some(root) = std::env::var_os(env_name) else {
+            continue;
+        };
+        let build_tools = PathBuf::from(root).join("build-tools");
+        let Ok(entries) = fs::read_dir(build_tools) else {
+            continue;
+        };
+
+        let mut candidates = entries
+            .filter_map(std::result::Result::ok)
+            .map(|entry| entry.path().join(name))
+            .filter(|path| path.exists())
+            .collect::<Vec<_>>();
+        candidates.sort();
+
+        if let Some(candidate) = candidates.pop() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn install_apk(apk_path: &Path, reset: bool) -> Result<()> {
+    print_info(&format!("Installing APK {}", apk_path.display()));
+    let output = Command::new("adb")
+        .args(["install", "-r"])
+        .arg(apk_path)
+        .output()
+        .wrap_err("Failed to run adb install")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("INSTALL_FAILED_UPDATE_INCOMPATIBLE") {
+            color_eyre::eyre::bail!(
+                "adb install failed with INSTALL_FAILED_UPDATE_INCOMPATIBLE. Uninstall the existing dev app or use an approved shared dev debug key before retrying.\n{stderr}"
+            );
+        }
+
+        color_eyre::eyre::bail!("adb install failed: {stderr}");
+    }
+
+    if reset {
+        print_info("Clearing Android dev app data");
+        run_status(Command::new("adb").args(["shell", "pm", "clear", ANDROID_PACKAGE_NAME]))?;
+    }
+
+    let component = format!("{ANDROID_PACKAGE_NAME}/{ANDROID_ACTIVITY_NAME}");
+    print_info("Launching Android dev app");
+    run_status(Command::new("adb").args(["shell", "am", "start", "-n", &component]))?;
+
+    print_success("Android artifact installed and launched");
+    Ok(())
+}
+
+fn run_status(command: &mut Command) -> Result<()> {
+    let status = command.status().wrap_err("Failed to run command")?;
+    if !status.success() {
+        color_eyre::eyre::bail!("command failed with status {status}");
+    }
+
+    Ok(())
+}
+
+fn replace_ios_core_inputs(repo_root: &Path, artifact_dir: &Path) -> Result<()> {
+    let backup_root = repo_root.join(ARTIFACT_ROOT).join("tmp").join(unique_tmp_name("ios-backup"));
+    recreate_dir(&backup_root)?;
+
+    let mut replacement = IosReplacement::default();
+    let result =
+        replace_ios_core_inputs_inner(repo_root, artifact_dir, &backup_root, &mut replacement);
+    if let Err(error) = result {
+        rollback_ios_core_inputs(repo_root, &backup_root, &replacement)?;
+        return Err(error).wrap_err("Rolled back iOS CoveCore artifact fetch after copy failure");
+    }
+
+    let _ = fs::remove_dir_all(&backup_root);
+    Ok(())
+}
+
+fn replace_ios_core_inputs_inner(
+    repo_root: &Path,
+    artifact_dir: &Path,
+    backup_root: &Path,
+    replacement: &mut IosReplacement,
+) -> Result<()> {
+    for relative in IOS_TARGET_DIRS {
+        let target = repo_root.join(relative);
+        let backup = backup_root.join(relative);
+        if target.exists() {
+            move_path(&target, &backup)?;
+            replacement.moved_targets.push((*relative).to_string());
+        }
+    }
+
+    for relative in IOS_TARGET_DIRS {
+        let source = artifact_dir.join(relative);
+        let target = repo_root.join(relative);
+        copy_path(&source, &target)?;
+        replacement.copied_targets.push((*relative).to_string());
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct IosReplacement {
+    moved_targets: Vec<String>,
+    copied_targets: Vec<String>,
+}
+
+fn rollback_ios_core_inputs(
+    repo_root: &Path,
+    backup_root: &Path,
+    replacement: &IosReplacement,
+) -> Result<()> {
+    for relative in &replacement.copied_targets {
+        let target = repo_root.join(relative);
+        if target.exists() {
+            remove_path(&target)?;
+        }
+    }
+
+    for relative in &replacement.moved_targets {
+        let backup = backup_root.join(relative);
+        let target = repo_root.join(relative);
+        if backup.exists() {
+            move_path(&backup, &target)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn warn_on_dirty_artifact_inputs() -> Result<()> {
+    let dirty = git_status_paths(DIRTY_WARNING_PATHS)?;
+    if dirty.trim().is_empty() {
+        return Ok(());
+    }
+
+    print_warning("Workspace has local changes that may not be reflected in pushed artifacts:");
+    for line in dirty.lines() {
+        println!("  {line}");
+    }
+
+    Ok(())
+}
+
+fn ensure_clean_ios_targets() -> Result<()> {
+    let dirty = git_status_paths(IOS_TARGET_DIRS)?;
+    if dirty.trim().is_empty() {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!(
+        "Refusing to fetch iOS artifact because generated CoveCore target paths are dirty:\n{dirty}"
+    );
+}
+
+fn git_status_paths(paths: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=all", "--"])
+        .args(paths)
+        .output()
+        .wrap_err("Failed to inspect git status")?;
+
+    if !output.status.success() {
+        color_eyre::eyre::bail!("git status failed");
+    }
+
+    String::from_utf8(output.stdout).wrap_err("git status output was not valid UTF-8")
+}
+
+fn current_head_sha() -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .wrap_err("Failed to read current git HEAD")?;
+
+    if !output.status.success() {
+        color_eyre::eyre::bail!("git rev-parse HEAD failed");
+    }
+
+    Ok(String::from_utf8(output.stdout)
+        .wrap_err("git HEAD output was not valid UTF-8")?
+        .trim()
+        .to_string())
+}
+
+fn current_branch() -> Result<String> {
+    let output = Command::new("git")
+        .args(["symbolic-ref", "--quiet", "--short", "HEAD"])
+        .output()
+        .wrap_err("Failed to read current git branch")?;
+
+    if !output.status.success() {
+        color_eyre::eyre::bail!("--ref is required when current workspace is detached");
+    }
+
+    let branch = String::from_utf8(output.stdout)
+        .wrap_err("Current git branch was not valid UTF-8")?
+        .trim()
+        .to_string();
+
+    if branch.is_empty() {
+        color_eyre::eyre::bail!("--ref is required when current branch is empty");
+    }
+
+    Ok(branch)
+}
+
+fn repo_root() -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .wrap_err("Failed to locate git repository root")?;
+
+    if !output.status.success() {
+        color_eyre::eyre::bail!("git rev-parse --show-toplevel failed");
+    }
+
+    let path = String::from_utf8(output.stdout)
+        .wrap_err("git repository root was not valid UTF-8")?
+        .trim()
+        .to_string();
+
+    Ok(PathBuf::from(path))
+}
+
+fn ensure_command(command: &str) -> Result<()> {
+    if command_exists(command) {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!("{command} is required for mobile artifact commands");
+}
+
+fn unique_tmp_name(prefix: &str) -> String {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+
+    format!("{prefix}-{pid}-{nanos}")
+}
+
+fn recreate_dir(path: &Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_dir_all(path)
+            .wrap_err_with(|| format!("Failed to remove {}", path.display()))?;
+    }
+
+    fs::create_dir_all(path).wrap_err_with(|| format!("Failed to create {}", path.display()))
+}
+
+fn copy_dir_replace(source: &Path, target: &Path) -> Result<()> {
+    if target.exists() {
+        fs::remove_dir_all(target)
+            .wrap_err_with(|| format!("Failed to remove {}", target.display()))?;
+    }
+
+    copy_path(source, target)
+}
+
+fn copy_path(source: &Path, target: &Path) -> Result<()> {
+    if source.is_dir() {
+        fs::create_dir_all(target)
+            .wrap_err_with(|| format!("Failed to create {}", target.display()))?;
+
+        for entry in
+            fs::read_dir(source).wrap_err_with(|| format!("Failed to read {}", source.display()))?
+        {
+            let entry = entry.wrap_err("Failed to read directory entry")?;
+            copy_path(&entry.path(), &target.join(entry.file_name()))?;
+        }
+
+        return Ok(());
+    }
+
+    let parent = target.parent().wrap_err("copy target has no parent")?;
+    fs::create_dir_all(parent)
+        .wrap_err_with(|| format!("Failed to create {}", parent.display()))?;
+    fs::copy(source, target)
+        .wrap_err_with(|| format!("Failed to copy {} to {}", source.display(), target.display()))?;
+
+    Ok(())
+}
+
+fn move_path(source: &Path, target: &Path) -> Result<()> {
+    let parent = target.parent().wrap_err("move target has no parent")?;
+    fs::create_dir_all(parent)
+        .wrap_err_with(|| format!("Failed to create {}", parent.display()))?;
+    fs::rename(source, target).or_else(|_| {
+        copy_path(source, target)?;
+        remove_path(source)
+    })
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)
+            .wrap_err_with(|| format!("Failed to remove {}", path.display()))?;
+    } else if path.exists() {
+        fs::remove_file(path).wrap_err_with(|| format!("Failed to remove {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn cutoff_time(days: u64) -> Result<SystemTime> {
+    let duration = Duration::from_secs(days.saturating_mul(24 * 60 * 60));
+    SystemTime::now().checked_sub(duration).ok_or_else(|| eyre!("Invalid cleanup cutoff"))
+}
+
+fn remove_old_children(
+    path: &Path,
+    cutoff: SystemTime,
+    remove_root_when_empty: bool,
+) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    for entry in
+        fs::read_dir(path).wrap_err_with(|| format!("Failed to read {}", path.display()))?
+    {
+        let entry = entry.wrap_err("Failed to read cleanup entry")?;
+        remove_allowlisted_path_if_old(&entry.path(), cutoff)?;
+    }
+
+    if remove_root_when_empty && fs::read_dir(path)?.next().is_none() {
+        fs::remove_dir(path).wrap_err_with(|| format!("Failed to remove {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn remove_allowlisted_children<F>(path: &Path, cutoff: SystemTime, allow: F) -> Result<()>
+where
+    F: Fn(&str) -> bool,
+{
+    if !path.exists() {
+        return Ok(());
+    }
+
+    for entry in
+        fs::read_dir(path).wrap_err_with(|| format!("Failed to read {}", path.display()))?
+    {
+        let entry = entry.wrap_err("Failed to read cleanup entry")?;
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
+        if allow(&name) {
+            remove_allowlisted_path_if_old(&entry.path(), cutoff)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn remove_allowlisted_path(path: &Path, cutoff: SystemTime) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    remove_allowlisted_path_if_old(path, cutoff)
+}
+
+fn remove_allowlisted_path_if_old(path: &Path, cutoff: SystemTime) -> Result<()> {
+    let metadata =
+        fs::metadata(path).wrap_err_with(|| format!("Failed to inspect {}", path.display()))?;
+    let modified = metadata
+        .modified()
+        .wrap_err_with(|| format!("Failed to read modified time for {}", path.display()))?;
+
+    if modified > cutoff {
+        return Ok(());
+    }
+
+    print_info(&format!("Removing {}", path.display()));
+    remove_path(path)
+}
+
+fn derived_data_root() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").wrap_err("HOME is required for DerivedData cleanup")?;
+
+    Ok(PathBuf::from(home).join("Library/Developer/Xcode/DerivedData"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_manifest(platform: ArtifactPlatform) -> ArtifactManifest {
+        ArtifactManifest {
+            schema_version: SCHEMA_VERSION,
+            platform,
+            profile: DEBUG_PROFILE.to_string(),
+            git_ref: "wk2".to_string(),
+            git_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            workflow_run_id: "123".to_string(),
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+            artifact_name: platform.artifact_name().to_string(),
+            rustc_version: "rustc 1.0.0".to_string(),
+            runner_os: "Linux".to_string(),
+            xcodebuild_version: None,
+        }
+    }
+
+    #[test]
+    fn validates_matching_manifest() {
+        let manifest = sample_manifest(ArtifactPlatform::Android);
+
+        validate_manifest(
+            &manifest,
+            ArtifactPlatform::Android,
+            ANDROID_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_unknown_schema() {
+        let mut manifest = sample_manifest(ArtifactPlatform::Android);
+        manifest.schema_version = 2;
+
+        assert!(validate_manifest(
+            &manifest,
+            ArtifactPlatform::Android,
+            ANDROID_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_non_debug_profile() {
+        let mut manifest = sample_manifest(ArtifactPlatform::Android);
+        manifest.profile = "release".to_string();
+
+        assert!(validate_manifest(
+            &manifest,
+            ArtifactPlatform::Android,
+            ANDROID_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_platform_mismatch() {
+        let manifest = sample_manifest(ArtifactPlatform::Android);
+
+        assert!(validate_manifest(
+            &manifest,
+            ArtifactPlatform::IosCore,
+            IOS_CORE_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_artifact_name_mismatch() {
+        let manifest = sample_manifest(ArtifactPlatform::Android);
+
+        assert!(validate_manifest(
+            &manifest,
+            ArtifactPlatform::Android,
+            IOS_CORE_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn ios_manifest_requires_xcodebuild_version() {
+        let manifest = sample_manifest(ArtifactPlatform::IosCore);
+
+        assert!(validate_manifest(
+            &manifest,
+            ArtifactPlatform::IosCore,
+            IOS_CORE_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn ios_manifest_accepts_xcodebuild_version() {
+        let mut manifest = sample_manifest(ArtifactPlatform::IosCore);
+        manifest.xcodebuild_version = Some("Xcode 26.0\nBuild version 1A1".to_string());
+
+        validate_manifest(
+            &manifest,
+            ArtifactPlatform::IosCore,
+            IOS_CORE_ARTIFACT_NAME,
+            Some("wk2"),
+            "123",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn classifies_head_mismatch() {
+        assert_eq!(
+            head_mismatch(
+                "0123456789abcdef0123456789abcdef01234567",
+                "0123456789abcdef0123456789abcdef01234567",
+            ),
+            HeadComparison::Matches
+        );
+        assert_eq!(head_mismatch("a", "b"), HeadComparison::Mismatches);
+    }
+
+    #[test]
+    fn rejects_unsafe_relative_paths() {
+        assert!(validate_relative_path(Path::new("../manifest.json")).is_err());
+        assert!(validate_relative_path(Path::new("android\\app.apk")).is_err());
+        assert!(validate_relative_path(Path::new("android/app.apk")).is_ok());
+    }
+
+    #[test]
+    fn rejects_unsafe_zip_entry_paths() {
+        assert!(validate_zip_entry_path(Path::new("../manifest.json")).is_err());
+        assert!(validate_zip_entry_path(Path::new("unexpected/file")).is_err());
+        assert!(validate_zip_entry_path(Path::new("manifest.json")).is_ok());
+    }
+
+    #[test]
+    fn rejects_zip_link_modes() {
+        assert!(reject_zip_link_entry("link", Some(0o120777)).is_err());
+        assert!(reject_zip_link_entry("hardlink", Some(0o010777)).is_err());
+        assert!(reject_zip_link_entry("file", Some(0o100644)).is_ok());
+    }
+
+    #[test]
+    fn rejects_unexpected_top_level_paths() {
+        assert!(validate_artifact_top_level(Path::new("tmp/file")).is_err());
+        assert!(validate_artifact_top_level(Path::new("android/app-dev-debug.apk")).is_ok());
+        assert!(validate_artifact_top_level(Path::new("ios/CoveCore")).is_ok());
+    }
+
+    #[test]
+    fn parses_aapt_package_name() {
+        let output = "package: name='org.bitcoinppl.cove.dev' versionCode='1'";
+
+        assert_eq!(parse_aapt_package_name(output).as_deref(), Some("org.bitcoinppl.cove.dev"));
+    }
+
+    #[test]
+    fn validates_sha_shape() {
+        assert!(validate_sha("0123456789abcdef0123456789abcdef01234567").is_ok());
+        assert!(validate_sha("not-a-sha").is_err());
+    }
+
+    #[test]
+    fn missing_expected_path_is_rejected() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(MANIFEST_PATH), "{}").unwrap();
+
+        assert!(validate_expected_paths(root.path(), ArtifactPlatform::Android).is_err());
+    }
+
+    #[test]
+    fn expected_android_paths_are_accepted() {
+        let root = tempfile::tempdir().unwrap();
+        let android = root.path().join("android");
+        fs::create_dir_all(&android).unwrap();
+        fs::write(root.path().join(MANIFEST_PATH), "{}").unwrap();
+        fs::write(root.path().join(ANDROID_APK_PATH), "apk").unwrap();
+        fs::write(root.path().join(ANDROID_OUTPUT_METADATA_PATH), "{}").unwrap();
+
+        assert!(validate_expected_paths(root.path(), ArtifactPlatform::Android).is_ok());
+    }
+
+    #[test]
+    fn tree_safety_rejects_unexpected_top_level_file() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("unexpected.txt"), "no").unwrap();
+
+        assert!(validate_tree_safety(root.path()).is_err());
+    }
+
+    #[test]
+    fn tree_safety_accepts_expected_layout() {
+        let root = tempfile::tempdir().unwrap();
+        let android = root.path().join("android");
+        fs::create_dir_all(&android).unwrap();
+        fs::write(root.path().join(MANIFEST_PATH), "{}").unwrap();
+        fs::write(android.join("app-dev-debug.apk"), "apk").unwrap();
+        fs::write(android.join("output-metadata.json"), "{}").unwrap();
+
+        assert!(validate_tree_safety(root.path()).is_ok());
+    }
+
+    #[test]
+    fn copy_path_copies_directories() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let target = root.path().join("target");
+        fs::create_dir_all(source.join("nested")).unwrap();
+        fs::write(source.join("nested/file.swift"), "swift").unwrap();
+
+        copy_path(&source, &target).unwrap();
+
+        assert_eq!(fs::read_to_string(target.join("nested/file.swift")).unwrap(), "swift");
+    }
+
+    #[test]
+    fn ios_replace_rolls_back_after_copy_failure() {
+        let root = tempfile::tempdir().unwrap();
+        let repo_root = root.path().join("repo");
+        let artifact = root.path().join("artifact");
+        let old_xcframework_file = repo_root.join(IOS_XCFRAMEWORK_PATH).join("old.txt");
+        let old_generated_file = repo_root.join(IOS_GENERATED_PATH).join("old.swift");
+        let new_xcframework_file = artifact.join(IOS_XCFRAMEWORK_PATH).join("new.txt");
+
+        fs::create_dir_all(old_xcframework_file.parent().unwrap()).unwrap();
+        fs::create_dir_all(old_generated_file.parent().unwrap()).unwrap();
+        fs::create_dir_all(new_xcframework_file.parent().unwrap()).unwrap();
+        fs::write(&old_xcframework_file, "old framework").unwrap();
+        fs::write(&old_generated_file, "old swift").unwrap();
+        fs::write(&new_xcframework_file, "new framework").unwrap();
+
+        assert!(replace_ios_core_inputs(&repo_root, &artifact).is_err());
+
+        assert_eq!(fs::read_to_string(old_xcframework_file).unwrap(), "old framework");
+        assert_eq!(fs::read_to_string(old_generated_file).unwrap(), "old swift");
+        assert!(!repo_root.join(IOS_XCFRAMEWORK_PATH).join("new.txt").exists());
+    }
+
+    #[test]
+    fn ios_rollback_leaves_unmoved_original_targets_in_place() {
+        let root = tempfile::tempdir().unwrap();
+        let repo_root = root.path().join("repo");
+        let backup_root = root.path().join("backup");
+        let original = repo_root.join(IOS_GENERATED_PATH).join("old.swift");
+
+        fs::create_dir_all(original.parent().unwrap()).unwrap();
+        fs::write(&original, "old swift").unwrap();
+
+        rollback_ios_core_inputs(&repo_root, &backup_root, &IosReplacement::default()).unwrap();
+
+        assert_eq!(fs::read_to_string(original).unwrap(), "old swift");
+    }
+
+    #[test]
+    fn cleanup_skips_new_entries() {
+        let root = tempfile::tempdir().unwrap();
+        let entry = root.path().join("new");
+        fs::create_dir_all(&entry).unwrap();
+        let cutoff = SystemTime::now() - Duration::from_secs(60);
+
+        remove_old_children(root.path(), cutoff, false).unwrap();
+
+        assert!(entry.exists());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile artifact workflows and commands to trigger, list, download, and install build artifacts for Android and iOS.
  * Introduced easier iOS run/build commands with support for selecting a simulator or physical device.

* **Bug Fixes**
  * Improved physical iOS device selection and handling for more reliable device runs.
  * Added safer artifact validation and rollback behavior when applying downloaded iOS content.

* **Documentation**
  * Updated setup and workflow docs with clearer iOS command-line instructions and newer `just` command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->