### PR TITLE
Pad recovery words below toolbar

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/secret_words/SecretWordsScreen.kt
@@ -192,12 +192,11 @@ fun SecretWordsScreen(
                     Modifier
                         .fillMaxWidth()
                         .heightIn(min = maxHeight)
+                        .padding(top = 16.dp)
                         .verticalScroll(rememberScrollState())
                         .padding(horizontal = 20.dp),
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
-                Spacer(Modifier.height(16.dp))
-
                 // words grid
                 if (words != null) {
                     RecoveryWordsGrid(

--- a/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
@@ -22,6 +22,7 @@ struct SecretWordsScreen: View {
 
     let rowHeight = 30.0
     private let numberOfColumns = 2
+    private let topContentInset = 16.0
 
     var numberOfRows: Int {
         (words?.words().count ?? 24) / numberOfColumns
@@ -50,13 +51,14 @@ struct SecretWordsScreen: View {
                 sizeCategory: sizeCategory,
                 availableHeight: proxy.size.height
             )
+            let contentHeight = max(proxy.size.height - topContentInset, 0)
 
             ScrollView {
                 mainContent(usesFlexibleSpacing: !compactLayout)
-                    .frame(minHeight: proxy.size.height, alignment: .top)
+                    .frame(minHeight: contentHeight, alignment: .top)
                     .safeAreaPadding(.bottom, 24)
             }
-            .padding(.top, 16)
+            .padding(.top, topContentInset)
             .scrollIndicators(.hidden)
         }
         .onAppear {

--- a/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
+++ b/ios/Cove/Flows/SelectedWalletFlow/SecretWordsScreen.swift
@@ -56,6 +56,7 @@ struct SecretWordsScreen: View {
                     .frame(minHeight: proxy.size.height, alignment: .top)
                     .safeAreaPadding(.bottom, 24)
             }
+            .padding(.top, 16)
             .scrollIndicators(.hidden)
         }
         .onAppear {
@@ -176,7 +177,8 @@ struct SecretWordsScreen: View {
                 }
             }
         }
-        .padding()
+        .padding(.horizontal)
+        .padding(.bottom)
     }
 }
 


### PR DESCRIPTION
## Summary

- keep a 16-point top inset above recovery words while scrolling on Android
- apply the same persistent toolbar spacing on iOS
- preserve the existing horizontal and bottom content padding

## Why

The previous Android spacer lived inside the scrollable content, so it scrolled
away and allowed recovery-word cards to clip directly against the toolbar. The
iOS layout used general content padding with the same behavior. Keeping the top
inset outside the scroll content gives both platforms a consistent visual gap.

## Validation

- `just fmt`
- `just clippy`
- `just lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved top spacing and content alignment on the Secret Words screen.
  * Updated scrolling layouts to maintain consistent padding across different screen sizes.
  * Refined horizontal and bottom spacing for a more balanced presentation on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->