### PR TITLE
Fix large QR export layout

### DIFF
--- a/android/app/src/androidTest/java/org/bitcoinppl/cove/views/QrExportProgressIndicatorTest.kt
+++ b/android/app/src/androidTest/java/org/bitcoinppl/cove/views/QrExportProgressIndicatorTest.kt
@@ -1,0 +1,56 @@
+package org.bitcoinppl.cove.views
+
+import android.graphics.Color
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.bitcoinppl.cove.test.LayoutRegressionTest
+import org.bitcoinppl.cove.ui.theme.CoveTheme
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LayoutRegressionTest
+@RunWith(AndroidJUnit4::class)
+class QrExportProgressIndicatorTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun manyFramesFitAndRenderAcrossAvailableWidth() {
+        val availableWidth = 260.dp
+
+        compose.setContent {
+            CoveTheme(dynamicColor = false) {
+                QrExportProgressIndicator(
+                    qrCount = 250,
+                    currentIndex = 249,
+                    modifier = Modifier.width(availableWidth),
+                )
+            }
+        }
+
+        val indicator = compose.onNodeWithContentDescription("QR frame")
+
+        indicator
+            .assertWidthIsEqualTo(availableWidth)
+            .assertHeightIsEqualTo(12.dp)
+
+        val bitmap = indicator.captureToImage().asAndroidBitmap()
+        val verticalCenter = bitmap.height / 2
+        val firstFrameColor = bitmap.getPixel(0, verticalCenter)
+        val lastFrameColor = bitmap.getPixel(bitmap.width - 1, verticalCenter)
+
+        assertNotEquals(Color.TRANSPARENT, firstFrameColor)
+        assertNotEquals(Color.TRANSPARENT, lastFrameColor)
+        assertNotEquals(firstFrameColor, lastFrameColor)
+    }
+}

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/QrExportView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/QrExportView.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -45,9 +46,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -256,27 +263,11 @@ fun QrExportView(
                             onClick = { density = density.decrease() },
                         )
 
-                        // progress indicator
-                        Row(
+                        QrExportProgressIndicator(
+                            qrCount = qrStrings.size,
+                            currentIndex = currentIndex,
                             modifier = Modifier.weight(1f),
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        ) {
-                            qrStrings.indices.forEach { index ->
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .weight(1f)
-                                            .height(12.dp)
-                                            .background(
-                                                color =
-                                                    MaterialTheme.colorScheme.primary.copy(
-                                                        alpha = if (index == currentIndex) 1f else 0.3f,
-                                                    ),
-                                                shape = RoundedCornerShape(2.dp),
-                                            ),
-                                )
-                            }
-                        }
+                        )
 
                         PlusButton(
                             enabled = density.canIncrease() && qrStrings.size > 1,
@@ -294,6 +285,46 @@ fun QrExportView(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun QrExportProgressIndicator(
+    qrCount: Int,
+    currentIndex: Int,
+    modifier: Modifier = Modifier,
+) {
+    val activeColor = MaterialTheme.colorScheme.primary
+    val inactiveColor = activeColor.copy(alpha = 0.3f)
+
+    Canvas(
+        modifier =
+            modifier
+                .height(12.dp)
+                .semantics {
+                    contentDescription = "QR frame"
+                    stateDescription = "${currentIndex + 1} of $qrCount"
+                },
+    ) {
+        val minimumSegmentWidth = 1.dp.toPx()
+        val preferredSpacing = 4.dp.toPx()
+        val spacing =
+            minOf(
+                preferredSpacing,
+                ((size.width - (qrCount * minimumSegmentWidth)) / (qrCount - 1)).coerceAtLeast(0f),
+            )
+        val segmentWidth =
+            ((size.width - ((qrCount - 1) * spacing)) / qrCount).coerceAtLeast(0f)
+        val cornerRadius = minOf(2.dp.toPx(), segmentWidth / 2, size.height / 2)
+
+        repeat(qrCount) { index ->
+            drawRoundRect(
+                color = if (index == currentIndex) activeColor else inactiveColor,
+                topLeft = Offset(x = index * (segmentWidth + spacing), y = 0f),
+                size = Size(width = segmentWidth, height = size.height),
+                cornerRadius = CornerRadius(cornerRadius),
+            )
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/views/QrExportView.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/views/QrExportView.kt
@@ -290,7 +290,7 @@ fun QrExportView(
 }
 
 @Composable
-private fun QrExportProgressIndicator(
+internal fun QrExportProgressIndicator(
     qrCount: Int,
     currentIndex: Int,
     modifier: Modifier = Modifier,

--- a/ios/Cove.xcodeproj/project.pbxproj
+++ b/ios/Cove.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C0B0001B2F10000000000001 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B0001A2F10000000000001 /* NavigationCoordinatorTests.swift */; };
 		C0B0001C2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B0001D2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift */; };
 		C0B0001F2F10000000000001 /* SwiftLogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B0001E2F10000000000001 /* SwiftLogStoreTests.swift */; };
+		C0B000202F30000000000001 /* QrExportLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B000212F30000000000001 /* QrExportLayoutTests.swift */; };
 		C0C000012F10000000000001 /* CloudBackupIOSSafetyHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C000022F10000000000001 /* CloudBackupIOSSafetyHelpersTests.swift */; };
 		C0C000032F10000000000001 /* PasskeyProviderImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C000042F10000000000001 /* PasskeyProviderImplTests.swift */; };
 		C0D000012F10000000000001 /* WalletTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D000022F10000000000001 /* WalletTransitionTests.swift */; };
@@ -87,6 +88,7 @@
 		C0B0001A2F10000000000001 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
 		C0B0001D2F10000000000001 /* HotWalletCreateScreenLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotWalletCreateScreenLayoutTests.swift; sourceTree = "<group>"; };
 		C0B0001E2F10000000000001 /* SwiftLogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLogStoreTests.swift; sourceTree = "<group>"; };
+		C0B000212F30000000000001 /* QrExportLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrExportLayoutTests.swift; sourceTree = "<group>"; };
 		C0C000022F10000000000001 /* CloudBackupIOSSafetyHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupIOSSafetyHelpersTests.swift; sourceTree = "<group>"; };
 		C0C000042F10000000000001 /* PasskeyProviderImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyProviderImplTests.swift; sourceTree = "<group>"; };
 		C0D000022F10000000000001 /* WalletTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransitionTests.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				C0B0001A2F10000000000001 /* NavigationCoordinatorTests.swift */,
 				C0B000152F00000000000001 /* OnboardingBackupViewsTests.swift */,
 				C0B000032F00000000000001 /* OnboardingPromptLayoutTests.swift */,
+				C0B000212F30000000000001 /* QrExportLayoutTests.swift */,
 				C0B0001E2F10000000000001 /* SwiftLogStoreTests.swift */,
 				C0C000042F10000000000001 /* PasskeyProviderImplTests.swift */,
 				C0B000132F00000000000001 /* TransactionsScanUiTests.swift */,
@@ -453,6 +456,7 @@
 				C0B0001B2F10000000000001 /* NavigationCoordinatorTests.swift in Sources */,
 				C0B000142F00000000000001 /* OnboardingBackupViewsTests.swift in Sources */,
 				C0B000012F00000000000001 /* OnboardingPromptLayoutTests.swift in Sources */,
+				C0B000202F30000000000001 /* QrExportLayoutTests.swift in Sources */,
 				C0B0001F2F10000000000001 /* SwiftLogStoreTests.swift in Sources */,
 				C0C000032F10000000000001 /* PasskeyProviderImplTests.swift in Sources */,
 				C0B000122F00000000000001 /* TransactionsScanUiTests.swift in Sources */,

--- a/ios/Cove/QrCodeView.swift
+++ b/ios/Cove/QrCodeView.swift
@@ -12,12 +12,10 @@ struct QrCodeView: View {
     let text: String
 
     var body: some View {
-        HStack {
-            generateQRCode(text: text)
-                .interpolation(.none)
-                .resizable()
-                .scaledToFit()
-        }
+        generateQRCode(text: text)
+            .interpolation(.none)
+            .resizable()
+            .aspectRatio(1, contentMode: .fit)
     }
 
     func generateQRCode(text: String) -> Image {

--- a/ios/Cove/Views/QrExportContentViews.swift
+++ b/ios/Cove/Views/QrExportContentViews.swift
@@ -43,7 +43,6 @@ private struct QrExportAnimatedQrView: View {
                 let index = abs(Int(context.date.distance(to: startedAt) / animationInterval) % qrs.count)
                 qrs[index]
                     .frame(maxWidth: .infinity)
-                    .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, 11)
                     .onChange(of: index) { _, newIndex in
                         currentIndex = newIndex
@@ -99,20 +98,44 @@ private struct QrExportAnimatedQrView: View {
     }
 }
 
-private struct QrExportProgressIndicator: View {
+struct QrExportProgressIndicator: View {
     let qrCount: Int
     let currentIndex: Int
 
     var body: some View {
-        HStack(spacing: 4) {
-            ForEach(0 ..< qrCount, id: \.self) { index in
-                Rectangle()
-                    .fill(Color.blue)
-                    .opacity(index == currentIndex ? 1 : 0.3)
-                    .frame(height: 12)
-                    .cornerRadius(2)
+        Canvas { context, size in
+            let minimumSegmentWidth: CGFloat = 1
+            let preferredSpacing: CGFloat = 4
+            let spacing = min(
+                preferredSpacing,
+                max(0, (size.width - (CGFloat(qrCount) * minimumSegmentWidth)) / CGFloat(qrCount - 1))
+            )
+            let segmentWidth = max(
+                0,
+                (size.width - (CGFloat(qrCount - 1) * spacing)) / CGFloat(qrCount)
+            )
+            let cornerRadius = min(2, segmentWidth / 2, size.height / 2)
+
+            for index in 0 ..< qrCount {
+                let rect = CGRect(
+                    x: CGFloat(index) * (segmentWidth + spacing),
+                    y: 0,
+                    width: segmentWidth,
+                    height: size.height
+                )
+                let color = Color.blue.opacity(index == currentIndex ? 1 : 0.3)
+
+                context.fill(
+                    Path(roundedRect: rect, cornerRadius: cornerRadius),
+                    with: .color(color)
+                )
             }
         }
+        .frame(maxWidth: .infinity)
+        .frame(height: 12)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("QR frame")
+        .accessibilityValue("\(currentIndex + 1) of \(qrCount)")
     }
 }
 

--- a/ios/CoveTests/QrExportLayoutTests.swift
+++ b/ios/CoveTests/QrExportLayoutTests.swift
@@ -1,0 +1,18 @@
+@testable import Cove
+import SwiftUI
+import XCTest
+
+@MainActor
+final class QrExportLayoutTests: XCTestCase {
+    func testManyQrFramesFitAvailableWidth() {
+        let availableSize = CGSize(width: 260, height: 12)
+        let controller = UIHostingController(
+            rootView: QrExportProgressIndicator(qrCount: 250, currentIndex: 0)
+        )
+
+        let fittedSize = controller.sizeThatFits(in: availableSize)
+
+        XCTAssertLessThanOrEqual(fittedSize.width, availableSize.width)
+        XCTAssertEqual(fittedSize.height, availableSize.height)
+    }
+}


### PR DESCRIPTION
## Summary

- keep animated QR frame indicators within the available width on iOS and Android
- keep the iOS QR image square and within its parent width
- add an iOS regression test with 250 animated QR frames

## Root cause

Large transactions create many animated QR frames. The old indicator added a fixed gap for every frame. With enough frames, the gaps made the indicator wider than the screen and expanded the QR layout with it.

## User impact

Transaction export QR codes stay fully visible and scannable when the user selects many UTXOs.

## Validation

- `just fmt`
- `just clippy`
- `just lint-swift`
- `just lint-android`
- `just compile-android`
- `just build-ios`
- `xcodebuild -scheme Cove -sdk iphonesimulator -arch arm64 build-for-testing`

The iOS test bundle compiled successfully. No simulator device was installed, so the focused iOS test did not run locally.
