### PR TITLE
Gate payjoin at the rust layer

### DIFF
--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -141,9 +141,9 @@ impl RustSendFlowManager {
 
         self.reconciler.send(Message::UpdateFocusField(None));
 
-        let (wallet_type, wallet_id, payjoin_endpoint) = {
+        let (wallet_type, wallet_id) = {
             let state = self.state.lock();
-            (state.metadata.wallet_type, state.metadata.id.clone(), state.payjoin_endpoint.clone())
+            (state.metadata.wallet_type, state.metadata.id.clone())
         };
 
         let me = self.clone();
@@ -190,9 +190,7 @@ impl RustSendFlowManager {
 
             // update the route send the frontend to the proper next screen
             let next_route = match wallet_type {
-                WalletType::Hot => {
-                    RouteFactory::new().send_confirm(wallet_id, details, payjoin_endpoint)
-                }
+                WalletType::Hot => RouteFactory::new().send_confirm(wallet_id, details, None),
                 WalletType::Cold | WalletType::XpubOnly => {
                     RouteFactory::new().send_hardware_export(wallet_id, details)
                 }

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -2231,6 +2231,59 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn payjoin_uri_completes_via_normal_broadcast_when_gated() {
+        let _guard = crate::test_support::global_state_test_lock().lock().await;
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        test_keychain();
+
+        crate::database::test_support::init_test_database();
+        let server = set_broadcast_esplora_node(200).await;
+
+        let metadata = WalletMetadata::preview_new();
+        let mut wallet = persisted_preview_wallet(metadata.clone());
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            BlockId { height: 1, hash: BlockHash::from_byte_array([1; 32]) },
+        );
+        receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(100_000));
+
+        // preview wallet skips keychain storage, so save the mnemonic manually for signing
+        Keychain::global()
+            .save_wallet_key(&metadata.id, test_mnemonic())
+            .expect("mnemonic stored in test keychain");
+
+        let (sender, _receiver) = flume::bounded(100);
+        let wallet_snapshot = test_wallet_snapshot(&wallet);
+        let mut actor =
+            super::WalletActor::new(wallet, sender, test_scan_status(), wallet_snapshot)
+                .expect("actor is created");
+
+        let result = actor
+            .build_tx(Amount::from_sat(50_000), Address::preview_new(), one_sat_vbyte_fee_rate())
+            .await;
+        let psbt = actor_value(result).await.expect("psbt is built");
+
+        let addr = spawn_actor(actor);
+
+        let result = call!(
+            addr.initiate_payment(psbt, Some("https://payjoin.example.com/endpoint".to_string()))
+        )
+        .await
+        .expect("initiate_payment actor responds");
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        restore_default_bitcoin_node();
+        server.server.abort();
+        let _ = crate::wallet::delete_wallet_specific_data(&metadata.id);
+
+        result.expect("broadcast succeeds");
+        assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn slow_height_refresh_does_not_block_unrelated_actor_messages() {
         let _guard = crate::test_support::global_state_test_lock().lock().await;
 

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -472,10 +472,11 @@ impl WalletActor {
             return Produces::ok(Err(error));
         }
 
-        let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
-            Ok(result) => result,
-            Err(error) => return Produces::ok(Err(error)),
-        };
+        if self.payjoin_actor.is_some() {
+            return Produces::ok(Err(Error::SignAndBroadcastError(
+                "a payjoin session is already in progress".to_string(),
+            )));
+        }
 
         match self.db.get_payjoin_sender_session() {
             Ok(None) => {}
@@ -533,20 +534,12 @@ impl WalletActor {
             }
         }
 
-        match payjoin_endpoint {
-            None => {
-                let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
-                    Ok(result) => result,
-                    Err(error) => return Produces::ok(Err(error)),
-                };
+        let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
+            Ok(result) => result,
+            Err(error) => return Produces::ok(Err(error)),
+        };
 
-                self.start_broadcast_transaction(transaction)
-            }
-            Some(endpoint) => {
-                let result = self.initiate_payjoin_payment(psbt, endpoint).await;
-                Produces::ok(result)
-            }
-        }
+        self.start_broadcast_transaction(transaction)
     }
 
     #[allow(dead_code)]

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -466,17 +466,16 @@ impl WalletActor {
     pub async fn initiate_payment(
         &mut self,
         psbt: Psbt,
-        payjoin_endpoint: Option<String>,
+        _payjoin_endpoint: Option<String>,
     ) -> ActorResult<Result<(), Error>> {
         if let Err(error) = self.ensure_ledger_ready_for_spend() {
             return Produces::ok(Err(error));
         }
 
-        if self.payjoin_actor.is_some() {
-            return Produces::ok(Err(Error::SignAndBroadcastError(
-                "a payjoin session is already in progress".to_string(),
-            )));
-        }
+        let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
+            Ok(result) => result,
+            Err(error) => return Produces::ok(Err(error)),
+        };
 
         match self.db.get_payjoin_sender_session() {
             Ok(None) => {}
@@ -550,6 +549,7 @@ impl WalletActor {
         }
     }
 
+    #[allow(dead_code)]
     async fn initiate_payjoin_payment(
         &mut self,
         psbt: Psbt,

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use act_zero::*;
 use bdk_wallet::chain::bitcoin::Psbt;
 use bitcoin::{


### PR DESCRIPTION
## Summary

PayJoin is not yet ready for production. This PR temporarily disables PayJoin at the Rust layer by ignoring any provided PayJoin endpoint during the send flow. If a PayJoin endpoint is present, the wallet falls back to a standard transaction broadcast.

The existing `initiate_payjoin_payment` implementation is retained and marked with `#[allow(dead_code)]`, allowing PayJoin to be re enabled in the future by wiring the endpoint back into the send flow without rewriting the underlying logic.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified payment initiation to sign and broadcast transactions directly.
  * Improved payment reliability by removing conditional payjoin routing from the standard payment flow.

* **Maintenance**
  * Retained payjoin components for future use without affecting regular payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->