### PR TITLE
Build only Android ARM64 by default

### DIFF
--- a/justfile
+++ b/justfile
@@ -106,19 +106,13 @@ mobile-artifact-fetch-ios-core ref:
 # build
 # ------------------------------------------------------------------------------
 
-# [long] Build Android debug Rust FFI and Kotlin bindings for all ABIs
-[group('build')]
-build-android:
-    just xtask build-android debug && just say "done android"
-
-alias ba := build-android
-
 # [bounded, external] Build Android debug Rust FFI and Kotlin bindings for the connected device ABI
 [group('build')]
-build-android-connected-device:
+build-android:
     just xtask build-android debug --connected-device && just say "done android connected device"
 
-alias bad := build-android-connected-device
+alias ba := build-android
+alias bad := build-android
 
 # [long] Build Android release APK
 [group('build')]

--- a/justfile
+++ b/justfile
@@ -106,13 +106,19 @@ mobile-artifact-fetch-ios-core ref:
 # build
 # ------------------------------------------------------------------------------
 
-# [bounded, external] Build Android debug Rust FFI and Kotlin bindings for the connected device ABI
+# [bounded] Build Android debug Rust FFI and Kotlin bindings for ARM64 devices
 [group('build')]
 build-android:
-    just xtask build-android debug --connected-device && just say "done android connected device"
+    just xtask build-android debug --arm64 && just say "done android arm64-v8a"
 
 alias ba := build-android
-alias bad := build-android
+
+# [bounded, external] Build Android debug Rust FFI and Kotlin bindings for the connected device ABI
+[group('build')]
+build-android-connected-device:
+    just xtask build-android debug --connected-device && just say "done android connected device"
+
+alias bad := build-android-connected-device
 
 # [long] Build Android release APK
 [group('build')]

--- a/rust/xtask/src/android.rs
+++ b/rust/xtask/src/android.rs
@@ -20,6 +20,7 @@ use xshell::{cmd, Shell};
 // Android build constants
 const ANDROID_TARGETS: &[&str] =
     &["aarch64-linux-android", "armv7-linux-androideabi", "x86_64-linux-android"];
+const ARM64_ANDROID_TARGET: &str = "aarch64-linux-android";
 const JNI_LIBS_DIR: &str = "../android/app/src/main/jniLibs";
 const ANDROID_KOTLIN_DIR: &str = "../android/app/src/main/java";
 const BINDINGS_DIR: &str = "./bindings/kotlin";
@@ -58,6 +59,7 @@ pub enum BuildProfile {
 #[derive(Debug, Clone, Copy)]
 pub enum AndroidBuildTargets {
     All,
+    Arm64,
     ConnectedDevice,
 }
 
@@ -136,6 +138,7 @@ fn connected_device_target(sh: &Shell) -> Result<&'static str> {
 fn resolve_targets(sh: &Shell, build_targets: AndroidBuildTargets) -> Result<Vec<&'static str>> {
     match build_targets {
         AndroidBuildTargets::All => Ok(ANDROID_TARGETS.to_vec()),
+        AndroidBuildTargets::Arm64 => Ok(vec![ARM64_ANDROID_TARGET]),
         AndroidBuildTargets::ConnectedDevice => Ok(vec![connected_device_target(sh)?]),
     }
 }
@@ -175,8 +178,14 @@ pub fn build_android(
         }
     }
 
-    if matches!(build_targets, AndroidBuildTargets::ConnectedDevice) {
-        print_warning("Only building native Rust library for the connected Android device ABI");
+    match build_targets {
+        AndroidBuildTargets::All => {}
+        AndroidBuildTargets::Arm64 => {
+            print_warning("Only building native Rust library for ARM64 Android devices");
+        }
+        AndroidBuildTargets::ConnectedDevice => {
+            print_warning("Only building native Rust library for the connected Android device ABI");
+        }
     }
 
     // build for each target

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -44,8 +44,12 @@ enum Commands {
         profile: String,
 
         /// Build only the native library ABI used by the connected Android device
-        #[arg(long)]
+        #[arg(long, conflicts_with = "arm64")]
         connected_device: bool,
+
+        /// Build only the native library ABI used by ARM64 Android devices
+        #[arg(long)]
+        arm64: bool,
     },
 
     /// Build and run Android app on device/emulator
@@ -263,10 +267,12 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::BumpVersion { bump_type, targets } => version::bump_version(bump_type, targets),
 
-        Commands::BuildAndroid { profile, connected_device } => {
+        Commands::BuildAndroid { profile, connected_device, arm64 } => {
             let build_profile = android::BuildProfile::from_str(&profile);
             let build_targets = if connected_device {
                 android::AndroidBuildTargets::ConnectedDevice
+            } else if arm64 {
+                android::AndroidBuildTargets::Arm64
             } else {
                 android::AndroidBuildTargets::All
             };


### PR DESCRIPTION
## Summary

- add an explicit ARM64 Android build target
- make `build-android` and `ba` build only `arm64-v8a`
- retain `bad` for opt-in connected-device ABI detection
- leave release Android builds unchanged

## Why

Local development only needs ARM64 for the physical device and configured
simulator, so building every supported ABI wastes time. The target must be
selected statically because CI does not provide `adb` or a connected device.

## Impact

`just ba` and the Android compile CI job build only the ARM64 native Rust
library without requiring a device. `just bad` remains available when explicit
connected-device detection is useful.

## Validation

- `just fmt`
- `just clippy`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo test -p xtask`
- dry-run validation for `build-android`, `ba`, and `bad`
