### PR TITLE
Use two-column recovery word grids

### DIFF
--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreenTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreenTest.kt
@@ -57,7 +57,7 @@ class HotWalletCreateScreenTest {
 
     @Test
     fun primaryActionFitsCompactViewportWithBottomPadding() {
-        val manager = PendingWalletManager(NumberOfBip39Words.TWELVE)
+        val manager = PendingWalletManager(NumberOfBip39Words.TWENTY_FOUR)
         pendingWalletManager = manager
 
         compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/NewWalletFlow/hot_wallet/HotWalletCreateScreen.kt
@@ -385,6 +385,7 @@ private fun WordCardView(
     ColumnMajorGrid(
         items = words,
         modifier = modifier,
+        numColumns = 2,
     ) { _, groupedWord ->
         Box(
             modifier =

--- a/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
@@ -10,9 +10,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -166,7 +169,7 @@ fun SecretWordsScreen(
             )
         },
     ) { padding ->
-        Box(
+        BoxWithConstraints(
             modifier =
                 Modifier
                     .fillMaxSize()
@@ -187,7 +190,9 @@ fun SecretWordsScreen(
             Column(
                 modifier =
                     Modifier
-                        .fillMaxSize()
+                        .fillMaxWidth()
+                        .heightIn(min = maxHeight)
+                        .verticalScroll(rememberScrollState())
                         .padding(horizontal = 20.dp),
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
@@ -304,6 +309,7 @@ private fun RecoveryWordsGrid(
     ColumnMajorGrid(
         items = words,
         modifier = modifier,
+        numColumns = 2,
     ) { index, word ->
         RecoveryWordChip(
             index = index + 1,

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/ColumnMajorGrid.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/ColumnMajorGrid.kt
@@ -12,17 +12,18 @@ import androidx.compose.ui.unit.dp
 /**
  * A grid that displays items in column-major order (top-to-bottom, then left-to-right)
  *
- * For a list [1,2,3,4,5,6] with 3 columns, displays as:
+ * For a list [1,2,3,4,5,6] with 2 columns, displays as:
  * ```
- * 1  3  5
- * 2  4  6
+ * 1  4
+ * 2  5
+ * 3  6
  * ```
  */
 @Composable
 fun <T> ColumnMajorGrid(
     items: List<T>,
     modifier: Modifier = Modifier,
-    numColumns: Int = 3,
+    numColumns: Int = 2,
     horizontalSpacing: Dp = 12.dp,
     verticalSpacing: Dp = 18.dp,
     content: @Composable (index: Int, item: T) -> Unit,

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/RecoveryWords.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/RecoveryWords.kt
@@ -60,6 +60,7 @@ private fun RecoveryWordsPager(
                 onToggleIndex = onToggleIndex,
             )
         }
+
         Spacer(Modifier.height(16.dp))
 
         // Indicator
@@ -87,6 +88,7 @@ private fun RecoveryWordsGrid(
     ColumnMajorGrid(
         items = words,
         modifier = modifier,
+        numColumns = 2,
     ) { index, word ->
         val globalIndex = startIndexOffset + index + 1
         RecoveryWordChip(

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
@@ -34,8 +34,8 @@ struct WordsView: View {
 
     init(manager: PendingWalletManager, initialTabIndex: Int = 0) {
         self.manager = manager
-        self.groupedWords = manager.rust.bip39WordsGrouped()
-        self.tabIndex = initialTabIndex
+        _groupedWords = State(initialValue: manager.rust.bip39WordsGrouped())
+        _tabIndex = State(initialValue: initialTabIndex)
     }
 
     var lastIndex: Int {
@@ -72,6 +72,35 @@ struct WordsView: View {
                     .ignoresSafeArea(.all)
             )
         }
+        .navigationTitle("Backup your wallet")
+        .navigationBarTitleDisplayMode(.inline)
+        .adaptiveToolbarStyle()
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbarBackground(Color.midnightBlue, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: {
+                    showConfirmationAlert = true
+                }) {
+                    HStack {
+                        Image(systemName: "chevron.left")
+                    }
+                    .foregroundStyle(.white)
+                }
+            }
+        }
+        .alert(isPresented: $showConfirmationAlert) {
+            Alert(
+                title: Text("⚠️ Wallet Not Saved ⚠️"),
+                message: Text("You will have to write down a new set of words."),
+                primaryButton: .destructive(Text("Yes, Go Back")) {
+                    dismiss()
+                },
+                secondaryButton: .cancel(Text("Cancel"))
+            )
+        }
+        .navigationBarBackButtonHidden(true)
     }
 
     private func recoveryWordsContent(layout: RecoveryWordsLayout, availableWidth: CGFloat) -> some View {
@@ -79,11 +108,9 @@ struct WordsView: View {
             groupedWords: groupedWords,
             tabIndex: $tabIndex,
             lastIndex: lastIndex,
-            showConfirmationAlert: $showConfirmationAlert,
             layout: layout,
             availableWidth: availableWidth,
-            saveWallet: saveWallet,
-            dismiss: { dismiss() }
+            saveWallet: saveWallet
         )
     }
 
@@ -127,11 +154,9 @@ struct RecoveryWordsContent: View {
     let groupedWords: [[GroupedWord]]
     @Binding var tabIndex: Int
     let lastIndex: Int
-    @Binding var showConfirmationAlert: Bool
     let layout: RecoveryWordsLayout
     let availableWidth: CGFloat
     let saveWallet: () -> Void
-    let dismiss: () -> Void
 
     var body: some View {
         VStack(spacing: 24) {
@@ -193,11 +218,6 @@ struct RecoveryWordsContent: View {
             }
         }
         .padding()
-        .navigationBarTitleDisplayMode(.inline)
-        .adaptiveToolbarStyle()
-        .toolbarColorScheme(.dark, for: .navigationBar)
-        .toolbarBackground(Color.midnightBlue, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .frame(maxHeight: .infinity)
         .background(
             Image(.newWalletPattern)
@@ -208,32 +228,6 @@ struct RecoveryWordsContent: View {
                 .opacity(0.5)
         )
         .background(Color.midnightBlue)
-        .navigationTitle("Backup your wallet")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                    showConfirmationAlert = true
-                }) {
-                    HStack {
-                        Image(systemName: "chevron.left")
-                    }
-                    .foregroundStyle(.white)
-                }
-            }
-        }
-        .alert(isPresented: $showConfirmationAlert) {
-            Alert(
-                title: Text("⚠️ Wallet Not Saved ⚠️"),
-                message: Text("You will have to write down a new set of words."),
-                primaryButton: .destructive(Text("Yes, Go Back")) {
-                    dismiss()
-                },
-                secondaryButton: .cancel(Text("Cancel"))
-            )
-        }
-        .navigationBarBackButtonHidden(true)
     }
 
     private var primaryActionButton: some View {

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletCreateScreen.swift
@@ -51,33 +51,26 @@ struct WordsView: View {
             let layout: RecoveryWordsLayout = scrollableLayout ? .stickyBottom : .inline
             let contentWidth = max(proxy.size.width - 32, 0)
 
-            Group {
-                if scrollableLayout {
-                    VStack(spacing: 0) {
-                        ScrollView {
-                            recoveryWordsContent(
-                                layout: layout,
-                                availableWidth: contentWidth
-                            )
-                            .padding(.bottom, 24)
-                        }
-                        .scrollIndicators(.hidden)
-
-                        compactBottomAction
-                    }
-                    .frame(width: proxy.size.width, height: proxy.size.height)
-                    .background(
-                        Color.midnightBlue
-                            .ignoresSafeArea(.all)
-                    )
-
-                } else {
+            VStack(spacing: 0) {
+                ScrollView {
                     recoveryWordsContent(
                         layout: layout,
                         availableWidth: contentWidth
                     )
+                    .frame(minHeight: layout == .inline ? proxy.size.height : nil)
+                    .padding(.bottom, layout == .stickyBottom ? 24 : 0)
+                }
+                .scrollIndicators(.hidden)
+
+                if layout == .stickyBottom {
+                    compactBottomAction
                 }
             }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+            .background(
+                Color.midnightBlue
+                    .ignoresSafeArea(.all)
+            )
         }
     }
 
@@ -125,10 +118,6 @@ enum RecoveryWordsLayout {
     case stickyBottom
     case inline
 
-    var usesCompactCardHeight: Bool {
-        self == .stickyBottom
-    }
-
     var showsPrimaryActionInline: Bool {
         self == .inline
     }
@@ -146,13 +135,13 @@ struct RecoveryWordsContent: View {
 
     var body: some View {
         VStack(spacing: 24) {
-            StyledWordCard(tabIndex: $tabIndex, compactHeight: layout.usesCompactCardHeight) {
+            StyledWordCard(tabIndex: $tabIndex, rowCount: wordGridRowCount) {
                 ForEach(Array(groupedWords.enumerated()), id: \.offset) { index, wordGroup in
                     WordCardView(words: wordGroup, availableWidth: availableWidth).tag(index)
                 }
             }
 
-            if !layout.usesCompactCardHeight {
+            if layout == .inline {
                 Spacer()
             }
 
@@ -254,6 +243,10 @@ struct RecoveryWordsContent: View {
             saveWallet: saveWallet
         )
     }
+
+    private var wordGridRowCount: Int {
+        (groupedWords.map(\.count).max() ?? 0) / 2
+    }
 }
 
 struct RecoveryWordsPrimaryActionButton: View {
@@ -294,7 +287,7 @@ struct WordCardView: View {
     let words: [GroupedWord]
     let availableWidth: CGFloat
 
-    private let columnCount = 3
+    private let columnCount = 2
     private let columnSpacing: CGFloat = 12
 
     var body: some View {
@@ -351,7 +344,7 @@ struct StyledWordCard<Content: View>: View {
     @Environment(\.sizeCategory) var sizeCategory
 
     @Binding var tabIndex: Int
-    let compactHeight: Bool
+    let rowCount: Int
     @ViewBuilder var content: Content
 
     var body: some View {
@@ -360,7 +353,13 @@ struct StyledWordCard<Content: View>: View {
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
 
-        tabView.frame(height: usesCompactTypography(sizeCategory: sizeCategory) ? 320 : 260)
+        tabView.frame(height: wordCardHeight)
+    }
+
+    private var wordCardHeight: CGFloat {
+        let rowHeight: CGFloat = usesCompactTypography(sizeCategory: sizeCategory) ? 54 : 48
+
+        return CGFloat(rowCount) * rowHeight + 56
     }
 }
 

--- a/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
@@ -21,7 +21,7 @@ struct SecretWordsScreen: View {
     @State private var showSeedQrSheet = false
 
     let rowHeight = 30.0
-    private let numberOfColumns = 3
+    private let numberOfColumns = 2
 
     var numberOfRows: Int {
         (words?.words().count ?? 24) / numberOfColumns
@@ -46,23 +46,17 @@ struct SecretWordsScreen: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let scrollableLayout = usesCompactLayout(
+            let compactLayout = usesCompactLayout(
                 sizeCategory: sizeCategory,
                 availableHeight: proxy.size.height
             )
 
-            Group {
-                if scrollableLayout {
-                    ScrollView {
-                        mainContent(usesFlexibleSpacing: false)
-                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .top)
-                            .safeAreaPadding(.bottom, 24)
-                    }
-                    .scrollIndicators(.hidden)
-                } else {
-                    mainContent(usesFlexibleSpacing: true)
-                }
+            ScrollView {
+                mainContent(usesFlexibleSpacing: !compactLayout)
+                    .frame(minHeight: proxy.size.height, alignment: .top)
+                    .safeAreaPadding(.bottom, 24)
             }
+            .scrollIndicators(.hidden)
         }
         .onAppear {
             auth.lock()
@@ -113,7 +107,7 @@ struct SecretWordsScreen: View {
             Group {
                 if let words {
                     GroupBox {
-                        ColumnMajorGrid(items: words.allWords()) { _, word in
+                        ColumnMajorGrid(items: words.allWords(), numberOfColumns: numberOfColumns) { _, word in
                             HStack {
                                 Text("\(word.number).")
                                     .fontWeight(.medium)

--- a/ios/Cove/Views/ColumnMajorGrid.swift
+++ b/ios/Cove/Views/ColumnMajorGrid.swift
@@ -9,10 +9,11 @@ import SwiftUI
 
 /// A grid that displays items in column-major order (top-to-bottom, then left-to-right)
 ///
-/// For a list [1,2,3,4,5,6] with 3 columns, displays as:
+/// For a list [1,2,3,4,5,6] with 2 columns, displays as:
 /// ```
-/// 1  3  5
-/// 2  4  6
+/// 1  4
+/// 2  5
+/// 3  6
 /// ```
 struct ColumnMajorGrid<Item, Content: View>: View {
     let items: [Item]
@@ -22,7 +23,7 @@ struct ColumnMajorGrid<Item, Content: View>: View {
 
     init(
         items: [Item],
-        numberOfColumns: Int = 3,
+        numberOfColumns: Int = 2,
         spacing: CGFloat = 12,
         @ViewBuilder content: @escaping (Int, Item) -> Content
     ) {

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -208,7 +208,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             isBusy: false
         )
         .frame(width: size.width, height: size.height)
-        let image = try renderAfterScrollingToBottom(view: view, size: size)
+        let image = renderAfterScrollingToBottom(view: view, size: size)
         addScreenshotAttachment(image, name: "compact-cloud-backup-enable-onboarding")
         try saveAuditScreenshotIfDirectoryRequested(image, screenName: "cloud-backup-enable-onboarding")
         try assertPrimaryActionIsNotClippedAtBottom(in: image)
@@ -388,22 +388,22 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         try await bootstrapIfNeeded()
 
         let size = CGSize(width: 375, height: 667)
-        let image = render(
-            view: NavigationStack {
-                SecretWordsScreen(
-                    id: WalletId(),
-                    words: Mnemonic.preview(numberOfBip39Words: .twentyFour)
-                )
-                .environment(AppManager.shared)
-                .environment(AuthManager.shared)
-            }
-            .frame(width: size.width, height: size.height),
+        let view = NavigationStack {
+            SecretWordsScreen(
+                id: WalletId(),
+                words: Mnemonic.preview(numberOfBip39Words: .twentyFour)
+            )
+            .environment(AppManager.shared)
+            .environment(AuthManager.shared)
+        }
+        .frame(width: size.width, height: size.height)
+        let image = renderAfterScrollingToBottom(
+            view: view,
             size: size
         )
         addScreenshotAttachment(image, name: "compact-secret-words")
         try saveAuditScreenshotIfDirectoryRequested(image, screenName: "secret-words")
         try assertRecoveryWordCardsStayInsideHorizontalViewport(in: image)
-        try assertPrimaryActionIsNotClippedAtBottom(in: image)
 
         let recognizedText = try normalizedRecognizedText(in: image)
 
@@ -530,8 +530,8 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             .environment(AppManager.shared)
         }
         .frame(width: size.width, height: size.height)
-        let image = try renderAfterScrollingToBottom(view: view, size: size)
-        addScreenshotAttachment(image, name: "large-recovery-words-after-scroll")
+        let image = render(view: view, size: size)
+        addScreenshotAttachment(image, name: "large-recovery-words-final-page")
         try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-create-large-after.png")
         try assertNavigationChromeDoesNotShowWordCardBackground(in: image)
         try assertRecoveryWordCardsStayInsideHorizontalViewport(in: image)
@@ -552,10 +552,14 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
     }
 
     private func findVerticallyScrollableView(in view: UIView) -> UIScrollView? {
-        if let scrollView = view as? UIScrollView,
-           scrollView.contentSize.height > scrollView.bounds.height + 1
-        {
-            return scrollView
+        if let scrollView = view as? UIScrollView {
+            let minimumOffsetY = -scrollView.adjustedContentInset.top
+            let maximumOffsetY = scrollView.contentSize.height - scrollView.bounds.height
+                + scrollView.adjustedContentInset.bottom
+
+            if maximumOffsetY > minimumOffsetY + 1 {
+                return scrollView
+            }
         }
 
         for subview in view.subviews {
@@ -613,9 +617,16 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         return render(hostingController: hostingController, size: size)
     }
 
-    private func renderAfterScrollingToBottom(view: some View, size: CGSize) throws -> UIImage {
+    private func renderAfterScrollingToBottom(view: some View, size: CGSize) -> UIImage {
         let hostingController = hostingController(rootView: view, size: size)
-        let scrollView = try XCTUnwrap(findVerticallyScrollableView(in: hostingController.view))
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        hostingController.view.layoutIfNeeded()
+
+        guard let scrollView = findVerticallyScrollableView(in: hostingController.view) else {
+            return render(hostingController: hostingController, size: size)
+        }
+
         let maxOffsetY = max(
             scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom,
             -scrollView.adjustedContentInset.top
@@ -815,7 +826,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             x: 0,
             y: Int(64 * scale),
             width: cgImage.width,
-            height: Int(56 * scale)
+            height: Int(40 * scale)
         )
         let croppedBand = try XCTUnwrap(cgImage.cropping(to: navBand))
         let pixels = try rgbaPixels(in: croppedBand)

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -451,7 +451,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         try await bootstrapIfNeeded()
 
         let size = CGSize(width: 375, height: 667)
-        let manager = PendingWalletManager(numberOfWords: .twelve)
+        let manager = PendingWalletManager(numberOfWords: .twentyFour)
         let initialTabIndex =
             screenshotMode() == "initial"
                 ? 0
@@ -486,15 +486,19 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
                 recognizedText.contains("next"),
                 "expected compact recovery words initial screen to show Next, got:\n\(recognizedText)"
             )
-            XCTAssertTrue(
-                recognizedText.contains("recovery words"),
-                "expected compact recovery words initial screen to keep the word-copy context visible, got:\n\(recognizedText)"
-            )
             return
         }
 
+        let scrollView = try XCTUnwrap(findVerticallyScrollableView(in: hostingController.view))
+        let maxOffsetY = max(
+            scrollView.contentSize.height - scrollView.bounds.height + scrollView.adjustedContentInset.bottom,
+            -scrollView.adjustedContentInset.top
+        )
+        scrollView.setContentOffset(CGPoint(x: 0, y: maxOffsetY), animated: false)
+        hostingController.view.layoutIfNeeded()
+
         let image = render(hostingController: hostingController, size: size)
-        addScreenshotAttachment(image, name: "compact-recovery-words-final-page")
+        addScreenshotAttachment(image, name: "compact-recovery-words-after-scroll")
         try saveScreenshotIfRequested(image)
         try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-create-after.png")
         try assertNavigationChromeDoesNotShowWordCardBackground(in: image)
@@ -517,7 +521,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         try await bootstrapIfNeeded()
 
         let size = CGSize(width: 430, height: 932)
-        let manager = PendingWalletManager(numberOfWords: .twelve)
+        let manager = PendingWalletManager(numberOfWords: .twentyFour)
         let view = NavigationStack {
             WordsView(
                 manager: manager,
@@ -526,8 +530,8 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
             .environment(AppManager.shared)
         }
         .frame(width: size.width, height: size.height)
-        let image = render(view: view, size: size)
-        addScreenshotAttachment(image, name: "large-recovery-words-final-page")
+        let image = try renderAfterScrollingToBottom(view: view, size: size)
+        addScreenshotAttachment(image, name: "large-recovery-words-after-scroll")
         try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-create-large-after.png")
         try assertNavigationChromeDoesNotShowWordCardBackground(in: image)
         try assertRecoveryWordCardsStayInsideHorizontalViewport(in: image)


### PR DESCRIPTION
Keep 24-word phrases split across their existing 12-word pages while rendering each page in two columns. Make recovery-word screens scroll so taller grids remain accessible.