### PR TITLE
Anchor import suggestions to keyboard

### DIFF
--- a/ios/Cove/Components/KeyboardAccessory/KeyboardAccessoryHost.swift
+++ b/ios/Cove/Components/KeyboardAccessory/KeyboardAccessoryHost.swift
@@ -35,6 +35,7 @@ final class KeyboardAccessoryController: ObservableObject {
     private var container: UIView?
     private weak var currentResponder: UIView?
     private var isAttached: Bool = false
+    private var shouldShowAccessory: Bool = false
     private var didBecomeActiveObserver: NSObjectProtocol?
     private var keyboardDidShowObserver: NSObjectProtocol?
     private var keyboardWillHideObserver: NSObjectProtocol?
@@ -89,18 +90,19 @@ final class KeyboardAccessoryController: ObservableObject {
     /// Reattach accessory when keyboard appears after focus transitions.
     /// Handles the case where first responder changes between text fields.
     private func reattachOnKeyboardShow() {
-        guard let container = self.container else { return }
+        guard shouldShowAccessory, !isAttached, let container else { return }
 
         // re-capture first responder
         UIResponder.captureCurrentFirstResponder(from: nil)
         guard let responder = UIResponder.currentFirstResponderView else { return }
 
-        // always reattach when keyboard shows (we track hide state via keyboardWillHide)
+        // record attachment before reloadInputViews can emit another keyboard notification
+        currentResponder = responder
+        isAttached = true
+
         // force rebuild: clear first, then re-set
         self.setAccessory(on: responder, accessoryView: nil, forceReload: false)
         self.setAccessory(on: responder, accessoryView: container, forceReload: true)
-        self.currentResponder = responder
-        self.isAttached = true
     }
 
     deinit {
@@ -116,6 +118,8 @@ final class KeyboardAccessoryController: ObservableObject {
     }
 
     func update(isVisible: Bool, height: CGFloat, @ViewBuilder accessory: () -> AnyView) {
+        shouldShowAccessory = isVisible
+
         guard let responderView = UIResponder.currentFirstResponderView else {
             return
         }
@@ -161,8 +165,7 @@ final class KeyboardAccessoryController: ObservableObject {
         self.hosting = hosting
         self.container = container
 
-        // only set the accessory view when actually visible
-        if isVisible {
+        if needsAttachment {
             // only reload when responder changes, not on first attachment (for smooth animation)
             setAccessory(on: responderView, accessoryView: container, forceReload: responderChanged)
             currentResponder = responderView

--- a/ios/Cove/Components/KeyboardAccessory/KeyboardAccessoryHost.swift
+++ b/ios/Cove/Components/KeyboardAccessory/KeyboardAccessoryHost.swift
@@ -10,35 +10,40 @@ import UIKit
 
 /// Bridges a SwiftUI accessory view into the native `inputAccessoryView` of the current first responder.
 struct KeyboardAccessoryHost<Accessory: View>: UIViewRepresentable {
-    var controller: KeyboardAccessoryController
     var isVisible: Bool = true
     var height: CGFloat
     @ViewBuilder var accessory: () -> Accessory
+
+    func makeCoordinator() -> KeyboardAccessoryController {
+        KeyboardAccessoryController()
+    }
 
     func makeUIView(context _: Context) -> UIView {
         UIView(frame: .zero)
     }
 
-    func updateUIView(_ uiView: UIView, context _: Context) {
+    func updateUIView(_ uiView: UIView, context: Context) {
         // Capture the current first responder each pass.
         UIResponder.captureCurrentFirstResponder(from: uiView.window)
-        controller.update(isVisible: isVisible, height: height) {
+        context.coordinator.update(isVisible: isVisible, height: height) {
             AnyView(accessory())
         }
+    }
+
+    static func dismantleUIView(_: UIView, coordinator: KeyboardAccessoryController) {
+        coordinator.detach()
     }
 }
 
 // MARK: - Controller
 
-final class KeyboardAccessoryController: ObservableObject {
+final class KeyboardAccessoryController {
     private var hosting: UIHostingController<AnyView>?
     private var container: UIView?
     private weak var currentResponder: UIView?
-    private var isAttached: Bool = false
     private var shouldShowAccessory: Bool = false
     private var didBecomeActiveObserver: NSObjectProtocol?
     private var keyboardDidShowObserver: NSObjectProtocol?
-    private var keyboardWillHideObserver: NSObjectProtocol?
 
     init() {
         didBecomeActiveObserver = NotificationCenter.default.addObserver(
@@ -56,16 +61,6 @@ final class KeyboardAccessoryController: ObservableObject {
         ) { [weak self] _ in
             self?.reattachOnKeyboardShow()
         }
-
-        keyboardWillHideObserver = NotificationCenter.default.addObserver(
-            forName: UIResponder.keyboardWillHideNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            // mark as detached so we know to reattach when keyboard shows again
-            self?.isAttached = false
-            self?.currentResponder = nil
-        }
     }
 
     /// Reattach the accessory view when app returns from background/notification center.
@@ -74,31 +69,42 @@ final class KeyboardAccessoryController: ObservableObject {
         // small delay to let iOS complete its transition
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self,
-                  self.isAttached,
-                  let responder = self.currentResponder,
+                  self.shouldShowAccessory,
                   let container = self.container
             else {
                 return
             }
 
+            UIResponder.captureCurrentFirstResponder(from: nil)
+            guard let responder = UIResponder.currentFirstResponderView else { return }
+
+            self.detachFromPreviousResponder(unless: responder)
+
             // force rebuild: clear first, then re-set
             self.setAccessory(on: responder, accessoryView: nil, forceReload: false)
             self.setAccessory(on: responder, accessoryView: container, forceReload: true)
+            self.currentResponder = responder
         }
     }
 
     /// Reattach accessory when keyboard appears after focus transitions.
     /// Handles the case where first responder changes between text fields.
     private func reattachOnKeyboardShow() {
-        guard shouldShowAccessory, !isAttached, let container else { return }
+        guard shouldShowAccessory, let container else { return }
 
         // re-capture first responder
         UIResponder.captureCurrentFirstResponder(from: nil)
         guard let responder = UIResponder.currentFirstResponderView else { return }
 
+        detachFromPreviousResponder(unless: responder)
+
+        guard accessoryView(on: responder) !== container else {
+            currentResponder = responder
+            return
+        }
+
         // record attachment before reloadInputViews can emit another keyboard notification
         currentResponder = responder
-        isAttached = true
 
         // force rebuild: clear first, then re-set
         self.setAccessory(on: responder, accessoryView: nil, forceReload: false)
@@ -112,28 +118,17 @@ final class KeyboardAccessoryController: ObservableObject {
         if let observer = keyboardDidShowObserver {
             NotificationCenter.default.removeObserver(observer)
         }
-        if let observer = keyboardWillHideObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
     }
 
     func update(isVisible: Bool, height: CGFloat, @ViewBuilder accessory: () -> AnyView) {
         shouldShowAccessory = isVisible
 
-        guard let responderView = UIResponder.currentFirstResponderView else {
+        guard isVisible else {
+            detach()
             return
         }
 
-        // check if visibility or responder changed
-        let responderChanged = currentResponder !== responderView
-        let needsAttachment = isVisible && (!isAttached || responderChanged)
-        let needsDetachment = !isVisible && isAttached
-
-        // remove when hidden; keeps native keyboard height stable
-        if needsDetachment {
-            setAccessory(on: responderView, accessoryView: nil, forceReload: true)
-            currentResponder = nil
-            isAttached = false
+        guard let responderView = UIResponder.currentFirstResponderView else {
             return
         }
 
@@ -147,6 +142,8 @@ final class KeyboardAccessoryController: ObservableObject {
         let container =
             container
                 ?? UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: height))
+        let heightChanged = container.frame.height != height
+        container.frame.size.height = height
         container.backgroundColor = .clear
         container.autoresizingMask = [.flexibleWidth]
         container.isUserInteractionEnabled = true
@@ -165,12 +162,52 @@ final class KeyboardAccessoryController: ObservableObject {
         self.hosting = hosting
         self.container = container
 
-        if needsAttachment {
-            // only reload when responder changes, not on first attachment (for smooth animation)
-            setAccessory(on: responderView, accessoryView: container, forceReload: responderChanged)
-            currentResponder = responderView
-            isAttached = true
+        let responderChanged = currentResponder !== responderView
+        detachFromPreviousResponder(unless: responderView)
+
+        if accessoryView(on: responderView) !== container || heightChanged {
+            // reload only when an existing input view must change
+            let forceReload = responderChanged || heightChanged
+            setAccessory(on: responderView, accessoryView: container, forceReload: forceReload)
         }
+
+        currentResponder = responderView
+    }
+
+    func detach() {
+        shouldShowAccessory = false
+
+        guard let responder = currentResponder else { return }
+
+        if accessoryView(on: responder) === container {
+            setAccessory(on: responder, accessoryView: nil, forceReload: responder.isFirstResponder)
+        }
+
+        currentResponder = nil
+    }
+
+    private func detachFromPreviousResponder(unless responder: UIView) {
+        guard let currentResponder, currentResponder !== responder else { return }
+
+        if accessoryView(on: currentResponder) === container {
+            setAccessory(on: currentResponder, accessoryView: nil, forceReload: false)
+        }
+
+        self.currentResponder = nil
+    }
+
+    private func accessoryView(on responder: UIView) -> UIView? {
+        if let textField = responder as? UITextField {
+            return textField.inputAccessoryView
+        }
+        if let textView = responder as? UITextView {
+            return textView.inputAccessoryView
+        }
+        if let searchBar = responder as? UISearchBar {
+            return searchBar.inputAccessoryView
+        }
+
+        return nil
     }
 
     private func setAccessory(on responder: UIView, accessoryView: UIView?, forceReload: Bool) {

--- a/ios/Cove/Extention/KeyboardObserver.swift
+++ b/ios/Cove/Extention/KeyboardObserver.swift
@@ -6,7 +6,6 @@ import UIKit
 @MainActor
 final class KeyboardObserver {
     var keyboardIsShowing = false
-    var keyboardHeight: CGFloat = 0
 
     // nonisolated so they can be accessed in deinit
     private nonisolated(unsafe) var showObserver: NSObjectProtocol?
@@ -17,14 +16,12 @@ final class KeyboardObserver {
             forName: UIResponder.keyboardWillShowNotification,
             object: nil,
             queue: .main
-        ) { [weak self] notification in
+        ) { [weak self] _ in
             guard let self else { return }
-            let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
 
             Task { @MainActor in
                 withAnimation(.easeInOut(duration: 0.25)) {
                     self.keyboardIsShowing = true
-                    self.keyboardHeight = keyboardFrame?.height ?? 0
                 }
             }
         }
@@ -39,7 +36,6 @@ final class KeyboardObserver {
             Task { @MainActor in
                 withAnimation(.easeInOut(duration: 0.25)) {
                     self.keyboardIsShowing = false
-                    self.keyboardHeight = 0
                 }
             }
         }

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreen.swift
@@ -94,6 +94,7 @@ struct HotWalletImportScreen: View {
     @FocusState var focusField: ImportFieldNumber?
 
     @State private var keyboardObserver = KeyboardObserver()
+    @StateObject private var keyboardAccessoryController = KeyboardAccessoryController()
 
     private var accessoryHeight: CGFloat {
         switch sizeCategory {
@@ -103,12 +104,6 @@ struct HotWalletImportScreen: View {
         case .extraExtraLarge: 52
         default: 54
         }
-    }
-
-    private var accessoryMinWidth: CGFloat {
-        let maxWidth = screenWidth - 32
-        let target: CGFloat = 240 // three-chip feel
-        return min(maxWidth, target)
     }
 
     @State var manager: ImportWalletManager = .init()
@@ -327,34 +322,31 @@ struct HotWalletImportScreen: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            let bottomSafeArea = geometry.safeAreaInsets.bottom
-
-            ZStack(alignment: .bottom) {
-                HotWalletImportMainContent(
-                    keyboardIsShowing: keyboardObserver.keyboardIsShowing,
-                    isCompactLayout: usesCompactTypography(sizeCategory: sizeCategory),
-                    numberOfWords: numberOfWords,
-                    tabIndex: $tabIndex,
-                    enteredWords: $enteredWords,
-                    filteredSuggestions: $filteredSuggestions,
-                    focusField: $focusField,
-                    onPasteMnemonic: handlePasteMnemonic,
-                    importWallet: { importWallet() }
+        HotWalletImportMainContent(
+            keyboardIsShowing: keyboardObserver.keyboardIsShowing,
+            isCompactLayout: usesCompactTypography(sizeCategory: sizeCategory),
+            numberOfWords: numberOfWords,
+            tabIndex: $tabIndex,
+            enteredWords: $enteredWords,
+            filteredSuggestions: $filteredSuggestions,
+            focusField: $focusField,
+            onPasteMnemonic: handlePasteMnemonic,
+            importWallet: { importWallet() }
+        )
+        .background {
+            KeyboardAccessoryHost(
+                controller: keyboardAccessoryController,
+                isVisible: keyboardObserver.keyboardIsShowing && focusField != nil
+                    && !filteredSuggestions.isEmpty,
+                height: accessoryHeight
+            ) {
+                HotWalletImportKeyboardToolbar(
+                    filteredSuggestions: filteredSuggestions,
+                    accessoryHeight: accessoryHeight,
+                    selectWord: selectWordInKeyboard
                 )
-
-                if keyboardObserver.keyboardIsShowing, focusField != nil, !filteredSuggestions.isEmpty {
-                    HotWalletImportKeyboardToolbar(
-                        filteredSuggestions: filteredSuggestions,
-                        accessoryHeight: accessoryHeight,
-                        selectWord: selectWordInKeyboard
-                    )
-                    .offset(y: -(keyboardObserver.keyboardHeight - bottomSafeArea))
-                    .transition(.opacity)
-                    .animation(.easeInOut(duration: 0.2), value: filteredSuggestions.isEmpty)
-                }
             }
-            .frame(width: geometry.size.width, height: geometry.size.height)
+            .frame(width: 0, height: 0)
         }
         .animation(.easeInOut(duration: 0.25), value: keyboardObserver.keyboardIsShowing)
         .padding()

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreen.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreen.swift
@@ -94,7 +94,6 @@ struct HotWalletImportScreen: View {
     @FocusState var focusField: ImportFieldNumber?
 
     @State private var keyboardObserver = KeyboardObserver()
-    @StateObject private var keyboardAccessoryController = KeyboardAccessoryController()
 
     private var accessoryHeight: CGFloat {
         switch sizeCategory {
@@ -335,7 +334,6 @@ struct HotWalletImportScreen: View {
         )
         .background {
             KeyboardAccessoryHost(
-                controller: keyboardAccessoryController,
                 isVisible: keyboardObserver.keyboardIsShowing && focusField != nil
                     && !filteredSuggestions.isEmpty,
                 height: accessoryHeight

--- a/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreenSections.swift
+++ b/ios/Cove/Flows/NewWalletFlow/HotWallet/HotWalletImportScreenSections.swift
@@ -48,6 +48,8 @@ struct HotWalletImportKeyboardToolbar: View {
         .frame(height: accessoryHeight)
         .background(.regularMaterial)
         .modifier(KeyboardToolbarShapeModifier())
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("hotWalletImport.suggestions")
     }
 }
 

--- a/ios/CoveUITests/OnboardingFullLaunchUITests.swift
+++ b/ios/CoveUITests/OnboardingFullLaunchUITests.swift
@@ -1,4 +1,3 @@
-import UIKit
 import XCTest
 
 final class OnboardingFullLaunchUITests: XCTestCase {
@@ -136,6 +135,46 @@ final class OnboardingFullLaunchUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Import your software wallet"].waitForExistence(timeout: 10))
         XCTAssertTrue(button(startingWith: "Enter recovery words").exists)
         XCTAssertTrue(button(startingWith: "Scan QR code").exists)
+    }
+
+    func testSoftwareWalletImportSuggestionsAreAnchoredToKeyboard() {
+        app.launch()
+
+        reachStorageChoices()
+        button(startingWith: "Software wallet").tap()
+        button(startingWith: "Enter recovery words").tap()
+        button(startingWith: "12 words").tap()
+
+        let firstField = app.textFields["hotWalletImport.word.1"]
+        XCTAssertTrue(firstField.waitForExistence(timeout: 10))
+        firstField.tap()
+
+        let keyboardTutorialContinue = app.buttons["Continue"]
+        if keyboardTutorialContinue.waitForExistence(timeout: 1) {
+            keyboardTutorialContinue.tap()
+        }
+
+        let keyboard = app.keyboards.firstMatch
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 10))
+        firstField.typeText("a")
+
+        let firstSuggestion = app.buttons["abandon"]
+        XCTAssertTrue(firstSuggestion.waitForExistence(timeout: 5))
+
+        let suggestions = app.descendants(matching: .any)["hotWalletImport.suggestions"]
+        XCTAssertTrue(suggestions.waitForExistence(timeout: 5))
+
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Import wallet word suggestions"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        let accessoryGap = keyboard.frame.minY - suggestions.frame.maxY
+        XCTAssertLessThanOrEqual(
+            accessoryGap,
+            20,
+            "expected word suggestions to be attached to the keyboard, got a \(accessoryGap)-point gap"
+        )
     }
 
     func testSoftwareWalletUserCanOpenQrScanner() {
@@ -316,13 +355,13 @@ final class OnboardingFullLaunchUITests: XCTestCase {
         button(startingWith: "12 words").tap()
         XCTAssertTrue(app.navigationBars["Import Wallet"].waitForExistence(timeout: 10))
 
-        let firstField = app.textFields["hotWalletImport.word.1"]
-        XCTAssertTrue(firstField.waitForExistence(timeout: 10))
-        firstField.tap()
-        UIPasteboard.general.string = knownEmptyMainnetMnemonic.joined(separator: " ")
-        firstField.typeKey("v", modifierFlags: .command)
+        for (index, word) in knownEmptyMainnetMnemonic.enumerated() {
+            let field = app.textFields["hotWalletImport.word.\(index + 1)"]
+            XCTAssertTrue(field.waitForExistence(timeout: 10))
+            field.tap()
+            field.typeText(word == "about" ? "abou" : "aba")
+        }
 
-        dismissKeyboardIfVisible()
         app.buttons["hotWalletImport.import"].tap()
 
         XCTAssertTrue(app.staticTexts["Protect this wallet with Cloud Backup?"].waitForExistence(timeout: 20))


### PR DESCRIPTION
## What changed

- attach recovery-word suggestions to the active text field's native input accessory view
- remove the manual keyboard-height offset and its unused height state
- add a UI test that verifies the suggestions stay next to the keyboard
- make full-launch wallet import tests enter recovery words without the system paste-permission prompt

## Why

The SwiftUI view extraction in `db1d7bd6` changed keyboard safe-area layout. The import screen still applied a full keyboard-height offset, so the suggestions moved twice and appeared next to the recovery-word fields.

Using the native input accessory view makes the keyboard own the suggestions' position. It also removes the layout dependency that caused the regression.

## Verification

- reproduced the regression on an iPhone 17 simulator
- confirmed the historical boundary: `db1d7bd6^` passed and `db1d7bd6` failed
- passed the recovery-word suggestion keyboard-anchor UI test
- passed all 18 compact and Dynamic Type layout regression tests
- passed software-wallet creation and known-wallet import full-launch tests
- passed the cloud-backup details cancel full-launch test
- passed `just fmt`
- passed `just clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard accessory positioning and reattachment when keyboard or app focus changes.
  * Prevented stale accessory content and layout issues during wallet recovery word entry.
  * Simplified keyboard visibility handling for more reliable toolbar behavior.

* **Accessibility**
  * Added an accessibility identifier to the recovery word suggestions toolbar.

* **Tests**
  * Added coverage verifying suggestions remain anchored to the software-wallet keyboard.
  * Improved automated recovery word entry coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->