### PR TITLE
Load wallet managers off main thread

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/AndroidManagerCache.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AndroidManagerCache.kt
@@ -106,18 +106,22 @@ internal class AndroidManagerCache(
     }
 
     private fun installWalletManager(manager: WalletManager): WalletManager {
-        walletManager?.let {
-            if (it === manager) return manager
-            if (it.id == manager.id) {
-                manager.close()
-                return it
+        val currentManager = walletManager
+        val installedManager =
+            when {
+                currentManager === manager -> manager
+                currentManager?.id == manager.id -> {
+                    manager.close()
+                    currentManager
+                }
+                else -> {
+                    clearWalletManager()
+                    walletManager = manager
+                    manager
+                }
             }
-        }
 
-        clearWalletManager()
-        walletManager = manager
-
-        return manager
+        return installedManager
     }
 
     internal fun getSendFlowManager(

--- a/android/app/src/main/java/org/bitcoinppl/cove/AndroidManagerCache.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AndroidManagerCache.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.bitcoinppl.cove.flows.SendFlow.SendFlowManager
 import org.bitcoinppl.cove.flows.SendFlow.SendFlowPresenter
 import org.bitcoinppl.cove_core.WalletMetadata
@@ -30,7 +31,7 @@ internal class AndroidManagerCache(
 
     internal fun setWalletManager(manager: WalletManager) {
         Log.d(tag, "setting wallet manager for wallet ${manager.id}")
-        walletManager = manager
+        installWalletManager(manager)
     }
 
     internal fun cachedWalletManager(id: WalletId): WalletManager? =
@@ -52,20 +53,64 @@ internal class AndroidManagerCache(
             }
 
             // selecting a different wallet is the boundary for ending in-flight scans
-            Log.d(tag, "closing old wallet manager for ${it.id}")
-            clearWalletManager()
+            Log.d(tag, "will replace old wallet manager for ${it.id}")
         }
 
         Log.d(tag, "did not find wallet manager for $id, creating new: ${walletManager?.id}")
 
         return try {
             val manager = WalletManager(id = id)
-            walletManager = manager
-            manager
+            installWalletManager(manager)
         } catch (e: Exception) {
             Log.e(tag, "Failed to create wallet manager", e)
             throw e
         }
+    }
+
+    internal suspend fun getWalletManagerLoaded(id: WalletId): WalletManager {
+        val cachedManager =
+            withContext(Dispatchers.Main.immediate) {
+                walletManager?.let {
+                    if (it.id == id) {
+                        Log.d(tag, "found and using wallet manager for $id")
+                        return@withContext it
+                    }
+
+                    Log.d(tag, "will replace old wallet manager for ${it.id}")
+                }
+
+                null
+            }
+        if (cachedManager != null) return cachedManager
+
+        Log.d(tag, "did not find wallet manager for $id, creating new: ${walletManager?.id}")
+
+        val manager =
+            try {
+                WalletManager.load(id)
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to create wallet manager", e)
+                throw e
+            }
+
+        return withContext(Dispatchers.Main.immediate) {
+            installWalletManager(manager)
+        }
+    }
+
+    private fun installWalletManager(manager: WalletManager): WalletManager {
+        walletManager?.let {
+            if (it === manager) return manager
+            if (it.id == manager.id) {
+                manager.close()
+                return it
+            }
+        }
+
+        clearWalletManager()
+        walletManager = manager
+
+        return manager
     }
 
     internal fun getSendFlowManager(

--- a/android/app/src/main/java/org/bitcoinppl/cove/AndroidManagerCache.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AndroidManagerCache.kt
@@ -12,6 +12,7 @@ import org.bitcoinppl.cove.flows.SendFlow.SendFlowManager
 import org.bitcoinppl.cove.flows.SendFlow.SendFlowPresenter
 import org.bitcoinppl.cove_core.WalletMetadata
 import org.bitcoinppl.cove_core.types.WalletId
+import kotlin.coroutines.cancellation.CancellationException
 
 @Stable
 @Suppress("InjectDispatcher", "TooGenericExceptionCaught", "TooManyFunctions")
@@ -68,7 +69,7 @@ internal class AndroidManagerCache(
     }
 
     internal suspend fun getWalletManagerLoaded(id: WalletId): WalletManager {
-        val cachedManager =
+        val previousManager =
             withContext(Dispatchers.Main.immediate) {
                 walletManager?.let {
                     if (it.id == id) {
@@ -81,9 +82,9 @@ internal class AndroidManagerCache(
 
                 null
             }
-        if (cachedManager != null) return cachedManager
+        if (previousManager?.id == id) return previousManager
 
-        Log.d(tag, "did not find wallet manager for $id, creating new: ${walletManager?.id}")
+        Log.d(tag, "did not find wallet manager for $id, creating new: ${previousManager?.id}")
 
         val manager =
             try {
@@ -94,6 +95,12 @@ internal class AndroidManagerCache(
             }
 
         return withContext(Dispatchers.Main.immediate) {
+            val currentManager = walletManager
+            if (currentManager != null && currentManager !== previousManager && currentManager.id != id) {
+                manager.close()
+                throw CancellationException("wallet manager load for $id was superseded")
+            }
+
             installWalletManager(manager)
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/AppManager.kt
@@ -85,7 +85,7 @@ class AppManager private constructor() : FfiReconcile {
 
             override suspend fun startWalletScanIfNeeded(walletId: WalletId): Result<Unit> =
                 runCatching {
-                    getWalletManager(walletId).startWalletScanIfNeeded()
+                    getWalletManagerLoaded(walletId).startWalletScanIfNeeded()
                 }.also { result ->
                     val error = result.exceptionOrNull()
                     if (error is CancellationException) {
@@ -206,6 +206,8 @@ class AppManager private constructor() : FfiReconcile {
      * caches the instance so we don't recreate unnecessarily
      */
     fun getWalletManager(id: WalletId): WalletManager = managerCache.getWalletManager(id)
+
+    suspend fun getWalletManagerLoaded(id: WalletId): WalletManager = managerCache.getWalletManagerLoaded(id)
 
     /**
      * get or create send flow manager for the given wallet manager

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -37,6 +37,11 @@ val WalletLedgerState.initialScanIncomplete: Boolean
 val WalletLedgerState.initialScanActive: Boolean
     get() = this is WalletLedgerState.InitialScanIncomplete && v1 == InitialScanActivity.ACTIVE
 
+private data class WalletManagerBootstrap(
+    val rust: RustWalletManager,
+    val initialState: WalletInitialState,
+)
+
 /**
  * wallet manager - manages wallet state, balance, transactions
  * ported from iOS WalletManager.swift
@@ -172,6 +177,25 @@ class WalletManager :
             val initialState = rust.initialState()
             android.util.Log.d("WalletManager", "Initialized WalletManager for $id")
             return WalletManager(initialState.metadata.id, rust, initialState)
+        }
+
+        suspend fun load(id: WalletId): WalletManager {
+            val bootstrap =
+                withContext(Dispatchers.IO) {
+                    val rust = RustWalletManager(id)
+                    val initialState = rust.initialState()
+                    android.util.Log.d("WalletManager", "Initialized WalletManager for $id")
+
+                    WalletManagerBootstrap(rust, initialState)
+                }
+
+            return withContext(Dispatchers.Main.immediate) {
+                WalletManager(
+                    bootstrap.initialState.metadata.id,
+                    bootstrap.rust,
+                    bootstrap.initialState,
+                )
+            }
         }
 
         // create from xpub

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -179,9 +180,12 @@ class WalletManager :
             return WalletManager(initialState.metadata.id, rust, initialState)
         }
 
-        suspend fun load(id: WalletId): WalletManager {
+        suspend fun load(
+            id: WalletId,
+            rustDispatcher: CoroutineDispatcher = Dispatchers.IO,
+        ): WalletManager {
             val bootstrap =
-                withContext(Dispatchers.IO) {
+                withContext(rustDispatcher) {
                     val rust = RustWalletManager(id)
                     val initialState = rust.initialState()
                     android.util.Log.d("WalletManager", "Initialized WalletManager for $id")

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SelectedWalletFlow/SelectedWalletContainer.kt
@@ -95,7 +95,7 @@ fun SelectedWalletContainer(
 
         try {
             android.util.Log.d(tag, "getting wallet $requestedId")
-            val wm = app.getWalletManager(requestedId)
+            val wm = app.getWalletManagerLoaded(requestedId)
 
             // only set manager if we're still loading the same wallet (not stale)
             if (isActive && requestedId == id) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SettingsFlow/WalletSettingsContainer.kt
@@ -45,7 +45,11 @@ fun WalletSettingsContainer(
     modifier: Modifier = Modifier,
 ) {
     var loadState by remember(id) {
-        mutableStateOf<WalletSettingsLoadState>(WalletSettingsLoadState.Loading)
+        mutableStateOf<WalletSettingsLoadState>(
+            app.cachedWalletManager(id)
+                ?.let(WalletSettingsLoadState::Ready)
+                ?: WalletSettingsLoadState.Loading,
+        )
     }
     var loadAttempt by remember(id) { mutableStateOf(0) }
     var recoveryGeneration by remember(id) { mutableStateOf(0) }
@@ -93,11 +97,19 @@ fun WalletSettingsContainer(
 
     // lazy load wallet manager
     LaunchedEffect(id, loadAttempt) {
+        app.cachedWalletManager(id)?.let { manager ->
+            loadState = WalletSettingsLoadState.Ready(manager)
+            return@LaunchedEffect
+        }
+
         loadState = WalletSettingsLoadState.Loading
 
         try {
             android.util.Log.d(tag, "getting wallet $id")
-            loadState = WalletSettingsLoadState.Ready(app.getWalletManager(id))
+            val manager = app.getWalletManagerLoaded(id)
+            if (manager.id == id) {
+                loadState = WalletSettingsLoadState.Ready(manager)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/ios/Cove/AppManager.swift
+++ b/ios/Cove/AppManager.swift
@@ -78,7 +78,9 @@ private let walletModeChangeDelayMs = 250
     }
 
     private static func requireBootstrapComplete() {
-        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" { return }
+        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+            return
+        }
 
         let step = bootstrapProgress()
         guard step == .complete else {
@@ -124,6 +126,11 @@ private let walletModeChangeDelayMs = 250
 
     func ensureWalletManager(id: WalletId) throws -> WalletManager {
         try managerCache.ensureWalletManager(id: id, delegate: self)
+    }
+
+    @MainActor
+    func ensureWalletManagerLoaded(id: WalletId) async throws -> WalletManager {
+        try await managerCache.ensureWalletManagerLoaded(id: id, delegate: self)
     }
 
     func beginInitialScanBackgroundTaskIfNeeded() {
@@ -399,7 +406,7 @@ private let walletModeChangeDelayMs = 250
             guard let self else { return }
 
             do {
-                let manager = try self.ensureWalletManager(id: id)
+                let manager = try await self.ensureWalletManagerLoaded(id: id)
                 try await manager.startWalletScanIfNeeded()
             } catch {
                 self.logger.error("Unable to prewarm selected wallet \(id): \(error)")

--- a/ios/Cove/Flows/SettingsFlow/WalletSettings/WalletSettingsContainer.swift
+++ b/ios/Cove/Flows/SettingsFlow/WalletSettings/WalletSettingsContainer.swift
@@ -37,7 +37,7 @@ struct WalletSettingsContainer: View {
 
     var body: some View {
         WalletManagerHost(walletId: id, loading: {
-            WalletSettingsLoadingOrError(error: error) {
+            WalletSettingsLoadingOrError(error: error, metadata: app.walletMetadata(id: id)) {
                 app.trySelectLatestOrNewWallet()
             }
         }, onError: { error in
@@ -51,12 +51,15 @@ struct WalletSettingsContainer: View {
 
 private struct WalletSettingsLoadingOrError: View {
     let error: String?
+    let metadata: WalletMetadata?
     let recover: () -> Void
 
     var body: some View {
         Group {
             if let error {
                 Text(error)
+            } else if let metadata {
+                WalletSettingsLoadingView(metadata: metadata)
             } else {
                 FullPageLoadingView()
             }
@@ -67,5 +70,100 @@ private struct WalletSettingsLoadingOrError: View {
             try? await Task.sleep(for: .seconds(5))
             recover()
         }
+    }
+}
+
+private struct WalletSettingsLoadingView: View {
+    let metadata: WalletMetadata
+
+    private let colorColumns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 5)
+
+    var body: some View {
+        List {
+            Section(header: Text("Wallet Information")) {
+                WalletSettingsLoadingRow(title: "Network", value: metadata.network.description)
+                WalletSettingsLoadingRow(title: "Wallet Type", value: String(metadata.walletType))
+            }
+
+            Section(header: Text("Settings")) {
+                HStack {
+                    Text("Name")
+                    Spacer()
+
+                    Text(metadata.name)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(Color(UIColor.tertiaryLabel))
+                        .font(.footnote)
+                        .fontWeight(.semibold)
+                }
+                .font(.subheadline)
+
+                VStack(spacing: 14) {
+                    HStack {
+                        Text("Wallet Color")
+                            .font(.subheadline)
+                        Spacer()
+                    }
+
+                    HStack {
+                        Rectangle()
+                            .fill(metadata.swiftColor)
+                            .cornerRadius(10)
+                            .frame(width: 80, height: 80)
+
+                        LazyVGrid(columns: colorColumns, spacing: 20) {
+                            ForEach(defaultWalletColors(), id: \.self) { color in
+                                ZStack {
+                                    if color == metadata.color {
+                                        Circle()
+                                            .stroke(Color(color).opacity(0.7), lineWidth: 2)
+                                            .frame(width: 32, height: 32)
+                                    }
+
+                                    Circle()
+                                        .fill(Color(color))
+                                        .frame(width: 28, height: 28)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding(.vertical, 8)
+
+                Toggle(isOn: .constant(metadata.showLabels)) {
+                    Text("Show transaction labels")
+                        .font(.subheadline)
+                }
+                .disabled(true)
+            }
+        }
+        .navigationTitle(metadata.name)
+        .overlay {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.large)
+                .frame(width: 72, height: 72)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}
+
+private struct WalletSettingsLoadingRow: View {
+    let title: LocalizedStringKey
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundColor(.secondary)
+        }
+        .font(.subheadline)
     }
 }

--- a/ios/Cove/ManagerCache.swift
+++ b/ios/Cove/ManagerCache.swift
@@ -40,13 +40,60 @@ import Observation
         logger.debug(
             "did not find vm for \(id), creating new vm: \(walletManager?.id ?? "none")"
         )
-        clearWalletManager()
 
         let walletManager = try WalletManager(id: id, delegate: delegate)
+        return installWalletManager(walletManager)
+    }
+
+    @MainActor
+    func ensureWalletManagerLoaded(
+        id: WalletId,
+        delegate: WalletManagerDelegate
+    ) async throws -> WalletManager {
+        if let walletManager = cachedWalletManager(id: id) {
+            logger.debug("found and using vm for \(id)")
+            return walletManager
+        }
+
+        let previousManager = walletManager
+        logger.debug(
+            "did not find vm for \(id), loading new vm: \(walletManager?.id ?? "none")"
+        )
+
+        let loadedWalletManager = try await WalletManager.load(id: id, delegate: delegate)
+        do {
+            try Task.checkCancellation()
+        } catch {
+            loadedWalletManager.close()
+            throw error
+        }
+
+        if let walletManager, walletManager !== previousManager, walletManager.id != id {
+            loadedWalletManager.close()
+            throw CancellationError()
+        }
+
+        return installWalletManager(loadedWalletManager)
+    }
+
+    private func installWalletManager(_ walletManager: WalletManager) -> WalletManager {
+        if let existing = self.walletManager {
+            if existing === walletManager {
+                return walletManager
+            }
+            if existing.id == walletManager.id {
+                walletManager.close()
+                return existing
+            }
+        }
+
+        clearWalletManager()
+
         backgroundScanTaskHandler.observeInitialScanLifecycle(for: walletManager) { [weak self] in
             self?.walletManager
         }
         self.walletManager = walletManager
+
         return walletManager
     }
 
@@ -157,7 +204,9 @@ extension Router {
 
 private extension Route {
     var isCoinControlRoute: Bool {
-        if case .coinControl = self { return true }
+        if case .coinControl = self {
+            return true
+        }
         return false
     }
 }

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -41,7 +41,7 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
     let notify: () -> Void
 }
 
-private struct WalletManagerBootstrap: Sendable {
+private struct WalletManagerBootstrap {
     let rust: RustWalletManager
     let initialState: WalletInitialState
 }

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -41,6 +41,11 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
     let notify: () -> Void
 }
 
+private struct WalletManagerBootstrap: Sendable {
+    let rust: RustWalletManager
+    let initialState: WalletInitialState
+}
+
 @Observable final class WalletManager: ReconcilingManager, WalletManagerReconciler {
     typealias Message = WalletManagerReconcileMessage
     typealias Action = WalletManagerAction
@@ -100,10 +105,11 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
     /// scroll position for transaction list (persists across navigation)
     var scrolledTransactionId: String?
 
-    init(id: WalletId, delegate: WalletManagerDelegate? = AppManager.shared) throws {
-        let rust = try RustWalletManager(id: id)
-        let initialState = rust.initialState()
-
+    private init(
+        rust: RustWalletManager,
+        initialState: WalletInitialState,
+        delegate: WalletManagerDelegate?
+    ) {
         self.id = initialState.metadata.id
         self.rust = rust
         self.loadState = initialState.loadState
@@ -116,6 +122,36 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
         unsignedTransactions = initialState.unsignedTransactions
 
         rust.listenForUpdates(reconciler: WeakReconciler(self))
+    }
+
+    convenience init(id: WalletId, delegate: WalletManagerDelegate? = AppManager.shared) throws {
+        let rust = try RustWalletManager(id: id)
+        let initialState = rust.initialState()
+
+        self.init(rust: rust, initialState: initialState, delegate: delegate)
+    }
+
+    @MainActor
+    static func load(id: WalletId, delegate: WalletManagerDelegate? = AppManager.shared) async throws -> WalletManager {
+        let bootstrap = try await Task.detached(priority: .userInitiated) {
+            let rust = try RustWalletManager(id: id)
+            let initialState = rust.initialState()
+
+            return WalletManagerBootstrap(rust: rust, initialState: initialState)
+        }.value
+
+        do {
+            try Task.checkCancellation()
+        } catch {
+            bootstrap.rust.shutdown()
+            throw error
+        }
+
+        return WalletManager(
+            rust: bootstrap.rust,
+            initialState: bootstrap.initialState,
+            delegate: delegate
+        )
     }
 
     func close() {
@@ -142,25 +178,14 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
         }
     }
 
-    init(xpub: String, delegate: WalletManagerDelegate? = AppManager.shared) throws {
+    convenience init(xpub: String, delegate: WalletManagerDelegate? = AppManager.shared) throws {
         let rust = try RustWalletManager.tryNewFromXpub(xpub: xpub)
         let initialState = rust.initialState()
 
-        self.rust = rust
-        self.loadState = initialState.loadState
-        self.scanStatus = initialState.scanStatus
-        self.ledgerState = initialState.ledgerState
-        self.balancePresentation = initialState.balancePresentation
-        self.balance = initialState.balance
-        self.delegate = delegate
-        walletMetadata = initialState.metadata
-        unsignedTransactions = initialState.unsignedTransactions
-        id = initialState.metadata.id
-
-        rust.listenForUpdates(reconciler: WeakReconciler(self))
+        self.init(rust: rust, initialState: initialState, delegate: delegate)
     }
 
-    init(
+    convenience init(
         tapSigner: TapSigner,
         deriveInfo: DeriveInfo,
         backup: Data? = nil,
@@ -175,18 +200,7 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
         )
         let initialState = rust.initialState()
 
-        self.rust = rust
-        self.loadState = initialState.loadState
-        self.scanStatus = initialState.scanStatus
-        self.ledgerState = initialState.ledgerState
-        self.balancePresentation = initialState.balancePresentation
-        self.balance = initialState.balance
-        self.delegate = delegate
-        walletMetadata = initialState.metadata
-        unsignedTransactions = initialState.unsignedTransactions
-        id = initialState.metadata.id
-
-        rust.listenForUpdates(reconciler: WeakReconciler(self))
+        self.init(rust: rust, initialState: initialState, delegate: delegate)
     }
 
     var unit: String {
@@ -620,7 +634,7 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
     }
 
     /// PREVIEW only
-    init(preview: String, _ walletMetadata: WalletMetadata? = nil) {
+    convenience init(preview: String, _ walletMetadata: WalletMetadata? = nil) {
         assert(preview == "preview_only")
 
         let rust =
@@ -630,19 +644,9 @@ private struct InitialScanLifecycleChangedHandler: @unchecked Sendable {
                 RustWalletManager.previewNewWallet()
             }
 
-        self.rust = rust
         let initialState = rust.initialState()
-        self.loadState = initialState.loadState
-        self.scanStatus = initialState.scanStatus
-        self.ledgerState = initialState.ledgerState
-        self.balancePresentation = initialState.balancePresentation
-        self.balance = initialState.balance
-        self.walletMetadata = initialState.metadata
-        self.delegate = nil
-        self.id = initialState.metadata.id
-        self.unsignedTransactions = initialState.unsignedTransactions
 
-        rust.listenForUpdates(reconciler: WeakReconciler(self))
+        self.init(rust: rust, initialState: initialState, delegate: nil)
     }
 
     deinit {

--- a/ios/Cove/WalletManagerHost.swift
+++ b/ios/Cove/WalletManagerHost.swift
@@ -52,8 +52,11 @@ struct WalletManagerHost<Loading: View, Content: View>: View {
         guard manager == nil else { return }
 
         do {
-            _ = try app.ensureWalletManager(id: walletId)
+            _ = try await app.ensureWalletManagerLoaded(id: walletId)
+        } catch is CancellationError {
+            return
         } catch {
+            guard !Task.isCancelled else { return }
             onError(error)
         }
     }


### PR DESCRIPTION
Restore async wallet manager loading for selected wallet and wallet settings so heavy Rust bootstrap work does not block Compose navigation.