### PR TITLE
Anchor hot wallet select content lower

### DIFF
--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletSelectScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletSelectScreen.swift
@@ -37,8 +37,8 @@ struct HotWalletSelectScreen: View {
             Group {
                 if scrollableLayout {
                     ScrollView {
-                        mainContent(usesFlexibleTopSpacer: false)
-                            .frame(minHeight: proxy.size.height, maxHeight: .infinity, alignment: .bottom)
+                        bottomActionLayout()
+                            .frame(minHeight: proxy.size.height)
                     }
                     .scrollIndicators(.hidden)
                 } else {
@@ -59,23 +59,6 @@ struct HotWalletSelectScreen: View {
         .navigationTitle("Add New Wallet")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
-    }
-
-    private func mainContent(usesFlexibleTopSpacer: Bool) -> some View {
-        VStack(spacing: 28) {
-            if usesFlexibleTopSpacer {
-                Spacer()
-            }
-
-            promptContent
-
-            Divider()
-                .overlay(.coveLightGray.opacity(0.50))
-
-            walletChoiceActions
-        }
-        .padding()
-        .frame(maxHeight: .infinity)
     }
 
     private func bottomActionLayout() -> some View {

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -44,6 +44,16 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         addScreenshotAttachment(image, name: "compact-hot-wallet-select")
         try saveAuditScreenshotIfDirectoryRequested(image, name: "hot-wallet-select-after.png")
         try assertPrimaryActionIsNotClippedAtBottom(in: image)
+        try assertTextIsInBottomScreenRegion(
+            "do you already",
+            maximumNormalizedMidY: 0.5,
+            in: image
+        )
+        try assertTextIsInBottomScreenRegion(
+            "create new wallet",
+            maximumNormalizedMidY: 0.25,
+            in: image
+        )
 
         let recognizedText = try normalizedRecognizedText(in: image)
 

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -712,6 +712,52 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
         )
     }
 
+    /// Vision text boxes use a bottom-left origin, so smaller midY is closer to the bottom
+    private func assertTextIsInBottomScreenRegion(
+        _ substring: String,
+        maximumNormalizedMidY: CGFloat,
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = false
+
+        let handler = VNImageRequestHandler(cgImage: cgImage)
+        try handler.perform([request])
+
+        let needle = substring.lowercased()
+        let observations = request.results ?? []
+        guard let observation = observations.first(where: { observation in
+            observation.topCandidates(1).first?
+                .string
+                .lowercased()
+                .contains(needle) == true
+        }) else {
+            let recognizedText = observations
+                .compactMap { $0.topCandidates(1).first?.string }
+                .joined(separator: "\n")
+
+            XCTFail(
+                "expected text containing \"\(substring)\" so layout position can be checked, got:\n\(recognizedText)",
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        let midY = observation.boundingBox.midY
+        XCTAssertLessThanOrEqual(
+            midY,
+            maximumNormalizedMidY,
+            "expected \"\(substring)\" midY \(midY) to stay within the bottom \(maximumNormalizedMidY) of the screen",
+            file: file,
+            line: line
+        )
+    }
+
     private func assertBluePrimaryActionIsNotClippedAtBottom(
         in image: UIImage,
         file: StaticString = #filePath,


### PR DESCRIPTION
## Summary
Always use the bottom-aligned action layout on the hot wallet select screen, and assert the prompt and primary actions stay in the lower half of compact screens.

## Why
Create/import controls were being clipped or sitting mid-page on compact layouts.

## Changes
- Force bottom-aligned action layout on `HotWalletSelectScreen`
- Add layout tests covering compact screens

## Test plan
- [ ] Hot wallet select create/import actions sit in the lower half on compact devices
- [ ] Layout tests pass