### PR TITLE
Prevent false Android max-send balance alert

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/SendFlowRouteLifecycle.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/SendFlowRouteLifecycle.kt
@@ -10,6 +10,11 @@ internal fun routeStackContainsSendWallet(
     walletId: WalletId,
 ): Boolean = default.sendWalletId() == walletId || routes.any { it.sendWalletId() == walletId }
 
+internal fun shouldShowNoBalanceAlertOnEntry(
+    sendRoute: SendRoute,
+    spendableSats: ULong,
+): Boolean = spendableSats == 0uL && sendRoute.requiresSpendableBalanceOnEntry()
+
 private fun Route.sendWalletId(): WalletId? =
     when (this) {
         is Route.Send -> v1.walletId()
@@ -22,4 +27,15 @@ private fun SendRoute.walletId(): WalletId =
         is SendRoute.CoinControlSetAmount -> id
         is SendRoute.HardwareExport -> id
         is SendRoute.Confirm -> v1.id
+    }
+
+private fun SendRoute.requiresSpendableBalanceOnEntry(): Boolean =
+    when (this) {
+        is SendRoute.SetAmount,
+        is SendRoute.CoinControlSetAmount,
+        -> true
+
+        is SendRoute.HardwareExport,
+        is SendRoute.Confirm,
+        -> false
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -27,6 +27,7 @@ import org.bitcoinppl.cove.Auth
 import org.bitcoinppl.cove.QrCodeScanView
 import org.bitcoinppl.cove.TaggedItem
 import org.bitcoinppl.cove.WalletManager
+import org.bitcoinppl.cove.shouldShowNoBalanceAlertOnEntry
 import org.bitcoinppl.cove.flows.SendFlow.ConfirmScreen.SendFlowConfirmScreen
 import org.bitcoinppl.cove.flows.SendFlow.HardwareScreen.SendFlowHardwareScreen
 import org.bitcoinppl.cove.flows.SendFlow.SetAmountScreen.CoinControlSetAmountScreen
@@ -155,9 +156,13 @@ fun SendFlowContainer(
                 }
             }
 
-            // check for zero balance
-            LaunchedEffect(wm.balance) {
-                if (wm.balance.spendable().asSats() == 0u.toULong()) {
+            LaunchedEffect(wm, sendRoute) {
+                if (
+                    shouldShowNoBalanceAlertOnEntry(
+                        sendRoute = sendRoute,
+                        spendableSats = wm.balance.spendable().asSats(),
+                    )
+                ) {
                     presenter.alertState = TaggedItem(SendFlowAlertState.Error(SendFlowException.NoBalance()))
                 }
             }

--- a/android/app/src/test/java/org/bitcoinppl/cove/SendFlowRouteLifecycleTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/SendFlowRouteLifecycleTest.kt
@@ -1,8 +1,12 @@
 package org.bitcoinppl.cove
 
 import org.bitcoinppl.cove_core.Route
+import org.bitcoinppl.cove_core.SendConfirmationInput
 import org.bitcoinppl.cove_core.SendRoute
+import org.bitcoinppl.cove_core.SendRouteConfirmArgs
 import org.bitcoinppl.cove_core.SettingsRoute
+import org.bitcoinppl.cove_core.types.ConfirmDetails
+import org.bitcoinppl.cove_core.types.NoHandle
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -71,6 +75,46 @@ class SendFlowRouteLifecycleTest {
                 default = Route.SelectedWallet("wallet-a"),
                 routes = listOf(Route.Send(SendRoute.SetAmount("wallet-b", null, null))),
                 walletId = "wallet-a",
+            ),
+        )
+    }
+
+    @Test
+    fun zeroBalanceIsRejectedWhenEnteringAmountSelection() {
+        assertTrue(
+            shouldShowNoBalanceAlertOnEntry(
+                sendRoute = SendRoute.SetAmount("wallet-a", null, null),
+                spendableSats = 0uL,
+            ),
+        )
+    }
+
+    @Test
+    fun positiveBalanceIsAllowedWhenEnteringAmountSelection() {
+        assertFalse(
+            shouldShowNoBalanceAlertOnEntry(
+                sendRoute = SendRoute.SetAmount("wallet-a", null, null),
+                spendableSats = 1uL,
+            ),
+        )
+    }
+
+    @Test
+    fun zeroBalanceAfterBroadcastDoesNotRejectConfirmationRoute() {
+        val confirmRoute =
+            SendRoute.Confirm(
+                SendRouteConfirmArgs(
+                    id = "wallet-a",
+                    details = ConfirmDetails(NoHandle),
+                    input = SendConfirmationInput.Unsigned,
+                    payjoinEndpoint = null,
+                ),
+            )
+
+        assertFalse(
+            shouldShowNoBalanceAlertOnEntry(
+                sendRoute = confirmRoute,
+                spendableSats = 0uL,
             ),
         )
     }


### PR DESCRIPTION
## Summary

- treat zero balance as an entry guard for amount-selection routes
- stop expected post-broadcast balance updates from raising a send-flow error
- add regression coverage for a zero balance on the confirmation route

## Root cause

Android keyed a send-flow `LaunchedEffect` to every wallet balance change. A successful max send correctly reduced the spendable balance to zero, which reran the effect and replaced the successful result with a false insufficient-funds alert.

## Impact

Android users can complete a max send without seeing a contradictory “You do not have any bitcoin” error after the transaction broadcasts. Initial zero-balance protection remains active when entering amount selection.

## Validation

- `./gradlew :app:testDevDebugUnitTest --tests org.bitcoinppl.cove.SendFlowRouteLifecycleTest`
- `just fmt`
- `just lint-android`
