### PR TITLE
Split SignAndBroadcastError into typed send error variants

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -60625,7 +60625,23 @@ sealed class WalletManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
 
-    class SignAndBroadcastException(
+    class SigningException(
+
+        val v1: kotlin.String
+        ) : WalletManagerException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+
+    class BroadcastException(
+
+        val v1: kotlin.String
+        ) : WalletManagerException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+
+    class PayjoinSessionException(
 
         val v1: kotlin.String
         ) : WalletManagerException() {
@@ -60801,38 +60817,44 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
             23 -> WalletManagerException.GetConfirmDetailsException(
                 FfiConverterString.read(buf),
                 )
-            24 -> WalletManagerException.SignAndBroadcastException(
+            24 -> WalletManagerException.SigningException(
                 FfiConverterString.read(buf),
                 )
-            25 -> WalletManagerException.Converter(
+            25 -> WalletManagerException.BroadcastException(
+                FfiConverterString.read(buf),
+                )
+            26 -> WalletManagerException.PayjoinSessionException(
+                FfiConverterString.read(buf),
+                )
+            27 -> WalletManagerException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            26 -> WalletManagerException.UnknownException(
+            28 -> WalletManagerException.UnknownException(
                 FfiConverterString.read(buf),
                 )
-            27 -> WalletManagerException.PsbtFinalizeException(
+            29 -> WalletManagerException.PsbtFinalizeException(
                 FfiConverterString.read(buf),
                 )
-            28 -> WalletManagerException.GetHistoricalPricesException(
+            30 -> WalletManagerException.GetHistoricalPricesException(
                 FfiConverterString.read(buf),
                 )
-            29 -> WalletManagerException.CsvCreationException(
+            31 -> WalletManagerException.CsvCreationException(
                 FfiConverterString.read(buf),
                 )
-            30 -> WalletManagerException.AddUtxosException(
+            32 -> WalletManagerException.AddUtxosException(
                 FfiConverterString.read(buf),
                 )
-            31 -> WalletManagerException.OutputLabelsException(
+            33 -> WalletManagerException.OutputLabelsException(
                 FfiConverterString.read(buf),
                 )
-            32 -> WalletManagerException.DatabaseCorruption(
+            34 -> WalletManagerException.DatabaseCorruption(
                 FfiConverterTypeWalletId.read(buf),
                 FfiConverterString.read(buf),
                 )
-            33 -> WalletManagerException.PendingUnsignedTransactionsLoadException(
+            35 -> WalletManagerException.PendingUnsignedTransactionsLoadException(
                 FfiConverterString.read(buf),
                 )
-            34 -> WalletManagerException.ReceiveAddressException(
+            36 -> WalletManagerException.ReceiveAddressException(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
@@ -60951,7 +60973,17 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
             )
-            is WalletManagerException.SignAndBroadcastException -> (
+            is WalletManagerException.SigningException -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.BroadcastException -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.PayjoinSessionException -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
@@ -61122,59 +61154,69 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.SignAndBroadcastException -> {
+            is WalletManagerException.SigningException -> {
                 buf.putInt(24)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.Converter -> {
+            is WalletManagerException.BroadcastException -> {
                 buf.putInt(25)
-                FfiConverterTypeConverterError.write(value.v1, buf)
+                FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.UnknownException -> {
+            is WalletManagerException.PayjoinSessionException -> {
                 buf.putInt(26)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.PsbtFinalizeException -> {
+            is WalletManagerException.Converter -> {
                 buf.putInt(27)
-                FfiConverterString.write(value.v1, buf)
+                FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.GetHistoricalPricesException -> {
+            is WalletManagerException.UnknownException -> {
                 buf.putInt(28)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.CsvCreationException -> {
+            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(29)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.AddUtxosException -> {
+            is WalletManagerException.GetHistoricalPricesException -> {
                 buf.putInt(30)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.OutputLabelsException -> {
+            is WalletManagerException.CsvCreationException -> {
                 buf.putInt(31)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.DatabaseCorruption -> {
+            is WalletManagerException.AddUtxosException -> {
                 buf.putInt(32)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.OutputLabelsException -> {
+                buf.putInt(33)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.DatabaseCorruption -> {
+                buf.putInt(34)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
                 FfiConverterString.write(value.`error`, buf)
                 Unit
             }
             is WalletManagerException.PendingUnsignedTransactionsLoadException -> {
-                buf.putInt(33)
+                buf.putInt(35)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.ReceiveAddressException -> {
-                buf.putInt(34)
+                buf.putInt(36)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -38806,7 +38806,11 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     case LockedOutputsSelected
     case GetConfirmDetailsError(String
     )
-    case SignAndBroadcastError(String
+    case SigningError(String
+    )
+    case BroadcastError(String
+    )
+    case PayjoinSessionError(String
     )
     case Converter(ConverterError
     )
@@ -38926,38 +38930,44 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
         case 23: return .GetConfirmDetailsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 24: return .SignAndBroadcastError(
+        case 24: return .SigningError(
             try FfiConverterString.read(from: &buf)
             )
-        case 25: return .Converter(
+        case 25: return .BroadcastError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 26: return .PayjoinSessionError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 27: return .Converter(
             try FfiConverterTypeConverterError.read(from: &buf)
             )
-        case 26: return .UnknownError(
+        case 28: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
-        case 27: return .PsbtFinalizeError(
+        case 29: return .PsbtFinalizeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 28: return .GetHistoricalPricesError(
+        case 30: return .GetHistoricalPricesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 29: return .CsvCreationError(
+        case 31: return .CsvCreationError(
             try FfiConverterString.read(from: &buf)
             )
-        case 30: return .AddUtxosError(
+        case 32: return .AddUtxosError(
             try FfiConverterString.read(from: &buf)
             )
-        case 31: return .OutputLabelsError(
+        case 33: return .OutputLabelsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 32: return .DatabaseCorruption(
+        case 34: return .DatabaseCorruption(
             id: try FfiConverterTypeWalletId.read(from: &buf),
             error: try FfiConverterString.read(from: &buf)
             )
-        case 33: return .PendingUnsignedTransactionsLoadError(
+        case 35: return .PendingUnsignedTransactionsLoadError(
             try FfiConverterString.read(from: &buf)
             )
-        case 34: return .ReceiveAddressError(
+        case 36: return .ReceiveAddressError(
             try FfiConverterString.read(from: &buf)
             )
 
@@ -39082,59 +39092,69 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .SignAndBroadcastError(v1):
+        case let .SigningError(v1):
             writeInt(&buf, Int32(24))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .Converter(v1):
+        case let .BroadcastError(v1):
             writeInt(&buf, Int32(25))
-            FfiConverterTypeConverterError.write(v1, into: &buf)
+            FfiConverterString.write(v1, into: &buf)
 
 
-        case let .UnknownError(v1):
+        case let .PayjoinSessionError(v1):
             writeInt(&buf, Int32(26))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .PsbtFinalizeError(v1):
+        case let .Converter(v1):
             writeInt(&buf, Int32(27))
-            FfiConverterString.write(v1, into: &buf)
+            FfiConverterTypeConverterError.write(v1, into: &buf)
 
 
-        case let .GetHistoricalPricesError(v1):
+        case let .UnknownError(v1):
             writeInt(&buf, Int32(28))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .CsvCreationError(v1):
+        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(29))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .AddUtxosError(v1):
+        case let .GetHistoricalPricesError(v1):
             writeInt(&buf, Int32(30))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .OutputLabelsError(v1):
+        case let .CsvCreationError(v1):
             writeInt(&buf, Int32(31))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .DatabaseCorruption(id,error):
+        case let .AddUtxosError(v1):
             writeInt(&buf, Int32(32))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .OutputLabelsError(v1):
+            writeInt(&buf, Int32(33))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .DatabaseCorruption(id,error):
+            writeInt(&buf, Int32(34))
             FfiConverterTypeWalletId.write(id, into: &buf)
             FfiConverterString.write(error, into: &buf)
 
 
         case let .PendingUnsignedTransactionsLoadError(v1):
-            writeInt(&buf, Int32(33))
+            writeInt(&buf, Int32(35))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .ReceiveAddressError(v1):
-            writeInt(&buf, Int32(34))
+            writeInt(&buf, Int32(36))
             FfiConverterString.write(v1, into: &buf)
 
         }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -354,8 +354,14 @@ pub enum WalletManagerError {
     #[error("Unable to get confirm details, {0}")]
     GetConfirmDetailsError(String),
 
-    #[error("Unable to sign and broadcast transaction, {0}")]
-    SignAndBroadcastError(String),
+    #[error("signing failed: {0}")]
+    SigningError(String),
+
+    #[error("broadcast failed: {0}")]
+    BroadcastError(String),
+
+    #[error("{0}")]
+    PayjoinSessionError(String),
 
     #[error(transparent)]
     Converter(#[from] ConverterError),

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -128,7 +128,7 @@ impl Actor for WalletActor {
                 self.send(WalletManagerReconcileMessage::NodeConnectionFailed(error_string));
             }
 
-            Error::SignAndBroadcastError(_) => {
+            Error::SigningError(_) | Error::BroadcastError(_) | Error::PayjoinSessionError(_) => {
                 self.send(WalletManagerReconcileMessage::SendFlowError(
                     SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
                 ));
@@ -222,7 +222,7 @@ impl WalletActor {
     }
 
     pub async fn notify_payjoin_error(&mut self, msg: String) -> ActorResult<()> {
-        self.send(WalletManagerReconcileMessage::WalletError(Error::SignAndBroadcastError(msg)));
+        self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(msg)));
         Produces::ok(())
     }
 
@@ -2302,9 +2302,7 @@ mod tests {
         let _ = crate::wallet::delete_wallet_specific_data(&metadata.id);
 
         assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 1);
-        assert!(
-            matches!(error, super::Error::SignAndBroadcastError(message) if message.contains("try again"))
-        );
+        assert!(matches!(error, super::Error::BroadcastError(_)));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -3028,13 +3026,7 @@ mod tests {
         let result = actor.initiate_payment(empty_psbt, None).await;
         let outcome = actor_value(result).await;
 
-        assert!(
-            matches!(
-                &outcome,
-                Err(super::Error::SignAndBroadcastError(msg)) if msg.contains("retrying")
-            ),
-            "expected 'retrying' error but got: {outcome:?}",
-        );
+        assert!(matches!(&outcome, Err(super::Error::PayjoinSessionError(_))));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -3079,7 +3071,7 @@ mod tests {
 
         let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
         assert!(session.is_none(), "gate should have cleared the stale session record");
-        assert!(matches!(outcome, Err(super::Error::SignAndBroadcastError(_))));
+        assert!(matches!(outcome, Err(super::Error::PayjoinSessionError(_))));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -474,7 +474,7 @@ impl WalletActor {
         }
 
         if self.payjoin_actor.is_some() {
-            return Produces::ok(Err(Error::SignAndBroadcastError(
+            return Produces::ok(Err(Error::PayjoinSessionError(
                 "a payjoin session is already in progress".to_string(),
             )));
         }
@@ -494,7 +494,7 @@ impl WalletActor {
                 if !can_cleanup {
                     // Broadcast hasn't completed yet, re-dispatch so the user doesn't need to restart.
                     send!(self.addr.resume_payjoin_session());
-                    return Produces::ok(Err(Error::SignAndBroadcastError(
+                    return Produces::ok(Err(Error::PayjoinSessionError(
                         "retrying a previous payjoin broadcast; please try again in a moment"
                             .to_string(),
                     )));
@@ -504,7 +504,7 @@ impl WalletActor {
                 // in memory without flushing to disk; only drop the session once it is durable.
                 if let Err(error) = self.wallet.persist() {
                     warn!("failed to persist wallet at send gate before payjoin cleanup: {error}");
-                    return Produces::ok(Err(Error::SignAndBroadcastError(
+                    return Produces::ok(Err(Error::PayjoinSessionError(
                         "a previous payjoin session is pending cleanup; please try again later"
                             .to_string(),
                     )));
@@ -512,7 +512,7 @@ impl WalletActor {
 
                 if let Err(error) = self.db.delete_payjoin_sender_session() {
                     warn!("payjoin session cleanup at send gate failed: {error}");
-                    return Produces::ok(Err(Error::SignAndBroadcastError(
+                    return Produces::ok(Err(Error::PayjoinSessionError(
                         "a previous payjoin session is pending cleanup; please try again later"
                             .to_string(),
                     )));
@@ -521,7 +521,7 @@ impl WalletActor {
                 // The completed tx may have been the payjoin proposal, so reusing the
                 // supplied PSBT (which is still the fallback) could cause a conflict.
                 // Ask the user to confirm again now that the record is cleared.
-                return Produces::ok(Err(Error::SignAndBroadcastError(
+                return Produces::ok(Err(Error::PayjoinSessionError(
                     "previous payjoin session cleared; please confirm your payment again"
                         .to_string(),
                 )));
@@ -529,7 +529,7 @@ impl WalletActor {
 
             Err(error) => {
                 error!("failed to check for pending payjoin session: {error}");
-                return Produces::ok(Err(Error::SignAndBroadcastError(
+                return Produces::ok(Err(Error::PayjoinSessionError(
                     "unable to verify payjoin session state; please try again later".to_string(),
                 )));
             }
@@ -577,7 +577,7 @@ impl WalletActor {
         mut psbt: Psbt,
     ) -> Result<(Psbt, BdkTransaction), Error> {
         fn err(s: &str) -> Error {
-            Error::SignAndBroadcastError(s.to_string())
+            Error::SigningError(s.to_string())
         }
 
         let network = self.wallet.network;
@@ -643,7 +643,7 @@ impl WalletActor {
 
     async fn node_client_for_broadcast(&mut self) -> ActorResult<Result<NodeClient, Error>> {
         Produces::ok(self.node_client().cloned().map_err(|_| {
-            Error::SignAndBroadcastError(
+            Error::BroadcastError(
                 "failed to broadcast transaction, could not get node client, try again".to_string(),
             )
         }))
@@ -798,7 +798,7 @@ impl WalletActor {
             error!(
                 "failed to persist wallet after payjoin broadcast; retaining session record for recovery: {error}"
             );
-            return Produces::ok(Err(Error::SignAndBroadcastError(
+            return Produces::ok(Err(Error::PayjoinSessionError(
                 "transaction was broadcast but wallet state could not be saved; please restart the app"
                     .to_string(),
             )));
@@ -903,8 +903,7 @@ impl WalletActor {
                 error!("failed to sign recovered payjoin proposal, pausing for retry: {error:?}");
                 // the receiver accepted a valid proposal; do not fall back — retain the record
                 // so the user can retry after resolving the signing failure
-                self
-                    .send(WalletManagerReconcileMessage::WalletError(Error::SignAndBroadcastError(
+                self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(
                     "could not sign the recovered payjoin proposal; unlock the wallet and restart"
                         .to_string(),
                 )));
@@ -1173,7 +1172,7 @@ async fn broadcast_to_node_with_connection(
         .await
         .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?
         .map_err(|error| {
-            BroadcastTransactionError::BroadcastFailed(Error::SignAndBroadcastError(format!(
+            BroadcastTransactionError::BroadcastFailed(Error::BroadcastError(format!(
                 "failed to broadcast transaction, unable to connect to node: {error:?}"
             )))
         })?;
@@ -1184,7 +1183,7 @@ async fn broadcast_to_node_with_connection(
         .map_err(BroadcastTransactionError::BroadcastFailed)?;
 
     node_client.broadcast_transaction(transaction.clone()).await.map_err(|error| {
-        BroadcastTransactionError::BroadcastFailed(Error::SignAndBroadcastError(format!(
+        BroadcastTransactionError::BroadcastFailed(Error::BroadcastError(format!(
             "failed to broadcast transaction, try again: {error:?}"
         )))
     })?;


### PR DESCRIPTION
## Summary

* Replace `SignAndBroadcastError(String)` with `SigningError`, `BroadcastError`, and `PayjoinSessionError`.
* Update all 19 call sites to return the correct variant.
* Update tests to match variants instead of parsing error strings.

## Why

Callers previously had to parse strings to identify failure types, and tests relied on fragile `contains()` checks. Typed variants allow Rust, Swift, and Kotlin to handle each error programmatically.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


ref issue #836 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet transaction error reporting by distinguishing signing, broadcasting, and payjoin-session failures.
  * Updated error messages and handling to make transaction issues clearer and easier to diagnose.
  * Refined payjoin notifications and transaction flows to accurately identify the source of failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->