### PR TITLE
Add cancellable Payjoin polling countdown

### DIFF
--- a/android/app/src/main/java/org/bitcoinppl/cove/RouterManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/RouterManager.kt
@@ -356,8 +356,8 @@ object RouteHelpers {
     fun sendConfirm(
         id: WalletId,
         details: ConfirmDetails,
-        payjoinEndpoint: String? = null,
-    ): Route = RouteFactory().sendConfirm(id, details, payjoinEndpoint)
+        mode: UnsignedPaymentMode = UnsignedPaymentMode.Standard,
+    ): Route = RouteFactory().sendConfirm(id, details, mode)
 
     fun sendConfirmSignedTransaction(
         id: WalletId,

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -172,6 +172,9 @@ class WalletManager :
     // TaggedItem ensures a new unique key each time so Compose always re-fires the observer
     var payjoinTxBroadcast by mutableStateOf<TaggedItem<Unit>?>(null)
 
+    // epoch seconds when the payjoin session will expire, set when polling starts
+    var payjoinDeadlineSecs by mutableStateOf<ULong?>(null)
+
     // cached transaction detail presentations (observable for Compose)
     val transactionDetailsPresentations: SnapshotStateMap<TxId, TransactionDetailsPresentation> =
         mutableStateMapOf()
@@ -624,6 +627,12 @@ class WalletManager :
         }
     }
 
+    suspend fun cancelPayjoin() {
+        withRustSuspend {
+            cancelPayjoin()
+        }
+    }
+
     fun displayConfirmationCount(confirmations: UInt): String =
         withRustOr("") {
             displayConfirmationCount(confirmations)
@@ -937,6 +946,7 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.WalletException -> {
                 logError("WalletException: ${message.v1}")
+                payjoinDeadlineSecs = null
             }
 
             is WalletManagerReconcileMessage.UnknownError -> {
@@ -945,6 +955,7 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.SendFlowException -> {
                 sendFlowErrorAlert = TaggedItem(message.v1)
+                payjoinDeadlineSecs = null
             }
 
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
@@ -982,6 +993,11 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
                 payjoinTxBroadcast = TaggedItem(Unit)
+                payjoinDeadlineSecs = null
+            }
+
+            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+                payjoinDeadlineSecs = message.deadlineSecs
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -168,12 +168,8 @@ class WalletManager :
     var labelRefreshFailed by mutableStateOf<TaggedItem<Unit>?>(null)
         private set
 
-    // non-null when a payjoin transaction has been broadcast (success or fallback);
-    // TaggedItem ensures a new unique key each time so Compose always re-fires the observer
-    var payjoinTxBroadcast by mutableStateOf<TaggedItem<Unit>?>(null)
-
-    // epoch seconds when the payjoin session will expire, set when polling starts
-    var payjoinDeadlineSecs by mutableStateOf<ULong?>(null)
+    // latest wallet-owned state for one Payjoin payment
+    var payjoinStatus by mutableStateOf<PayjoinStatus?>(null)
 
     // cached transaction detail presentations (observable for Compose)
     val transactionDetailsPresentations: SnapshotStateMap<TxId, TransactionDetailsPresentation> =
@@ -621,15 +617,18 @@ class WalletManager :
         }
     }
 
-    suspend fun initiatePayment(psbt: Psbt, payjoinEndpoint: String?) {
+    suspend fun initiatePayment(
+        psbt: Psbt,
+        mode: UnsignedPaymentMode,
+    ) {
         withRustSuspend {
-            initiatePayment(psbt, payjoinEndpoint)
+            initiatePayment(psbt, mode)
         }
     }
 
-    suspend fun cancelPayjoin() {
+    suspend fun cancelPayjoin(sessionId: PayjoinSessionId) {
         withRustSuspend {
-            cancelPayjoin()
+            cancelPayjoin(sessionId)
         }
     }
 
@@ -946,7 +945,6 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.WalletException -> {
                 logError("WalletException: ${message.v1}")
-                payjoinDeadlineSecs = null
             }
 
             is WalletManagerReconcileMessage.UnknownError -> {
@@ -955,7 +953,6 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.SendFlowException -> {
                 sendFlowErrorAlert = TaggedItem(message.v1)
-                payjoinDeadlineSecs = null
             }
 
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
@@ -991,13 +988,8 @@ class WalletManager :
                 }
             }
 
-            is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
-                payjoinTxBroadcast = TaggedItem(Unit)
-                payjoinDeadlineSecs = null
-            }
-
-            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
-                payjoinDeadlineSecs = message.deadlineSecs
+            is WalletManagerReconcileMessage.PayjoinStatusChanged -> {
+                payjoinStatus = message.v1
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/WalletManager.kt
@@ -118,6 +118,9 @@ class WalletManager :
     // TaggedItem ensures a new unique key each time so Compose always re-fires the observer
     var payjoinTxBroadcast by mutableStateOf<TaggedItem<Unit>?>(null)
 
+    // epoch seconds when the payjoin session will expire, set when polling starts
+    var payjoinDeadlineSecs by mutableStateOf<ULong?>(null)
+
     // cached transaction detail presentations (observable for Compose)
     val transactionDetailsPresentations: SnapshotStateMap<TxId, TransactionDetailsPresentation> =
         mutableStateMapOf()
@@ -539,6 +542,12 @@ class WalletManager :
         }
     }
 
+    suspend fun cancelPayjoin() {
+        withRustSuspend {
+            cancelPayjoin()
+        }
+    }
+
     fun displayConfirmationCount(confirmations: UInt): String =
         withRustOr("") {
             displayConfirmationCount(confirmations)
@@ -853,6 +862,7 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.WalletException -> {
                 logError("WalletException: ${message.v1}")
+                payjoinDeadlineSecs = null
             }
 
             is WalletManagerReconcileMessage.UnknownError -> {
@@ -861,6 +871,7 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.SendFlowException -> {
                 sendFlowErrorAlert = TaggedItem(message.v1)
+                payjoinDeadlineSecs = null
             }
 
             is WalletManagerReconcileMessage.HotWalletKeyMissing -> {
@@ -898,6 +909,11 @@ class WalletManager :
 
             is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
                 payjoinTxBroadcast = TaggedItem(Unit)
+                payjoinDeadlineSecs = null
+            }
+
+            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+                payjoinDeadlineSecs = message.deadlineSecs
             }
         }
     }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
@@ -86,6 +86,7 @@ fun SendFlowConfirmScreen(
     sendState: SendState,
     onBack: () -> Unit,
     onSwipeToSend: () -> Unit,
+    onCancelPayjoin: () -> Unit = {},
 ) {
     var sheetState by remember { mutableStateOf<SheetState?>(null) }
     val address = details.sendingTo().spacedOut()
@@ -195,6 +196,13 @@ fun SendFlowConfirmScreen(
                         }
 
                         Column {
+                            if (sendState is SendState.PayjoinWaiting) {
+                                PayjoinWaitingBanner(
+                                    deadlineSecs = sendState.deadlineSecs,
+                                    onCancel = onCancelPayjoin,
+                                )
+                            }
+
                             SwipeToSendStub(
                                 text = stringResource(R.string.action_swipe_to_send),
                                 sendState = sendState,
@@ -597,7 +605,9 @@ private fun SwipeToSendStub(
         // state overlay - matches iOS SwipeToSendView
         when (sendState) {
             is SendState.Idle -> Unit // handled above
-            is SendState.Sending -> {
+            is SendState.Sending,
+            is SendState.PayjoinWaiting,
+            -> {
                 Row(
                     modifier = Modifier.align(Alignment.Center),
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -706,6 +716,57 @@ private fun ThreeDotsAnimation() {
                         }
                         .background(Color.White, CircleShape),
             )
+        }
+    }
+}
+
+@Composable
+private fun PayjoinWaitingBanner(
+    deadlineSecs: ULong,
+    onCancel: () -> Unit,
+) {
+    var remainingSecs by remember { mutableIntStateOf(0) }
+
+    @Suppress("MagicNumber")
+    LaunchedEffect(deadlineSecs) {
+        val msPerSec = 1000L
+        while (true) {
+            val now = System.currentTimeMillis() / msPerSec
+            val remaining = (deadlineSecs.toLong() - now).coerceAtLeast(0)
+            remainingSecs = remaining.toInt()
+            if (remaining <= 0) break
+            kotlinx.coroutines.delay(msPerSec)
+        }
+    }
+
+    val minutes = remainingSecs / 60
+    val seconds = remainingSecs % 60
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(24.dp),
+            strokeWidth = 2.dp,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "Waiting for receiver",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = String.format(java.util.Locale.US, "%d:%02d remaining", minutes, seconds),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TextButton(onClick = onCancel) {
+            Text("Cancel and send normally")
         }
     }
 }

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/ConfirmScreen/SendFlowConfirmScreen.kt
@@ -641,7 +641,9 @@ private fun SwipeToSendStub(
                     )
                 }
             }
-            is SendState.Error -> {
+            is SendState.Error,
+            is SendState.PayjoinFailed,
+            -> {
                 Row(
                     modifier = Modifier.align(Alignment.Center),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,6 +44,7 @@ sealed interface SendState {
     data object Sending : SendState
 
     data class PayjoinWaiting(
+        val sessionId: PayjoinSessionId,
         val deadlineSecs: ULong,
     ) : SendState
 
@@ -53,6 +53,18 @@ sealed interface SendState {
     data class Error(
         val message: String,
     ) : SendState
+}
+
+private sealed interface SendConfirmationAlert {
+    data object Sent : SendConfirmationAlert
+
+    data class SendFailed(
+        val message: String,
+    ) : SendConfirmationAlert
+
+    data class PayjoinCancellationFailed(
+        val message: String,
+    ) : SendConfirmationAlert
 }
 
 /** send flow container - manages WalletManager + SendFlowManager lifecycle */
@@ -457,13 +469,12 @@ private fun SendFlowRouteToScreen(
         is SendRoute.Confirm -> {
             val details = sendRoute.v1.details
             val input = sendRoute.v1.input
-            val payjoinEndpoint = sendRoute.v1.payjoinEndpoint
+            val unsignedMode = (input as? SendConfirmationInput.Unsigned)?.mode
+            val payjoinIntent = (unsignedMode as? UnsignedPaymentMode.Payjoin)?.intent
 
             var sendState by remember { mutableStateOf<SendState>(SendState.Idle) }
             var finalizedTransaction by remember { mutableStateOf<BitcoinTransaction?>(null) }
-            var showSuccessAlert by remember { mutableStateOf(false) }
-            var showErrorAlert by remember { mutableStateOf(false) }
-            var payjoinInitiated by rememberSaveable { mutableStateOf(false) }
+            var confirmationAlert by remember { mutableStateOf<SendConfirmationAlert?>(null) }
             val scope = rememberCoroutineScope()
 
             // lock on appear for hot wallets
@@ -474,30 +485,41 @@ private fun SendFlowRouteToScreen(
                 }
             }
 
-            // restore or transition to waiting UI from manager-owned deadline;
-            // payjoinInitiated survives config changes so only this screen's session matches
-            LaunchedEffect(walletManager.payjoinDeadlineSecs) {
-                val deadline = walletManager.payjoinDeadlineSecs
-                if (deadline != null && payjoinInitiated) {
-                    sendState = SendState.PayjoinWaiting(deadline)
+            // restore and apply only the status owned by this confirmation
+            LaunchedEffect(walletManager.payjoinStatus) {
+                val intent = payjoinIntent ?: return@LaunchedEffect
+                when (val status = walletManager.payjoinStatus) {
+                    is PayjoinStatus.Negotiating -> {
+                        if (status.sessionId != intent.sessionId) return@LaunchedEffect
+                        sendState = SendState.Sending
+                    }
+
+                    is PayjoinStatus.Polling -> {
+                        if (status.sessionId != intent.sessionId) return@LaunchedEffect
+                        sendState = SendState.PayjoinWaiting(status.sessionId, status.deadlineSecs)
+                    }
+
+                    is PayjoinStatus.Broadcast -> {
+                        if (status.sessionId != intent.sessionId) return@LaunchedEffect
+                        sendState = SendState.Sent
+                        confirmationAlert = SendConfirmationAlert.Sent
+                        Auth.unlock()
+                    }
+
+                    is PayjoinStatus.Failed -> {
+                        if (status.sessionId != intent.sessionId) return@LaunchedEffect
+                        sendState = SendState.Error(status.message)
+                        confirmationAlert = SendConfirmationAlert.SendFailed(status.message)
+                    }
+
+                    null -> Unit
                 }
             }
 
-            // show success UI on payjoin broadcast; TaggedItem key changes each time so
-            // no manual reset is needed even if the user sends multiple payjoin transactions
-            LaunchedEffect(walletManager.payjoinTxBroadcast) {
-                val isWaiting =
-                    sendState == SendState.Sending || sendState is SendState.PayjoinWaiting
-                if (walletManager.payjoinTxBroadcast != null && isWaiting) {
-                    sendState = SendState.Sent
-                    showSuccessAlert = true
-                    Auth.unlock()
-                }
-            }
-
-            // payjoin broadcast failure arrives via sendFlowErrorAlert reconcile (not the
-            // catch block), so unblock the UI from Sending and show the error alert
+            // handle non-Payjoin signing and broadcast errors for this confirmation
             LaunchedEffect(walletManager.sendFlowErrorAlert) {
+                if (payjoinIntent != null) return@LaunchedEffect
+
                 val isWaiting =
                     sendState == SendState.Sending || sendState is SendState.PayjoinWaiting
                 if (walletManager.sendFlowErrorAlert != null && isWaiting) {
@@ -507,7 +529,7 @@ private fun SendFlowRouteToScreen(
                             is SendFlowErrorAlert.ConfirmDetails -> alert.v1
                         }
                     sendState = SendState.Error(message)
-                    showErrorAlert = true
+                    confirmationAlert = SendConfirmationAlert.SendFailed(message)
                 }
             }
 
@@ -588,86 +610,106 @@ private fun SendFlowRouteToScreen(
                                             ?: error("Unable to finalize transaction")
                                     walletManager.broadcastTransaction(txnToBroadcast)
                                 }
-                                SendConfirmationInput.Unsigned -> {
-                                    if (payjoinEndpoint != null) {
-                                        payjoinInitiated = true
-                                    }
-
-                                    walletManager.initiatePayment(details.psbt(), payjoinEndpoint)
-
-                                    // for payjoin, stay in Sending — PayjoinTxBroadcast reconcile triggers success UI
-                                    if (payjoinEndpoint != null) return@launch
+                                is SendConfirmationInput.Unsigned -> {
+                                    walletManager.initiatePayment(
+                                        details.psbt(),
+                                        input.mode,
+                                    )
+                                    // for Payjoin, stay in Sending until the terminal status arrives
+                                    if (payjoinIntent != null) return@launch
                                 }
                             }
                             sendState = SendState.Sent
-                            showSuccessAlert = true
+                            confirmationAlert = SendConfirmationAlert.Sent
                             Auth.unlock()
                         } catch (e: WalletManagerException) {
-                            sendState = SendState.Error(e.message ?: "Unknown error")
-                            showErrorAlert = true
+                            val message = e.message ?: "Unknown error"
+                            sendState = SendState.Error(message)
+                            confirmationAlert = SendConfirmationAlert.SendFailed(message)
                         } catch (e: Exception) {
-                            sendState = SendState.Error(e.message ?: "Unknown error")
-                            showErrorAlert = true
+                            val message = e.message ?: "Unknown error"
+                            sendState = SendState.Error(message)
+                            confirmationAlert = SendConfirmationAlert.SendFailed(message)
                         }
                     }
                 },
                 onCancelPayjoin = {
-                    sendState = SendState.Sending
-                    scope.launch {
-                        walletManager.cancelPayjoin()
+                    payjoinIntent?.let { intent ->
+                        val waitingState = sendState as? SendState.PayjoinWaiting ?: return@let
+                        if (waitingState.sessionId != intent.sessionId) return@let
+
+                        sendState = SendState.Sending
+                        scope.launch {
+                            try {
+                                walletManager.cancelPayjoin(intent.sessionId)
+                            } catch (e: WalletManagerException) {
+                                sendState = waitingState
+                                confirmationAlert =
+                                    SendConfirmationAlert.PayjoinCancellationFailed(
+                                        e.message ?: "Unknown error",
+                                    )
+                            } catch (e: Exception) {
+                                sendState = waitingState
+                                confirmationAlert =
+                                    SendConfirmationAlert.PayjoinCancellationFailed(
+                                        e.message ?: "Unknown error",
+                                    )
+                            }
+                        }
                     }
                 },
             )
 
-            // success alert dialog
-            if (showSuccessAlert) {
-                AlertDialog(
-                    onDismissRequest = {
-                        showSuccessAlert = false
+            when (val alert = confirmationAlert) {
+                SendConfirmationAlert.Sent -> {
+                    val dismiss = {
+                        confirmationAlert = null
                         app.loadAndReset(Route.SelectedWallet(walletManager.id))
-                    },
-                    title = { Text("Success") },
-                    text = { Text("Transaction sent successfully!") },
-                    confirmButton = {
-                        TextButton(
-                            onClick = {
-                                showSuccessAlert = false
-                                app.loadAndReset(Route.SelectedWallet(walletManager.id))
-                            },
-                        ) {
-                            Text("OK")
-                        }
-                    },
-                )
-            }
-
-            // error alert dialog
-            if (showErrorAlert) {
-                AlertDialog(
-                    onDismissRequest = {
-                        showErrorAlert = false
-                        sendState = SendState.Idle
-                    },
-                    title = { Text("Error") },
-                    text = {
-                        val errorMessage =
-                            when (val state = sendState) {
-                                is SendState.Error -> state.message
-                                else -> "Failed to send transaction"
+                    }
+                    AlertDialog(
+                        onDismissRequest = dismiss,
+                        title = { Text("Success") },
+                        text = { Text("Transaction sent successfully!") },
+                        confirmButton = {
+                            TextButton(onClick = dismiss) {
+                                Text("OK")
                             }
-                        Text(errorMessage)
-                    },
-                    confirmButton = {
-                        TextButton(
-                            onClick = {
-                                showErrorAlert = false
-                                sendState = SendState.Idle
-                            },
-                        ) {
-                            Text("OK")
-                        }
-                    },
-                )
+                        },
+                    )
+                }
+
+                is SendConfirmationAlert.SendFailed -> {
+                    val dismiss = {
+                        confirmationAlert = null
+                        sendState = SendState.Idle
+                    }
+                    AlertDialog(
+                        onDismissRequest = dismiss,
+                        title = { Text("Error") },
+                        text = { Text(alert.message) },
+                        confirmButton = {
+                            TextButton(onClick = dismiss) {
+                                Text("OK")
+                            }
+                        },
+                    )
+                }
+
+                is SendConfirmationAlert.PayjoinCancellationFailed -> {
+                    val dismiss = { confirmationAlert = null }
+                    AlertDialog(
+                        onDismissRequest = dismiss,
+                        title = { Text("Unable to cancel Payjoin") },
+                        text = { Text(alert.message) },
+                        confirmButton = {
+                            TextButton(onClick = dismiss) {
+                                Text("OK")
+                            }
+                        },
+                    )
+                }
+
+                null -> Unit
             }
         }
         is SendRoute.HardwareExport -> {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -53,12 +53,20 @@ sealed interface SendState {
     data class Error(
         val message: String,
     ) : SendState
+
+    data class PayjoinFailed(
+        val message: String,
+    ) : SendState
 }
 
 private sealed interface SendConfirmationAlert {
     data object Sent : SendConfirmationAlert
 
     data class SendFailed(
+        val message: String,
+    ) : SendConfirmationAlert
+
+    data class PayjoinFailed(
         val message: String,
     ) : SendConfirmationAlert
 
@@ -508,8 +516,8 @@ private fun SendFlowRouteToScreen(
 
                     is PayjoinStatus.Failed -> {
                         if (status.sessionId != intent.sessionId) return@LaunchedEffect
-                        sendState = SendState.Error(status.message)
-                        confirmationAlert = SendConfirmationAlert.SendFailed(status.message)
+                        sendState = SendState.PayjoinFailed(status.message)
+                        confirmationAlert = SendConfirmationAlert.PayjoinFailed(status.message)
                     }
 
                     null -> Unit
@@ -686,6 +694,20 @@ private fun SendFlowRouteToScreen(
                     AlertDialog(
                         onDismissRequest = dismiss,
                         title = { Text("Error") },
+                        text = { Text(alert.message) },
+                        confirmButton = {
+                            TextButton(onClick = dismiss) {
+                                Text("OK")
+                            }
+                        },
+                    )
+                }
+
+                is SendConfirmationAlert.PayjoinFailed -> {
+                    val dismiss = { confirmationAlert = null }
+                    AlertDialog(
+                        onDismissRequest = dismiss,
+                        title = { Text("Payjoin payment paused") },
                         text = { Text(alert.message) },
                         confirmButton = {
                             TextButton(onClick = dismiss) {

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -43,6 +43,10 @@ sealed interface SendState {
 
     data object Sending : SendState
 
+    data class PayjoinWaiting(
+        val deadlineSecs: ULong,
+    ) : SendState
+
     data object Sent : SendState
 
     data class Error(
@@ -468,10 +472,21 @@ private fun SendFlowRouteToScreen(
                 }
             }
 
+            // restore or transition to waiting UI from manager-owned deadline;
+            // survives Compose recreation on config changes like rotation
+            LaunchedEffect(walletManager.payjoinDeadlineSecs) {
+                val deadline = walletManager.payjoinDeadlineSecs
+                if (deadline != null) {
+                    sendState = SendState.PayjoinWaiting(deadline)
+                }
+            }
+
             // show success UI on payjoin broadcast; TaggedItem key changes each time so
             // no manual reset is needed even if the user sends multiple payjoin transactions
             LaunchedEffect(walletManager.payjoinTxBroadcast) {
-                if (walletManager.payjoinTxBroadcast != null && sendState == SendState.Sending) {
+                val isWaiting =
+                    sendState == SendState.Sending || sendState is SendState.PayjoinWaiting
+                if (walletManager.payjoinTxBroadcast != null && isWaiting) {
                     sendState = SendState.Sent
                     showSuccessAlert = true
                     Auth.unlock()
@@ -481,7 +496,9 @@ private fun SendFlowRouteToScreen(
             // payjoin broadcast failure arrives via sendFlowErrorAlert reconcile (not the
             // catch block), so unblock the UI from Sending and show the error alert
             LaunchedEffect(walletManager.sendFlowErrorAlert) {
-                if (walletManager.sendFlowErrorAlert != null && sendState == SendState.Sending) {
+                val isWaiting =
+                    sendState == SendState.Sending || sendState is SendState.PayjoinWaiting
+                if (walletManager.sendFlowErrorAlert != null && isWaiting) {
                     val message =
                         when (val alert = walletManager.sendFlowErrorAlert!!.item) {
                             is SendFlowErrorAlert.SignAndBroadcast -> alert.v1
@@ -585,6 +602,12 @@ private fun SendFlowRouteToScreen(
                             sendState = SendState.Error(e.message ?: "Unknown error")
                             showErrorAlert = true
                         }
+                    }
+                },
+                onCancelPayjoin = {
+                    sendState = SendState.Sending
+                    scope.launch {
+                        walletManager.cancelPayjoin()
                     }
                 },
             )

--- a/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove/flows/SendFlow/SendFlowContainer.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -462,6 +463,7 @@ private fun SendFlowRouteToScreen(
             var finalizedTransaction by remember { mutableStateOf<BitcoinTransaction?>(null) }
             var showSuccessAlert by remember { mutableStateOf(false) }
             var showErrorAlert by remember { mutableStateOf(false) }
+            var payjoinInitiated by rememberSaveable { mutableStateOf(false) }
             val scope = rememberCoroutineScope()
 
             // lock on appear for hot wallets
@@ -473,10 +475,10 @@ private fun SendFlowRouteToScreen(
             }
 
             // restore or transition to waiting UI from manager-owned deadline;
-            // survives Compose recreation on config changes like rotation
+            // payjoinInitiated survives config changes so only this screen's session matches
             LaunchedEffect(walletManager.payjoinDeadlineSecs) {
                 val deadline = walletManager.payjoinDeadlineSecs
-                if (deadline != null) {
+                if (deadline != null && payjoinInitiated) {
                     sendState = SendState.PayjoinWaiting(deadline)
                 }
             }
@@ -587,7 +589,12 @@ private fun SendFlowRouteToScreen(
                                     walletManager.broadcastTransaction(txnToBroadcast)
                                 }
                                 SendConfirmationInput.Unsigned -> {
+                                    if (payjoinEndpoint != null) {
+                                        payjoinInitiated = true
+                                    }
+
                                     walletManager.initiatePayment(details.psbt(), payjoinEndpoint)
+
                                     // for payjoin, stay in Sending — PayjoinTxBroadcast reconcile triggers success UI
                                     if (payjoinEndpoint != null) return@launch
                                 }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1701,6 +1701,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_current_block_height(
@@ -2968,6 +2970,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(`ptr`: Long,`ledgerState`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(`ptr`: Long,`signedTransaction`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(`ptr`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_convert_from_fiat_string(`ptr`: Long,`fiatAmount`: RustBuffer.ByValue,`prices`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
@@ -4931,6 +4935,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3646.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string() != 26279.toShort()) {
@@ -24450,6 +24457,8 @@ public interface RustWalletManagerInterface {
 
     suspend fun `broadcastTransaction`(`signedTransaction`: BitcoinTransaction)
 
+    suspend fun `cancelPayjoin`()
+
     fun `convertFromFiatString`(`fiatAmount`: kotlin.String, `prices`: PriceResponse): Amount
 
     suspend fun `currentBlockHeight`(): kotlin.UInt
@@ -24862,6 +24871,28 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
                 uniffiHandle,
 
         FfiConverterTypeBitcoinTransaction.lower(`signedTransaction`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
+
+
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `cancelPayjoin`() {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(
+                uniffiHandle,
+
             )
         },
         { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
@@ -64961,6 +64992,15 @@ sealed class WalletManagerReconcileMessage: Disposable  {
     object PayjoinTxBroadcast : WalletManagerReconcileMessage()
 
 
+    data class PayjoinPollingStarted(
+        val `deadlineSecs`: kotlin.ULong) : WalletManagerReconcileMessage()
+
+    {
+
+
+        companion object
+    }
+
 
 
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -65110,6 +65150,13 @@ sealed class WalletManagerReconcileMessage: Disposable  {
             }
             is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {// Nothing to destroy
             }
+            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+
+    Disposable.destroy(
+        this.`deadlineSecs`
+    )
+
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
@@ -65189,6 +65236,9 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 FfiConverterULong.read(buf),
                 )
             22 -> WalletManagerReconcileMessage.PayjoinTxBroadcast
+            23 -> WalletManagerReconcileMessage.PayjoinPollingStarted(
+                FfiConverterULong.read(buf),
+                )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -65346,6 +65396,13 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 4UL
             )
         }
+        is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterULong.allocationSize(value.`deadlineSecs`)
+            )
+        }
     }
 
     override fun write(value: WalletManagerReconcileMessage, buf: ByteBuffer) {
@@ -65456,6 +65513,11 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             }
             is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
                 buf.putInt(22)
+                Unit
+            }
+            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+                buf.putInt(23)
+                FfiConverterULong.write(value.`deadlineSecs`, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -1673,6 +1673,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction(
     ): Short
+    external fun uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin(
+    ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string(
     ): Short
     external fun uniffi_cove_checksum_method_rustwalletmanager_current_block_height(
@@ -2912,6 +2914,8 @@ internal object UniffiLib {
     external fun uniffi_cove_fn_method_rustwalletmanager_balance_presentation_for_state(`ptr`: Long,`ledgerState`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(`ptr`: Long,`signedTransaction`: Long,
+    ): Long
+    external fun uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(`ptr`: Long,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_convert_from_fiat_string(`ptr`: Long,`fiatAmount`: RustBuffer.ByValue,`prices`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
@@ -4805,6 +4809,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3646.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string() != 26279.toShort()) {
@@ -23576,6 +23583,8 @@ public interface RustWalletManagerInterface {
 
     suspend fun `broadcastTransaction`(`signedTransaction`: BitcoinTransaction)
 
+    suspend fun `cancelPayjoin`()
+
     fun `convertFromFiatString`(`fiatAmount`: kotlin.String, `prices`: PriceResponse): Amount
 
     suspend fun `currentBlockHeight`(): kotlin.UInt
@@ -23988,6 +23997,28 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
                 uniffiHandle,
 
         FfiConverterTypeBitcoinTransaction.lower(`signedTransaction`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.ffi_cove_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.ffi_cove_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+
+        // Error FFI converter
+        WalletManagerException.ErrorHandler,
+    )
+    }
+
+
+    @Throws(WalletManagerException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `cancelPayjoin`() {
+        return uniffiRustCallAsync(
+        callWithHandle { uniffiHandle ->
+            UniffiLib.uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(
+                uniffiHandle,
+
             )
         },
         { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
@@ -61457,6 +61488,15 @@ sealed class WalletManagerReconcileMessage: Disposable  {
     object PayjoinTxBroadcast : WalletManagerReconcileMessage()
 
 
+    data class PayjoinPollingStarted(
+        val `deadlineSecs`: kotlin.ULong) : WalletManagerReconcileMessage()
+
+    {
+
+
+        companion object
+    }
+
 
 
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -61606,6 +61646,13 @@ sealed class WalletManagerReconcileMessage: Disposable  {
             }
             is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {// Nothing to destroy
             }
+            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+
+    Disposable.destroy(
+        this.`deadlineSecs`
+    )
+
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
@@ -61685,6 +61732,9 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 FfiConverterULong.read(buf),
                 )
             22 -> WalletManagerReconcileMessage.PayjoinTxBroadcast
+            23 -> WalletManagerReconcileMessage.PayjoinPollingStarted(
+                FfiConverterULong.read(buf),
+                )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -61842,6 +61892,13 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 4UL
             )
         }
+        is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterULong.allocationSize(value.`deadlineSecs`)
+            )
+        }
     }
 
     override fun write(value: WalletManagerReconcileMessage, buf: ByteBuffer) {
@@ -61952,6 +62009,11 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             }
             is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
                 buf.putInt(22)
+                Unit
+            }
+            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+                buf.putInt(23)
+                FfiConverterULong.write(value.`deadlineSecs`, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/cove.kt
@@ -88,6 +88,8 @@ import org.bitcoinppl.cove_core.types.FfiConverterTypeFfiColor
 import org.bitcoinppl.cove_core.types.FfiConverterTypeFfiColorScheme
 import org.bitcoinppl.cove_core.types.FfiConverterTypeNetwork
 import org.bitcoinppl.cove_core.types.FfiConverterTypeOutPoint
+import org.bitcoinppl.cove_core.types.FfiConverterTypePayjoinIntent
+import org.bitcoinppl.cove_core.types.FfiConverterTypePayjoinSessionId
 import org.bitcoinppl.cove_core.types.FfiConverterTypePsbt
 import org.bitcoinppl.cove_core.types.FfiConverterTypeQrDensity
 import org.bitcoinppl.cove_core.types.FfiConverterTypeSentAndReceived
@@ -100,6 +102,8 @@ import org.bitcoinppl.cove_core.types.FfiConverterTypeUtxoType
 import org.bitcoinppl.cove_core.types.FfiConverterTypeWalletId
 import org.bitcoinppl.cove_core.types.Network
 import org.bitcoinppl.cove_core.types.OutPoint
+import org.bitcoinppl.cove_core.types.PayjoinIntent
+import org.bitcoinppl.cove_core.types.PayjoinSessionId
 import org.bitcoinppl.cove_core.types.Psbt
 import org.bitcoinppl.cove_core.types.QrDensity
 import org.bitcoinppl.cove_core.types.SentAndReceived
@@ -138,6 +142,8 @@ import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferFfiColor
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferFfiColorScheme
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferNetwork
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferOutPoint
+import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferPayjoinIntent
+import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferPayjoinSessionId
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferPsbt
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferQrDensity
 import org.bitcoinppl.cove_core.types.RustBuffer as RustBufferSentAndReceived
@@ -2971,7 +2977,7 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(`ptr`: Long,`signedTransaction`: Long,
     ): Long
-    external fun uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(`ptr`: Long,
+    external fun uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(`ptr`: Long,`sessionId`: RustBufferPayjoinSessionId.ByValue,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_convert_from_fiat_string(`ptr`: Long,`fiatAmount`: RustBuffer.ByValue,`prices`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
@@ -3011,7 +3017,7 @@ internal object UniffiLib {
     ): Byte
     external fun uniffi_cove_fn_method_rustwalletmanager_initial_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_method_rustwalletmanager_initiate_payment(`ptr`: Long,`psbt`: Long,`payjoinEndpoint`: RustBuffer.ByValue,
+    external fun uniffi_cove_fn_method_rustwalletmanager_initiate_payment(`ptr`: Long,`psbt`: Long,`mode`: RustBuffer.ByValue,
     ): Long
     external fun uniffi_cove_fn_method_rustwalletmanager_label_manager(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
@@ -3203,7 +3209,7 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_routefactory_send(`ptr`: Long,`send`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
-    external fun uniffi_cove_fn_method_routefactory_send_confirm(`ptr`: Long,`id`: RustBufferWalletId.ByValue,`details`: Long,`payjoinEndpoint`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    external fun uniffi_cove_fn_method_routefactory_send_confirm(`ptr`: Long,`id`: RustBufferWalletId.ByValue,`details`: Long,`mode`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_fn_method_routefactory_send_confirm_signed_psbt(`ptr`: Long,`id`: RustBufferWalletId.ByValue,`details`: Long,`psbt`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
@@ -4937,7 +4943,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3646.toShort()) {
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3414.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string() != 26279.toShort()) {
@@ -4997,7 +5003,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_initial_state() != 46436.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_rustwalletmanager_initiate_payment() != 13212.toShort()) {
+    if (lib.uniffi_cove_checksum_method_rustwalletmanager_initiate_payment() != 23416.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_rustwalletmanager_label_manager() != 23571.toShort()) {
@@ -5219,7 +5225,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_cove_checksum_method_routefactory_send() != 19857.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_cove_checksum_method_routefactory_send_confirm() != 6786.toShort()) {
+    if (lib.uniffi_cove_checksum_method_routefactory_send_confirm() != 4948.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_cove_checksum_method_routefactory_send_confirm_signed_psbt() != 63483.toShort()) {
@@ -19805,7 +19811,7 @@ public interface RouteFactoryInterface {
 
     fun `send`(`send`: SendRoute): Route
 
-    fun `sendConfirm`(`id`: WalletId, `details`: ConfirmDetails, `payjoinEndpoint`: kotlin.String?): Route
+    fun `sendConfirm`(`id`: WalletId, `details`: ConfirmDetails, `mode`: UnsignedPaymentMode): Route
 
     fun `sendConfirmSignedPsbt`(`id`: WalletId, `details`: ConfirmDetails, `psbt`: Psbt): Route
 
@@ -20179,7 +20185,7 @@ open class RouteFactory: Disposable, AutoCloseable, RouteFactoryInterface
     }
 
 
-    override fun `sendConfirm`(`id`: WalletId, `details`: ConfirmDetails, `payjoinEndpoint`: kotlin.String?): Route {
+    override fun `sendConfirm`(`id`: WalletId, `details`: ConfirmDetails, `mode`: UnsignedPaymentMode): Route {
             return FfiConverterTypeRoute.lift(
     callWithHandle {
     uniffiRustCall() { _status ->
@@ -20188,7 +20194,7 @@ open class RouteFactory: Disposable, AutoCloseable, RouteFactoryInterface
 
         FfiConverterTypeWalletId.lower(`id`),
         FfiConverterTypeConfirmDetails.lower(`details`),
-        FfiConverterOptionalString.lower(`payjoinEndpoint`),_status)
+        FfiConverterTypeUnsignedPaymentMode.lower(`mode`),_status)
 }
     }
     )
@@ -24457,7 +24463,7 @@ public interface RustWalletManagerInterface {
 
     suspend fun `broadcastTransaction`(`signedTransaction`: BitcoinTransaction)
 
-    suspend fun `cancelPayjoin`()
+    suspend fun `cancelPayjoin`(`sessionId`: PayjoinSessionId)
 
     fun `convertFromFiatString`(`fiatAmount`: kotlin.String, `prices`: PriceResponse): Amount
 
@@ -24524,7 +24530,7 @@ public interface RustWalletManagerInterface {
     /**
      * Send entry point for unsigned hot wallet PSBTs
      */
-    suspend fun `initiatePayment`(`psbt`: Psbt, `payjoinEndpoint`: kotlin.String?)
+    suspend fun `initiatePayment`(`psbt`: Psbt, `mode`: UnsignedPaymentMode)
 
     fun `labelManager`(): LabelManager
 
@@ -24887,12 +24893,13 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
 
     @Throws(WalletManagerException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `cancelPayjoin`() {
+    override suspend fun `cancelPayjoin`(`sessionId`: PayjoinSessionId) {
         return uniffiRustCallAsync(
         callWithHandle { uniffiHandle ->
             UniffiLib.uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(
                 uniffiHandle,
 
+        FfiConverterTypePayjoinSessionId.lower(`sessionId`),
             )
         },
         { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
@@ -25268,14 +25275,14 @@ open class RustWalletManager: Disposable, AutoCloseable, RustWalletManagerInterf
      */
     @Throws(WalletManagerException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `initiatePayment`(`psbt`: Psbt, `payjoinEndpoint`: kotlin.String?) {
+    override suspend fun `initiatePayment`(`psbt`: Psbt, `mode`: UnsignedPaymentMode) {
         return uniffiRustCallAsync(
         callWithHandle { uniffiHandle ->
             UniffiLib.uniffi_cove_fn_method_rustwalletmanager_initiate_payment(
                 uniffiHandle,
 
         FfiConverterTypePsbt.lower(`psbt`),
-        FfiConverterOptionalString.lower(`payjoinEndpoint`),
+        FfiConverterTypeUnsignedPaymentMode.lower(`mode`),
             )
         },
         { future, callback, continuation -> UniffiLib.ffi_cove_rust_future_poll_void(future, callback, continuation) },
@@ -35636,8 +35643,6 @@ data class SendRouteConfirmArgs (
     var `details`: ConfirmDetails
     ,
     var `input`: SendConfirmationInput
-    ,
-    var `payjoinEndpoint`: kotlin.String?
 
 ): Disposable{
 
@@ -35651,8 +35656,7 @@ data class SendRouteConfirmArgs (
     Disposable.destroy(
         this.`id`,
         this.`details`,
-        this.`input`,
-        this.`payjoinEndpoint`
+        this.`input`
     )
     }
 
@@ -35668,22 +35672,19 @@ public object FfiConverterTypeSendRouteConfirmArgs: FfiConverterRustBuffer<SendR
             FfiConverterTypeWalletId.read(buf),
             FfiConverterTypeConfirmDetails.read(buf),
             FfiConverterTypeSendConfirmationInput.read(buf),
-            FfiConverterOptionalString.read(buf),
         )
     }
 
     override fun allocationSize(value: SendRouteConfirmArgs) = (
             FfiConverterTypeWalletId.allocationSize(value.`id`) +
             FfiConverterTypeConfirmDetails.allocationSize(value.`details`) +
-            FfiConverterTypeSendConfirmationInput.allocationSize(value.`input`) +
-            FfiConverterOptionalString.allocationSize(value.`payjoinEndpoint`)
+            FfiConverterTypeSendConfirmationInput.allocationSize(value.`input`)
     )
 
     override fun write(value: SendRouteConfirmArgs, buf: ByteBuffer) {
             FfiConverterTypeWalletId.write(value.`id`, buf)
             FfiConverterTypeConfirmDetails.write(value.`details`, buf)
             FfiConverterTypeSendConfirmationInput.write(value.`input`, buf)
-            FfiConverterOptionalString.write(value.`payjoinEndpoint`, buf)
     }
 }
 
@@ -54419,6 +54420,189 @@ public object FfiConverterTypeOtherBackupsOperation : FfiConverterRustBuffer<Oth
 
 
 
+/**
+ * The terminal transaction selected for a Payjoin payment
+ */
+
+enum class PayjoinBroadcastOutcome {
+
+    PROPOSAL,
+    FALLBACK;
+
+
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypePayjoinBroadcastOutcome: FfiConverterRustBuffer<PayjoinBroadcastOutcome> {
+    override fun read(buf: ByteBuffer) = try {
+        PayjoinBroadcastOutcome.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: PayjoinBroadcastOutcome) = 4UL
+
+    override fun write(value: PayjoinBroadcastOutcome, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+/**
+ * The latest wallet-owned state for one Payjoin payment
+ */
+sealed class PayjoinStatus {
+
+    data class Negotiating(
+        val `sessionId`: org.bitcoinppl.cove_core.types.PayjoinSessionId) : PayjoinStatus()
+
+    {
+
+
+        companion object
+    }
+
+    data class Polling(
+        val `sessionId`: org.bitcoinppl.cove_core.types.PayjoinSessionId,
+        val `deadlineSecs`: kotlin.ULong) : PayjoinStatus()
+
+    {
+
+
+        companion object
+    }
+
+    data class Broadcast(
+        val `sessionId`: org.bitcoinppl.cove_core.types.PayjoinSessionId,
+        val `outcome`: org.bitcoinppl.cove_core.PayjoinBroadcastOutcome) : PayjoinStatus()
+
+    {
+
+
+        companion object
+    }
+
+    data class Failed(
+        val `sessionId`: org.bitcoinppl.cove_core.types.PayjoinSessionId,
+        val `message`: kotlin.String) : PayjoinStatus()
+
+    {
+
+
+        companion object
+    }
+
+
+
+
+
+
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypePayjoinStatus : FfiConverterRustBuffer<PayjoinStatus>{
+    override fun read(buf: ByteBuffer): PayjoinStatus {
+        return when(buf.getInt()) {
+            1 -> PayjoinStatus.Negotiating(
+                FfiConverterTypePayjoinSessionId.read(buf),
+                )
+            2 -> PayjoinStatus.Polling(
+                FfiConverterTypePayjoinSessionId.read(buf),
+                FfiConverterULong.read(buf),
+                )
+            3 -> PayjoinStatus.Broadcast(
+                FfiConverterTypePayjoinSessionId.read(buf),
+                FfiConverterTypePayjoinBroadcastOutcome.read(buf),
+                )
+            4 -> PayjoinStatus.Failed(
+                FfiConverterTypePayjoinSessionId.read(buf),
+                FfiConverterString.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: PayjoinStatus): ULong = when(value) {
+        is PayjoinStatus.Negotiating -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypePayjoinSessionId.allocationSize(value.`sessionId`)
+            )
+        }
+        is PayjoinStatus.Polling -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypePayjoinSessionId.allocationSize(value.`sessionId`)
+                + FfiConverterULong.allocationSize(value.`deadlineSecs`)
+            )
+        }
+        is PayjoinStatus.Broadcast -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypePayjoinSessionId.allocationSize(value.`sessionId`)
+                + FfiConverterTypePayjoinBroadcastOutcome.allocationSize(value.`outcome`)
+            )
+        }
+        is PayjoinStatus.Failed -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypePayjoinSessionId.allocationSize(value.`sessionId`)
+                + FfiConverterString.allocationSize(value.`message`)
+            )
+        }
+    }
+
+    override fun write(value: PayjoinStatus, buf: ByteBuffer) {
+        when(value) {
+            is PayjoinStatus.Negotiating -> {
+                buf.putInt(1)
+                FfiConverterTypePayjoinSessionId.write(value.`sessionId`, buf)
+                Unit
+            }
+            is PayjoinStatus.Polling -> {
+                buf.putInt(2)
+                FfiConverterTypePayjoinSessionId.write(value.`sessionId`, buf)
+                FfiConverterULong.write(value.`deadlineSecs`, buf)
+                Unit
+            }
+            is PayjoinStatus.Broadcast -> {
+                buf.putInt(3)
+                FfiConverterTypePayjoinSessionId.write(value.`sessionId`, buf)
+                FfiConverterTypePayjoinBroadcastOutcome.write(value.`outcome`, buf)
+                Unit
+            }
+            is PayjoinStatus.Failed -> {
+                buf.putInt(4)
+                FfiConverterTypePayjoinSessionId.write(value.`sessionId`, buf)
+                FfiConverterString.write(value.`message`, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
 sealed class PendingOrConfirmed {
 
     data class Pending(
@@ -56285,8 +56469,14 @@ public object FfiConverterTypeSeedQrError : FfiConverterRustBuffer<SeedQrExcepti
 
 sealed class SendConfirmationInput: Disposable  {
 
-    object Unsigned : SendConfirmationInput()
+    data class Unsigned(
+        val `mode`: org.bitcoinppl.cove_core.UnsignedPaymentMode) : SendConfirmationInput()
 
+    {
+
+
+        companion object
+    }
 
     data class SignedTransaction(
         val v1: org.bitcoinppl.cove_core.BitcoinTransaction) : SendConfirmationInput()
@@ -56311,7 +56501,12 @@ sealed class SendConfirmationInput: Disposable  {
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
-            is SendConfirmationInput.Unsigned -> {// Nothing to destroy
+            is SendConfirmationInput.Unsigned -> {
+
+    Disposable.destroy(
+        this.`mode`
+    )
+
             }
             is SendConfirmationInput.SignedTransaction -> {
 
@@ -56344,7 +56539,9 @@ sealed class SendConfirmationInput: Disposable  {
 public object FfiConverterTypeSendConfirmationInput : FfiConverterRustBuffer<SendConfirmationInput>{
     override fun read(buf: ByteBuffer): SendConfirmationInput {
         return when(buf.getInt()) {
-            1 -> SendConfirmationInput.Unsigned
+            1 -> SendConfirmationInput.Unsigned(
+                FfiConverterTypeUnsignedPaymentMode.read(buf),
+                )
             2 -> SendConfirmationInput.SignedTransaction(
                 FfiConverterTypeBitcoinTransaction.read(buf),
                 )
@@ -56360,6 +56557,7 @@ public object FfiConverterTypeSendConfirmationInput : FfiConverterRustBuffer<Sen
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
+                + FfiConverterTypeUnsignedPaymentMode.allocationSize(value.`mode`)
             )
         }
         is SendConfirmationInput.SignedTransaction -> {
@@ -56382,6 +56580,7 @@ public object FfiConverterTypeSendConfirmationInput : FfiConverterRustBuffer<Sen
         when(value) {
             is SendConfirmationInput.Unsigned -> {
                 buf.putInt(1)
+                FfiConverterTypeUnsignedPaymentMode.write(value.`mode`, buf)
                 Unit
             }
             is SendConfirmationInput.SignedTransaction -> {
@@ -61491,6 +61690,82 @@ public object FfiConverterTypeTrickPinError : FfiConverterRustBuffer<TrickPinExc
 
 
 
+/**
+ * The protocol used to send an unsigned hot-wallet payment
+ */
+sealed class UnsignedPaymentMode {
+
+    object Standard : UnsignedPaymentMode()
+
+
+    data class Payjoin(
+        val `intent`: org.bitcoinppl.cove_core.types.PayjoinIntent) : UnsignedPaymentMode()
+
+    {
+
+
+        companion object
+    }
+
+
+
+
+
+
+
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeUnsignedPaymentMode : FfiConverterRustBuffer<UnsignedPaymentMode>{
+    override fun read(buf: ByteBuffer): UnsignedPaymentMode {
+        return when(buf.getInt()) {
+            1 -> UnsignedPaymentMode.Standard
+            2 -> UnsignedPaymentMode.Payjoin(
+                FfiConverterTypePayjoinIntent.read(buf),
+                )
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: UnsignedPaymentMode): ULong = when(value) {
+        is UnsignedPaymentMode.Standard -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is UnsignedPaymentMode.Payjoin -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterTypePayjoinIntent.allocationSize(value.`intent`)
+            )
+        }
+    }
+
+    override fun write(value: UnsignedPaymentMode, buf: ByteBuffer) {
+        when(value) {
+            is UnsignedPaymentMode.Standard -> {
+                buf.putInt(1)
+                Unit
+            }
+            is UnsignedPaymentMode.Payjoin -> {
+                buf.putInt(2)
+                FfiConverterTypePayjoinIntent.write(value.`intent`, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
 
 
 sealed class UnsignedTransactionsTableException: kotlin.Exception() {
@@ -64142,6 +64417,24 @@ sealed class WalletManagerException: kotlin.Exception() {
             get() = "v1=${ v1 }"
     }
 
+    class PayjoinCancellationFailed(
+
+        val v1: kotlin.String
+        ) : WalletManagerException() {
+        override val message
+            get() = "v1=${ v1 }"
+    }
+
+    class PayjoinSessionMismatch(
+
+        val `requested`: PayjoinSessionId,
+
+        val `active`: PayjoinSessionId
+        ) : WalletManagerException() {
+        override val message
+            get() = "requested=${ `requested` }, active=${ `active` }"
+    }
+
     class Converter(
 
         val v1: ConverterException
@@ -64347,42 +64640,49 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
             28 -> WalletManagerException.PayjoinSessionException(
                 FfiConverterString.read(buf),
                 )
-            29 -> WalletManagerException.Converter(
+            29 -> WalletManagerException.PayjoinCancellationFailed(
+                FfiConverterString.read(buf),
+                )
+            30 -> WalletManagerException.PayjoinSessionMismatch(
+                FfiConverterTypePayjoinSessionId.read(buf),
+                FfiConverterTypePayjoinSessionId.read(buf),
+                )
+            31 -> WalletManagerException.Converter(
                 FfiConverterTypeConverterError.read(buf),
                 )
-            30 -> WalletManagerException.UnknownException(
+            32 -> WalletManagerException.UnknownException(
                 FfiConverterString.read(buf),
                 )
-            31 -> WalletManagerException.PsbtFinalizeException(
+            33 -> WalletManagerException.PsbtFinalizeException(
                 FfiConverterString.read(buf),
                 )
-            32 -> WalletManagerException.GetHistoricalPricesException(
+            34 -> WalletManagerException.GetHistoricalPricesException(
                 FfiConverterString.read(buf),
                 )
-            33 -> WalletManagerException.CsvCreationException(
+            35 -> WalletManagerException.CsvCreationException(
                 FfiConverterString.read(buf),
                 )
-            34 -> WalletManagerException.AddUtxosException(
+            36 -> WalletManagerException.AddUtxosException(
                 FfiConverterString.read(buf),
                 )
-            35 -> WalletManagerException.OutputLabelsException(
+            37 -> WalletManagerException.OutputLabelsException(
                 FfiConverterString.read(buf),
                 )
-            36 -> WalletManagerException.DatabaseCorruption(
+            38 -> WalletManagerException.DatabaseCorruption(
                 FfiConverterTypeWalletId.read(buf),
                 FfiConverterString.read(buf),
                 )
-            37 -> WalletManagerException.PendingUnsignedTransactionsLoadException(
+            39 -> WalletManagerException.PendingUnsignedTransactionsLoadException(
                 FfiConverterString.read(buf),
                 )
-            38 -> WalletManagerException.ReceiveAddressException(
+            40 -> WalletManagerException.ReceiveAddressException(
                 FfiConverterString.read(buf),
                 )
-            39 -> WalletManagerException.ManagerClosed()
-            40 -> WalletManagerException.WalletLifecycle(
+            41 -> WalletManagerException.ManagerClosed()
+            42 -> WalletManagerException.WalletLifecycle(
                 FfiConverterTypeWalletLifecycleFailure.read(buf),
                 )
-            41 -> WalletManagerException.AddressTypeSwitchCommittedWithRecoveryPending(
+            43 -> WalletManagerException.AddressTypeSwitchCommittedWithRecoveryPending(
                 FfiConverterTypeWalletAddressType.read(buf),
                 FfiConverterSequenceTypeAddressTypeSwitchRecoveryFailure.read(buf),
                 )
@@ -64525,6 +64825,17 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.PayjoinCancellationFailed -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.v1)
+            )
+            is WalletManagerException.PayjoinSessionMismatch -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterTypePayjoinSessionId.allocationSize(value.`requested`)
+                + FfiConverterTypePayjoinSessionId.allocationSize(value.`active`)
             )
             is WalletManagerException.Converter -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
@@ -64731,68 +65042,79 @@ public object FfiConverterTypeWalletManagerError : FfiConverterRustBuffer<Wallet
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.Converter -> {
+            is WalletManagerException.PayjoinCancellationFailed -> {
                 buf.putInt(29)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.PayjoinSessionMismatch -> {
+                buf.putInt(30)
+                FfiConverterTypePayjoinSessionId.write(value.`requested`, buf)
+                FfiConverterTypePayjoinSessionId.write(value.`active`, buf)
+                Unit
+            }
+            is WalletManagerException.Converter -> {
+                buf.putInt(31)
                 FfiConverterTypeConverterError.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.UnknownException -> {
-                buf.putInt(30)
-                FfiConverterString.write(value.v1, buf)
-                Unit
-            }
-            is WalletManagerException.PsbtFinalizeException -> {
-                buf.putInt(31)
-                FfiConverterString.write(value.v1, buf)
-                Unit
-            }
-            is WalletManagerException.GetHistoricalPricesException -> {
                 buf.putInt(32)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.CsvCreationException -> {
+            is WalletManagerException.PsbtFinalizeException -> {
                 buf.putInt(33)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.AddUtxosException -> {
+            is WalletManagerException.GetHistoricalPricesException -> {
                 buf.putInt(34)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.OutputLabelsException -> {
+            is WalletManagerException.CsvCreationException -> {
                 buf.putInt(35)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerException.DatabaseCorruption -> {
+            is WalletManagerException.AddUtxosException -> {
                 buf.putInt(36)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.OutputLabelsException -> {
+                buf.putInt(37)
+                FfiConverterString.write(value.v1, buf)
+                Unit
+            }
+            is WalletManagerException.DatabaseCorruption -> {
+                buf.putInt(38)
                 FfiConverterTypeWalletId.write(value.`id`, buf)
                 FfiConverterString.write(value.`error`, buf)
                 Unit
             }
             is WalletManagerException.PendingUnsignedTransactionsLoadException -> {
-                buf.putInt(37)
+                buf.putInt(39)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.ReceiveAddressException -> {
-                buf.putInt(38)
+                buf.putInt(40)
                 FfiConverterString.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.ManagerClosed -> {
-                buf.putInt(39)
+                buf.putInt(41)
                 Unit
             }
             is WalletManagerException.WalletLifecycle -> {
-                buf.putInt(40)
+                buf.putInt(42)
                 FfiConverterTypeWalletLifecycleFailure.write(value.v1, buf)
                 Unit
             }
             is WalletManagerException.AddressTypeSwitchCommittedWithRecoveryPending -> {
-                buf.putInt(41)
+                buf.putInt(43)
                 FfiConverterTypeWalletAddressType.write(value.`addressType`, buf)
                 FfiConverterSequenceTypeAddressTypeSwitchRecoveryFailure.write(value.`failures`, buf)
                 Unit
@@ -64989,11 +65311,8 @@ sealed class WalletManagerReconcileMessage: Disposable  {
         companion object
     }
 
-    object PayjoinTxBroadcast : WalletManagerReconcileMessage()
-
-
-    data class PayjoinPollingStarted(
-        val `deadlineSecs`: kotlin.ULong) : WalletManagerReconcileMessage()
+    data class PayjoinStatusChanged(
+        val v1: org.bitcoinppl.cove_core.PayjoinStatus) : WalletManagerReconcileMessage()
 
     {
 
@@ -65148,12 +65467,10 @@ sealed class WalletManagerReconcileMessage: Disposable  {
     )
 
             }
-            is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {// Nothing to destroy
-            }
-            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
+            is WalletManagerReconcileMessage.PayjoinStatusChanged -> {
 
     Disposable.destroy(
-        this.`deadlineSecs`
+        this.v1
     )
 
             }
@@ -65235,9 +65552,8 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
             21 -> WalletManagerReconcileMessage.ReceiveAddressClosed(
                 FfiConverterULong.read(buf),
                 )
-            22 -> WalletManagerReconcileMessage.PayjoinTxBroadcast
-            23 -> WalletManagerReconcileMessage.PayjoinPollingStarted(
-                FfiConverterULong.read(buf),
+            22 -> WalletManagerReconcileMessage.PayjoinStatusChanged(
+                FfiConverterTypePayjoinStatus.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
@@ -65390,17 +65706,11 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 + FfiConverterULong.allocationSize(value.v1)
             )
         }
-        is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
+        is WalletManagerReconcileMessage.PayjoinStatusChanged -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
-            )
-        }
-        is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
-            // Add the size for the Int that specifies the variant plus the size needed for all fields
-            (
-                4UL
-                + FfiConverterULong.allocationSize(value.`deadlineSecs`)
+                + FfiConverterTypePayjoinStatus.allocationSize(value.v1)
             )
         }
     }
@@ -65511,13 +65821,9 @@ public object FfiConverterTypeWalletManagerReconcileMessage : FfiConverterRustBu
                 FfiConverterULong.write(value.v1, buf)
                 Unit
             }
-            is WalletManagerReconcileMessage.PayjoinTxBroadcast -> {
+            is WalletManagerReconcileMessage.PayjoinStatusChanged -> {
                 buf.putInt(22)
-                Unit
-            }
-            is WalletManagerReconcileMessage.PayjoinPollingStarted -> {
-                buf.putInt(23)
-                FfiConverterULong.write(value.`deadlineSecs`, buf)
+                FfiConverterTypePayjoinStatus.write(value.v1, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -69419,6 +69725,8 @@ public typealias FfiConverterTypeTimestamp = FfiConverterULong
 
 
 
+
+
 object KeychainExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<KeychainException> {
     override fun lift(error_buf: RustBuffer.ByValue): KeychainException =
         org.bitcoinppl.cove_core.device.KeychainException.ErrorHandler.lift(
@@ -69484,6 +69792,8 @@ object UrExceptionExternalErrorHandler : UniffiRustCallStatusErrorHandler<UrExce
             }
         )
 }
+
+
 
 
 

--- a/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
+++ b/android/app/src/main/java/org/bitcoinppl/cove_core/types/cove_types.kt
@@ -1197,6 +1197,10 @@ internal object UniffiLib {
     ): Long
     external fun uniffi_cove_types_fn_method_feerateoptionswithtotalfee_transaction_size(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
+    external fun uniffi_cove_types_fn_clone_payjoinendpoint(`handle`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): Long
+    external fun uniffi_cove_types_fn_free_payjoinendpoint(`handle`: Long,uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
     external fun uniffi_cove_types_fn_clone_psbt(`handle`: Long,uniffi_out_err: UniffiRustCallStatus,
     ): Long
     external fun uniffi_cove_types_fn_free_psbt(`handle`: Long,uniffi_out_err: UniffiRustCallStatus,
@@ -1287,6 +1291,12 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_cove_types_fn_method_bitcoinunit_uniffi_trait_display(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+    external fun uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_eq_eq(`ptr`: RustBuffer.ByValue,`other`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): Byte
+    external fun uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_eq_ne(`ptr`: RustBuffer.ByValue,`other`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): Byte
+    external fun uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_hash(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
+    ): Long
     external fun uniffi_cove_types_fn_method_utxo_date(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
     external fun uniffi_cove_types_fn_method_utxo_hash_to_uint(`ptr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus,
@@ -7183,6 +7193,252 @@ public object FfiConverterTypeOutPoint: FfiConverter<OutPoint, Long> {
 //
 
 
+/**
+ * A BIP-77 v2 endpoint that passed Payjoin URI validation
+ */
+public interface PayjoinEndpointInterface {
+
+    companion object
+}
+
+/**
+ * A BIP-77 v2 endpoint that passed Payjoin URI validation
+ */
+open class PayjoinEndpoint: Disposable, AutoCloseable, PayjoinEndpointInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    /**
+     * Whether the current object has been destroyed and its reference is gone in the Rust side.
+     */
+    val uniffiIsDestroyed: Boolean get() = wasDestroyed.get()
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_cove_types_fn_free_payjoinendpoint(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_cove_types_fn_clone_payjoinendpoint(handle, status)
+        }
+    }
+
+
+
+
+
+
+
+
+    /**
+     * @suppress
+     */
+    companion object
+
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypePayjoinEndpoint: FfiConverter<PayjoinEndpoint, Long> {
+    override fun lower(value: PayjoinEndpoint): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): PayjoinEndpoint {
+        return PayjoinEndpoint(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): PayjoinEndpoint {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: PayjoinEndpoint) = 8UL
+
+    override fun write(value: PayjoinEndpoint, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
 public interface PsbtInterface {
 
     /**
@@ -9354,13 +9610,21 @@ public object FfiConverterTypeBlockSizeLast: FfiConverterRustBuffer<BlockSizeLas
 
 
 data class PayJoinParams (
-    var `endpoint`: kotlin.String
+    var `endpoint`: PayjoinEndpoint
 
-){
-
-
+): Disposable{
 
 
+
+
+
+    @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
+    override fun destroy() {
+
+    Disposable.destroy(
+        this.`endpoint`
+    )
+    }
 
     companion object
 }
@@ -9371,16 +9635,92 @@ data class PayJoinParams (
 public object FfiConverterTypePayJoinParams: FfiConverterRustBuffer<PayJoinParams> {
     override fun read(buf: ByteBuffer): PayJoinParams {
         return PayJoinParams(
-            FfiConverterString.read(buf),
+            FfiConverterTypePayjoinEndpoint.read(buf),
         )
     }
 
     override fun allocationSize(value: PayJoinParams) = (
-            FfiConverterString.allocationSize(value.`endpoint`)
+            FfiConverterTypePayjoinEndpoint.allocationSize(value.`endpoint`)
     )
 
     override fun write(value: PayJoinParams, buf: ByteBuffer) {
-            FfiConverterString.write(value.`endpoint`, buf)
+            FfiConverterTypePayjoinEndpoint.write(value.`endpoint`, buf)
+    }
+}
+
+
+
+/**
+ * The immutable data that identifies and starts one Payjoin payment
+ */
+data class PayjoinIntent (
+    /**
+     * The stable identity of this payment attempt
+     */
+    var `sessionId`: PayjoinSessionId
+    ,
+    /**
+     * The validated receiver endpoint
+     */
+    var `endpoint`: PayjoinEndpoint
+
+): Disposable{
+
+
+
+
+    // The local Rust `Eq` implementation - only `eq` is used.
+    override fun equals(other: Any?): Boolean {
+        if (other !is PayjoinIntent) return false
+        return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_eq_eq(FfiConverterTypePayjoinIntent.lower(this),
+
+        FfiConverterTypePayjoinIntent.lower(`other`),_status)
+}
+    )
+    }
+    // The local Rust `Hash` implementation
+    override fun hashCode(): Int {
+        return FfiConverterULong.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_hash(FfiConverterTypePayjoinIntent.lower(this),
+        _status)
+}
+    ).toInt()
+    }
+
+    @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
+    override fun destroy() {
+
+    Disposable.destroy(
+        this.`sessionId`,
+        this.`endpoint`
+    )
+    }
+
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypePayjoinIntent: FfiConverterRustBuffer<PayjoinIntent> {
+    override fun read(buf: ByteBuffer): PayjoinIntent {
+        return PayjoinIntent(
+            FfiConverterTypePayjoinSessionId.read(buf),
+            FfiConverterTypePayjoinEndpoint.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: PayjoinIntent) = (
+            FfiConverterTypePayjoinSessionId.allocationSize(value.`sessionId`) +
+            FfiConverterTypePayjoinEndpoint.allocationSize(value.`endpoint`)
+    )
+
+    override fun write(value: PayjoinIntent, buf: ByteBuffer) {
+            FfiConverterTypePayjoinSessionId.write(value.`sessionId`, buf)
+            FfiConverterTypePayjoinEndpoint.write(value.`endpoint`, buf)
     }
 }
 
@@ -11019,6 +11359,11 @@ public object FfiConverterSequenceTypeNetwork: FfiConverterRustBuffer<List<Netwo
 
 public typealias FfiOpacity = kotlin.UByte
 public typealias FfiConverterTypeFfiOpacity = FfiConverterUByte
+
+
+
+public typealias PayjoinSessionId = kotlin.String
+public typealias FfiConverterTypePayjoinSessionId = FfiConverterString
 
 
 

--- a/android/app/src/test/java/org/bitcoinppl/cove/SendFlowRouteLifecycleTest.kt
+++ b/android/app/src/test/java/org/bitcoinppl/cove/SendFlowRouteLifecycleTest.kt
@@ -5,6 +5,7 @@ import org.bitcoinppl.cove_core.SendConfirmationInput
 import org.bitcoinppl.cove_core.SendRoute
 import org.bitcoinppl.cove_core.SendRouteConfirmArgs
 import org.bitcoinppl.cove_core.SettingsRoute
+import org.bitcoinppl.cove_core.UnsignedPaymentMode
 import org.bitcoinppl.cove_core.types.ConfirmDetails
 import org.bitcoinppl.cove_core.types.NoHandle
 import org.junit.Assert.assertFalse
@@ -106,8 +107,7 @@ class SendFlowRouteLifecycleTest {
                 SendRouteConfirmArgs(
                     id = "wallet-a",
                     details = ConfirmDetails(NoHandle),
-                    input = SendConfirmationInput.Unsigned,
-                    payjoinEndpoint = null,
+                    input = SendConfirmationInput.Unsigned(UnsignedPaymentMode.Standard),
                 ),
             )
 

--- a/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
+++ b/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
@@ -13,6 +13,7 @@ private let swipeToSendMinimumTrailingTextPadding: CGFloat = 16
 enum SendState: Hashable, Equatable {
     case idle
     case sending
+    case payjoinWaiting(deadlineSecs: UInt64)
     case sent
     case error(String)
 }
@@ -207,7 +208,7 @@ private struct SwipeToSendStatus: View {
             switch sendState {
             case .idle:
                 EmptyView()
-            case .sending:
+            case .sending, .payjoinWaiting:
                 SwipeToSendSendingStatus()
             case .sent:
                 SwipeToSendSentStatus()

--- a/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
+++ b/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
@@ -16,6 +16,7 @@ enum SendState: Hashable, Equatable {
     case payjoinWaiting(sessionId: PayjoinSessionId, deadlineSecs: UInt64)
     case sent
     case error(String)
+    case payjoinFailed(String)
 }
 
 struct SwipeToSendView: View {
@@ -214,7 +215,9 @@ private struct SwipeToSendStatus: View {
             case .sent:
                 SwipeToSendSentStatus()
             case .error:
-                SwipeToSendErrorStatus(sendState: $sendState)
+                SwipeToSendErrorStatus(sendState: $sendState, resetsToIdle: true)
+            case .payjoinFailed:
+                SwipeToSendErrorStatus(sendState: $sendState, resetsToIdle: false)
             }
         }
         .foregroundStyle(.white)
@@ -244,6 +247,7 @@ private struct SwipeToSendSentStatus: View {
 
 private struct SwipeToSendErrorStatus: View {
     @Binding var sendState: SendState
+    let resetsToIdle: Bool
 
     var body: some View {
         HStack(spacing: 10) {
@@ -256,7 +260,11 @@ private struct SwipeToSendErrorStatus: View {
     }
 
     private func resetAfterDelay() {
+        guard resetsToIdle else { return }
+        let retryableError = sendState
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            guard sendState == retryableError else { return }
             sendState = .idle
         }
     }

--- a/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
+++ b/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
@@ -13,7 +13,7 @@ private let swipeToSendMinimumTrailingTextPadding: CGFloat = 16
 enum SendState: Hashable, Equatable {
     case idle
     case sending
-    case payjoinWaiting(deadlineSecs: UInt64)
+    case payjoinWaiting(sessionId: PayjoinSessionId, deadlineSecs: UInt64)
     case sent
     case error(String)
 }

--- a/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
+++ b/ios/Cove/Flows/SendFlow/ConfirmScreen/SwipeToSendView.swift
@@ -175,6 +175,7 @@ private struct SwipeToSendHandle: View {
                     .onChanged(dragChanged)
                     .onEnded(dragEnded)
             )
+            .allowsHitTesting(sendState == .idle)
     }
 
     private func dragChanged(_ value: DragGesture.Value) {

--- a/ios/Cove/Flows/SendFlow/SendFlowAlerts.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowAlerts.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum SendFlowConfirmAlertState: Equatable {
     case sent(WalletId)
     case broadcastError(String)
+    case payjoinFailed(String)
     case payjoinCancellationError(String)
 }
 
@@ -78,6 +79,17 @@ extension SendFlowConfirmAlertState: TaggedAlertPresentable {
                 actions: {
                     Button("OK") {
                         context.sendState.wrappedValue = .idle
+                        context.dismissAlert()
+                    }
+                }
+            ).eraseToAny()
+
+        case let .payjoinFailed(error):
+            AlertBuilder(
+                title: "Payjoin Payment Paused",
+                message: error,
+                actions: {
+                    Button("OK") {
                         context.dismissAlert()
                     }
                 }

--- a/ios/Cove/Flows/SendFlow/SendFlowAlerts.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowAlerts.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum SendFlowConfirmAlertState: Equatable {
     case sent(WalletId)
     case broadcastError(String)
+    case payjoinCancellationError(String)
 }
 
 struct SendFlowErrorAlertContext {
@@ -77,6 +78,17 @@ extension SendFlowConfirmAlertState: TaggedAlertPresentable {
                 actions: {
                     Button("OK") {
                         context.sendState.wrappedValue = .idle
+                        context.dismissAlert()
+                    }
+                }
+            ).eraseToAny()
+
+        case let .payjoinCancellationError(error):
+            AlertBuilder(
+                title: "Unable to Cancel Payjoin",
+                message: error,
+                actions: {
+                    Button("OK") {
                         context.dismissAlert()
                     }
                 }

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -20,7 +20,6 @@ struct SendFlowConfirmScreen: View {
     @State var manager: WalletManager
     let details: ConfirmDetails
     let input: SendConfirmationInput
-    let payjoinEndpoint: String?
 
     let prices: PriceResponse? = nil
 
@@ -54,6 +53,14 @@ struct SendFlowConfirmScreen: View {
         SendFlowConfirmAlertContext(presenter: presenter, sendState: $sendState)
     }
 
+    private var payjoinIntent: PayjoinIntent? {
+        guard case let .unsigned(mode) = input,
+              case let .payjoin(intent) = mode
+        else { return nil }
+
+        return intent
+    }
+
     var body: some View {
         if case let .signedPsbt(psbt) = input, finalizedTransaction == nil {
             SendFlowFinalizePsbtView(
@@ -78,15 +85,14 @@ struct SendFlowConfirmScreen: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.coveBg)
             .overlay(alignment: .bottom) {
-                if case let .payjoinWaiting(deadline) = sendState {
+                if case let .payjoinWaiting(_, deadline) = sendState {
                     PayjoinWaitingBanner(deadlineSecs: deadline, onCancel: cancelPayjoin)
                         .padding(.bottom, sendConfirmationFooterHeight + 16)
                 }
             }
             .onDisappear(perform: handleDisappear)
-            .onAppear(perform: restorePayjoinWaitingState)
-            .onChange(of: manager.payjoinDeadlineSecs, payjoinPollingStarted)
-            .onChange(of: manager.payjoinTxBroadcast, payjoinBroadcastChanged)
+            .onAppear { applyPayjoinStatus(manager.payjoinStatus) }
+            .onChange(of: manager.payjoinStatus, payjoinStatusChanged)
             .onChange(of: manager.sendFlowErrorAlert, sendFlowErrorChanged)
             .presentingAlert(
                 presenter.confirmationAlertStateBinding,
@@ -109,37 +115,62 @@ struct SendFlowConfirmScreen: View {
         if sinceLocked < 5 { auth.lockState = .unlocked }
     }
 
-    private func restorePayjoinWaitingState() {
-        guard
-            let deadline = manager.payjoinDeadlineSecs,
-            case .sending = sendState
-        else { return }
-
-        sendState = .payjoinWaiting(deadlineSecs: deadline)
+    private func payjoinStatusChanged(_: PayjoinStatus?, _ status: PayjoinStatus?) {
+        applyPayjoinStatus(status)
     }
 
-    private func payjoinPollingStarted(_: UInt64?, _ deadline: UInt64?) {
-        guard let deadline, case .sending = sendState else { return }
+    private func applyPayjoinStatus(_ status: PayjoinStatus?) {
+        guard let status, let intent = payjoinIntent else { return }
 
-        sendState = .payjoinWaiting(deadlineSecs: deadline)
-    }
+        switch status {
+        case let .negotiating(sessionId):
+            guard sessionId == intent.sessionId else { return }
+            sendState = .sending
 
-    private func payjoinBroadcastChanged(_: UUID?, _ uuid: UUID?) {
-        guard uuid != nil else { return }
-        switch sendState {
-        case .sending, .payjoinWaiting: break
-        default: return
+        case let .polling(sessionId, deadlineSecs):
+            guard sessionId == intent.sessionId else { return }
+            sendState = .payjoinWaiting(sessionId: sessionId, deadlineSecs: deadlineSecs)
+
+        case let .broadcast(sessionId, _):
+            guard sessionId == intent.sessionId else { return }
+            sendState = .sent
+            presenter.confirmationAlertState = .init(.sent(id))
+            auth.unlock()
+
+        case let .failed(sessionId, message):
+            guard sessionId == intent.sessionId else { return }
+            sendState = .error(message)
+            presenter.confirmationAlertState = .init(.broadcastError(message))
         }
-
-        sendState = .sent
-        presenter.confirmationAlertState = .init(.sent(id))
-        auth.unlock()
     }
 
     private func cancelPayjoin() {
+        guard let intent = payjoinIntent,
+              case let .payjoinWaiting(sessionId, deadlineSecs) = sendState,
+              sessionId == intent.sessionId
+        else { return }
+
         sendState = .sending
         Task {
-            try? await manager.cancelPayjoin()
+            do {
+                try await manager.cancelPayjoin(sessionId: intent.sessionId)
+            } catch let error as WalletManagerError {
+                sendState = .payjoinWaiting(
+                    sessionId: sessionId,
+                    deadlineSecs: deadlineSecs
+                )
+                presenter.confirmationAlertState = .init(
+                    .payjoinCancellationError(error.description)
+                )
+            } catch {
+                sendState = .payjoinWaiting(
+                    sessionId: sessionId,
+                    deadlineSecs: deadlineSecs
+                )
+                presenter.confirmationAlertState = .init(
+                    .payjoinCancellationError(error.localizedDescription)
+                )
+            }
         }
     }
 
@@ -147,17 +178,20 @@ struct SendFlowConfirmScreen: View {
         _: TaggedItem<SendFlowErrorAlert>?,
         _ alert: TaggedItem<SendFlowErrorAlert>?
     ) {
+        guard payjoinIntent == nil else { return }
+
         switch sendState {
         case .sending, .payjoinWaiting: break
         default: return
         }
         guard let alert else { return }
 
-        let errorMessage =
-            switch alert.item {
-            case let .signAndBroadcast(error): error
-            case let .confirmDetails(error): error
-            }
+        let errorMessage: String = switch alert.item {
+        case let .signAndBroadcast(error):
+            error
+        case let .confirmDetails(error):
+            error
+        }
 
         sendState = .error(errorMessage)
         manager.sendFlowErrorAlert = nil
@@ -175,13 +209,10 @@ struct SendFlowConfirmScreen: View {
                     throw SendConfirmationError.unfinalizedSignedPsbt
                 }
                 try await manager.broadcastTransaction(finalizedTransaction)
-            case .unsigned:
-                try await manager.initiatePayment(
-                    psbt: details.psbt(),
-                    payjoinEndpoint: payjoinEndpoint
-                )
-                // for payjoin, stay in .sending until PayjoinTxBroadcast reconciles
-                if payjoinEndpoint == nil {
+            case let .unsigned(mode):
+                try await manager.initiatePayment(psbt: details.psbt(), mode: mode)
+                // for Payjoin, stay in sending until the terminal status reconciles
+                if payjoinIntent == nil {
                     sendState = .sent
                     presenter.confirmationAlertState = .init(.sent(id))
                     auth.unlock()
@@ -548,8 +579,7 @@ private enum SendConfirmationError: LocalizedError {
                                     id: WalletId(),
                                     manager: manager,
                                     details: confirmDetailsPreviewNew(),
-                                    input: .unsigned,
-                                    payjoinEndpoint: nil
+                                    input: .unsigned(mode: .standard)
                                 )
                                 .environment(AppManager.shared)
                                 .environment(AuthManager.shared)
@@ -577,8 +607,7 @@ private enum SendConfirmationError: LocalizedError {
             id: WalletId(),
             manager: WalletManager(preview: .only),
             details: confirmDetailsPreviewNew(),
-            input: .unsigned,
-            payjoinEndpoint: nil
+            input: .unsigned(mode: .standard)
         )
         .environment(AppManager.shared)
         .environment(AuthManager.shared)

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -139,8 +139,8 @@ struct SendFlowConfirmScreen: View {
 
         case let .failed(sessionId, message):
             guard sessionId == intent.sessionId else { return }
-            sendState = .error(message)
-            presenter.confirmationAlertState = .init(.broadcastError(message))
+            sendState = .payjoinFailed(message)
+            presenter.confirmationAlertState = .init(.payjoinFailed(message))
         }
     }
 

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -84,6 +84,7 @@ struct SendFlowConfirmScreen: View {
                 }
             }
             .onDisappear(perform: handleDisappear)
+            .onAppear(perform: restorePayjoinWaitingState)
             .onChange(of: manager.payjoinDeadlineSecs, payjoinPollingStarted)
             .onChange(of: manager.payjoinTxBroadcast, payjoinBroadcastChanged)
             .onChange(of: manager.sendFlowErrorAlert, sendFlowErrorChanged)
@@ -108,8 +109,18 @@ struct SendFlowConfirmScreen: View {
         if sinceLocked < 5 { auth.lockState = .unlocked }
     }
 
+    private func restorePayjoinWaitingState() {
+        guard
+            let deadline = manager.payjoinDeadlineSecs,
+            case .sending = sendState
+        else { return }
+
+        sendState = .payjoinWaiting(deadlineSecs: deadline)
+    }
+
     private func payjoinPollingStarted(_: UInt64?, _ deadline: UInt64?) {
         guard let deadline, case .sending = sendState else { return }
+
         sendState = .payjoinWaiting(deadlineSecs: deadline)
     }
 
@@ -128,7 +139,7 @@ struct SendFlowConfirmScreen: View {
     private func cancelPayjoin() {
         sendState = .sending
         Task {
-            try? await manager.rust.cancelPayjoin()
+            try? await manager.cancelPayjoin()
         }
     }
 

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -77,7 +77,14 @@ struct SendFlowConfirmScreen: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.coveBg)
+            .overlay(alignment: .bottom) {
+                if case let .payjoinWaiting(deadline) = sendState {
+                    PayjoinWaitingBanner(deadlineSecs: deadline, onCancel: cancelPayjoin)
+                        .padding(.bottom, sendConfirmationFooterHeight + 16)
+                }
+            }
             .onDisappear(perform: handleDisappear)
+            .onChange(of: manager.payjoinDeadlineSecs, payjoinPollingStarted)
             .onChange(of: manager.payjoinTxBroadcast, payjoinBroadcastChanged)
             .onChange(of: manager.sendFlowErrorAlert, sendFlowErrorChanged)
             .presentingAlert(
@@ -101,21 +108,39 @@ struct SendFlowConfirmScreen: View {
         if sinceLocked < 5 { auth.lockState = .unlocked }
     }
 
+    private func payjoinPollingStarted(_: UInt64?, _ deadline: UInt64?) {
+        guard let deadline, case .sending = sendState else { return }
+        sendState = .payjoinWaiting(deadlineSecs: deadline)
+    }
+
     private func payjoinBroadcastChanged(_: UUID?, _ uuid: UUID?) {
-        // UUID changes each time so this fires reliably across multiple sends
-        guard uuid != nil, case .sending = sendState else { return }
+        guard uuid != nil else { return }
+        switch sendState {
+        case .sending, .payjoinWaiting: break
+        default: return
+        }
 
         sendState = .sent
         presenter.confirmationAlertState = .init(.sent(id))
         auth.unlock()
     }
 
+    private func cancelPayjoin() {
+        sendState = .sending
+        Task {
+            try? await manager.rust.cancelPayjoin()
+        }
+    }
+
     private func sendFlowErrorChanged(
         _: TaggedItem<SendFlowErrorAlert>?,
         _ alert: TaggedItem<SendFlowErrorAlert>?
     ) {
-        // payjoin broadcast failure arrives via reconcile, so unblock the sending UI here
-        guard let alert, case .sending = sendState else { return }
+        switch sendState {
+        case .sending, .payjoinWaiting: break
+        default: return
+        }
+        guard let alert else { return }
 
         let errorMessage =
             switch alert.item {
@@ -556,5 +581,38 @@ private enum SendConfirmationError: LocalizedError {
                 manager: WalletManager(preview: .only)
             )
         )
+    }
+}
+
+private struct PayjoinWaitingBanner: View {
+    let deadlineSecs: UInt64
+    let onCancel: () -> Void
+
+    @State private var remainingSecs: Int = 0
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Waiting for receiver")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text("\(remainingSecs / 60):\(String(format: "%02d", remainingSecs % 60)) remaining")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button("Cancel and send normally", action: onCancel)
+                .font(.subheadline)
+        }
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+        .task {
+            while !Task.isCancelled {
+                let now = UInt64(Date().timeIntervalSince1970)
+                remainingSecs = max(0, Int(deadlineSecs) - Int(now))
+                if remainingSecs <= 0 { break }
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
     }
 }

--- a/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowConfirmScreen.swift
@@ -77,7 +77,14 @@ struct SendFlowConfirmScreen: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.coveBg)
+            .overlay(alignment: .bottom) {
+                if case let .payjoinWaiting(deadline) = sendState {
+                    PayjoinWaitingBanner(deadlineSecs: deadline, onCancel: cancelPayjoin)
+                        .padding(.bottom, sendConfirmationFooterHeight + 16)
+                }
+            }
             .onDisappear(perform: handleDisappear)
+            .onChange(of: manager.payjoinDeadlineSecs, payjoinPollingStarted)
             .onChange(of: manager.payjoinTxBroadcast, payjoinBroadcastChanged)
             .onChange(of: manager.sendFlowErrorAlert, sendFlowErrorChanged)
             .presentingAlert(
@@ -101,21 +108,39 @@ struct SendFlowConfirmScreen: View {
         if sinceLocked < 5 { auth.lockState = .unlocked }
     }
 
+    private func payjoinPollingStarted(_: UInt64?, _ deadline: UInt64?) {
+        guard let deadline, case .sending = sendState else { return }
+        sendState = .payjoinWaiting(deadlineSecs: deadline)
+    }
+
     private func payjoinBroadcastChanged(_: UUID?, _ uuid: UUID?) {
-        // UUID changes each time so this fires reliably across multiple sends
-        guard uuid != nil, case .sending = sendState else { return }
+        guard uuid != nil else { return }
+        switch sendState {
+        case .sending, .payjoinWaiting: break
+        default: return
+        }
 
         sendState = .sent
         presenter.confirmationAlertState = .init(.sent(id))
         auth.unlock()
     }
 
+    private func cancelPayjoin() {
+        sendState = .sending
+        Task {
+            try? await manager.rust.cancelPayjoin()
+        }
+    }
+
     private func sendFlowErrorChanged(
         _: TaggedItem<SendFlowErrorAlert>?,
         _ alert: TaggedItem<SendFlowErrorAlert>?
     ) {
-        // payjoin broadcast failure arrives via reconcile, so unblock the sending UI here
-        guard let alert, case .sending = sendState else { return }
+        switch sendState {
+        case .sending, .payjoinWaiting: break
+        default: return
+        }
+        guard let alert else { return }
 
         let errorMessage =
             switch alert.item {
@@ -552,5 +577,38 @@ private enum SendConfirmationError: LocalizedError {
                 manager: WalletManager(preview: .only)
             )
         )
+    }
+}
+
+private struct PayjoinWaitingBanner: View {
+    let deadlineSecs: UInt64
+    let onCancel: () -> Void
+
+    @State private var remainingSecs: Int = 0
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Waiting for receiver")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text("\(remainingSecs / 60):\(String(format: "%02d", remainingSecs % 60)) remaining")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button("Cancel and send normally", action: onCancel)
+                .font(.subheadline)
+        }
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+        .task {
+            while !Task.isCancelled {
+                let now = UInt64(Date().timeIntervalSince1970)
+                remainingSecs = max(0, Int(deadlineSecs) - Int(now))
+                if remainingSecs <= 0 { break }
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
     }
 }

--- a/ios/Cove/Flows/SendFlow/SendFlowContainer.swift
+++ b/ios/Cove/Flows/SendFlow/SendFlowContainer.swift
@@ -204,8 +204,7 @@ private struct SendFlowRouteView: View {
                 id: confirm.id,
                 manager: manager,
                 details: confirm.details,
-                input: confirm.input,
-                payjoinEndpoint: confirm.payjoinEndpoint
+                input: confirm.input
             )
         case let .hardwareExport(id: id, details: details):
             SendFlowHardwareScreen(id: id, manager: manager, details: details)

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -174,6 +174,9 @@ enum WalletManagerPreview {
     /// UUID changes each time so onChange always fires even across multiple sends
     var payjoinTxBroadcast: UUID? = nil
 
+    /// epoch seconds when the payjoin session will expire, set when polling starts
+    var payjoinDeadlineSecs: UInt64? = nil
+
     /// cached transaction detail presentations
     var transactionDetailsPresentations: [TxId: TransactionDetailsPresentation] = [:]
     var transactionLockStates: [TxId: TransactionLockState] = [:]
@@ -700,7 +703,8 @@ enum WalletManagerPreview {
             applyTransactionMessage(message)
         case .walletBalanceChanged, .unsignedTransactionsChanged, .walletMetadataChanged,
              .walletScannerResponse, .nodeConnectionFailed, .walletError, .unknownError,
-             .sendFlowError, .hotWalletKeyMissing, .payjoinTxBroadcast:
+             .sendFlowError, .hotWalletKeyMissing, .payjoinTxBroadcast,
+             .payjoinPollingStarted:
             applyWalletStateMessage(message)
         case .receiveAddressUpdated, .receiveAddressPresentationUpdated,
              .receiveAddressLoadingChanged, .receiveAddressError, .receiveAddressClosed:
@@ -903,6 +907,7 @@ extension WalletManager {
 
         case let .walletError(error):
             logger.error("WalletError \(error)")
+            payjoinDeadlineSecs = nil
 
         case let .unknownError(error):
             // TODO: show to user
@@ -910,12 +915,17 @@ extension WalletManager {
 
         case let .sendFlowError(error):
             sendFlowErrorAlert = TaggedItem(error)
+            payjoinDeadlineSecs = nil
 
         case let .hotWalletKeyMissing(walletId):
             delegate?.showWalletAlert(.hotWalletKeyMissing(walletId: walletId))
 
         case .payjoinTxBroadcast:
             payjoinTxBroadcast = UUID()
+            payjoinDeadlineSecs = nil
+
+        case let .payjoinPollingStarted(deadlineSecs):
+            payjoinDeadlineSecs = deadlineSecs
 
         default:
             preconditionFailure("Expected a wallet state reconcile message")

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -101,6 +101,9 @@ enum WalletManagerPreview {
     /// UUID changes each time so onChange always fires even across multiple sends
     var payjoinTxBroadcast: UUID? = nil
 
+    /// epoch seconds when the payjoin session will expire, set when polling starts
+    var payjoinDeadlineSecs: UInt64? = nil
+
     /// cached transaction detail presentations
     var transactionDetailsPresentations: [TxId: TransactionDetailsPresentation] = [:]
     var transactionLockStates: [TxId: TransactionLockState] = [:]
@@ -454,7 +457,8 @@ enum WalletManagerPreview {
             applyTransactionMessage(message)
         case .walletBalanceChanged, .unsignedTransactionsChanged, .walletMetadataChanged,
              .walletScannerResponse, .nodeConnectionFailed, .walletError, .unknownError,
-             .sendFlowError, .hotWalletKeyMissing, .payjoinTxBroadcast:
+             .sendFlowError, .hotWalletKeyMissing, .payjoinTxBroadcast,
+             .payjoinPollingStarted:
             applyWalletStateMessage(message)
         case .receiveAddressUpdated, .receiveAddressPresentationUpdated,
              .receiveAddressLoadingChanged, .receiveAddressError, .receiveAddressClosed:
@@ -561,6 +565,7 @@ enum WalletManagerPreview {
 
         case let .walletError(error):
             logger.error("WalletError \(error)")
+            payjoinDeadlineSecs = nil
 
         case let .unknownError(error):
             // TODO: show to user
@@ -568,12 +573,17 @@ enum WalletManagerPreview {
 
         case let .sendFlowError(error):
             sendFlowErrorAlert = TaggedItem(error)
+            payjoinDeadlineSecs = nil
 
         case let .hotWalletKeyMissing(walletId):
             delegate?.showWalletAlert(.hotWalletKeyMissing(walletId: walletId))
 
         case .payjoinTxBroadcast:
             payjoinTxBroadcast = UUID()
+            payjoinDeadlineSecs = nil
+
+        case let .payjoinPollingStarted(deadlineSecs):
+            payjoinDeadlineSecs = deadlineSecs
 
         default:
             preconditionFailure("Expected a wallet state reconcile message")

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -483,6 +483,10 @@ enum WalletManagerPreview {
         }
     }
 
+    func cancelPayjoin() async throws {
+        try await withRustAsync { try await $0.cancelPayjoin() }
+    }
+
     func finalizePsbt(_ psbt: Psbt) async throws -> BitcoinTransaction {
         try await withRustAsync { try await $0.finalizePsbt(psbt: psbt) }
     }

--- a/ios/Cove/WalletManager.swift
+++ b/ios/Cove/WalletManager.swift
@@ -170,12 +170,8 @@ enum WalletManagerPreview {
     /// errors in SendFlow
     var sendFlowErrorAlert: TaggedItem<SendFlowErrorAlert>? = nil
 
-    /// non-nil when a payjoin transaction has been broadcast (success or fallback);
-    /// UUID changes each time so onChange always fires even across multiple sends
-    var payjoinTxBroadcast: UUID? = nil
-
-    /// epoch seconds when the payjoin session will expire, set when polling starts
-    var payjoinDeadlineSecs: UInt64? = nil
+    /// latest wallet-owned state for one Payjoin payment
+    var payjoinStatus: PayjoinStatus? = nil
 
     /// cached transaction detail presentations
     var transactionDetailsPresentations: [TxId: TransactionDetailsPresentation] = [:]
@@ -477,14 +473,17 @@ enum WalletManagerPreview {
         try await withRustAsync { try await $0.broadcastTransaction(signedTransaction: transaction) }
     }
 
-    func initiatePayment(psbt: Psbt, payjoinEndpoint: String?) async throws {
+    func initiatePayment(
+        psbt: Psbt,
+        mode: UnsignedPaymentMode
+    ) async throws {
         try await withRustAsync {
-            try await $0.initiatePayment(psbt: psbt, payjoinEndpoint: payjoinEndpoint)
+            try await $0.initiatePayment(psbt: psbt, mode: mode)
         }
     }
 
-    func cancelPayjoin() async throws {
-        try await withRustAsync { try await $0.cancelPayjoin() }
+    func cancelPayjoin(sessionId: PayjoinSessionId) async throws {
+        try await withRustAsync { try await $0.cancelPayjoin(sessionId: sessionId) }
     }
 
     func finalizePsbt(_ psbt: Psbt) async throws -> BitcoinTransaction {
@@ -707,8 +706,7 @@ enum WalletManagerPreview {
             applyTransactionMessage(message)
         case .walletBalanceChanged, .unsignedTransactionsChanged, .walletMetadataChanged,
              .walletScannerResponse, .nodeConnectionFailed, .walletError, .unknownError,
-             .sendFlowError, .hotWalletKeyMissing, .payjoinTxBroadcast,
-             .payjoinPollingStarted:
+             .sendFlowError, .hotWalletKeyMissing, .payjoinStatusChanged:
             applyWalletStateMessage(message)
         case .receiveAddressUpdated, .receiveAddressPresentationUpdated,
              .receiveAddressLoadingChanged, .receiveAddressError, .receiveAddressClosed:
@@ -911,7 +909,6 @@ extension WalletManager {
 
         case let .walletError(error):
             logger.error("WalletError \(error)")
-            payjoinDeadlineSecs = nil
 
         case let .unknownError(error):
             // TODO: show to user
@@ -919,17 +916,12 @@ extension WalletManager {
 
         case let .sendFlowError(error):
             sendFlowErrorAlert = TaggedItem(error)
-            payjoinDeadlineSecs = nil
 
         case let .hotWalletKeyMissing(walletId):
             delegate?.showWalletAlert(.hotWalletKeyMissing(walletId: walletId))
 
-        case .payjoinTxBroadcast:
-            payjoinTxBroadcast = UUID()
-            payjoinDeadlineSecs = nil
-
-        case let .payjoinPollingStarted(deadlineSecs):
-            payjoinDeadlineSecs = deadlineSecs
+        case let .payjoinStatusChanged(status):
+            payjoinStatus = status
 
         default:
             preconditionFailure("Expected a wallet state reconcile message")

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -10140,6 +10140,8 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func broadcastTransaction(signedTransaction: BitcoinTransaction) async throws
 
+    func cancelPayjoin() async throws
+
     func convertFromFiatString(fiatAmount: String, prices: PriceResponse)  -> Amount
 
     func currentBlockHeight() async throws  -> UInt32
@@ -10522,6 +10524,23 @@ open func broadcastTransaction(signedTransaction: BitcoinTransaction)async throw
                 uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(
                     self.uniffiCloneHandle(),
                     FfiConverterTypeBitcoinTransaction_lower(signedTransaction)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_void,
+            completeFunc: ffi_cove_rust_future_complete_void,
+            freeFunc: ffi_cove_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
+}
+
+open func cancelPayjoin()async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(
+                    self.uniffiCloneHandle()
+
                 )
             },
             pollFunc: ffi_cove_rust_future_poll_void,
@@ -39239,6 +39258,8 @@ public enum WalletManagerReconcileMessage {
     case receiveAddressClosed(UInt64
     )
     case payjoinTxBroadcast
+    case payjoinPollingStarted(deadlineSecs: UInt64
+    )
 
 
 
@@ -39323,6 +39344,9 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         )
 
         case 22: return .payjoinTxBroadcast
+
+        case 23: return .payjoinPollingStarted(deadlineSecs: try FfiConverterUInt64.read(from: &buf)
+        )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -39438,6 +39462,11 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
 
         case .payjoinTxBroadcast:
             writeInt(&buf, Int32(22))
+
+
+        case let .payjoinPollingStarted(deadlineSecs):
+            writeInt(&buf, Int32(23))
+            FfiConverterUInt64.write(deadlineSecs, into: &buf)
 
         }
     }
@@ -45359,6 +45388,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3646) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string() != 26279) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -10562,6 +10562,8 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func broadcastTransaction(signedTransaction: BitcoinTransaction) async throws
 
+    func cancelPayjoin() async throws
+
     func convertFromFiatString(fiatAmount: String, prices: PriceResponse)  -> Amount
 
     func currentBlockHeight() async throws  -> UInt32
@@ -10942,6 +10944,23 @@ open func broadcastTransaction(signedTransaction: BitcoinTransaction)async throw
                 uniffi_cove_fn_method_rustwalletmanager_broadcast_transaction(
                     self.uniffiCloneHandle(),
                     FfiConverterTypeBitcoinTransaction_lower(signedTransaction)
+                )
+            },
+            pollFunc: ffi_cove_rust_future_poll_void,
+            completeFunc: ffi_cove_rust_future_complete_void,
+            freeFunc: ffi_cove_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeWalletManagerError_lift
+        )
+}
+
+open func cancelPayjoin()async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(
+                    self.uniffiCloneHandle()
+
                 )
             },
             pollFunc: ffi_cove_rust_future_poll_void,
@@ -41926,6 +41945,8 @@ public enum WalletManagerReconcileMessage {
     case receiveAddressClosed(UInt64
     )
     case payjoinTxBroadcast
+    case payjoinPollingStarted(deadlineSecs: UInt64
+    )
 
 
 
@@ -42010,6 +42031,9 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         )
 
         case 22: return .payjoinTxBroadcast
+
+        case 23: return .payjoinPollingStarted(deadlineSecs: try FfiConverterUInt64.read(from: &buf)
+        )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -42125,6 +42149,11 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
 
         case .payjoinTxBroadcast:
             writeInt(&buf, Int32(22))
+
+
+        case let .payjoinPollingStarted(deadlineSecs):
+            writeInt(&buf, Int32(23))
+            FfiConverterUInt64.write(deadlineSecs, into: &buf)
 
         }
     }
@@ -48231,6 +48260,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3646) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string() != 26279) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove.swift
@@ -7752,7 +7752,7 @@ public protocol RouteFactoryProtocol: AnyObject, Sendable {
 
     func send(send: SendRoute)  -> Route
 
-    func sendConfirm(id: WalletId, details: ConfirmDetails, payjoinEndpoint: String?)  -> Route
+    func sendConfirm(id: WalletId, details: ConfirmDetails, mode: UnsignedPaymentMode)  -> Route
 
     func sendConfirmSignedPsbt(id: WalletId, details: ConfirmDetails, psbt: Psbt)  -> Route
 
@@ -8004,14 +8004,14 @@ open func send(send: SendRoute) -> Route  {
 })
 }
 
-open func sendConfirm(id: WalletId, details: ConfirmDetails, payjoinEndpoint: String?) -> Route  {
+open func sendConfirm(id: WalletId, details: ConfirmDetails, mode: UnsignedPaymentMode) -> Route  {
     return try!  FfiConverterTypeRoute_lift(try! rustCall() {
         uniffiCallStatus in
     uniffi_cove_fn_method_routefactory_send_confirm(
             self.uniffiCloneHandle(),
         FfiConverterTypeWalletId_lower(id),
         FfiConverterTypeConfirmDetails_lower(details),
-        FfiConverterOptionString.lower(payjoinEndpoint),uniffiCallStatus
+        FfiConverterTypeUnsignedPaymentMode_lower(mode),uniffiCallStatus
     )
 })
 }
@@ -10562,7 +10562,7 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
 
     func broadcastTransaction(signedTransaction: BitcoinTransaction) async throws
 
-    func cancelPayjoin() async throws
+    func cancelPayjoin(sessionId: PayjoinSessionId) async throws
 
     func convertFromFiatString(fiatAmount: String, prices: PriceResponse)  -> Amount
 
@@ -10629,7 +10629,7 @@ public protocol RustWalletManagerProtocol: AnyObject, Sendable {
     /**
      * Send entry point for unsigned hot wallet PSBTs
      */
-    func initiatePayment(psbt: Psbt, payjoinEndpoint: String?) async throws
+    func initiatePayment(psbt: Psbt, mode: UnsignedPaymentMode) async throws
 
     func labelManager()  -> LabelManager
 
@@ -10954,13 +10954,13 @@ open func broadcastTransaction(signedTransaction: BitcoinTransaction)async throw
         )
 }
 
-open func cancelPayjoin()async throws   {
+open func cancelPayjoin(sessionId: PayjoinSessionId)async throws   {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_cove_fn_method_rustwalletmanager_cancel_payjoin(
-                    self.uniffiCloneHandle()
-
+                    self.uniffiCloneHandle(),
+                    FfiConverterTypePayjoinSessionId_lower(sessionId)
                 )
             },
             pollFunc: ffi_cove_rust_future_poll_void,
@@ -11243,13 +11243,13 @@ open func initialState() -> WalletInitialState  {
     /**
      * Send entry point for unsigned hot wallet PSBTs
      */
-open func initiatePayment(psbt: Psbt, payjoinEndpoint: String?)async throws   {
+open func initiatePayment(psbt: Psbt, mode: UnsignedPaymentMode)async throws   {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_cove_fn_method_rustwalletmanager_initiate_payment(
                     self.uniffiCloneHandle(),
-                    FfiConverterTypePsbt_lower(psbt),FfiConverterOptionString.lower(payjoinEndpoint)
+                    FfiConverterTypePsbt_lower(psbt),FfiConverterTypeUnsignedPaymentMode_lower(mode)
                 )
             },
             pollFunc: ffi_cove_rust_future_poll_void,
@@ -19090,15 +19090,13 @@ public struct SendRouteConfirmArgs {
     public var id: WalletId
     public var details: ConfirmDetails
     public var input: SendConfirmationInput
-    public var payjoinEndpoint: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: WalletId, details: ConfirmDetails, input: SendConfirmationInput, payjoinEndpoint: String?) {
+    public init(id: WalletId, details: ConfirmDetails, input: SendConfirmationInput) {
         self.id = id
         self.details = details
         self.input = input
-        self.payjoinEndpoint = payjoinEndpoint
     }
 
 
@@ -19119,8 +19117,7 @@ public struct FfiConverterTypeSendRouteConfirmArgs: FfiConverterRustBuffer {
             try SendRouteConfirmArgs(
                 id: FfiConverterTypeWalletId.read(from: &buf),
                 details: FfiConverterTypeConfirmDetails.read(from: &buf),
-                input: FfiConverterTypeSendConfirmationInput.read(from: &buf),
-                payjoinEndpoint: FfiConverterOptionString.read(from: &buf)
+                input: FfiConverterTypeSendConfirmationInput.read(from: &buf)
         )
     }
 
@@ -19128,7 +19125,6 @@ public struct FfiConverterTypeSendRouteConfirmArgs: FfiConverterRustBuffer {
         FfiConverterTypeWalletId.write(value.id, into: &buf)
         FfiConverterTypeConfirmDetails.write(value.details, into: &buf)
         FfiConverterTypeSendConfirmationInput.write(value.input, into: &buf)
-        FfiConverterOptionString.write(value.payjoinEndpoint, into: &buf)
     }
 }
 
@@ -34195,6 +34191,173 @@ public func FfiConverterTypeOtherBackupsOperation_lower(_ value: OtherBackupsOpe
 
 
 
+/**
+ * The terminal transaction selected for a Payjoin payment
+ */
+
+public enum PayjoinBroadcastOutcome: Equatable, Hashable {
+
+    case proposal
+    case fallback
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension PayjoinBroadcastOutcome: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayjoinBroadcastOutcome: FfiConverterRustBuffer {
+    typealias SwiftType = PayjoinBroadcastOutcome
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayjoinBroadcastOutcome {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .proposal
+
+        case 2: return .fallback
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: PayjoinBroadcastOutcome, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .proposal:
+            writeInt(&buf, Int32(1))
+
+
+        case .fallback:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinBroadcastOutcome_lift(_ buf: RustBuffer) throws -> PayjoinBroadcastOutcome {
+    return try FfiConverterTypePayjoinBroadcastOutcome.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinBroadcastOutcome_lower(_ value: PayjoinBroadcastOutcome) -> RustBuffer {
+    return FfiConverterTypePayjoinBroadcastOutcome.lower(value)
+}
+
+
+
+/**
+ * The latest wallet-owned state for one Payjoin payment
+ */
+
+public enum PayjoinStatus: Equatable, Hashable {
+
+    case negotiating(sessionId: PayjoinSessionId
+    )
+    case polling(sessionId: PayjoinSessionId, deadlineSecs: UInt64
+    )
+    case broadcast(sessionId: PayjoinSessionId, outcome: PayjoinBroadcastOutcome
+    )
+    case failed(sessionId: PayjoinSessionId, message: String
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension PayjoinStatus: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayjoinStatus: FfiConverterRustBuffer {
+    typealias SwiftType = PayjoinStatus
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayjoinStatus {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .negotiating(sessionId: try FfiConverterTypePayjoinSessionId.read(from: &buf)
+        )
+
+        case 2: return .polling(sessionId: try FfiConverterTypePayjoinSessionId.read(from: &buf), deadlineSecs: try FfiConverterUInt64.read(from: &buf)
+        )
+
+        case 3: return .broadcast(sessionId: try FfiConverterTypePayjoinSessionId.read(from: &buf), outcome: try FfiConverterTypePayjoinBroadcastOutcome.read(from: &buf)
+        )
+
+        case 4: return .failed(sessionId: try FfiConverterTypePayjoinSessionId.read(from: &buf), message: try FfiConverterString.read(from: &buf)
+        )
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: PayjoinStatus, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case let .negotiating(sessionId):
+            writeInt(&buf, Int32(1))
+            FfiConverterTypePayjoinSessionId.write(sessionId, into: &buf)
+
+
+        case let .polling(sessionId,deadlineSecs):
+            writeInt(&buf, Int32(2))
+            FfiConverterTypePayjoinSessionId.write(sessionId, into: &buf)
+            FfiConverterUInt64.write(deadlineSecs, into: &buf)
+
+
+        case let .broadcast(sessionId,outcome):
+            writeInt(&buf, Int32(3))
+            FfiConverterTypePayjoinSessionId.write(sessionId, into: &buf)
+            FfiConverterTypePayjoinBroadcastOutcome.write(outcome, into: &buf)
+
+
+        case let .failed(sessionId,message):
+            writeInt(&buf, Int32(4))
+            FfiConverterTypePayjoinSessionId.write(sessionId, into: &buf)
+            FfiConverterString.write(message, into: &buf)
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinStatus_lift(_ buf: RustBuffer) throws -> PayjoinStatus {
+    return try FfiConverterTypePayjoinStatus.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinStatus_lower(_ value: PayjoinStatus) -> RustBuffer {
+    return FfiConverterTypePayjoinStatus.lower(value)
+}
+
+
+
 
 public enum PendingOrConfirmed: Equatable, Hashable {
 
@@ -35884,7 +36047,8 @@ public func FfiConverterTypeSeedQrError_lower(_ value: SeedQrError) -> RustBuffe
 
 public enum SendConfirmationInput {
 
-    case unsigned
+    case unsigned(mode: UnsignedPaymentMode
+    )
     case signedTransaction(BitcoinTransaction
     )
     case signedPsbt(Psbt
@@ -35910,7 +36074,8 @@ public struct FfiConverterTypeSendConfirmationInput: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
 
-        case 1: return .unsigned
+        case 1: return .unsigned(mode: try FfiConverterTypeUnsignedPaymentMode.read(from: &buf)
+        )
 
         case 2: return .signedTransaction(try FfiConverterTypeBitcoinTransaction.read(from: &buf)
         )
@@ -35926,8 +36091,9 @@ public struct FfiConverterTypeSendConfirmationInput: FfiConverterRustBuffer {
         switch value {
 
 
-        case .unsigned:
+        case let .unsigned(mode):
             writeInt(&buf, Int32(1))
+            FfiConverterTypeUnsignedPaymentMode.write(mode, into: &buf)
 
 
         case let .signedTransaction(v1):
@@ -39541,6 +39707,78 @@ public func FfiConverterTypeTrickPinError_lower(_ value: TrickPinError) -> RustB
 }
 
 
+/**
+ * The protocol used to send an unsigned hot-wallet payment
+ */
+
+public enum UnsignedPaymentMode: Equatable, Hashable {
+
+    case standard
+    case payjoin(intent: PayjoinIntent
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension UnsignedPaymentMode: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeUnsignedPaymentMode: FfiConverterRustBuffer {
+    typealias SwiftType = UnsignedPaymentMode
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UnsignedPaymentMode {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .standard
+
+        case 2: return .payjoin(intent: try FfiConverterTypePayjoinIntent.read(from: &buf)
+        )
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: UnsignedPaymentMode, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .standard:
+            writeInt(&buf, Int32(1))
+
+
+        case let .payjoin(intent):
+            writeInt(&buf, Int32(2))
+            FfiConverterTypePayjoinIntent.write(intent, into: &buf)
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeUnsignedPaymentMode_lift(_ buf: RustBuffer) throws -> UnsignedPaymentMode {
+    return try FfiConverterTypeUnsignedPaymentMode.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeUnsignedPaymentMode_lower(_ value: UnsignedPaymentMode) -> RustBuffer {
+    return FfiConverterTypeUnsignedPaymentMode.lower(value)
+}
+
+
+
 public
 enum UnsignedTransactionsTableError: Swift.Error, Equatable, Hashable, Foundation.LocalizedError {
 
@@ -41494,6 +41732,10 @@ enum WalletManagerError: Swift.Error, Equatable, Hashable, Foundation.LocalizedE
     )
     case PayjoinSessionError(String
     )
+    case PayjoinCancellationFailed(String
+    )
+    case PayjoinSessionMismatch(requested: PayjoinSessionId, active: PayjoinSessionId
+    )
     case Converter(ConverterError
     )
     case UnknownError(String
@@ -41630,42 +41872,49 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
         case 28: return .PayjoinSessionError(
             try FfiConverterString.read(from: &buf)
             )
-        case 29: return .Converter(
+        case 29: return .PayjoinCancellationFailed(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 30: return .PayjoinSessionMismatch(
+            requested: try FfiConverterTypePayjoinSessionId.read(from: &buf),
+            active: try FfiConverterTypePayjoinSessionId.read(from: &buf)
+            )
+        case 31: return .Converter(
             try FfiConverterTypeConverterError.read(from: &buf)
             )
-        case 30: return .UnknownError(
+        case 32: return .UnknownError(
             try FfiConverterString.read(from: &buf)
             )
-        case 31: return .PsbtFinalizeError(
+        case 33: return .PsbtFinalizeError(
             try FfiConverterString.read(from: &buf)
             )
-        case 32: return .GetHistoricalPricesError(
+        case 34: return .GetHistoricalPricesError(
             try FfiConverterString.read(from: &buf)
             )
-        case 33: return .CsvCreationError(
+        case 35: return .CsvCreationError(
             try FfiConverterString.read(from: &buf)
             )
-        case 34: return .AddUtxosError(
+        case 36: return .AddUtxosError(
             try FfiConverterString.read(from: &buf)
             )
-        case 35: return .OutputLabelsError(
+        case 37: return .OutputLabelsError(
             try FfiConverterString.read(from: &buf)
             )
-        case 36: return .DatabaseCorruption(
+        case 38: return .DatabaseCorruption(
             id: try FfiConverterTypeWalletId.read(from: &buf),
             error: try FfiConverterString.read(from: &buf)
             )
-        case 37: return .PendingUnsignedTransactionsLoadError(
+        case 39: return .PendingUnsignedTransactionsLoadError(
             try FfiConverterString.read(from: &buf)
             )
-        case 38: return .ReceiveAddressError(
+        case 40: return .ReceiveAddressError(
             try FfiConverterString.read(from: &buf)
             )
-        case 39: return .ManagerClosed
-        case 40: return .WalletLifecycle(
+        case 41: return .ManagerClosed
+        case 42: return .WalletLifecycle(
             try FfiConverterTypeWalletLifecycleFailure.read(from: &buf)
             )
-        case 41: return .AddressTypeSwitchCommittedWithRecoveryPending(
+        case 43: return .AddressTypeSwitchCommittedWithRecoveryPending(
             addressType: try FfiConverterTypeWalletAddressType.read(from: &buf),
             failures: try FfiConverterSequenceTypeAddressTypeSwitchRecoveryFailure.read(from: &buf)
             )
@@ -41815,68 +42064,79 @@ public struct FfiConverterTypeWalletManagerError: FfiConverterRustBuffer {
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .Converter(v1):
+        case let .PayjoinCancellationFailed(v1):
             writeInt(&buf, Int32(29))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .PayjoinSessionMismatch(requested,active):
+            writeInt(&buf, Int32(30))
+            FfiConverterTypePayjoinSessionId.write(requested, into: &buf)
+            FfiConverterTypePayjoinSessionId.write(active, into: &buf)
+
+
+        case let .Converter(v1):
+            writeInt(&buf, Int32(31))
             FfiConverterTypeConverterError.write(v1, into: &buf)
 
 
         case let .UnknownError(v1):
-            writeInt(&buf, Int32(30))
-            FfiConverterString.write(v1, into: &buf)
-
-
-        case let .PsbtFinalizeError(v1):
-            writeInt(&buf, Int32(31))
-            FfiConverterString.write(v1, into: &buf)
-
-
-        case let .GetHistoricalPricesError(v1):
             writeInt(&buf, Int32(32))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .CsvCreationError(v1):
+        case let .PsbtFinalizeError(v1):
             writeInt(&buf, Int32(33))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .AddUtxosError(v1):
+        case let .GetHistoricalPricesError(v1):
             writeInt(&buf, Int32(34))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .OutputLabelsError(v1):
+        case let .CsvCreationError(v1):
             writeInt(&buf, Int32(35))
             FfiConverterString.write(v1, into: &buf)
 
 
-        case let .DatabaseCorruption(id,error):
+        case let .AddUtxosError(v1):
             writeInt(&buf, Int32(36))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .OutputLabelsError(v1):
+            writeInt(&buf, Int32(37))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .DatabaseCorruption(id,error):
+            writeInt(&buf, Int32(38))
             FfiConverterTypeWalletId.write(id, into: &buf)
             FfiConverterString.write(error, into: &buf)
 
 
         case let .PendingUnsignedTransactionsLoadError(v1):
-            writeInt(&buf, Int32(37))
+            writeInt(&buf, Int32(39))
             FfiConverterString.write(v1, into: &buf)
 
 
         case let .ReceiveAddressError(v1):
-            writeInt(&buf, Int32(38))
+            writeInt(&buf, Int32(40))
             FfiConverterString.write(v1, into: &buf)
 
 
         case .ManagerClosed:
-            writeInt(&buf, Int32(39))
+            writeInt(&buf, Int32(41))
 
 
         case let .WalletLifecycle(v1):
-            writeInt(&buf, Int32(40))
+            writeInt(&buf, Int32(42))
             FfiConverterTypeWalletLifecycleFailure.write(v1, into: &buf)
 
 
         case let .AddressTypeSwitchCommittedWithRecoveryPending(addressType,failures):
-            writeInt(&buf, Int32(41))
+            writeInt(&buf, Int32(43))
             FfiConverterTypeWalletAddressType.write(addressType, into: &buf)
             FfiConverterSequenceTypeAddressTypeSwitchRecoveryFailure.write(failures, into: &buf)
 
@@ -41944,8 +42204,7 @@ public enum WalletManagerReconcileMessage {
     )
     case receiveAddressClosed(UInt64
     )
-    case payjoinTxBroadcast
-    case payjoinPollingStarted(deadlineSecs: UInt64
+    case payjoinStatusChanged(PayjoinStatus
     )
 
 
@@ -42030,9 +42289,7 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
         case 21: return .receiveAddressClosed(try FfiConverterUInt64.read(from: &buf)
         )
 
-        case 22: return .payjoinTxBroadcast
-
-        case 23: return .payjoinPollingStarted(deadlineSecs: try FfiConverterUInt64.read(from: &buf)
+        case 22: return .payjoinStatusChanged(try FfiConverterTypePayjoinStatus.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -42147,13 +42404,9 @@ public struct FfiConverterTypeWalletManagerReconcileMessage: FfiConverterRustBuf
             FfiConverterUInt64.write(v1, into: &buf)
 
 
-        case .payjoinTxBroadcast:
+        case let .payjoinStatusChanged(v1):
             writeInt(&buf, Int32(22))
-
-
-        case let .payjoinPollingStarted(deadlineSecs):
-            writeInt(&buf, Int32(23))
-            FfiConverterUInt64.write(deadlineSecs, into: &buf)
+            FfiConverterTypePayjoinStatus.write(v1, into: &buf)
 
         }
     }
@@ -48262,7 +48515,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_broadcast_transaction() != 50937) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3646) {
+    if (uniffi_cove_checksum_method_rustwalletmanager_cancel_payjoin() != 3414) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_convert_from_fiat_string() != 26279) {
@@ -48322,7 +48575,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_rustwalletmanager_initial_state() != 46436) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_rustwalletmanager_initiate_payment() != 13212) {
+    if (uniffi_cove_checksum_method_rustwalletmanager_initiate_payment() != 23416) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_rustwalletmanager_label_manager() != 23571) {
@@ -48544,7 +48797,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_cove_checksum_method_routefactory_send() != 19857) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_cove_checksum_method_routefactory_send_confirm() != 6786) {
+    if (uniffi_cove_checksum_method_routefactory_send_confirm() != 4948) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_cove_checksum_method_routefactory_send_confirm_signed_psbt() != 63483) {

--- a/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
+++ b/ios/CoveCore/Sources/CoveCore/generated/cove_types.swift
@@ -3280,6 +3280,118 @@ public func FfiConverterTypeOutPoint_lower(_ value: OutPoint) -> UInt64 {
 
 
 
+/**
+ * A BIP-77 v2 endpoint that passed Payjoin URI validation
+ */
+public protocol PayjoinEndpointProtocol: AnyObject, Sendable {
+
+}
+/**
+ * A BIP-77 v2 endpoint that passed Payjoin URI validation
+ */
+open class PayjoinEndpoint: PayjoinEndpointProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_cove_types_fn_clone_payjoinendpoint(self.handle, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_cove_types_fn_free_payjoinendpoint(handle, $0) }
+    }
+
+
+
+
+
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayjoinEndpoint: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = PayjoinEndpoint
+
+    public static func lift(_ handle: UInt64) throws -> PayjoinEndpoint {
+        return PayjoinEndpoint(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: PayjoinEndpoint) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayjoinEndpoint {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: PayjoinEndpoint, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinEndpoint_lift(_ handle: UInt64) throws -> PayjoinEndpoint {
+    return try FfiConverterTypePayjoinEndpoint.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinEndpoint_lower(_ value: PayjoinEndpoint) -> UInt64 {
+    return FfiConverterTypePayjoinEndpoint.lower(value)
+}
+
+
+
+
+
+
 public protocol PsbtProtocol: AnyObject, Sendable {
 
     /**
@@ -4553,12 +4665,12 @@ public func FfiConverterTypeBlockSizeLast_lower(_ value: BlockSizeLast) -> RustB
 }
 
 
-public struct PayJoinParams: Equatable, Hashable {
-    public var endpoint: String
+public struct PayJoinParams {
+    public var endpoint: PayjoinEndpoint
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(endpoint: String) {
+    public init(endpoint: PayjoinEndpoint) {
         self.endpoint = endpoint
     }
 
@@ -4578,12 +4690,12 @@ public struct FfiConverterTypePayJoinParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayJoinParams {
         return
             try PayJoinParams(
-                endpoint: FfiConverterString.read(from: &buf)
+                endpoint: FfiConverterTypePayjoinEndpoint.read(from: &buf)
         )
     }
 
     public static func write(_ value: PayJoinParams, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.endpoint, into: &buf)
+        FfiConverterTypePayjoinEndpoint.write(value.endpoint, into: &buf)
     }
 }
 
@@ -4600,6 +4712,99 @@ public func FfiConverterTypePayJoinParams_lift(_ buf: RustBuffer) throws -> PayJ
 #endif
 public func FfiConverterTypePayJoinParams_lower(_ value: PayJoinParams) -> RustBuffer {
     return FfiConverterTypePayJoinParams.lower(value)
+}
+
+
+/**
+ * The immutable data that identifies and starts one Payjoin payment
+ */
+public struct PayjoinIntent: Equatable, Hashable {
+    /**
+     * The stable identity of this payment attempt
+     */
+    public var sessionId: PayjoinSessionId
+    /**
+     * The validated receiver endpoint
+     */
+    public var endpoint: PayjoinEndpoint
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * The stable identity of this payment attempt
+         */sessionId: PayjoinSessionId,
+        /**
+         * The validated receiver endpoint
+         */endpoint: PayjoinEndpoint) {
+        self.sessionId = sessionId
+        self.endpoint = endpoint
+    }
+
+
+
+
+// The local Rust `Eq` implementation - only `eq` is used.
+public static func == (self: PayjoinIntent, other: PayjoinIntent) -> Bool {
+    return try!  FfiConverterBool.lift(
+        try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_eq_eq(
+            FfiConverterTypePayjoinIntent_lower(self),
+        FfiConverterTypePayjoinIntent_lower(other),uniffiCallStatus
+    )
+}
+    )
+}
+// The local Rust `Hash` implementation
+public func hash(into hasher: inout Hasher) {
+    let val = try!  FfiConverterUInt64.lift(
+        try! rustCall() {
+        uniffiCallStatus in
+    uniffi_cove_types_fn_method_payjoinintent_uniffi_trait_hash(
+            FfiConverterTypePayjoinIntent_lower(self),uniffiCallStatus
+    )
+}
+    )
+    hasher.combine(val)
+}
+}
+
+#if compiler(>=6)
+extension PayjoinIntent: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayjoinIntent: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayjoinIntent {
+        return
+            try PayjoinIntent(
+                sessionId: FfiConverterTypePayjoinSessionId.read(from: &buf),
+                endpoint: FfiConverterTypePayjoinEndpoint.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PayjoinIntent, into buf: inout [UInt8]) {
+        FfiConverterTypePayjoinSessionId.write(value.sessionId, into: &buf)
+        FfiConverterTypePayjoinEndpoint.write(value.endpoint, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinIntent_lift(_ buf: RustBuffer) throws -> PayjoinIntent {
+    return try FfiConverterTypePayjoinIntent.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinIntent_lower(_ value: PayjoinIntent) -> RustBuffer {
+    return FfiConverterTypePayjoinIntent.lower(value)
 }
 
 
@@ -6259,6 +6464,46 @@ public func FfiConverterTypeFfiOpacity_lift(_ value: UInt8) throws -> FfiOpacity
 #endif
 public func FfiConverterTypeFfiOpacity_lower(_ value: FfiOpacity) -> UInt8 {
     return FfiConverterTypeFfiOpacity.lower(value)
+}
+
+
+
+public typealias PayjoinSessionId = String
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayjoinSessionId: FfiConverter {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayjoinSessionId {
+        return try FfiConverterString.read(from: &buf)
+    }
+
+    public static func write(_ value: PayjoinSessionId, into buf: inout [UInt8]) {
+        return FfiConverterString.write(value, into: &buf)
+    }
+
+    public static func lift(_ value: RustBuffer) throws -> PayjoinSessionId {
+        return try FfiConverterString.lift(value)
+    }
+
+    public static func lower(_ value: PayjoinSessionId) -> RustBuffer {
+        return FfiConverterString.lower(value)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinSessionId_lift(_ value: RustBuffer) throws -> PayjoinSessionId {
+    return try FfiConverterTypePayjoinSessionId.lift(value)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayjoinSessionId_lower(_ value: PayjoinSessionId) -> RustBuffer {
+    return FfiConverterTypePayjoinSessionId.lower(value)
 }
 
 

--- a/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
+++ b/ios/CoveTests/HotWalletCreateScreenLayoutTests.swift
@@ -283,8 +283,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
                     id: WalletId(),
                     manager: manager,
                     details: confirmDetailsPreviewNew(),
-                    input: .unsigned,
-                    payjoinEndpoint: nil
+                    input: .unsigned(mode: .standard)
                 )
                 .environment(AppManager.shared)
                 .environment(AuthManager.shared)
@@ -317,8 +316,7 @@ final class HotWalletCreateScreenLayoutTests: XCTestCase {
                     id: WalletId(),
                     manager: manager,
                     details: confirmDetailsPreviewNew(),
-                    input: .unsigned,
-                    payjoinEndpoint: nil
+                    input: .unsigned(mode: .standard)
                 )
                 .environment(AppManager.shared)
                 .environment(AuthManager.shared)

--- a/rust/crates/cove-types/src/address.rs
+++ b/rust/crates/cove-types/src/address.rs
@@ -18,7 +18,7 @@ use payjoin::UriExt as _;
 use serde::Deserialize;
 use strum::IntoEnumIterator as _;
 
-use crate::{Network, amount::Amount, transaction::TransactionDirection};
+use crate::{Network, PayjoinEndpoint, amount::Amount, transaction::TransactionDirection};
 
 #[derive(
     Debug,
@@ -57,7 +57,7 @@ pub struct AddressInfoWithDerivation {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Record)]
 pub struct PayJoinParams {
-    pub endpoint: String,
+    pub endpoint: Arc<PayjoinEndpoint>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Object)]
@@ -233,7 +233,7 @@ fn parse_bitcoin_uri(input: &str) -> Result<ParsedBitcoinUri, Error> {
         // Extract payjoin params if present
         let payjoin = match checked.check_pj_supported() {
             Ok(pj_uri) => {
-                let endpoint = pj_uri.extras.endpoint();
+                let endpoint = PayjoinEndpoint::from_validated(pj_uri.extras.endpoint());
                 Some(PayJoinParams { endpoint })
             }
             Err(_) => None,
@@ -654,7 +654,7 @@ mod tests {
         assert_eq!(parsed.address, "bc1q00000002ltfnxz6lt9g655akfz0lm6k9wva2rm");
         assert_eq!(parsed.amount, Some(Amount::from_btc(0.001).unwrap()));
         let pj = parsed.payjoin.as_ref().unwrap();
-        assert!(pj.endpoint.to_lowercase().contains("payjo.in"));
+        assert!(pj.endpoint.as_str().to_lowercase().contains("payjo.in"));
     }
 
     #[test]
@@ -694,7 +694,7 @@ mod tests {
         let address_with_network = AddressWithNetwork::try_new(&a).unwrap();
 
         let pj = address_with_network.payjoin.as_ref().unwrap();
-        assert!(pj.endpoint.to_lowercase().contains("payjo.in"));
+        assert!(pj.endpoint.as_str().to_lowercase().contains("payjo.in"));
         assert_eq!(address_with_network.amount, Some(Amount::from_btc(0.001).unwrap()));
     }
 

--- a/rust/crates/cove-types/src/lib.rs
+++ b/rust/crates/cove-types/src/lib.rs
@@ -3,6 +3,7 @@ uniffi::setup_scaffolding!();
 mod address_index;
 mod block_size;
 mod chain_position;
+mod payjoin;
 mod wallet_id;
 
 pub mod address;
@@ -25,6 +26,7 @@ pub use confirm::{ConfirmDetails, ConfirmDetailsError, InputOutputDetails, Split
 
 pub use chain_position::ChainPosition;
 pub use network::Network;
+pub use payjoin::{PayjoinEndpoint, PayjoinIntent, PayjoinSessionId};
 pub use wallet_id::WalletId;
 
 pub use transaction::out_point::OutPoint;

--- a/rust/crates/cove-types/src/payjoin.rs
+++ b/rust/crates/cove-types/src/payjoin.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use cove_macros::new_type;
+use nid::Nanoid;
+
+new_type!(PayjoinSessionId, String);
+
+impl PayjoinSessionId {
+    /// Creates a new stable identity for one Payjoin payment attempt
+    #[must_use]
+    pub fn generate() -> Self {
+        let nanoid: Nanoid = Nanoid::new();
+        Self(nanoid.to_string())
+    }
+}
+
+/// A BIP-77 v2 endpoint that passed Payjoin URI validation
+#[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Object)]
+pub struct PayjoinEndpoint(String);
+
+impl PayjoinEndpoint {
+    /// Creates an endpoint from a value that already passed Payjoin URI validation
+    #[must_use]
+    pub(crate) fn from_validated(endpoint: String) -> Arc<Self> {
+        Arc::new(Self(endpoint))
+    }
+
+    /// Returns the validated endpoint string
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The immutable data that identifies and starts one Payjoin payment
+#[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Record)]
+#[uniffi::export(Eq, Hash)]
+pub struct PayjoinIntent {
+    /// The stable identity of this payment attempt
+    pub session_id: PayjoinSessionId,
+    /// The validated receiver endpoint
+    pub endpoint: Arc<PayjoinEndpoint>,
+}
+
+impl PayjoinIntent {
+    /// Creates a fresh payment intent for a validated Payjoin endpoint
+    #[must_use]
+    pub fn new(endpoint: Arc<PayjoinEndpoint>) -> Self {
+        Self { session_id: PayjoinSessionId::generate(), endpoint }
+    }
+}

--- a/rust/src/database/wallet_data.rs
+++ b/rust/src/database/wallet_data.rs
@@ -17,7 +17,7 @@ use crate::{
     wallet::{WalletAddressType, metadata::WalletId},
 };
 use cove_common::consts::{WALLET_DATA_DIR, wallet_data_dir_path};
-use cove_types::redb::Json;
+use cove_types::{PayjoinSessionId, redb::Json};
 
 use ahash::AHashMap as HashMap;
 
@@ -116,11 +116,10 @@ pub enum PendingAction {
 /// Event log for an in-flight payjoin sender session, allowing it to survive app restarts
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PayjoinSenderSession {
+    pub session_id: PayjoinSessionId,
+    pub created_at_secs: u64,
     pub events: Vec<String>,
     pub fallback_tx: TransactionBytes,
-    #[serde(default)]
-    pub created_at_secs: Option<u64>,
-    #[serde(default)]
     pub pending_action: Option<PendingAction>,
 }
 
@@ -920,9 +919,10 @@ mod tests {
         let wallet_id = WalletId::preview_new_random();
         let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec![r#"{"PostedOriginalPsbt":[]}"#.to_string()],
             fallback_tx: vec![0x02, 0x00, 0x00, 0x00].into(),
-            created_at_secs: None,
             pending_action: None,
         };
 
@@ -932,13 +932,29 @@ mod tests {
     }
 
     #[test]
+    fn payjoin_sender_session_requires_an_identity() {
+        let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
+            events: Vec::new(),
+            fallback_tx: Vec::new().into(),
+            pending_action: None,
+        };
+        let mut value = serde_json::to_value(session).unwrap();
+        value.as_object_mut().unwrap().remove("session_id");
+
+        assert!(serde_json::from_value::<PayjoinSenderSession>(value).is_err());
+    }
+
+    #[test]
     fn delete_payjoin_sender_session_clears_session() {
         let wallet_id = WalletId::preview_new_random();
         let (db, _tmp) = test_support::new_test_wallet_data_db(wallet_id);
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec![r#"{"Closed":"Failure"}"#.to_string()],
             fallback_tx: vec![0x02, 0x00, 0x00, 0x00].into(),
-            created_at_secs: None,
             pending_action: None,
         };
 

--- a/rust/src/manager/send_flow_manager/finalize.rs
+++ b/rust/src/manager/send_flow_manager/finalize.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use crate::{
     app::AppAction,
     manager::deferred_dispatch::DeferredDispatch,
-    router::RouteFactory,
+    router::{RouteFactory, UnsignedPaymentMode},
     wallet::{Address, metadata::WalletType},
 };
-use cove_types::{amount::Amount, fees::FeeRateOptionWithTotalFee};
+use cove_types::{PayjoinIntent, amount::Amount, fees::FeeRateOptionWithTotalFee};
 
 use super::{EnterMode, Message, RustSendFlowManager, SendFlowAlertState, SendFlowError};
 
@@ -141,9 +141,9 @@ impl RustSendFlowManager {
 
         self.reconciler.send(Message::UpdateFocusField(None));
 
-        let (wallet_type, wallet_id) = {
+        let (wallet_type, wallet_id, payjoin_endpoint) = {
             let state = self.state.lock();
-            (state.metadata.wallet_type, state.metadata.id.clone())
+            (state.metadata.wallet_type, state.metadata.id.clone(), state.payjoin_endpoint.clone())
         };
 
         let me = self.clone();
@@ -190,7 +190,14 @@ impl RustSendFlowManager {
 
             // update the route send the frontend to the proper next screen
             let next_route = match wallet_type {
-                WalletType::Hot => RouteFactory::new().send_confirm(wallet_id, details, None),
+                WalletType::Hot => {
+                    let payment_mode =
+                        payjoin_endpoint.map_or(UnsignedPaymentMode::Standard, |endpoint| {
+                            UnsignedPaymentMode::Payjoin { intent: PayjoinIntent::new(endpoint) }
+                        });
+
+                    RouteFactory::new().send_confirm(wallet_id, details, payment_mode)
+                }
                 WalletType::Cold | WalletType::XpubOnly => {
                     RouteFactory::new().send_hardware_export(wallet_id, details)
                 }

--- a/rust/src/manager/send_flow_manager/state.rs
+++ b/rust/src/manager/send_flow_manager/state.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, MutexGuard};
 
 use cove_types::{
+    PayjoinEndpoint,
     amount::Amount,
     fees::{FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee},
     utxo::UtxoList,
@@ -51,7 +52,7 @@ pub struct SendFlowManagerState {
 
     pub fee_selection: Option<FeeSelection>,
 
-    pub payjoin_endpoint: Option<String>,
+    pub payjoin_endpoint: Option<Arc<PayjoinEndpoint>>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Record)]

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -37,7 +37,7 @@ use crate::{
     keychain::{Keychain, KeychainError},
     label_manager::LabelManager,
     psbt::Psbt,
-    router::Route,
+    router::{Route, UnsignedPaymentMode},
     transaction::{
         Amount, Transaction, TransactionDetailsPresentation, TxId, Unit, ffi::BitcoinTransaction,
         unsigned_transaction::UnsignedTransaction,
@@ -55,7 +55,7 @@ use crate::{
 };
 
 use cove_types::confirm::{ConfirmDetails, SplitOutput};
-use cove_types::{confirm::AddressAndAmount, fees::FeeRateOptions};
+use cove_types::{PayjoinSessionId, confirm::AddressAndAmount, fees::FeeRateOptions};
 
 use super::{
     coin_control_manager::RustCoinControlManager,
@@ -98,8 +98,23 @@ pub enum WalletManagerReconcileMessage {
     ReceiveAddressError(String),
     ReceiveAddressClosed(u64),
 
-    PayjoinTxBroadcast,
-    PayjoinPollingStarted { deadline_secs: u64 },
+    PayjoinStatusChanged(PayjoinStatus),
+}
+
+/// The terminal transaction selected for a Payjoin payment
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum PayjoinBroadcastOutcome {
+    Proposal,
+    Fallback,
+}
+
+/// The latest wallet-owned state for one Payjoin payment
+#[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum PayjoinStatus {
+    Negotiating { session_id: PayjoinSessionId },
+    Polling { session_id: PayjoinSessionId, deadline_secs: u64 },
+    Broadcast { session_id: PayjoinSessionId, outcome: PayjoinBroadcastOutcome },
+    Failed { session_id: PayjoinSessionId, message: String },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
@@ -373,6 +388,12 @@ pub enum WalletManagerError {
 
     #[error("{0}")]
     PayjoinSessionError(String),
+
+    #[error("payjoin cancellation failed: {0}")]
+    PayjoinCancellationFailed(String),
+
+    #[error("payjoin session {requested} does not own the active session {active}")]
+    PayjoinSessionMismatch { requested: PayjoinSessionId, active: PayjoinSessionId },
 
     #[error(transparent)]
     Converter(#[from] ConverterError),
@@ -787,12 +808,12 @@ impl RustWalletManager {
     pub async fn initiate_payment(
         &self,
         psbt: Arc<Psbt>,
-        payjoin_endpoint: Option<String>,
+        mode: UnsignedPaymentMode,
     ) -> Result<(), Error> {
         self.ensure_ledger_ready_for_spend()?;
 
         let psbt = Arc::unwrap_or_clone(psbt);
-        call!(self.actor.initiate_payment(psbt.into(), payjoin_endpoint))
+        call!(self.actor.initiate_payment(psbt.into(), mode))
             .await
             .map_err(|_| Error::ActorNotFound)??;
 
@@ -825,8 +846,8 @@ impl RustWalletManager {
     }
 
     #[uniffi::method]
-    pub async fn cancel_payjoin(&self) -> Result<(), Error> {
-        call!(self.actor.cancel_payjoin()).await.unwrap()?;
+    pub async fn cancel_payjoin(&self, session_id: PayjoinSessionId) -> Result<(), Error> {
+        call!(self.actor.cancel_payjoin(session_id)).await.map_err(|_| Error::ActorNotFound)??;
         let _ = self.force_wallet_scan().await;
         Ok(())
     }

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -97,6 +97,7 @@ pub enum WalletManagerReconcileMessage {
     ReceiveAddressClosed(u64),
 
     PayjoinTxBroadcast,
+    PayjoinPollingStarted { deadline_secs: u64 },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
@@ -749,6 +750,13 @@ impl RustWalletManager {
 
         self.force_wallet_scan().await;
 
+        Ok(())
+    }
+
+    #[uniffi::method]
+    pub async fn cancel_payjoin(&self) -> Result<(), Error> {
+        call!(self.actor.cancel_payjoin()).await.unwrap()?;
+        self.force_wallet_scan().await;
         Ok(())
     }
 

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -827,7 +827,7 @@ impl RustWalletManager {
     #[uniffi::method]
     pub async fn cancel_payjoin(&self) -> Result<(), Error> {
         call!(self.actor.cancel_payjoin()).await.unwrap()?;
-        self.force_wallet_scan().await;
+        let _ = self.force_wallet_scan().await;
         Ok(())
     }
 

--- a/rust/src/manager/wallet_manager.rs
+++ b/rust/src/manager/wallet_manager.rs
@@ -99,6 +99,7 @@ pub enum WalletManagerReconcileMessage {
     ReceiveAddressClosed(u64),
 
     PayjoinTxBroadcast,
+    PayjoinPollingStarted { deadline_secs: u64 },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
@@ -820,6 +821,13 @@ impl RustWalletManager {
 
         self.force_wallet_scan().await?;
 
+        Ok(())
+    }
+
+    #[uniffi::method]
+    pub async fn cancel_payjoin(&self) -> Result<(), Error> {
+        call!(self.actor.cancel_payjoin()).await.unwrap()?;
+        self.force_wallet_scan().await;
         Ok(())
     }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -57,7 +57,39 @@ use self::scan::{
     RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart, ScanRequestOrder, WalletScanActor,
     WalletScanEvent, WalletScanEventKind, should_update_full_scan_metadata,
 };
-use super::{SingleOrMany, WalletManagerReconcileMessage};
+use super::{PayjoinBroadcastOutcome, PayjoinStatus, SingleOrMany, WalletManagerReconcileMessage};
+use cove_types::PayjoinSessionId;
+
+#[derive(Debug)]
+pub(crate) enum ActivePayjoin {
+    Negotiating { session_id: PayjoinSessionId, actor: Addr<PayjoinActor> },
+    Broadcasting { session_id: PayjoinSessionId, outcome: PayjoinBroadcastOutcome },
+    RecoveryBlocked { session_id: PayjoinSessionId },
+}
+
+impl ActivePayjoin {
+    pub(crate) fn session_id(&self) -> &PayjoinSessionId {
+        match self {
+            Self::Negotiating { session_id, .. }
+            | Self::Broadcasting { session_id, .. }
+            | Self::RecoveryBlocked { session_id } => session_id,
+        }
+    }
+
+    pub(crate) fn is_broadcasting(
+        &self,
+        session_id: &PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+    ) -> bool {
+        matches!(
+            self,
+            Self::Broadcasting {
+                session_id: active_id,
+                outcome: active_outcome,
+            } if active_id == session_id && *active_outcome == outcome
+        )
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct WalletActor {
@@ -81,7 +113,7 @@ pub(crate) struct WalletActor {
     receive_address_refresh_timer: Option<AbortableTask<()>>,
     scan_actor: Option<Addr<WalletScanActor>>,
     scan_generation: WalletScanGeneration,
-    payjoin_actor: Option<Addr<PayjoinActor>>,
+    pub(crate) payjoin: Option<ActivePayjoin>,
 
     // cached values, source of truth is the redb database saved with wallet metadata
     last_scan_finished: Option<Duration>,
@@ -141,10 +173,20 @@ impl Actor for WalletActor {
                 self.send(WalletManagerReconcileMessage::NodeConnectionFailed(error_string));
             }
 
-            Error::SigningError(_) | Error::BroadcastError(_) | Error::PayjoinSessionError(_) => {
+            Error::SigningError(_) | Error::BroadcastError(_) => {
                 self.send(WalletManagerReconcileMessage::SendFlowError(
                     SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
                 ));
+            }
+
+            Error::PayjoinSessionError(_)
+            | Error::PayjoinCancellationFailed(_)
+            | Error::PayjoinSessionMismatch { .. } => {
+                if let Some(session_id) = self.active_payjoin_session_id().cloned() {
+                    self.send_payjoin_failure(session_id, error.to_string());
+                } else {
+                    self.send(WalletManagerReconcileMessage::WalletError(error));
+                }
             }
 
             Error::GetConfirmDetailsError(_) => {
@@ -426,7 +468,7 @@ impl WalletActor {
             receive_address_refresh_timer: None,
             scan_actor: None,
             scan_generation: WalletScanGeneration::INITIAL,
-            payjoin_actor: None,
+            payjoin: None,
             db,
         }
     }
@@ -438,56 +480,137 @@ impl WalletActor {
 
     /// Resumes a persisted payjoin session from a previous app run, if one exists
     pub async fn resume_payjoin_session(&mut self) -> ActorResult<()> {
-        if self.payjoin_actor.is_some() {
+        if self.payjoin.is_some() {
             return Produces::ok(());
         }
 
         match resume_session(self.db.clone(), self.addr.clone()) {
             SessionResumption::None => {}
 
-            SessionResumption::Resume(actor) => {
-                self.payjoin_actor = Some(spawn_actor(*actor));
+            SessionResumption::Resume(actor) => self.spawn_payjoin_actor(*actor),
+
+            SessionResumption::BroadcastStoredProposal { session_id, proposal_tx } => {
+                self.payjoin = Some(ActivePayjoin::Broadcasting {
+                    session_id: session_id.clone(),
+                    outcome: PayjoinBroadcastOutcome::Proposal,
+                });
+                send!(self.addr.handle_payjoin_proposal_broadcast(session_id, proposal_tx));
             }
 
-            SessionResumption::BroadcastStoredProposal { proposal_tx } => {
-                send!(self.addr.handle_payjoin_proposal_broadcast(proposal_tx));
+            SessionResumption::SignRecoveredProposal { session_id, proposal_psbt, fallback_tx } => {
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                send!(self.addr.handle_recovered_payjoin_success(
+                    session_id,
+                    proposal_psbt,
+                    fallback_tx
+                ));
             }
 
-            SessionResumption::SignRecoveredProposal { proposal_psbt, fallback_tx } => {
-                send!(self.addr.handle_recovered_payjoin_success(proposal_psbt, fallback_tx));
+            SessionResumption::BroadcastFallback { session_id, fallback_tx } => {
+                self.payjoin = Some(ActivePayjoin::Broadcasting {
+                    session_id: session_id.clone(),
+                    outcome: PayjoinBroadcastOutcome::Fallback,
+                });
+                send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
             }
 
-            SessionResumption::BroadcastFallback { fallback_tx } => {
-                send!(self.addr.handle_payjoin_fallback(fallback_tx));
+            SessionResumption::ReportError { session_id: Some(session_id), message } => {
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(session_id, message);
             }
 
-            SessionResumption::ReportError { message } => {
-                send!(self.addr.notify_payjoin_error(message));
+            SessionResumption::ReportError { session_id: None, message } => {
+                self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(
+                    message,
+                )));
             }
         }
 
         Produces::ok(())
     }
 
-    pub async fn notify_payjoin_error(&mut self, msg: String) -> ActorResult<()> {
-        self.send(WalletManagerReconcileMessage::SendFlowError(
-            SendFlowErrorAlert::SignAndBroadcast(msg),
-        ));
+    pub async fn notify_payjoin_error(
+        &mut self,
+        session_id: PayjoinSessionId,
+        message: String,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
+        self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+        self.send_payjoin_failure(session_id, message);
         Produces::ok(())
     }
 
-    pub async fn cancel_payjoin(&mut self) -> ActorResult<Result<(), Error>> {
-        if let Some(actor) = self.payjoin_actor.take()
-            && let Ok(Some(fallback_tx)) = call!(actor.cancel_and_fallback()).await
-        {
-            send!(self.addr.handle_payjoin_fallback(fallback_tx));
+    pub async fn cancel_payjoin(
+        &mut self,
+        requested_id: PayjoinSessionId,
+    ) -> ActorResult<Result<(), Error>> {
+        let Some(active) = self.payjoin.take() else {
+            return Produces::ok(Ok(()));
+        };
+
+        let ActivePayjoin::Negotiating { session_id, actor } = active else {
+            let active_id = active.session_id().clone();
+            self.payjoin = Some(active);
+
+            return if active_id == requested_id {
+                Produces::ok(Ok(()))
+            } else {
+                Produces::ok(Err(Error::PayjoinSessionMismatch {
+                    requested: requested_id,
+                    active: active_id,
+                }))
+            };
+        };
+
+        if session_id != requested_id {
+            self.payjoin =
+                Some(ActivePayjoin::Negotiating { session_id: session_id.clone(), actor });
+            return Produces::ok(Err(Error::PayjoinSessionMismatch {
+                requested: requested_id,
+                active: session_id,
+            }));
         }
 
-        Produces::ok(Ok(()))
+        match call!(actor.cancel_and_fallback()).await {
+            Ok(Some(fallback_tx)) => {
+                self.payjoin = Some(ActivePayjoin::Broadcasting {
+                    session_id: session_id.clone(),
+                    outcome: PayjoinBroadcastOutcome::Fallback,
+                });
+                send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
+                Produces::ok(Ok(()))
+            }
+
+            Ok(None) => {
+                self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id });
+                Produces::ok(Ok(()))
+            }
+
+            Err(error) => {
+                self.payjoin = Some(ActivePayjoin::Negotiating { session_id, actor });
+                Produces::ok(Err(error).map_err_str(Error::PayjoinCancellationFailed))
+            }
+        }
     }
 
-    pub async fn notify_payjoin_polling_started(&mut self, deadline_secs: u64) -> ActorResult<()> {
-        self.send(WalletManagerReconcileMessage::PayjoinPollingStarted { deadline_secs });
+    pub async fn notify_payjoin_polling_started(
+        &mut self,
+        session_id: PayjoinSessionId,
+        deadline_secs: u64,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
+        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(PayjoinStatus::Polling {
+            session_id,
+            deadline_secs,
+        }));
         Produces::ok(())
     }
 
@@ -861,14 +984,23 @@ impl WalletActor {
         match terminal_payjoin_authority {
             Some(authority) => {
                 let mut payjoin_quiesced = true;
-                if let Some(actor) = self.payjoin_actor.take()
-                    && let Err(error) =
-                        call!(actor.cancel_and_fallback_for_terminal_shutdown(authority.clone()))
+                if let Some(active) = self.payjoin.take() {
+                    match active {
+                        ActivePayjoin::Negotiating { session_id, actor } => {
+                            if let Err(error) = call!(
+                                actor.cancel_and_fallback_for_terminal_shutdown(authority.clone())
+                            )
                             .await
-                {
-                    first_error.get_or_insert_with(|| error.to_string());
-                    self.payjoin_actor = Some(actor);
-                    payjoin_quiesced = false;
+                            {
+                                first_error.get_or_insert_with(|| error.to_string());
+                                self.payjoin =
+                                    Some(ActivePayjoin::Negotiating { session_id, actor });
+                                payjoin_quiesced = false;
+                            }
+                        }
+
+                        terminal => self.payjoin = Some(terminal),
+                    }
                 }
 
                 if payjoin_quiesced {
@@ -889,21 +1021,28 @@ impl WalletActor {
                 }
             }
             None => {
-                if let Some(actor) = self.payjoin_actor.take() {
-                    let terminal_fallback = match call!(actor.cancel_and_fallback()).await {
-                        Ok(fallback) => fallback,
-                        Err(error) => {
-                            first_error.get_or_insert_with(|| error.to_string());
-                            self.payjoin_actor = Some(actor);
-                            None
-                        }
-                    };
+                if let Some(active) = self.payjoin.take() {
+                    match active {
+                        ActivePayjoin::Negotiating { session_id, actor } => {
+                            let terminal_fallback = match call!(actor.cancel_and_fallback()).await {
+                                Ok(fallback) => fallback,
+                                Err(error) => {
+                                    first_error.get_or_insert_with(|| error.to_string());
+                                    self.payjoin =
+                                        Some(ActivePayjoin::Negotiating { session_id, actor });
+                                    None
+                                }
+                            };
 
-                    if let Some(fallback) = terminal_fallback
-                        && let Err(error) =
-                            self.broadcast_payjoin_terminal_for_shutdown(fallback).await
-                    {
-                        first_error.get_or_insert_with(|| error.to_string());
+                            if let Some(fallback) = terminal_fallback
+                                && let Err(error) =
+                                    self.broadcast_payjoin_terminal_for_shutdown(fallback).await
+                            {
+                                first_error.get_or_insert_with(|| error.to_string());
+                            }
+                        }
+
+                        terminal => self.payjoin = Some(terminal),
                     }
                 }
             }
@@ -1464,6 +1603,29 @@ fn ledger_ready_for_spend(completed_initial_scan: bool) -> Result<(), Error> {
 }
 
 impl WalletActor {
+    pub(crate) fn active_payjoin_session_id(&self) -> Option<&PayjoinSessionId> {
+        self.payjoin.as_ref().map(ActivePayjoin::session_id)
+    }
+
+    pub(crate) fn is_active_payjoin(&self, session_id: &PayjoinSessionId) -> bool {
+        self.active_payjoin_session_id() == Some(session_id)
+    }
+
+    pub(crate) fn is_active_payjoin_broadcast(
+        &self,
+        session_id: &PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+    ) -> bool {
+        self.payjoin.as_ref().is_some_and(|active| active.is_broadcasting(session_id, outcome))
+    }
+
+    pub(crate) fn send_payjoin_failure(&self, session_id: PayjoinSessionId, message: String) {
+        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(PayjoinStatus::Failed {
+            session_id,
+            message,
+        }));
+    }
+
     fn send(&self, msg: WalletManagerReconcileMessage) {
         match &msg {
             WalletManagerReconcileMessage::WalletBalanceChanged(balance) => {
@@ -1762,6 +1924,7 @@ mod tests {
     use cove_device::keychain::Keychain;
     use cove_tokio::FutureTimeoutExt as _;
     use cove_types::{
+        PayjoinSessionId,
         fees::{FeeRateOption, FeeRateOptions, FeeSpeed},
         network::Network as CoveNetwork,
     };
@@ -1801,6 +1964,7 @@ mod tests {
             TransactionLockState, WalletManagerReconcileMessage, WalletScanStatus, WalletSnapshot,
         },
         node::Node,
+        router::UnsignedPaymentMode,
         transaction_watcher::TransactionWatcherEvent,
         wallet::{
             Address, Wallet, WalletAddressType,
@@ -3082,13 +3246,18 @@ mod tests {
         let terminal_tx = test_broadcast_transaction();
         let persister =
             crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        persister.create_session(&terminal_tx).unwrap();
-        actor.payjoin_actor = Some(spawn_actor(
-            crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
-                persister,
-                terminal_tx,
+        let session_id = PayjoinSessionId::generate();
+        persister.create_session(&terminal_tx, session_id.clone()).unwrap();
+        actor.payjoin = Some(super::ActivePayjoin::Negotiating {
+            session_id: session_id.clone(),
+            actor: spawn_actor(
+                crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
+                    persister,
+                    terminal_tx,
+                    session_id,
+                ),
             ),
-        ));
+        });
         actor.db = db.clone();
 
         let (authority, preparation) =
@@ -3098,7 +3267,7 @@ mod tests {
         drop(preparation);
         failed_server.server.abort();
 
-        assert!(actor.payjoin_actor.is_none(), "the failed broadcast leaves no child actor");
+        assert!(actor.payjoin.is_none(), "the failed broadcast leaves no active child actor");
         assert_eq!(
             db.get_payjoin_sender_session().unwrap().unwrap().pending_action,
             Some(crate::database::wallet_data::PendingAction::BroadcastFallback),
@@ -3106,6 +3275,79 @@ mod tests {
         );
 
         restore_default_bitcoin_node();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_payjoin_keeps_child_when_fallback_commit_fails() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+
+        let wallet = Wallet::preview_new_wallet();
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor = new_test_wallet_actor(wallet, sender);
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        let persister =
+            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
+        let session_id = PayjoinSessionId::generate();
+
+        actor.payjoin = Some(super::ActivePayjoin::Negotiating {
+            session_id: session_id.clone(),
+            actor: spawn_actor(
+                crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
+                    persister,
+                    test_broadcast_transaction(),
+                    session_id.clone(),
+                ),
+            ),
+        });
+        actor.db = db;
+
+        let outcome = actor_value(actor.cancel_payjoin(session_id).await).await;
+
+        assert!(matches!(outcome, Err(super::Error::PayjoinCancellationFailed(_))));
+        assert!(
+            matches!(actor.payjoin, Some(super::ActivePayjoin::Negotiating { .. })),
+            "the Payjoin child must remain so cancellation can be retried"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_payjoin_rejects_another_session_without_losing_the_active_child() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+
+        let wallet = Wallet::preview_new_wallet();
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor = new_test_wallet_actor(wallet, sender);
+        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
+        let persister =
+            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
+        let active_id = PayjoinSessionId::generate();
+        let requested_id = PayjoinSessionId::generate();
+
+        actor.payjoin = Some(super::ActivePayjoin::Negotiating {
+            session_id: active_id.clone(),
+            actor: spawn_actor(
+                crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
+                    persister,
+                    test_broadcast_transaction(),
+                    active_id.clone(),
+                ),
+            ),
+        });
+        actor.db = db;
+
+        let outcome = actor_value(actor.cancel_payjoin(requested_id.clone()).await).await;
+
+        assert_eq!(
+            outcome,
+            Err(super::Error::PayjoinSessionMismatch {
+                requested: requested_id,
+                active: active_id.clone(),
+            })
+        );
+        assert_eq!(actor.active_payjoin_session_id(), Some(&active_id));
+        assert!(matches!(actor.payjoin, Some(super::ActivePayjoin::Negotiating { .. })));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -3121,7 +3363,7 @@ mod tests {
         let terminal_tx = test_broadcast_transaction();
         let persister =
             crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        persister.create_session(&terminal_tx).unwrap();
+        persister.create_session(&terminal_tx, PayjoinSessionId::generate()).unwrap();
         persister.set_pending_fallback().unwrap();
         actor.db = db.clone();
 
@@ -3142,7 +3384,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn payjoin_uri_completes_via_normal_broadcast_when_gated() {
+    async fn standard_payment_completes_via_normal_broadcast() {
         let _guard = crate::test_support::global_state_test_lock().lock().await;
 
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -3175,11 +3417,9 @@ mod tests {
 
         let addr = spawn_actor(actor);
 
-        let result = call!(
-            addr.initiate_payment(psbt, Some("https://payjoin.example.com/endpoint".to_string()))
-        )
-        .await
-        .expect("initiate_payment actor responds");
+        let result = call!(addr.initiate_payment(psbt, UnsignedPaymentMode::Standard))
+            .await
+            .expect("initiate_payment actor responds");
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -4344,13 +4584,13 @@ mod tests {
         };
 
         crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone())
-            .create_session(&fallback_tx)
+            .create_session(&fallback_tx, PayjoinSessionId::generate())
             .unwrap();
 
         actor.db = db;
 
         let empty_psbt = bitcoin::Psbt::from_unsigned_tx(fallback_tx).unwrap();
-        let result = actor.initiate_payment(empty_psbt, None).await;
+        let result = actor.initiate_payment(empty_psbt, UnsignedPaymentMode::Standard).await;
         let outcome = actor_value(result).await;
 
         assert!(matches!(&outcome, Err(super::Error::PayjoinSessionError(_))));
@@ -4378,7 +4618,7 @@ mod tests {
 
         let persister =
             crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        persister.create_session(&terminal_tx).unwrap();
+        persister.create_session(&terminal_tx, PayjoinSessionId::generate()).unwrap();
         persister.set_pending_fallback().unwrap();
 
         actor.db = db;
@@ -4390,7 +4630,7 @@ mod tests {
             output: vec![],
         })
         .unwrap();
-        let result = actor.initiate_payment(dummy_psbt, None).await;
+        let result = actor.initiate_payment(dummy_psbt, UnsignedPaymentMode::Standard).await;
         let outcome = actor_value(result).await;
 
         let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
@@ -4417,13 +4657,14 @@ mod tests {
 
         let persister =
             crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        persister.create_session(&terminal_tx).unwrap();
+        let session_id = PayjoinSessionId::generate();
+        persister.create_session(&terminal_tx, session_id).unwrap();
         persister.set_pending_proposal(&terminal_tx).unwrap();
 
         let (addr, _receiver) = spawn_test_wallet_actor(wallet);
         call!(addr.set_test_wallet_data_db(db.clone())).await.expect("actor responds");
 
-        call!(addr.handle_payjoin_proposal_broadcast(terminal_tx)).await.expect("actor responds");
+        call!(addr.resume_payjoin_session()).await.expect("actor responds");
 
         for _ in 0..50 {
             let session = db.get_payjoin_sender_session().expect("db query succeeded");
@@ -4455,11 +4696,14 @@ mod tests {
             output: vec![],
         };
 
+        let session_id = PayjoinSessionId::generate();
         crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone())
-            .create_session(&fallback_tx)
+            .create_session(&fallback_tx, session_id.clone())
             .unwrap();
 
         actor.db = db;
+        actor.payjoin =
+            Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
 
         let proposal_psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
             version: bitcoin::transaction::Version::TWO,
@@ -4469,7 +4713,8 @@ mod tests {
         })
         .unwrap();
 
-        let result = actor.handle_recovered_payjoin_success(proposal_psbt, fallback_tx).await;
+        let result =
+            actor.handle_recovered_payjoin_success(session_id, proposal_psbt, fallback_tx).await;
         actor_value(result).await;
 
         let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -477,9 +477,12 @@ impl WalletActor {
     }
 
     pub async fn cancel_payjoin(&mut self) -> ActorResult<Result<(), Error>> {
-        if let Some(actor) = self.payjoin_actor.take() {
-            send!(actor.cancel_and_fallback());
+        if let Some(actor) = self.payjoin_actor.take()
+            && let Ok(Some(fallback_tx)) = call!(actor.cancel_and_fallback()).await
+        {
+            send!(self.addr.handle_payjoin_fallback(fallback_tx));
         }
+
         Produces::ok(Ok(()))
     }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -470,7 +470,21 @@ impl WalletActor {
     }
 
     pub async fn notify_payjoin_error(&mut self, msg: String) -> ActorResult<()> {
-        self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(msg)));
+        self.send(WalletManagerReconcileMessage::SendFlowError(
+            SendFlowErrorAlert::SignAndBroadcast(msg),
+        ));
+        Produces::ok(())
+    }
+
+    pub async fn cancel_payjoin(&mut self) -> ActorResult<Result<(), Error>> {
+        if let Some(actor) = self.payjoin_actor.take() {
+            send!(actor.cancel_and_fallback());
+        }
+        Produces::ok(Ok(()))
+    }
+
+    pub async fn notify_payjoin_polling_started(&mut self, deadline_secs: u64) -> ActorResult<()> {
+        self.send(WalletManagerReconcileMessage::PayjoinPollingStarted { deadline_secs });
         Produces::ok(())
     }
 

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -22,14 +22,21 @@ use crate::{
         metadata::WalletMetadata,
     },
 };
+mod broadcast;
 mod node;
+mod payjoin;
 mod receive_address;
 mod scan;
 mod transaction_confirmation;
 mod transactions;
 
-use super::payjoin::{PayjoinActor, PayjoinSessionPersister, SessionResumption, resume_session};
-use act_zero::{runtimes::tokio::spawn_actor, *};
+#[cfg(test)]
+mod test_support;
+
+use act_zero::{
+    Actor, ActorError, ActorResult, Addr, AddrLike as _, Produces, WeakAddr, call,
+    runtimes::tokio::spawn_actor, send,
+};
 use act_zero_ext::into_actor_result;
 use ahash::HashMap;
 use bdk_wallet::{
@@ -57,39 +64,7 @@ use self::scan::{
     RETURNING_WALLET_SCAN_PROGRESS_DELAY, ScanProgressStart, ScanRequestOrder, WalletScanActor,
     WalletScanEvent, WalletScanEventKind, should_update_full_scan_metadata,
 };
-use super::{PayjoinBroadcastOutcome, PayjoinStatus, SingleOrMany, WalletManagerReconcileMessage};
-use cove_types::PayjoinSessionId;
-
-#[derive(Debug)]
-pub(crate) enum ActivePayjoin {
-    Negotiating { session_id: PayjoinSessionId, actor: Addr<PayjoinActor> },
-    Broadcasting { session_id: PayjoinSessionId, outcome: PayjoinBroadcastOutcome },
-    RecoveryBlocked { session_id: PayjoinSessionId },
-}
-
-impl ActivePayjoin {
-    pub(crate) fn session_id(&self) -> &PayjoinSessionId {
-        match self {
-            Self::Negotiating { session_id, .. }
-            | Self::Broadcasting { session_id, .. }
-            | Self::RecoveryBlocked { session_id } => session_id,
-        }
-    }
-
-    pub(crate) fn is_broadcasting(
-        &self,
-        session_id: &PayjoinSessionId,
-        outcome: PayjoinBroadcastOutcome,
-    ) -> bool {
-        matches!(
-            self,
-            Self::Broadcasting {
-                session_id: active_id,
-                outcome: active_outcome,
-            } if active_id == session_id && *active_outcome == outcome
-        )
-    }
-}
+use super::{SingleOrMany, WalletManagerReconcileMessage};
 
 #[derive(Debug)]
 pub(crate) struct WalletActor {
@@ -113,7 +88,7 @@ pub(crate) struct WalletActor {
     receive_address_refresh_timer: Option<AbortableTask<()>>,
     scan_actor: Option<Addr<WalletScanActor>>,
     scan_generation: WalletScanGeneration,
-    pub(crate) payjoin: Option<ActivePayjoin>,
+    payjoin: Option<payjoin::ActivePayjoin>,
 
     // cached values, source of truth is the redb database saved with wallet metadata
     last_scan_finished: Option<Duration>,
@@ -476,142 +451,6 @@ impl WalletActor {
     pub async fn balance(&mut self) -> ActorResult<Balance> {
         let balance = self.wallet.balance();
         Produces::ok(balance)
-    }
-
-    /// Resumes a persisted payjoin session from a previous app run, if one exists
-    pub async fn resume_payjoin_session(&mut self) -> ActorResult<()> {
-        if self.payjoin.is_some() {
-            return Produces::ok(());
-        }
-
-        match resume_session(self.db.clone(), self.addr.clone()) {
-            SessionResumption::None => {}
-
-            SessionResumption::Resume(actor) => self.spawn_payjoin_actor(*actor),
-
-            SessionResumption::BroadcastStoredProposal { session_id, proposal_tx } => {
-                self.payjoin = Some(ActivePayjoin::Broadcasting {
-                    session_id: session_id.clone(),
-                    outcome: PayjoinBroadcastOutcome::Proposal,
-                });
-                send!(self.addr.handle_payjoin_proposal_broadcast(session_id, proposal_tx));
-            }
-
-            SessionResumption::SignRecoveredProposal { session_id, proposal_psbt, fallback_tx } => {
-                self.payjoin =
-                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-                send!(self.addr.handle_recovered_payjoin_success(
-                    session_id,
-                    proposal_psbt,
-                    fallback_tx
-                ));
-            }
-
-            SessionResumption::BroadcastFallback { session_id, fallback_tx } => {
-                self.payjoin = Some(ActivePayjoin::Broadcasting {
-                    session_id: session_id.clone(),
-                    outcome: PayjoinBroadcastOutcome::Fallback,
-                });
-                send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
-            }
-
-            SessionResumption::ReportError { session_id: Some(session_id), message } => {
-                self.payjoin =
-                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-                self.send_payjoin_failure(session_id, message);
-            }
-
-            SessionResumption::ReportError { session_id: None, message } => {
-                self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(
-                    message,
-                )));
-            }
-        }
-
-        Produces::ok(())
-    }
-
-    pub async fn notify_payjoin_error(
-        &mut self,
-        session_id: PayjoinSessionId,
-        message: String,
-    ) -> ActorResult<()> {
-        if !self.is_active_payjoin(&session_id) {
-            return Produces::ok(());
-        }
-
-        self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-        self.send_payjoin_failure(session_id, message);
-        Produces::ok(())
-    }
-
-    pub async fn cancel_payjoin(
-        &mut self,
-        requested_id: PayjoinSessionId,
-    ) -> ActorResult<Result<(), Error>> {
-        let Some(active) = self.payjoin.take() else {
-            return Produces::ok(Ok(()));
-        };
-
-        let ActivePayjoin::Negotiating { session_id, actor } = active else {
-            let active_id = active.session_id().clone();
-            self.payjoin = Some(active);
-
-            return if active_id == requested_id {
-                Produces::ok(Ok(()))
-            } else {
-                Produces::ok(Err(Error::PayjoinSessionMismatch {
-                    requested: requested_id,
-                    active: active_id,
-                }))
-            };
-        };
-
-        if session_id != requested_id {
-            self.payjoin =
-                Some(ActivePayjoin::Negotiating { session_id: session_id.clone(), actor });
-            return Produces::ok(Err(Error::PayjoinSessionMismatch {
-                requested: requested_id,
-                active: session_id,
-            }));
-        }
-
-        match call!(actor.cancel_and_fallback()).await {
-            Ok(Some(fallback_tx)) => {
-                self.payjoin = Some(ActivePayjoin::Broadcasting {
-                    session_id: session_id.clone(),
-                    outcome: PayjoinBroadcastOutcome::Fallback,
-                });
-                send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
-                Produces::ok(Ok(()))
-            }
-
-            Ok(None) => {
-                self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id });
-                Produces::ok(Ok(()))
-            }
-
-            Err(error) => {
-                self.payjoin = Some(ActivePayjoin::Negotiating { session_id, actor });
-                Produces::ok(Err(error).map_err_str(Error::PayjoinCancellationFailed))
-            }
-        }
-    }
-
-    pub async fn notify_payjoin_polling_started(
-        &mut self,
-        session_id: PayjoinSessionId,
-        deadline_secs: u64,
-    ) -> ActorResult<()> {
-        if !self.is_active_payjoin(&session_id) {
-            return Produces::ok(());
-        }
-
-        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(PayjoinStatus::Polling {
-            session_id,
-            deadline_secs,
-        }));
-        Produces::ok(())
     }
 
     #[into_actor_result]
@@ -981,71 +820,8 @@ impl WalletActor {
             self.receive_address_watcher = Some(watcher);
         }
         self.stop_receive_address_refresh_timer();
-        match terminal_payjoin_authority {
-            Some(authority) => {
-                let mut payjoin_quiesced = true;
-                if let Some(active) = self.payjoin.take() {
-                    match active {
-                        ActivePayjoin::Negotiating { session_id, actor } => {
-                            if let Err(error) = call!(
-                                actor.cancel_and_fallback_for_terminal_shutdown(authority.clone())
-                            )
-                            .await
-                            {
-                                first_error.get_or_insert_with(|| error.to_string());
-                                self.payjoin =
-                                    Some(ActivePayjoin::Negotiating { session_id, actor });
-                                payjoin_quiesced = false;
-                            }
-                        }
-
-                        terminal => self.payjoin = Some(terminal),
-                    }
-                }
-
-                if payjoin_quiesced {
-                    let terminal_transaction = PayjoinSessionPersister::new(self.db.clone())
-                        .terminal_transaction_for_shutdown(&authority)
-                        .map_err(|error| error.to_string());
-
-                    match terminal_transaction {
-                        Ok(Some(transaction)) => {
-                            // keep node latency outside the destructive shutdown deadline
-                            self.schedule_payjoin_terminal_broadcast(transaction);
-                        }
-                        Ok(None) => {}
-                        Err(error) => {
-                            first_error.get_or_insert(error);
-                        }
-                    }
-                }
-            }
-            None => {
-                if let Some(active) = self.payjoin.take() {
-                    match active {
-                        ActivePayjoin::Negotiating { session_id, actor } => {
-                            let terminal_fallback = match call!(actor.cancel_and_fallback()).await {
-                                Ok(fallback) => fallback,
-                                Err(error) => {
-                                    first_error.get_or_insert_with(|| error.to_string());
-                                    self.payjoin =
-                                        Some(ActivePayjoin::Negotiating { session_id, actor });
-                                    None
-                                }
-                            };
-
-                            if let Some(fallback) = terminal_fallback
-                                && let Err(error) =
-                                    self.broadcast_payjoin_terminal_for_shutdown(fallback).await
-                            {
-                                first_error.get_or_insert_with(|| error.to_string());
-                            }
-                        }
-
-                        terminal => self.payjoin = Some(terminal),
-                    }
-                }
-            }
+        if let Err(error) = self.quiesce_payjoin(terminal_payjoin_authority).await {
+            first_error.get_or_insert(error);
         }
         self.state = ActorState::Initial;
         self.quiesce_transaction_watchers(&mut first_error).await;
@@ -1603,29 +1379,6 @@ fn ledger_ready_for_spend(completed_initial_scan: bool) -> Result<(), Error> {
 }
 
 impl WalletActor {
-    pub(crate) fn active_payjoin_session_id(&self) -> Option<&PayjoinSessionId> {
-        self.payjoin.as_ref().map(ActivePayjoin::session_id)
-    }
-
-    pub(crate) fn is_active_payjoin(&self, session_id: &PayjoinSessionId) -> bool {
-        self.active_payjoin_session_id() == Some(session_id)
-    }
-
-    pub(crate) fn is_active_payjoin_broadcast(
-        &self,
-        session_id: &PayjoinSessionId,
-        outcome: PayjoinBroadcastOutcome,
-    ) -> bool {
-        self.payjoin.as_ref().is_some_and(|active| active.is_broadcasting(session_id, outcome))
-    }
-
-    pub(crate) fn send_payjoin_failure(&self, session_id: PayjoinSessionId, message: String) {
-        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(PayjoinStatus::Failed {
-            session_id,
-            message,
-        }));
-    }
-
     fn send(&self, msg: WalletManagerReconcileMessage) {
         match &msg {
             WalletManagerReconcileMessage::WalletBalanceChanged(balance) => {
@@ -1866,43 +1619,6 @@ impl SpendPolicy {
 }
 
 #[cfg(test)]
-mod test_support {
-    use std::sync::Arc;
-
-    use flume::Sender;
-    use parking_lot::RwLock;
-
-    use crate::{
-        database::wallet_data::WalletDataDb,
-        manager::wallet_manager::{WalletScanStatus, WalletSnapshot},
-        wallet::Wallet,
-    };
-
-    use super::{SingleOrMany, WalletActor};
-
-    impl WalletActor {
-        pub(crate) fn new_with_db(
-            wallet: Wallet,
-            reconciler: Sender<SingleOrMany>,
-            scan_status: Arc<RwLock<WalletScanStatus>>,
-            wallet_snapshot: Arc<RwLock<WalletSnapshot>>,
-            db: WalletDataDb,
-        ) -> Self {
-            let metadata = Arc::new(RwLock::new(wallet.metadata.clone()));
-
-            Self::new_with_metadata_and_db(
-                wallet,
-                reconciler,
-                scan_status,
-                wallet_snapshot,
-                db,
-                metadata,
-            )
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use act_zero::{runtimes::tokio::spawn_actor, *};
     use bdk_wallet::{
@@ -1924,11 +1640,9 @@ mod tests {
     use cove_device::keychain::Keychain;
     use cove_tokio::FutureTimeoutExt as _;
     use cove_types::{
-        PayjoinSessionId,
         fees::{FeeRateOption, FeeRateOptions, FeeSpeed},
         network::Network as CoveNetwork,
     };
-    use parking_lot::RwLock;
     use std::{
         collections::{BTreeMap, HashSet},
         str::FromStr as _,
@@ -1953,15 +1667,21 @@ mod tests {
         full_scan_updates_initial_metadata, initial_scan_route, ledger_ready_for_spend,
         metadata_with_full_scan_performed, progressive_scan_update_response,
         reset_scan_lifecycle_state_for_address_type_switch, should_accept_wallet_scan_generation,
-        should_skip_recent_scan, trusted_spendable_output, wallet_scan_progress_start,
+        should_skip_recent_scan,
+        test_support::{
+            actor_value, mark_wallet_ledger_ready, new_test_wallet_actor,
+            restore_default_bitcoin_node, set_broadcast_esplora_node, spawn_test_wallet_actor,
+            test_broadcast_transaction, test_keychain,
+        },
+        trusted_spendable_output, wallet_scan_progress_start,
     };
     use crate::{
         database::wallet_data::{
-            WalletDataDb, label::test_support::wallet_data_db_with_mismatched_output_table,
+            label::test_support::wallet_data_db_with_mismatched_output_table,
             test_support::new_test_wallet_data_db,
         },
         manager::wallet_manager::{
-            TransactionLockState, WalletManagerReconcileMessage, WalletScanStatus, WalletSnapshot,
+            TransactionLockState, WalletManagerReconcileMessage, WalletScanStatus,
         },
         node::Node,
         router::UnsignedPaymentMode,
@@ -1988,33 +1708,9 @@ mod tests {
         server: JoinHandle<()>,
     }
 
-    struct BroadcastEsploraNode {
-        broadcast_requests: Arc<AtomicUsize>,
-        server: JoinHandle<()>,
-    }
-
-    struct PendingBroadcastEsploraNode {
-        broadcast_requests: Arc<AtomicUsize>,
-        release: tokio::sync::watch::Sender<bool>,
-        server: JoinHandle<()>,
-    }
-
-    async fn actor_value<T>(result: ActorResult<T>) -> T {
-        result
-            .expect("actor method should not fail")
-            .await
-            .expect("actor method should produce a value")
-    }
-
     impl super::WalletActor {
         async fn in_memory_wallet_metadata(&mut self) -> ActorResult<WalletMetadata> {
             Produces::ok(self.wallet.metadata.clone())
-        }
-
-        async fn set_test_wallet_data_db(&mut self, db: WalletDataDb) -> act_zero::ActorResult<()> {
-            self.db = db;
-
-            act_zero::Produces::ok(())
         }
 
         async fn set_last_height_fetched_for_test(
@@ -2120,47 +1816,6 @@ mod tests {
             .expect("address is regtest")
     }
 
-    fn test_broadcast_transaction() -> BdkTransaction {
-        BdkTransaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: Vec::new(),
-            output: Vec::new(),
-        }
-    }
-
-    fn test_scan_status() -> Arc<RwLock<WalletScanStatus>> {
-        Arc::new(RwLock::new(WalletScanStatus::Idle))
-    }
-
-    fn test_wallet_snapshot(wallet: &Wallet) -> Arc<RwLock<WalletSnapshot>> {
-        Arc::new(RwLock::new(WalletSnapshot::from_wallet(wallet)))
-    }
-
-    fn new_test_wallet_actor(
-        wallet: Wallet,
-        sender: flume::Sender<SingleOrMany>,
-    ) -> super::WalletActor {
-        crate::test_support::ensure_tokio_runtime();
-
-        let wallet_snapshot = test_wallet_snapshot(&wallet);
-        let metadata = Arc::new(RwLock::new(wallet.metadata.clone()));
-
-        super::WalletActor::new_with_metadata(
-            wallet,
-            sender,
-            test_scan_status(),
-            wallet_snapshot,
-            metadata,
-        )
-        .expect("actor is created")
-    }
-
-    fn test_keychain() -> &'static Keychain {
-        crate::test_support::init_test_keychain();
-        Keychain::global()
-    }
-
     fn test_mnemonic() -> Mnemonic {
         Mnemonic::from_str(TEST_MNEMONIC).expect("test mnemonic is valid")
     }
@@ -2183,16 +1838,6 @@ mod tests {
 
         pubport::descriptor::Descriptors::try_from_line(&descriptor)
             .expect("descriptor pair parses")
-    }
-
-    fn spawn_test_wallet_actor(
-        wallet: Wallet,
-    ) -> (Addr<super::WalletActor>, flume::Receiver<SingleOrMany>) {
-        let (sender, receiver) = flume::bounded(100);
-        let actor = new_test_wallet_actor(wallet, sender);
-        let addr = spawn_actor(actor);
-
-        (addr, receiver)
     }
 
     fn persisted_preview_wallet(metadata: WalletMetadata) -> Wallet {
@@ -2475,132 +2120,6 @@ mod tests {
         })
         .await
         .expect("height refresh persists");
-    }
-
-    async fn set_broadcast_esplora_node(broadcast_status: u16) -> BroadcastEsploraNode {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("test esplora server binds");
-        let address = listener.local_addr().expect("test esplora server has address");
-        let node = Node::new_esplora(
-            "broadcast test esplora node".to_string(),
-            format!("http://{address}"),
-            CoveNetwork::Bitcoin,
-        );
-
-        crate::database::Database::global()
-            .global_config
-            .set_selected_node(&node)
-            .expect("test node config is saved");
-
-        let broadcast_requests = Arc::new(AtomicUsize::new(0));
-        let broadcast_counter = broadcast_requests.clone();
-        let server = tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else { return };
-                let broadcast_counter = broadcast_counter.clone();
-                tokio::spawn(async move {
-                    let mut request = [0; 8192];
-                    let bytes_read = stream.read(&mut request).await.unwrap_or_default();
-                    let request = String::from_utf8_lossy(&request[..bytes_read]);
-
-                    let body = if request.starts_with("POST /tx ") {
-                        broadcast_counter.fetch_add(1, Ordering::SeqCst);
-                        "broadcast"
-                    } else {
-                        "1"
-                    };
-
-                    let status =
-                        if request.starts_with("POST /tx ") { broadcast_status } else { 200 };
-                    let reason = if status == 200 { "OK" } else { "Internal Server Error" };
-                    let response = format!(
-                        "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
-                        body.len(),
-                        body
-                    );
-                    let _ = stream.write_all(response.as_bytes()).await;
-                });
-            }
-        });
-
-        BroadcastEsploraNode { broadcast_requests, server }
-    }
-
-    async fn set_pending_broadcast_esplora_node() -> PendingBroadcastEsploraNode {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("test esplora server binds");
-        let address = listener.local_addr().expect("test esplora server has address");
-        let node = Node::new_esplora(
-            "pending broadcast test esplora node".to_string(),
-            format!("http://{address}"),
-            CoveNetwork::Bitcoin,
-        );
-
-        crate::database::Database::global()
-            .global_config
-            .set_selected_node(&node)
-            .expect("test node config is saved");
-
-        let broadcast_requests = Arc::new(AtomicUsize::new(0));
-        let broadcast_counter = broadcast_requests.clone();
-        let (release, release_request) = tokio::sync::watch::channel(false);
-        let server = tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else { return };
-                let broadcast_counter = broadcast_counter.clone();
-                let release_request = release_request.clone();
-                tokio::spawn(async move {
-                    let mut request = [0; 8192];
-                    let bytes_read = stream.read(&mut request).await.unwrap_or_default();
-                    let request = String::from_utf8_lossy(&request[..bytes_read]);
-                    let is_broadcast = request.starts_with("POST /tx ");
-                    if is_broadcast {
-                        broadcast_counter.fetch_add(1, Ordering::SeqCst);
-                        let mut release_request = release_request.clone();
-                        while !*release_request.borrow() {
-                            if release_request.changed().await.is_err() {
-                                return;
-                            }
-                        }
-                    }
-
-                    let body = if is_broadcast { "broadcast" } else { "1" };
-                    let response = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
-                        body.len(),
-                        body
-                    );
-                    let _ = stream.write_all(response.as_bytes()).await;
-                });
-            }
-        });
-
-        PendingBroadcastEsploraNode { broadcast_requests, release, server }
-    }
-
-    async fn wait_for_broadcast_request_count(broadcast_requests: &Arc<AtomicUsize>, count: usize) {
-        tokio::time::timeout(Duration::from_secs(2), async {
-            loop {
-                if broadcast_requests.load(Ordering::SeqCst) >= count {
-                    return;
-                }
-
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("broadcast request count is reached");
-    }
-
-    fn restore_default_bitcoin_node() {
-        let node = Node::default(CoveNetwork::Bitcoin);
-
-        crate::database::Database::global()
-            .global_config
-            .set_selected_node(&node)
-            .expect("default node config is saved");
-    }
-
-    fn mark_wallet_ledger_ready(wallet: &mut Wallet) {
-        wallet.metadata.internal.performed_full_scan_at = Some(1);
     }
 
     fn locked_actor_fixture() -> LockedActorFixture {
@@ -3211,176 +2730,6 @@ mod tests {
 
         assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 1);
         assert!(matches!(error, super::Error::BroadcastError(_)));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn terminal_payjoin_fallback_waits_for_node_broadcast() {
-        let _guard = crate::test_support::global_state_test_lock().lock().await;
-
-        crate::database::test_support::init_test_database();
-        let server = set_broadcast_esplora_node(200).await;
-        let wallet = Wallet::preview_new_wallet();
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-
-        actor
-            .broadcast_payjoin_terminal_for_shutdown(test_broadcast_transaction())
-            .await
-            .expect("terminal fallback reaches the node before shutdown returns");
-
-        restore_default_bitcoin_node();
-        server.server.abort();
-        assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn destructive_quiesce_succeeds_after_terminal_broadcast_failure() {
-        let _guard = crate::test_support::global_state_test_lock().lock().await;
-
-        crate::database::test_support::init_test_database();
-        let failed_server = set_broadcast_esplora_node(500).await;
-        let wallet = Wallet::preview_new_wallet();
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-        let terminal_tx = test_broadcast_transaction();
-        let persister =
-            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        let session_id = PayjoinSessionId::generate();
-        persister.create_session(&terminal_tx, session_id.clone()).unwrap();
-        actor.payjoin = Some(super::ActivePayjoin::Negotiating {
-            session_id: session_id.clone(),
-            actor: spawn_actor(
-                crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
-                    persister,
-                    terminal_tx,
-                    session_id,
-                ),
-            ),
-        });
-        actor.db = db.clone();
-
-        let (authority, preparation) =
-            crate::wallet_lifecycle::test_support::begin_wallet_deletion(db.id.clone());
-        actor_value(actor.quiesce_for_terminal_shutdown(authority).await).await;
-        wait_for_broadcast_request_count(&failed_server.broadcast_requests, 1).await;
-        drop(preparation);
-        failed_server.server.abort();
-
-        assert!(actor.payjoin.is_none(), "the failed broadcast leaves no active child actor");
-        assert_eq!(
-            db.get_payjoin_sender_session().unwrap().unwrap().pending_action,
-            Some(crate::database::wallet_data::PendingAction::BroadcastFallback),
-            "the retry marker must remain after the failed broadcast"
-        );
-
-        restore_default_bitcoin_node();
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn cancel_payjoin_keeps_child_when_fallback_commit_fails() {
-        crate::database::test_support::init_test_database();
-        crate::test_support::ensure_tokio_runtime();
-
-        let wallet = Wallet::preview_new_wallet();
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-        let persister =
-            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        let session_id = PayjoinSessionId::generate();
-
-        actor.payjoin = Some(super::ActivePayjoin::Negotiating {
-            session_id: session_id.clone(),
-            actor: spawn_actor(
-                crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
-                    persister,
-                    test_broadcast_transaction(),
-                    session_id.clone(),
-                ),
-            ),
-        });
-        actor.db = db;
-
-        let outcome = actor_value(actor.cancel_payjoin(session_id).await).await;
-
-        assert!(matches!(outcome, Err(super::Error::PayjoinCancellationFailed(_))));
-        assert!(
-            matches!(actor.payjoin, Some(super::ActivePayjoin::Negotiating { .. })),
-            "the Payjoin child must remain so cancellation can be retried"
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn cancel_payjoin_rejects_another_session_without_losing_the_active_child() {
-        crate::database::test_support::init_test_database();
-        crate::test_support::ensure_tokio_runtime();
-
-        let wallet = Wallet::preview_new_wallet();
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-        let persister =
-            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        let active_id = PayjoinSessionId::generate();
-        let requested_id = PayjoinSessionId::generate();
-
-        actor.payjoin = Some(super::ActivePayjoin::Negotiating {
-            session_id: active_id.clone(),
-            actor: spawn_actor(
-                crate::manager::wallet_manager::payjoin::test_support::terminal_actor(
-                    persister,
-                    test_broadcast_transaction(),
-                    active_id.clone(),
-                ),
-            ),
-        });
-        actor.db = db;
-
-        let outcome = actor_value(actor.cancel_payjoin(requested_id.clone()).await).await;
-
-        assert_eq!(
-            outcome,
-            Err(super::Error::PayjoinSessionMismatch {
-                requested: requested_id,
-                active: active_id.clone(),
-            })
-        );
-        assert_eq!(actor.active_payjoin_session_id(), Some(&active_id));
-        assert!(matches!(actor.payjoin, Some(super::ActivePayjoin::Negotiating { .. })));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn destructive_quiesce_does_not_wait_for_terminal_broadcast() {
-        let _guard = crate::test_support::global_state_test_lock().lock().await;
-
-        crate::database::test_support::init_test_database();
-        let pending_server = set_pending_broadcast_esplora_node().await;
-        let wallet = Wallet::preview_new_wallet();
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-        let terminal_tx = test_broadcast_transaction();
-        let persister =
-            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        persister.create_session(&terminal_tx, PayjoinSessionId::generate()).unwrap();
-        persister.set_pending_fallback().unwrap();
-        actor.db = db.clone();
-
-        let (authority, preparation) =
-            crate::wallet_lifecycle::test_support::begin_wallet_deletion(db.id.clone());
-        tokio::time::timeout(
-            Duration::from_secs(1),
-            actor_value(actor.quiesce_for_terminal_shutdown(authority).await),
-        )
-        .await
-        .expect("destructive quiesce does not wait for a pending node request");
-        wait_for_broadcast_request_count(&pending_server.broadcast_requests, 1).await;
-
-        pending_server.release.send(true).expect("pending broadcast request is listening");
-        drop(preparation);
-        pending_server.server.abort();
-        restore_default_bitcoin_node();
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -4563,165 +3912,6 @@ mod tests {
         assert_eq!(
             wallet_scan_progress_start(true, true),
             ScanProgressStart::Delayed(EMPTY_WALLET_SCAN_PROGRESS_DELAY)
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn send_gate_retries_pending_terminal_action_and_rejects_new_send() {
-        crate::database::test_support::init_test_database();
-        let mut wallet = Wallet::preview_new_wallet();
-        mark_wallet_ledger_ready(&mut wallet);
-
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-
-        let fallback_tx = bitcoin::Transaction {
-            version: bitcoin::transaction::Version::TWO,
-            lock_time: bitcoin::absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
-        crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone())
-            .create_session(&fallback_tx, PayjoinSessionId::generate())
-            .unwrap();
-
-        actor.db = db;
-
-        let empty_psbt = bitcoin::Psbt::from_unsigned_tx(fallback_tx).unwrap();
-        let result = actor.initiate_payment(empty_psbt, UnsignedPaymentMode::Standard).await;
-        let outcome = actor_value(result).await;
-
-        assert!(matches!(&outcome, Err(super::Error::PayjoinSessionError(_))));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn send_gate_clears_stale_session_when_terminal_tx_already_in_wallet() {
-        crate::database::test_support::init_test_database();
-        crate::test_support::ensure_tokio_runtime();
-        test_keychain();
-        let mut wallet = Wallet::preview_new_wallet();
-        mark_wallet_ledger_ready(&mut wallet);
-        insert_checkpoint(
-            &mut wallet.bdk,
-            BlockId { height: 1, hash: BlockHash::from_byte_array([4; 32]) },
-        );
-
-        let outpoint = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(10_000));
-        let terminal_tx =
-            (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
-
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-
-        let persister =
-            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        persister.create_session(&terminal_tx, PayjoinSessionId::generate()).unwrap();
-        persister.set_pending_fallback().unwrap();
-
-        actor.db = db;
-
-        let dummy_psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
-            version: bitcoin::transaction::Version::TWO,
-            lock_time: bitcoin::absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        })
-        .unwrap();
-        let result = actor.initiate_payment(dummy_psbt, UnsignedPaymentMode::Standard).await;
-        let outcome = actor_value(result).await;
-
-        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
-        assert!(session.is_none(), "gate should have cleared the stale session record");
-        assert!(matches!(outcome, Err(super::Error::PayjoinSessionError(_))));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn broadcast_payjoin_terminal_skips_rebroadcast_when_tx_already_in_wallet() {
-        crate::database::test_support::init_test_database();
-        crate::test_support::ensure_tokio_runtime();
-        let mut wallet = Wallet::preview_new_wallet();
-        mark_wallet_ledger_ready(&mut wallet);
-        insert_checkpoint(
-            &mut wallet.bdk,
-            BlockId { height: 1, hash: BlockHash::from_byte_array([5; 32]) },
-        );
-
-        let outpoint = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(10_000));
-        let terminal_tx =
-            (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
-
-        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
-
-        let persister =
-            crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone());
-        let session_id = PayjoinSessionId::generate();
-        persister.create_session(&terminal_tx, session_id).unwrap();
-        persister.set_pending_proposal(&terminal_tx).unwrap();
-
-        let (addr, _receiver) = spawn_test_wallet_actor(wallet);
-        call!(addr.set_test_wallet_data_db(db.clone())).await.expect("actor responds");
-
-        call!(addr.resume_payjoin_session()).await.expect("actor responds");
-
-        for _ in 0..50 {
-            let session = db.get_payjoin_sender_session().expect("db query succeeded");
-            if session.is_none() {
-                return;
-            }
-
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-
-        panic!("session should be cleared when terminal tx is already in wallet");
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn recovered_payjoin_signing_failure_retains_session_record() {
-        crate::database::test_support::init_test_database();
-        test_keychain();
-        let mut wallet = Wallet::preview_new_wallet();
-        mark_wallet_ledger_ready(&mut wallet);
-
-        let (sender, _receiver) = flume::bounded(10);
-        let mut actor = new_test_wallet_actor(wallet, sender);
-        let (db, _tmp) = new_test_wallet_data_db(actor.wallet.id.clone());
-
-        let fallback_tx = bitcoin::Transaction {
-            version: bitcoin::transaction::Version::TWO,
-            lock_time: bitcoin::absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
-        let session_id = PayjoinSessionId::generate();
-        crate::manager::wallet_manager::payjoin::PayjoinSessionPersister::new(db.clone())
-            .create_session(&fallback_tx, session_id.clone())
-            .unwrap();
-
-        actor.db = db;
-        actor.payjoin =
-            Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-
-        let proposal_psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
-            version: bitcoin::transaction::Version::TWO,
-            lock_time: bitcoin::absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        })
-        .unwrap();
-
-        let result =
-            actor.handle_recovered_payjoin_success(session_id, proposal_psbt, fallback_tx).await;
-        actor_value(result).await;
-
-        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
-        assert!(session.is_some(), "session must be retained when signing fails");
-        assert!(
-            session.unwrap().pending_action.is_none(),
-            "signing failure must not select fallback"
         );
     }
 }

--- a/rust/src/manager/wallet_manager/actor.rs
+++ b/rust/src/manager/wallet_manager/actor.rs
@@ -233,7 +233,21 @@ impl WalletActor {
     }
 
     pub async fn notify_payjoin_error(&mut self, msg: String) -> ActorResult<()> {
-        self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(msg)));
+        self.send(WalletManagerReconcileMessage::SendFlowError(
+            SendFlowErrorAlert::SignAndBroadcast(msg),
+        ));
+        Produces::ok(())
+    }
+
+    pub async fn cancel_payjoin(&mut self) -> ActorResult<Result<(), Error>> {
+        if let Some(actor) = self.payjoin_actor.take() {
+            send!(actor.cancel_and_fallback());
+        }
+        Produces::ok(Ok(()))
+    }
+
+    pub async fn notify_payjoin_polling_started(&mut self, deadline_secs: u64) -> ActorResult<()> {
+        self.send(WalletManagerReconcileMessage::PayjoinPollingStarted { deadline_secs });
         Produces::ok(())
     }
 

--- a/rust/src/manager/wallet_manager/actor/broadcast.rs
+++ b/rust/src/manager/wallet_manager/actor/broadcast.rs
@@ -1,0 +1,68 @@
+use act_zero::{ActorResult, Produces, WeakAddr, call};
+use bitcoin::{Transaction, Txid};
+
+use crate::{manager::wallet_manager::Error, node::client::NodeClient};
+
+use super::WalletActor;
+
+#[derive(Debug)]
+pub(crate) enum BroadcastTransactionError {
+    BroadcastFailed(Error),
+    PostBroadcastFailed(Error),
+}
+
+impl BroadcastTransactionError {
+    pub(crate) fn into_error(self) -> Error {
+        match self {
+            Self::BroadcastFailed(error) | Self::PostBroadcastFailed(error) => error,
+        }
+    }
+}
+
+impl WalletActor {
+    async fn node_client_for_broadcast(&mut self) -> ActorResult<Result<NodeClient, Error>> {
+        Produces::ok(self.node_client().cloned().map_err(|_| {
+            Error::BroadcastError(
+                "failed to broadcast transaction, could not get node client, try again".to_string(),
+            )
+        }))
+    }
+}
+
+pub(crate) async fn broadcast_to_node_with_connection(
+    addr: WeakAddr<WalletActor>,
+    connection: Produces<Result<(), Error>>,
+    transaction: &Transaction,
+) -> Result<(), BroadcastTransactionError> {
+    connection
+        .await
+        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?
+        .map_err(|error| {
+            BroadcastTransactionError::BroadcastFailed(Error::BroadcastError(format!(
+                "failed to broadcast transaction, unable to connect to node: {error:?}"
+            )))
+        })?;
+
+    let node_client = call!(addr.node_client_for_broadcast())
+        .await
+        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?
+        .map_err(BroadcastTransactionError::BroadcastFailed)?;
+
+    node_client.broadcast_transaction(transaction.clone()).await.map_err(|error| {
+        BroadcastTransactionError::BroadcastFailed(Error::BroadcastError(format!(
+            "failed to broadcast transaction, try again: {error:?}"
+        )))
+    })?;
+
+    Ok(())
+}
+
+pub(crate) async fn transaction_known_to_node(addr: WeakAddr<WalletActor>, txid: Txid) -> bool {
+    let node_client = match call!(addr.node_client_for_broadcast()).await {
+        Ok(Ok(node_client)) => node_client,
+        _ => return false,
+    };
+
+    let response = node_client.get_transaction(txid).await;
+    matches!(response, Ok(Some(ref found)) if found.compute_txid() == txid)
+}

--- a/rust/src/manager/wallet_manager/actor/payjoin.rs
+++ b/rust/src/manager/wallet_manager/actor/payjoin.rs
@@ -783,7 +783,7 @@ mod tests {
                 actor_value, mark_wallet_ledger_ready, new_test_wallet_actor,
                 new_test_wallet_actor_with_db, restore_default_bitcoin_node,
                 set_broadcast_esplora_node, set_pending_broadcast_esplora_node,
-                test_broadcast_transaction, test_keychain, wait_for_broadcast_request_count,
+                test_broadcast_transaction, test_keychain, wait_for_broadcast_request,
             },
             payjoin::{PayjoinSessionPersister, test_support::terminal_actor},
         },
@@ -849,7 +849,7 @@ mod tests {
 
         let (authority, preparation) = begin_wallet_deletion(db.id.clone());
         actor_value(actor.quiesce_for_terminal_shutdown(authority).await).await;
-        wait_for_broadcast_request_count(&failed_server.broadcast_requests, 1).await;
+        wait_for_broadcast_request(&failed_server.broadcast_requested).await;
         drop(preparation);
         failed_server.server.abort();
 
@@ -947,7 +947,7 @@ mod tests {
         )
         .await
         .expect("destructive quiesce does not wait for a pending node request");
-        wait_for_broadcast_request_count(&pending_server.broadcast_requests, 1).await;
+        wait_for_broadcast_request(&pending_server.broadcast_requested).await;
 
         pending_server.release.send(true).expect("pending broadcast request is listening");
         drop(preparation);

--- a/rust/src/manager/wallet_manager/actor/payjoin.rs
+++ b/rust/src/manager/wallet_manager/actor/payjoin.rs
@@ -1,0 +1,1110 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use act_zero::{
+    ActorResult, Addr, AddrLike as _, Produces, WeakAddr, call, runtimes::tokio::spawn_actor, send,
+};
+use bdk_wallet::chain::bitcoin::Psbt;
+use bitcoin::{Transaction as BdkTransaction, Txid};
+use cove_types::{PayjoinIntent, PayjoinSessionId};
+use cove_util::result_ext::ResultExt as _;
+use tracing::{error, warn};
+
+use crate::{
+    database::Database,
+    manager::wallet_manager::{
+        Error, PayjoinBroadcastOutcome, PayjoinStatus, WalletManagerReconcileMessage,
+        payjoin::{
+            PayjoinActor, PayjoinSessionPersister, SessionResumption, build_sender, resume_session,
+        },
+    },
+    node::{Node, client::NodeClient},
+    wallet_lifecycle::TerminalPayjoinPersistenceAuthority,
+};
+
+use super::{
+    WalletActor,
+    broadcast::{
+        BroadcastTransactionError, broadcast_to_node_with_connection, transaction_known_to_node,
+    },
+};
+
+#[derive(Debug)]
+pub(crate) enum ActivePayjoin {
+    Negotiating { session_id: PayjoinSessionId, actor: Addr<PayjoinActor> },
+    Broadcasting { session_id: PayjoinSessionId, outcome: PayjoinBroadcastOutcome },
+    RecoveryBlocked { session_id: PayjoinSessionId },
+}
+
+impl ActivePayjoin {
+    fn session_id(&self) -> &PayjoinSessionId {
+        match self {
+            Self::Negotiating { session_id, .. }
+            | Self::Broadcasting { session_id, .. }
+            | Self::RecoveryBlocked { session_id } => session_id,
+        }
+    }
+
+    fn is_broadcasting(
+        &self,
+        session_id: &PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+    ) -> bool {
+        matches!(
+            self,
+            Self::Broadcasting {
+                session_id: active_id,
+                outcome: active_outcome,
+            } if active_id == session_id && *active_outcome == outcome
+        )
+    }
+}
+
+impl WalletActor {
+    /// Resumes a persisted payjoin session from a previous app run, if one exists
+    pub async fn resume_payjoin_session(&mut self) -> ActorResult<()> {
+        if self.payjoin.is_some() {
+            return Produces::ok(());
+        }
+
+        match resume_session(self.db.clone(), self.addr.clone()) {
+            SessionResumption::None => {}
+
+            SessionResumption::Resume(actor) => self.spawn_payjoin_actor(*actor),
+
+            SessionResumption::BroadcastStoredProposal { session_id, proposal_tx } => {
+                self.payjoin = Some(ActivePayjoin::Broadcasting {
+                    session_id: session_id.clone(),
+                    outcome: PayjoinBroadcastOutcome::Proposal,
+                });
+                send!(self.addr.handle_payjoin_proposal_broadcast(session_id, proposal_tx));
+            }
+
+            SessionResumption::SignRecoveredProposal { session_id, proposal_psbt, fallback_tx } => {
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                send!(self.addr.handle_recovered_payjoin_success(
+                    session_id,
+                    proposal_psbt,
+                    fallback_tx
+                ));
+            }
+
+            SessionResumption::BroadcastFallback { session_id, fallback_tx } => {
+                self.payjoin = Some(ActivePayjoin::Broadcasting {
+                    session_id: session_id.clone(),
+                    outcome: PayjoinBroadcastOutcome::Fallback,
+                });
+                send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
+            }
+
+            SessionResumption::ReportError { session_id: Some(session_id), message } => {
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(session_id, message);
+            }
+
+            SessionResumption::ReportError { session_id: None, message } => {
+                self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(
+                    message,
+                )));
+            }
+        }
+
+        Produces::ok(())
+    }
+
+    pub async fn notify_payjoin_error(
+        &mut self,
+        session_id: PayjoinSessionId,
+        message: String,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
+        self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+        self.send_payjoin_failure(session_id, message);
+        Produces::ok(())
+    }
+
+    pub async fn cancel_payjoin(
+        &mut self,
+        requested_id: PayjoinSessionId,
+    ) -> ActorResult<Result<(), Error>> {
+        let Some(active) = self.payjoin.take() else {
+            return Produces::ok(Ok(()));
+        };
+
+        let ActivePayjoin::Negotiating { session_id, actor } = active else {
+            let active_id = active.session_id().clone();
+            self.payjoin = Some(active);
+
+            return if active_id == requested_id {
+                Produces::ok(Ok(()))
+            } else {
+                Produces::ok(Err(Error::PayjoinSessionMismatch {
+                    requested: requested_id,
+                    active: active_id,
+                }))
+            };
+        };
+
+        if session_id != requested_id {
+            self.payjoin =
+                Some(ActivePayjoin::Negotiating { session_id: session_id.clone(), actor });
+            return Produces::ok(Err(Error::PayjoinSessionMismatch {
+                requested: requested_id,
+                active: session_id,
+            }));
+        }
+
+        match call!(actor.cancel_and_fallback()).await {
+            Ok(Some(fallback_tx)) => {
+                self.payjoin = Some(ActivePayjoin::Broadcasting {
+                    session_id: session_id.clone(),
+                    outcome: PayjoinBroadcastOutcome::Fallback,
+                });
+                send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
+                Produces::ok(Ok(()))
+            }
+
+            Ok(None) => {
+                self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id });
+                Produces::ok(Ok(()))
+            }
+
+            Err(error) => {
+                self.payjoin = Some(ActivePayjoin::Negotiating { session_id, actor });
+                Produces::ok(Err(error).map_err_str(Error::PayjoinCancellationFailed))
+            }
+        }
+    }
+
+    pub async fn notify_payjoin_polling_started(
+        &mut self,
+        session_id: PayjoinSessionId,
+        deadline_secs: u64,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
+        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(PayjoinStatus::Polling {
+            session_id,
+            deadline_secs,
+        }));
+        Produces::ok(())
+    }
+
+    pub(crate) async fn quiesce_payjoin(
+        &mut self,
+        terminal_payjoin_authority: Option<TerminalPayjoinPersistenceAuthority>,
+    ) -> Result<(), String> {
+        match terminal_payjoin_authority {
+            Some(authority) => {
+                if let Some(active) = self.payjoin.take() {
+                    match active {
+                        ActivePayjoin::Negotiating { session_id, actor } => {
+                            if let Err(error) = call!(
+                                actor.cancel_and_fallback_for_terminal_shutdown(authority.clone())
+                            )
+                            .await
+                            {
+                                self.payjoin =
+                                    Some(ActivePayjoin::Negotiating { session_id, actor });
+                                return Err(error.to_string());
+                            }
+                        }
+
+                        terminal => self.payjoin = Some(terminal),
+                    }
+                }
+
+                let terminal_transaction = PayjoinSessionPersister::new(self.db.clone())
+                    .terminal_transaction_for_shutdown(&authority)
+                    .map_err(|error| error.to_string())?;
+
+                if let Some(transaction) = terminal_transaction {
+                    // keep node latency outside the destructive shutdown deadline
+                    self.schedule_payjoin_terminal_broadcast(transaction);
+                }
+            }
+            None => {
+                if let Some(active) = self.payjoin.take() {
+                    match active {
+                        ActivePayjoin::Negotiating { session_id, actor } => {
+                            let fallback = match call!(actor.cancel_and_fallback()).await {
+                                Ok(fallback) => fallback,
+                                Err(error) => {
+                                    self.payjoin =
+                                        Some(ActivePayjoin::Negotiating { session_id, actor });
+                                    return Err(error.to_string());
+                                }
+                            };
+
+                            if let Some(fallback) = fallback {
+                                self.broadcast_payjoin_terminal_for_shutdown(fallback)
+                                    .await
+                                    .map_err(|error| error.to_string())?;
+                            }
+                        }
+
+                        terminal => self.payjoin = Some(terminal),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn active_payjoin_session_id(&self) -> Option<&PayjoinSessionId> {
+        self.payjoin.as_ref().map(ActivePayjoin::session_id)
+    }
+
+    fn is_active_payjoin(&self, session_id: &PayjoinSessionId) -> bool {
+        self.active_payjoin_session_id() == Some(session_id)
+    }
+
+    fn is_active_payjoin_broadcast(
+        &self,
+        session_id: &PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+    ) -> bool {
+        self.payjoin.as_ref().is_some_and(|active| active.is_broadcasting(session_id, outcome))
+    }
+
+    pub(crate) fn send_payjoin_failure(&self, session_id: PayjoinSessionId, message: String) {
+        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(PayjoinStatus::Failed {
+            session_id,
+            message,
+        }));
+    }
+
+    pub(crate) fn prepare_for_payment(&mut self) -> Result<(), Error> {
+        if self.payjoin.is_some() {
+            return Err(Error::PayjoinSessionError(
+                "a payjoin session is already in progress".to_string(),
+            ));
+        }
+
+        let Some(_) = self.db.get_payjoin_sender_session().map_err(|error| {
+            error!("failed to check for pending payjoin session: {error}");
+            Error::PayjoinSessionError(
+                "unable to verify payjoin session state; please try again later".to_string(),
+            )
+        })?
+        else {
+            return Ok(());
+        };
+
+        // if the session has a terminal marker and the tx is already in the local wallet,
+        // the only remaining work is session cleanup and does not need the network
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        let can_cleanup =
+            persister.pending_txid().is_some_and(|txid| self.wallet.bdk.get_tx(txid).is_some());
+
+        if !can_cleanup {
+            // resume the pending broadcast so the user does not need to restart
+            send!(self.addr.resume_payjoin_session());
+            return Err(Error::PayjoinSessionError(
+                "retrying a previous payjoin broadcast; please try again in a moment".to_string(),
+            ));
+        }
+
+        // a prior broadcast can apply the tx in memory before the wallet reaches disk
+        if let Err(error) = self.wallet.persist() {
+            warn!("failed to persist wallet at send gate before payjoin cleanup: {error}");
+            return Err(Error::PayjoinSessionError(
+                "a previous payjoin session is pending cleanup; please try again later".to_string(),
+            ));
+        }
+
+        if let Err(error) = self.db.delete_payjoin_sender_session() {
+            warn!("payjoin session cleanup at send gate failed: {error}");
+            return Err(Error::PayjoinSessionError(
+                "a previous payjoin session is pending cleanup; please try again later".to_string(),
+            ));
+        }
+
+        // the completed tx can be the proposal, while the supplied PSBT is still the fallback
+        Err(Error::PayjoinSessionError(
+            "previous payjoin session cleared; please confirm your payment again".to_string(),
+        ))
+    }
+
+    pub(crate) async fn initiate_payjoin_payment(
+        &mut self,
+        psbt: Psbt,
+        intent: PayjoinIntent,
+    ) -> Result<(), Error> {
+        let PayjoinIntent { session_id, endpoint } = intent;
+        let (signed_psbt, fallback_tx) = self.do_sign_original_psbt(psbt).await?;
+        let network: bitcoin::Network = self.wallet.network.into();
+
+        // persist the session before the first network request so it survives app restarts
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.create_session(&fallback_tx, session_id.clone()) {
+            warn!("payjoin session could not be persisted, broadcasting fallback tx: {error}");
+            self.payjoin = Some(ActivePayjoin::Broadcasting {
+                session_id: session_id.clone(),
+                outcome: PayjoinBroadcastOutcome::Fallback,
+            });
+            send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
+            return Ok(());
+        }
+
+        let Ok(sender) = build_sender(
+            signed_psbt,
+            &fallback_tx,
+            endpoint.as_str().to_string(),
+            network,
+            &persister,
+        )
+        .inspect_err(|error| warn!("payjoin setup failed, broadcasting fallback tx: {error}")) else {
+            self.payjoin = Some(ActivePayjoin::Broadcasting {
+                session_id: session_id.clone(),
+                outcome: PayjoinBroadcastOutcome::Fallback,
+            });
+            send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
+            return Ok(());
+        };
+
+        let actor =
+            PayjoinActor::new(self.addr.clone(), persister, sender, fallback_tx, session_id);
+        self.spawn_payjoin_actor(actor);
+        Ok(())
+    }
+
+    fn start_payjoin_terminal_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+        tx: BdkTransaction,
+    ) {
+        if !self.is_active_payjoin(&session_id) {
+            return;
+        }
+
+        self.payjoin =
+            Some(ActivePayjoin::Broadcasting { session_id: session_id.clone(), outcome });
+        let connection = self.deferred_node_connection();
+
+        self.addr.send_fut_with(|addr| async move {
+            let result = broadcast_payjoin_terminal_with_connection(
+                addr.clone(),
+                connection,
+                session_id.clone(),
+                outcome,
+                tx,
+            )
+            .await;
+            send!(addr.handle_payjoin_terminal_broadcast_result(session_id, outcome, result));
+        });
+    }
+
+    fn start_payjoin_fallback_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        tx: BdkTransaction,
+    ) {
+        if !self.is_active_payjoin(&session_id) {
+            return;
+        }
+
+        match self.db.get_payjoin_sender_session() {
+            Ok(None) => {}
+
+            Ok(Some(_)) => {
+                let persister = PayjoinSessionPersister::new(self.db.clone());
+                if let Err(error) = persister.set_pending_fallback() {
+                    error!("failed to persist fallback intent before broadcast, aborting: {error}");
+                    self.payjoin =
+                        Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                    self.send_payjoin_failure(
+                        session_id,
+                        "failed to persist recovery state; please restart the app".to_string(),
+                    );
+                    return;
+                }
+            }
+
+            Err(error) => {
+                error!("failed to check for payjoin session before fallback, aborting: {error}");
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(
+                    session_id,
+                    "failed to persist recovery state; please restart the app".to_string(),
+                );
+                return;
+            }
+        }
+
+        self.start_payjoin_terminal_broadcast(session_id, PayjoinBroadcastOutcome::Fallback, tx);
+    }
+
+    /// Schedule best-effort broadcast of the exact committed Payjoin transaction
+    fn schedule_payjoin_terminal_broadcast(&mut self, tx: BdkTransaction) {
+        let node = Database::global().global_config.selected_node();
+        let node_client = self.node_client().ok().cloned();
+
+        cove_tokio::task::spawn(async move {
+            if let Err(error) = broadcast_payjoin_terminal_with_client(node_client, node, tx).await
+            {
+                warn!(
+                    "failed to broadcast committed Payjoin transaction during destructive wallet shutdown; the durable terminal marker remains for retry: {error}"
+                );
+            }
+        });
+    }
+
+    /// Broadcast the exact committed Payjoin transaction
+    async fn broadcast_payjoin_terminal_for_shutdown(
+        &mut self,
+        tx: BdkTransaction,
+    ) -> Result<(), Error> {
+        let node = Database::global().global_config.selected_node();
+        let node_client = self.node_client().ok().cloned();
+
+        broadcast_payjoin_terminal_with_client(node_client, node, tx).await
+    }
+
+    fn start_payjoin_proposal_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        proposal_tx: BdkTransaction,
+    ) {
+        if !self.is_active_payjoin(&session_id) {
+            return;
+        }
+
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
+            error!("failed to persist proposal broadcast intent, aborting: {error}");
+            self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+            self.send_payjoin_failure(
+                session_id,
+                "failed to persist recovery state; please restart the app".to_string(),
+            );
+            return;
+        }
+
+        self.start_payjoin_terminal_broadcast(
+            session_id,
+            PayjoinBroadcastOutcome::Proposal,
+            proposal_tx,
+        );
+    }
+
+    async fn payjoin_terminal_tx_in_wallet(&mut self, txid: Txid) -> ActorResult<bool> {
+        Produces::ok(self.wallet.bdk.get_tx(txid).is_some())
+    }
+
+    async fn apply_payjoin_terminal_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+        tx: BdkTransaction,
+    ) -> ActorResult<Result<(), Error>> {
+        use WalletManagerReconcileMessage as Msg;
+
+        if !self.is_active_payjoin_broadcast(&session_id, outcome) {
+            return Produces::ok(Ok(()));
+        }
+
+        let now =
+            SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_else(|e| {
+                warn!("System clock skew detected: {e}");
+                0
+            });
+
+        let txid = tx.compute_txid();
+
+        self.wallet.bdk.apply_unconfirmed_txs([(tx, now)]);
+
+        // keep the session record until wallet state is durable so startup can recover
+        if let Err(error) = self.wallet.persist() {
+            error!(
+                "failed to persist wallet after payjoin broadcast; retaining session record for recovery: {error}"
+            );
+            return Produces::ok(Err(Error::PayjoinSessionError(
+                "transaction was broadcast but wallet state could not be saved; please restart the app"
+                    .to_string(),
+            )));
+        }
+
+        let session_cleared = match self.db.delete_payjoin_sender_session() {
+            Ok(()) => true,
+            Err(error) => {
+                warn!("failed to clear payjoin session record: {error}");
+                false
+            }
+        };
+
+        let balance = self.wallet.balance();
+        self.send(Msg::WalletBalanceChanged(balance.into()));
+
+        let transactions = self.do_transactions().await;
+        self.send(Msg::UpdatedTransactions(transactions));
+
+        send!(self.addr.start_transaction_watcher(txid));
+
+        if session_cleared {
+            self.send(Msg::PayjoinStatusChanged(PayjoinStatus::Broadcast { session_id, outcome }));
+            self.payjoin = None;
+        } else {
+            // tx is broadcast and wallet-persisted, but the session record remains
+            // initiate_payment will reject new sends until the record is gone
+            // on restart resume_payjoin_session re-dispatches the stored terminal tx
+            // because it is already in the wallet, broadcast is skipped and cleanup is retried
+            self.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+            self.send_payjoin_failure(
+                session_id,
+                "transaction was broadcast; restart the app to unlock sending".to_string(),
+            );
+        }
+
+        Produces::ok(Ok(()))
+    }
+
+    async fn handle_payjoin_terminal_broadcast_result(
+        &mut self,
+        session_id: PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+        result: Result<(), BroadcastTransactionError>,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin_broadcast(&session_id, outcome) {
+            return Produces::ok(());
+        }
+
+        match result {
+            Ok(()) => {}
+
+            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
+                error!("payjoin broadcast failed: {error}");
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(session_id, error.to_string());
+            }
+
+            Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
+                error!("payjoin broadcast bookkeeping failed: {error}");
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(session_id, error.to_string());
+            }
+        }
+
+        Produces::ok(())
+    }
+
+    pub async fn handle_payjoin_success(
+        &mut self,
+        session_id: PayjoinSessionId,
+        proposal_psbt: Psbt,
+        fallback_tx: BdkTransaction,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
+        let Ok((_, proposal_tx)) =
+            self.do_sign_original_psbt(proposal_psbt).await.inspect_err(|error| {
+                error!("failed to sign payjoin proposal, falling back to original tx: {error:?}")
+            })
+        else {
+            self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
+            return Produces::ok(());
+        };
+
+        self.start_payjoin_proposal_broadcast(session_id, proposal_tx);
+        Produces::ok(())
+    }
+
+    pub async fn handle_payjoin_proposal_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        proposal_tx: BdkTransaction,
+    ) -> ActorResult<()> {
+        self.start_payjoin_terminal_broadcast(
+            session_id,
+            PayjoinBroadcastOutcome::Proposal,
+            proposal_tx,
+        );
+        Produces::ok(())
+    }
+
+    /// Handles a recovered session that closed with a receiver proposal but no stored tx.
+    /// On signing failure the session record is retained — the receiver's proposal was valid
+    /// and the user should retry after resolving the signing issue.
+    /// If the proposal intent cannot be persisted, `fallback_tx` is broadcast instead —
+    /// no terminal marker was written so falling back is safe at that point.
+    pub async fn handle_recovered_payjoin_success(
+        &mut self,
+        session_id: PayjoinSessionId,
+        proposal_psbt: Psbt,
+        fallback_tx: BdkTransaction,
+    ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
+        let proposal_tx = match self.do_sign_original_psbt(proposal_psbt).await {
+            Ok((_, tx)) => tx,
+            Err(error) => {
+                error!("failed to sign recovered payjoin proposal, pausing for retry: {error:?}");
+                // the receiver accepted a valid proposal; do not fall back — retain the record
+                // so the user can retry after resolving the signing failure
+                self.payjoin =
+                    Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(
+                    session_id,
+                    "could not sign the recovered payjoin proposal; unlock the wallet and restart"
+                        .to_string(),
+                );
+                return Produces::ok(());
+            }
+        };
+
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
+            error!("failed to persist recovered proposal intent, falling back: {error}");
+            // no terminal marker was written yet; safe to fall back to the original tx
+            self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
+            return Produces::ok(());
+        }
+
+        self.start_payjoin_terminal_broadcast(
+            session_id,
+            PayjoinBroadcastOutcome::Proposal,
+            proposal_tx,
+        );
+        Produces::ok(())
+    }
+
+    pub async fn handle_payjoin_fallback(
+        &mut self,
+        session_id: PayjoinSessionId,
+        fallback_tx: BdkTransaction,
+    ) -> ActorResult<()> {
+        self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
+        Produces::ok(())
+    }
+
+    fn spawn_payjoin_actor(&mut self, actor: PayjoinActor) {
+        let session_id = actor.session_id.clone();
+        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(
+            PayjoinStatus::Negotiating { session_id: session_id.clone() },
+        ));
+        self.payjoin = Some(ActivePayjoin::Negotiating { session_id, actor: spawn_actor(actor) });
+    }
+}
+
+async fn broadcast_payjoin_terminal_with_client(
+    node_client: Option<NodeClient>,
+    node: Node,
+    tx: BdkTransaction,
+) -> Result<(), Error> {
+    let node_client = match node_client {
+        Some(node_client) => node_client,
+        None => super::node::checked_node_client(&node).await?,
+    };
+    let txid = tx.compute_txid();
+
+    if let Err(error) = node_client.broadcast_transaction(tx).await {
+        let known_to_node = node_client
+            .get_transaction(txid)
+            .await
+            .is_ok_and(|found| found.is_some_and(|transaction| transaction.compute_txid() == txid));
+        if !known_to_node {
+            return Err(Error::BroadcastError(format!(
+                "failed to broadcast committed Payjoin transaction during wallet shutdown: {error:?}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+async fn broadcast_payjoin_terminal_with_connection(
+    addr: WeakAddr<WalletActor>,
+    connection: Produces<Result<(), Error>>,
+    session_id: PayjoinSessionId,
+    outcome: PayjoinBroadcastOutcome,
+    transaction: BdkTransaction,
+) -> Result<(), BroadcastTransactionError> {
+    let txid = transaction.compute_txid();
+    let already_in_wallet = call!(addr.payjoin_terminal_tx_in_wallet(txid))
+        .await
+        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?;
+
+    if !already_in_wallet {
+        match broadcast_to_node_with_connection(addr.clone(), connection, &transaction).await {
+            Ok(()) => {}
+
+            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
+                if !transaction_known_to_node(addr.clone(), txid).await {
+                    return Err(BroadcastTransactionError::BroadcastFailed(error));
+                }
+            }
+
+            Err(error) => return Err(error),
+        }
+    }
+
+    call!(addr.apply_payjoin_terminal_broadcast(session_id, outcome, transaction))
+        .await
+        .map_err(|_| BroadcastTransactionError::PostBroadcastFailed(Error::ActorNotFound))?
+        .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::atomic::Ordering, time::Duration};
+
+    use act_zero::{call, runtimes::tokio::spawn_actor};
+    use bdk_wallet::test_utils::{insert_checkpoint, receive_output_in_latest_block};
+    use bitcoin::{
+        Amount, BlockHash, Psbt, Transaction, absolute::LockTime, hashes::Hash as _,
+        transaction::Version,
+    };
+    use cove_types::PayjoinSessionId;
+
+    use crate::{
+        database::wallet_data::{
+            PendingAction, WalletDataDb, test_support::new_test_wallet_data_db,
+        },
+        manager::wallet_manager::{
+            Error, PayjoinBroadcastOutcome,
+            actor::test_support::{
+                actor_value, mark_wallet_ledger_ready, new_test_wallet_actor,
+                new_test_wallet_actor_with_db, restore_default_bitcoin_node,
+                set_broadcast_esplora_node, set_pending_broadcast_esplora_node,
+                test_broadcast_transaction, test_keychain, wait_for_broadcast_request_count,
+            },
+            payjoin::{PayjoinSessionPersister, test_support::terminal_actor},
+        },
+        router::UnsignedPaymentMode,
+        wallet::Wallet,
+        wallet_lifecycle::test_support::begin_wallet_deletion,
+    };
+
+    use super::ActivePayjoin;
+
+    fn new_actor_with_db(wallet: Wallet, db: WalletDataDb) -> super::WalletActor {
+        let (sender, _receiver) = flume::bounded(10);
+        new_test_wallet_actor_with_db(wallet, sender, db)
+    }
+
+    fn empty_transaction() -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn terminal_payjoin_fallback_waits_for_node_broadcast() {
+        let _guard = crate::test_support::global_state_test_lock().lock().await;
+
+        crate::database::test_support::init_test_database();
+        let server = set_broadcast_esplora_node(200).await;
+        let wallet = Wallet::preview_new_wallet();
+        let (sender, _receiver) = flume::bounded(10);
+        let mut actor = new_test_wallet_actor(wallet, sender);
+
+        actor
+            .broadcast_payjoin_terminal_for_shutdown(test_broadcast_transaction())
+            .await
+            .expect("terminal fallback reaches the node before shutdown returns");
+
+        restore_default_bitcoin_node();
+        server.server.abort();
+        assert_eq!(server.broadcast_requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn destructive_quiesce_succeeds_after_terminal_broadcast_failure() {
+        let _guard = crate::test_support::global_state_test_lock().lock().await;
+
+        crate::database::test_support::init_test_database();
+        let failed_server = set_broadcast_esplora_node(500).await;
+        let wallet = Wallet::preview_new_wallet();
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let terminal_tx = test_broadcast_transaction();
+        let persister = PayjoinSessionPersister::new(db.clone());
+        let session_id = PayjoinSessionId::generate();
+        persister.create_session(&terminal_tx, session_id.clone()).unwrap();
+
+        let mut actor = new_actor_with_db(wallet, db.clone());
+        actor.payjoin = Some(ActivePayjoin::Negotiating {
+            session_id: session_id.clone(),
+            actor: spawn_actor(terminal_actor(persister, terminal_tx, session_id)),
+        });
+
+        let (authority, preparation) = begin_wallet_deletion(db.id.clone());
+        actor_value(actor.quiesce_for_terminal_shutdown(authority).await).await;
+        wait_for_broadcast_request_count(&failed_server.broadcast_requests, 1).await;
+        drop(preparation);
+        failed_server.server.abort();
+
+        assert!(actor.payjoin.is_none(), "the failed broadcast leaves no active child actor");
+        assert_eq!(
+            db.get_payjoin_sender_session().unwrap().unwrap().pending_action,
+            Some(PendingAction::BroadcastFallback),
+            "the retry marker must remain after the failed broadcast"
+        );
+
+        restore_default_bitcoin_node();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_payjoin_keeps_child_when_fallback_commit_fails() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+
+        let wallet = Wallet::preview_new_wallet();
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let persister = PayjoinSessionPersister::new(db.clone());
+        let session_id = PayjoinSessionId::generate();
+        let mut actor = new_actor_with_db(wallet, db);
+
+        actor.payjoin = Some(ActivePayjoin::Negotiating {
+            session_id: session_id.clone(),
+            actor: spawn_actor(terminal_actor(
+                persister,
+                test_broadcast_transaction(),
+                session_id.clone(),
+            )),
+        });
+
+        let outcome = actor_value(actor.cancel_payjoin(session_id).await).await;
+
+        assert!(matches!(outcome, Err(Error::PayjoinCancellationFailed(_))));
+        assert!(
+            matches!(actor.payjoin, Some(ActivePayjoin::Negotiating { .. })),
+            "the Payjoin child must remain so cancellation can be retried"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_payjoin_rejects_another_session_without_losing_the_active_child() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+
+        let wallet = Wallet::preview_new_wallet();
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let persister = PayjoinSessionPersister::new(db.clone());
+        let active_id = PayjoinSessionId::generate();
+        let requested_id = PayjoinSessionId::generate();
+        let mut actor = new_actor_with_db(wallet, db);
+
+        actor.payjoin = Some(ActivePayjoin::Negotiating {
+            session_id: active_id.clone(),
+            actor: spawn_actor(terminal_actor(
+                persister,
+                test_broadcast_transaction(),
+                active_id.clone(),
+            )),
+        });
+
+        let outcome = actor_value(actor.cancel_payjoin(requested_id.clone()).await).await;
+
+        assert_eq!(
+            outcome,
+            Err(Error::PayjoinSessionMismatch {
+                requested: requested_id,
+                active: active_id.clone(),
+            })
+        );
+        assert_eq!(actor.active_payjoin_session_id(), Some(&active_id));
+        assert!(matches!(actor.payjoin, Some(ActivePayjoin::Negotiating { .. })));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn destructive_quiesce_does_not_wait_for_terminal_broadcast() {
+        let _guard = crate::test_support::global_state_test_lock().lock().await;
+
+        crate::database::test_support::init_test_database();
+        let pending_server = set_pending_broadcast_esplora_node().await;
+        let wallet = Wallet::preview_new_wallet();
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let terminal_tx = test_broadcast_transaction();
+        let persister = PayjoinSessionPersister::new(db.clone());
+        persister.create_session(&terminal_tx, PayjoinSessionId::generate()).unwrap();
+        persister.set_pending_fallback().unwrap();
+
+        let mut actor = new_actor_with_db(wallet, db.clone());
+        let (authority, preparation) = begin_wallet_deletion(db.id.clone());
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            actor_value(actor.quiesce_for_terminal_shutdown(authority).await),
+        )
+        .await
+        .expect("destructive quiesce does not wait for a pending node request");
+        wait_for_broadcast_request_count(&pending_server.broadcast_requests, 1).await;
+
+        pending_server.release.send(true).expect("pending broadcast request is listening");
+        drop(preparation);
+        pending_server.server.abort();
+        restore_default_bitcoin_node();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_gate_retries_pending_terminal_action_and_rejects_new_send() {
+        crate::database::test_support::init_test_database();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let fallback_tx = empty_transaction();
+
+        PayjoinSessionPersister::new(db.clone())
+            .create_session(&fallback_tx, PayjoinSessionId::generate())
+            .unwrap();
+
+        let mut actor = new_actor_with_db(wallet, db);
+        let empty_psbt = Psbt::from_unsigned_tx(fallback_tx).unwrap();
+        let result = actor.initiate_payment(empty_psbt, UnsignedPaymentMode::Standard).await;
+        let outcome = actor_value(result).await;
+
+        assert!(matches!(&outcome, Err(Error::PayjoinSessionError(_))));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_gate_clears_stale_session_when_terminal_tx_already_in_wallet() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+        test_keychain();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            bdk_wallet::chain::BlockId { height: 1, hash: BlockHash::from_byte_array([4; 32]) },
+        );
+
+        let outpoint = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(10_000));
+        let terminal_tx =
+            (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let persister = PayjoinSessionPersister::new(db.clone());
+        persister.create_session(&terminal_tx, PayjoinSessionId::generate()).unwrap();
+        persister.set_pending_fallback().unwrap();
+
+        let mut actor = new_actor_with_db(wallet, db);
+        let dummy_psbt = Psbt::from_unsigned_tx(empty_transaction()).unwrap();
+        let result = actor.initiate_payment(dummy_psbt, UnsignedPaymentMode::Standard).await;
+        let outcome = actor_value(result).await;
+
+        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
+        assert!(session.is_none(), "gate should have cleared the stale session record");
+        assert!(matches!(outcome, Err(Error::PayjoinSessionError(_))));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_terminal_result_cannot_close_the_active_payjoin_session() {
+        crate::test_support::ensure_tokio_runtime();
+
+        let wallet = Wallet::preview_new_wallet();
+        let wallet_data_db =
+            WalletDataDb::new_in_memory(wallet.id.clone()).expect("wallet data database opens");
+        let (reconciler, receiver) = flume::bounded(1);
+        let mut actor = new_test_wallet_actor_with_db(wallet, reconciler, wallet_data_db);
+
+        let active_id = PayjoinSessionId::generate();
+        let stale_id = PayjoinSessionId::generate();
+        let transaction = empty_transaction();
+        let txid = transaction.compute_txid();
+
+        actor.payjoin = Some(ActivePayjoin::Broadcasting {
+            session_id: active_id.clone(),
+            outcome: PayjoinBroadcastOutcome::Proposal,
+        });
+
+        let outcome = actor_value(
+            actor
+                .apply_payjoin_terminal_broadcast(
+                    stale_id,
+                    PayjoinBroadcastOutcome::Proposal,
+                    transaction,
+                )
+                .await,
+        )
+        .await;
+
+        assert_eq!(outcome, Ok(()));
+        assert_eq!(actor.active_payjoin_session_id(), Some(&active_id));
+        assert!(actor.wallet.bdk.get_tx(txid).is_none());
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_payjoin_terminal_skips_rebroadcast_when_tx_already_in_wallet() {
+        crate::database::test_support::init_test_database();
+        crate::test_support::ensure_tokio_runtime();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        insert_checkpoint(
+            &mut wallet.bdk,
+            bdk_wallet::chain::BlockId { height: 1, hash: BlockHash::from_byte_array([5; 32]) },
+        );
+
+        let outpoint = receive_output_in_latest_block(&mut wallet.bdk, Amount::from_sat(10_000));
+        let terminal_tx =
+            (*wallet.bdk.get_tx(outpoint.txid).expect("tx in wallet").tx_node.tx).clone();
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let persister = PayjoinSessionPersister::new(db.clone());
+        let session_id = PayjoinSessionId::generate();
+        persister.create_session(&terminal_tx, session_id).unwrap();
+        persister.set_pending_proposal(&terminal_tx).unwrap();
+
+        let actor = new_actor_with_db(wallet, db.clone());
+        let addr = spawn_actor(actor);
+        call!(addr.resume_payjoin_session()).await.expect("actor responds");
+
+        for _ in 0..50 {
+            let session = db.get_payjoin_sender_session().expect("db query succeeded");
+            if session.is_none() {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        panic!("session should be cleared when terminal tx is already in wallet");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn recovered_payjoin_signing_failure_retains_session_record() {
+        crate::database::test_support::init_test_database();
+        test_keychain();
+        let mut wallet = Wallet::preview_new_wallet();
+        mark_wallet_ledger_ready(&mut wallet);
+        let (db, _tmp) = new_test_wallet_data_db(wallet.id.clone());
+        let fallback_tx = empty_transaction();
+        let session_id = PayjoinSessionId::generate();
+
+        PayjoinSessionPersister::new(db.clone())
+            .create_session(&fallback_tx, session_id.clone())
+            .unwrap();
+
+        let mut actor = new_actor_with_db(wallet, db);
+        actor.payjoin = Some(ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+        let proposal_psbt = Psbt::from_unsigned_tx(empty_transaction()).unwrap();
+
+        let result =
+            actor.handle_recovered_payjoin_success(session_id, proposal_psbt, fallback_tx).await;
+        actor_value(result).await;
+
+        let session = actor.db.get_payjoin_sender_session().expect("db query succeeded");
+        assert!(session.is_some(), "session must be retained when signing fails");
+        assert!(
+            session.unwrap().pending_action.is_none(),
+            "signing failure must not select fallback"
+        );
+    }
+}

--- a/rust/src/manager/wallet_manager/actor/test_support.rs
+++ b/rust/src/manager/wallet_manager/actor/test_support.rs
@@ -11,6 +11,7 @@ use parking_lot::RwLock;
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _},
     net::TcpListener,
+    sync::Notify,
     task::JoinHandle,
 };
 
@@ -46,11 +47,12 @@ impl WalletActor {
 
 pub(crate) struct BroadcastEsploraNode {
     pub(crate) broadcast_requests: Arc<AtomicUsize>,
+    pub(crate) broadcast_requested: Arc<Notify>,
     pub(crate) server: JoinHandle<()>,
 }
 
 pub(crate) struct PendingBroadcastEsploraNode {
-    pub(crate) broadcast_requests: Arc<AtomicUsize>,
+    pub(crate) broadcast_requested: Arc<Notify>,
     pub(crate) release: tokio::sync::watch::Sender<bool>,
     pub(crate) server: JoinHandle<()>,
 }
@@ -129,10 +131,13 @@ pub(crate) async fn set_broadcast_esplora_node(broadcast_status: u16) -> Broadca
 
     let broadcast_requests = Arc::new(AtomicUsize::new(0));
     let broadcast_counter = broadcast_requests.clone();
+    let broadcast_requested = Arc::new(Notify::new());
+    let broadcast_notification = broadcast_requested.clone();
     let server = tokio::spawn(async move {
         loop {
             let Ok((mut stream, _)) = listener.accept().await else { return };
             let broadcast_counter = broadcast_counter.clone();
+            let broadcast_notification = broadcast_notification.clone();
 
             tokio::spawn(async move {
                 let mut request = [0; 8192];
@@ -141,6 +146,7 @@ pub(crate) async fn set_broadcast_esplora_node(broadcast_status: u16) -> Broadca
 
                 let body = if request.starts_with("POST /tx ") {
                     broadcast_counter.fetch_add(1, Ordering::SeqCst);
+                    broadcast_notification.notify_one();
                     "broadcast"
                 } else {
                     "1"
@@ -158,7 +164,7 @@ pub(crate) async fn set_broadcast_esplora_node(broadcast_status: u16) -> Broadca
         }
     });
 
-    BroadcastEsploraNode { broadcast_requests, server }
+    BroadcastEsploraNode { broadcast_requests, broadcast_requested, server }
 }
 
 pub(crate) async fn set_pending_broadcast_esplora_node() -> PendingBroadcastEsploraNode {
@@ -175,13 +181,13 @@ pub(crate) async fn set_pending_broadcast_esplora_node() -> PendingBroadcastEspl
         .set_selected_node(&node)
         .expect("test node config is saved");
 
-    let broadcast_requests = Arc::new(AtomicUsize::new(0));
-    let broadcast_counter = broadcast_requests.clone();
+    let broadcast_requested = Arc::new(Notify::new());
+    let broadcast_notification = broadcast_requested.clone();
     let (release, release_request) = tokio::sync::watch::channel(false);
     let server = tokio::spawn(async move {
         loop {
             let Ok((mut stream, _)) = listener.accept().await else { return };
-            let broadcast_counter = broadcast_counter.clone();
+            let broadcast_notification = broadcast_notification.clone();
             let release_request = release_request.clone();
 
             tokio::spawn(async move {
@@ -190,7 +196,7 @@ pub(crate) async fn set_pending_broadcast_esplora_node() -> PendingBroadcastEspl
                 let request = String::from_utf8_lossy(&request[..bytes_read]);
                 let is_broadcast = request.starts_with("POST /tx ");
                 if is_broadcast {
-                    broadcast_counter.fetch_add(1, Ordering::SeqCst);
+                    broadcast_notification.notify_one();
                     let mut release_request = release_request.clone();
 
                     while !*release_request.borrow() {
@@ -211,24 +217,13 @@ pub(crate) async fn set_pending_broadcast_esplora_node() -> PendingBroadcastEspl
         }
     });
 
-    PendingBroadcastEsploraNode { broadcast_requests, release, server }
+    PendingBroadcastEsploraNode { broadcast_requested, release, server }
 }
 
-pub(crate) async fn wait_for_broadcast_request_count(
-    broadcast_requests: &Arc<AtomicUsize>,
-    count: usize,
-) {
-    tokio::time::timeout(std::time::Duration::from_secs(2), async {
-        loop {
-            if broadcast_requests.load(Ordering::SeqCst) >= count {
-                return;
-            }
-
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("broadcast request count is reached");
+pub(crate) async fn wait_for_broadcast_request(broadcast_requested: &Notify) {
+    tokio::time::timeout(std::time::Duration::from_secs(10), broadcast_requested.notified())
+        .await
+        .expect("broadcast request reaches the test node");
 }
 
 pub(crate) fn restore_default_bitcoin_node() {

--- a/rust/src/manager/wallet_manager/actor/test_support.rs
+++ b/rust/src/manager/wallet_manager/actor/test_support.rs
@@ -1,0 +1,245 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use act_zero::{ActorResult, Addr, runtimes::tokio::spawn_actor};
+use bitcoin::{Transaction, absolute::LockTime, transaction::Version};
+use cove_device::keychain::Keychain;
+use cove_types::network::Network as CoveNetwork;
+use parking_lot::RwLock;
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::TcpListener,
+    task::JoinHandle,
+};
+
+use crate::{
+    database::wallet_data::WalletDataDb,
+    manager::wallet_manager::{WalletScanStatus, WalletSnapshot},
+    node::Node,
+    wallet::Wallet,
+};
+
+use super::{SingleOrMany, WalletActor};
+
+impl WalletActor {
+    pub(crate) fn new_with_db(
+        wallet: Wallet,
+        reconciler: flume::Sender<SingleOrMany>,
+        scan_status: Arc<RwLock<WalletScanStatus>>,
+        wallet_snapshot: Arc<RwLock<WalletSnapshot>>,
+        db: WalletDataDb,
+    ) -> Self {
+        let metadata = Arc::new(RwLock::new(wallet.metadata.clone()));
+
+        Self::new_with_metadata_and_db(
+            wallet,
+            reconciler,
+            scan_status,
+            wallet_snapshot,
+            db,
+            metadata,
+        )
+    }
+}
+
+pub(crate) struct BroadcastEsploraNode {
+    pub(crate) broadcast_requests: Arc<AtomicUsize>,
+    pub(crate) server: JoinHandle<()>,
+}
+
+pub(crate) struct PendingBroadcastEsploraNode {
+    pub(crate) broadcast_requests: Arc<AtomicUsize>,
+    pub(crate) release: tokio::sync::watch::Sender<bool>,
+    pub(crate) server: JoinHandle<()>,
+}
+
+pub(crate) async fn actor_value<T>(result: ActorResult<T>) -> T {
+    result
+        .expect("actor method should not fail")
+        .await
+        .expect("actor method should produce a value")
+}
+
+pub(crate) fn test_broadcast_transaction() -> Transaction {
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: Vec::new(),
+        output: Vec::new(),
+    }
+}
+
+pub(crate) fn new_test_wallet_actor(
+    wallet: Wallet,
+    sender: flume::Sender<SingleOrMany>,
+) -> WalletActor {
+    crate::test_support::ensure_tokio_runtime();
+
+    let wallet_snapshot = Arc::new(RwLock::new(WalletSnapshot::from_wallet(&wallet)));
+    let scan_status = Arc::new(RwLock::new(WalletScanStatus::Idle));
+    let metadata = Arc::new(RwLock::new(wallet.metadata.clone()));
+
+    WalletActor::new_with_metadata(wallet, sender, scan_status, wallet_snapshot, metadata)
+        .expect("actor is created")
+}
+
+pub(crate) fn new_test_wallet_actor_with_db(
+    wallet: Wallet,
+    sender: flume::Sender<SingleOrMany>,
+    db: WalletDataDb,
+) -> WalletActor {
+    crate::test_support::ensure_tokio_runtime();
+
+    let wallet_snapshot = Arc::new(RwLock::new(WalletSnapshot::from_wallet(&wallet)));
+    let scan_status = Arc::new(RwLock::new(WalletScanStatus::Idle));
+
+    WalletActor::new_with_db(wallet, sender, scan_status, wallet_snapshot, db)
+}
+
+pub(crate) fn test_keychain() -> &'static Keychain {
+    crate::test_support::init_test_keychain();
+    Keychain::global()
+}
+
+pub(crate) fn spawn_test_wallet_actor(
+    wallet: Wallet,
+) -> (Addr<WalletActor>, flume::Receiver<SingleOrMany>) {
+    let (sender, receiver) = flume::bounded(100);
+    let actor = new_test_wallet_actor(wallet, sender);
+    let addr = spawn_actor(actor);
+
+    (addr, receiver)
+}
+
+pub(crate) async fn set_broadcast_esplora_node(broadcast_status: u16) -> BroadcastEsploraNode {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("test esplora server binds");
+    let address = listener.local_addr().expect("test esplora server has address");
+    let node = Node::new_esplora(
+        "broadcast test esplora node".to_string(),
+        format!("http://{address}"),
+        CoveNetwork::Bitcoin,
+    );
+
+    crate::database::Database::global()
+        .global_config
+        .set_selected_node(&node)
+        .expect("test node config is saved");
+
+    let broadcast_requests = Arc::new(AtomicUsize::new(0));
+    let broadcast_counter = broadcast_requests.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else { return };
+            let broadcast_counter = broadcast_counter.clone();
+
+            tokio::spawn(async move {
+                let mut request = [0; 8192];
+                let bytes_read = stream.read(&mut request).await.unwrap_or_default();
+                let request = String::from_utf8_lossy(&request[..bytes_read]);
+
+                let body = if request.starts_with("POST /tx ") {
+                    broadcast_counter.fetch_add(1, Ordering::SeqCst);
+                    "broadcast"
+                } else {
+                    "1"
+                };
+
+                let status = if request.starts_with("POST /tx ") { broadcast_status } else { 200 };
+                let reason = if status == 200 { "OK" } else { "Internal Server Error" };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    BroadcastEsploraNode { broadcast_requests, server }
+}
+
+pub(crate) async fn set_pending_broadcast_esplora_node() -> PendingBroadcastEsploraNode {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("test esplora server binds");
+    let address = listener.local_addr().expect("test esplora server has address");
+    let node = Node::new_esplora(
+        "pending broadcast test esplora node".to_string(),
+        format!("http://{address}"),
+        CoveNetwork::Bitcoin,
+    );
+
+    crate::database::Database::global()
+        .global_config
+        .set_selected_node(&node)
+        .expect("test node config is saved");
+
+    let broadcast_requests = Arc::new(AtomicUsize::new(0));
+    let broadcast_counter = broadcast_requests.clone();
+    let (release, release_request) = tokio::sync::watch::channel(false);
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else { return };
+            let broadcast_counter = broadcast_counter.clone();
+            let release_request = release_request.clone();
+
+            tokio::spawn(async move {
+                let mut request = [0; 8192];
+                let bytes_read = stream.read(&mut request).await.unwrap_or_default();
+                let request = String::from_utf8_lossy(&request[..bytes_read]);
+                let is_broadcast = request.starts_with("POST /tx ");
+                if is_broadcast {
+                    broadcast_counter.fetch_add(1, Ordering::SeqCst);
+                    let mut release_request = release_request.clone();
+
+                    while !*release_request.borrow() {
+                        if release_request.changed().await.is_err() {
+                            return;
+                        }
+                    }
+                }
+
+                let body = if is_broadcast { "broadcast" } else { "1" };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    PendingBroadcastEsploraNode { broadcast_requests, release, server }
+}
+
+pub(crate) async fn wait_for_broadcast_request_count(
+    broadcast_requests: &Arc<AtomicUsize>,
+    count: usize,
+) {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if broadcast_requests.load(Ordering::SeqCst) >= count {
+                return;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("broadcast request count is reached");
+}
+
+pub(crate) fn restore_default_bitcoin_node() {
+    let node = Node::default(CoveNetwork::Bitcoin);
+
+    crate::database::Database::global()
+        .global_config
+        .set_selected_node(&node)
+        .expect("default node config is saved");
+}
+
+pub(crate) fn mark_wallet_ledger_ready(wallet: &mut Wallet) {
+    wallet.metadata.internal.performed_full_scan_at = Some(1);
+}

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -16,6 +16,7 @@ use bitcoin::{
 use cove_bdk::coin_selection::CoveDefaultCoinSelection;
 use cove_device::keychain::Keychain;
 use cove_types::{
+    PayjoinIntent, PayjoinSessionId,
     confirm::{AddressAndAmount, ConfirmDetails, ExtraItem, InputOutputDetails, SplitOutput},
     fees::{FeeRateOption, FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee},
     utxo::{UtxoList, UtxoType},
@@ -27,12 +28,13 @@ use tracing::{debug, error, warn};
 use crate::{
     database::Database,
     manager::wallet_manager::{
-        Error, SendFlowErrorAlert, WalletManagerBuildTxError, WalletManagerError,
+        Error, PayjoinBroadcastOutcome, WalletManagerBuildTxError, WalletManagerError,
         WalletManagerFeesError, WalletManagerReconcileMessage,
         actor::{SpendPolicy, WalletActor, current_wallet_unspent_outpoints_for_txid},
         payjoin::{PayjoinActor, PayjoinSessionPersister, build_sender},
     },
     node::{Node, client::NodeClient},
+    router::UnsignedPaymentMode,
     transaction::{FeeRate, Transaction, TransactionDetails, TransactionDetailsPresentation, TxId},
     wallet::Address,
     wallet_secret::WalletSecretExt as _,
@@ -480,13 +482,13 @@ impl WalletActor {
     pub async fn initiate_payment(
         &mut self,
         psbt: Psbt,
-        _payjoin_endpoint: Option<String>,
+        mode: UnsignedPaymentMode,
     ) -> ActorResult<Result<(), Error>> {
         if let Err(error) = self.ensure_ledger_ready_for_spend() {
             return Produces::ok(Err(error));
         }
 
-        if self.payjoin_actor.is_some() {
+        if self.payjoin.is_some() {
             return Produces::ok(Err(Error::PayjoinSessionError(
                 "a payjoin session is already in progress".to_string(),
             )));
@@ -548,39 +550,62 @@ impl WalletActor {
             }
         }
 
-        let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
-            Ok(result) => result,
-            Err(error) => return Produces::ok(Err(error)),
-        };
+        match mode {
+            UnsignedPaymentMode::Standard => {
+                let (_, transaction) = match self.do_sign_original_psbt(psbt).await {
+                    Ok(result) => result,
+                    Err(error) => return Produces::ok(Err(error)),
+                };
 
-        self.start_broadcast_transaction(transaction)
+                self.start_broadcast_transaction(transaction)
+            }
+
+            UnsignedPaymentMode::Payjoin { intent } => {
+                let result = self.initiate_payjoin_payment(psbt, intent).await;
+                Produces::ok(result)
+            }
+        }
     }
 
-    #[allow(dead_code)]
     async fn initiate_payjoin_payment(
         &mut self,
         psbt: Psbt,
-        endpoint: String,
+        intent: PayjoinIntent,
     ) -> Result<(), Error> {
+        let PayjoinIntent { session_id, endpoint } = intent;
         let (signed_psbt, fallback_tx) = self.do_sign_original_psbt(psbt).await?;
         let network: bitcoin::Network = self.wallet.network.into();
 
         // persist the session before the first network request so it survives app restarts
         let persister = PayjoinSessionPersister::new(self.db.clone());
-        if let Err(error) = persister.create_session(&fallback_tx) {
+        if let Err(error) = persister.create_session(&fallback_tx, session_id.clone()) {
             warn!("payjoin session could not be persisted, broadcasting fallback tx: {error}");
-            send!(self.addr.handle_payjoin_fallback(fallback_tx));
+            self.payjoin = Some(super::ActivePayjoin::Broadcasting {
+                session_id: session_id.clone(),
+                outcome: PayjoinBroadcastOutcome::Fallback,
+            });
+            send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
             return Ok(());
         }
 
-        let Ok(sender) = build_sender(signed_psbt, &fallback_tx, endpoint, network, &persister)
-            .inspect_err(|error| warn!("payjoin setup failed, broadcasting fallback tx: {error}"))
-        else {
-            send!(self.addr.handle_payjoin_fallback(fallback_tx));
+        let Ok(sender) = build_sender(
+            signed_psbt,
+            &fallback_tx,
+            endpoint.as_str().to_string(),
+            network,
+            &persister,
+        )
+        .inspect_err(|error| warn!("payjoin setup failed, broadcasting fallback tx: {error}")) else {
+            self.payjoin = Some(super::ActivePayjoin::Broadcasting {
+                session_id: session_id.clone(),
+                outcome: PayjoinBroadcastOutcome::Fallback,
+            });
+            send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
             return Ok(());
         };
 
-        let actor = PayjoinActor::new(self.addr.clone(), persister, sender, fallback_tx);
+        let actor =
+            PayjoinActor::new(self.addr.clone(), persister, sender, fallback_tx, session_id);
         self.spawn_payjoin_actor(actor);
         Ok(())
     }
@@ -727,17 +752,42 @@ impl WalletActor {
         send!(self.addr.start_transaction_watcher(txid));
     }
 
-    fn start_payjoin_terminal_broadcast(&mut self, tx: BdkTransaction) {
+    fn start_payjoin_terminal_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
+        tx: BdkTransaction,
+    ) {
+        if !self.is_active_payjoin(&session_id) {
+            return;
+        }
+
+        self.payjoin =
+            Some(super::ActivePayjoin::Broadcasting { session_id: session_id.clone(), outcome });
         let connection = self.deferred_node_connection();
 
         self.addr.send_fut_with(|addr| async move {
-            let result =
-                broadcast_payjoin_terminal_with_connection(addr.clone(), connection, tx).await;
-            send!(addr.handle_payjoin_terminal_broadcast_result(result));
+            let result = broadcast_payjoin_terminal_with_connection(
+                addr.clone(),
+                connection,
+                session_id.clone(),
+                outcome,
+                tx,
+            )
+            .await;
+            send!(addr.handle_payjoin_terminal_broadcast_result(session_id, outcome, result));
         });
     }
 
-    fn start_payjoin_fallback_broadcast(&mut self, tx: BdkTransaction) {
+    fn start_payjoin_fallback_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        tx: BdkTransaction,
+    ) {
+        if !self.is_active_payjoin(&session_id) {
+            return;
+        }
+
         match self.db.get_payjoin_sender_session() {
             Ok(None) => {}
 
@@ -745,29 +795,30 @@ impl WalletActor {
                 let persister = PayjoinSessionPersister::new(self.db.clone());
                 if let Err(error) = persister.set_pending_fallback() {
                     error!("failed to persist fallback intent before broadcast, aborting: {error}");
-                    self.send(WalletManagerReconcileMessage::SendFlowError(
-                        SendFlowErrorAlert::SignAndBroadcast(
-                            "failed to persist recovery state; please restart the app".to_string(),
-                        ),
-                    ));
-                    self.payjoin_actor = None;
+                    self.payjoin = Some(super::ActivePayjoin::RecoveryBlocked {
+                        session_id: session_id.clone(),
+                    });
+                    self.send_payjoin_failure(
+                        session_id,
+                        "failed to persist recovery state; please restart the app".to_string(),
+                    );
                     return;
                 }
             }
 
             Err(error) => {
                 error!("failed to check for payjoin session before fallback, aborting: {error}");
-                self.send(WalletManagerReconcileMessage::SendFlowError(
-                    SendFlowErrorAlert::SignAndBroadcast(
-                        "failed to persist recovery state; please restart the app".to_string(),
-                    ),
-                ));
-                self.payjoin_actor = None;
+                self.payjoin =
+                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(
+                    session_id,
+                    "failed to persist recovery state; please restart the app".to_string(),
+                );
                 return;
             }
         }
 
-        self.start_payjoin_terminal_broadcast(tx);
+        self.start_payjoin_terminal_broadcast(session_id, PayjoinBroadcastOutcome::Fallback, tx);
     }
 
     /// Schedule best-effort broadcast of the exact committed Payjoin transaction
@@ -796,20 +847,32 @@ impl WalletActor {
         broadcast_payjoin_terminal_with_client(node_client, node, tx).await
     }
 
-    fn start_payjoin_proposal_broadcast(&mut self, proposal_tx: BdkTransaction) {
-        let persister = PayjoinSessionPersister::new(self.db.clone());
-        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
-            error!("failed to persist proposal broadcast intent, aborting: {error}");
-            self.send(WalletManagerReconcileMessage::SendFlowError(
-                SendFlowErrorAlert::SignAndBroadcast(
-                    "failed to persist recovery state; please restart the app".to_string(),
-                ),
-            ));
-            self.payjoin_actor = None;
+    fn start_payjoin_proposal_broadcast(
+        &mut self,
+        session_id: PayjoinSessionId,
+        proposal_tx: BdkTransaction,
+    ) {
+        if !self.is_active_payjoin(&session_id) {
             return;
         }
 
-        self.start_payjoin_terminal_broadcast(proposal_tx);
+        let persister = PayjoinSessionPersister::new(self.db.clone());
+        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
+            error!("failed to persist proposal broadcast intent, aborting: {error}");
+            self.payjoin =
+                Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+            self.send_payjoin_failure(
+                session_id,
+                "failed to persist recovery state; please restart the app".to_string(),
+            );
+            return;
+        }
+
+        self.start_payjoin_terminal_broadcast(
+            session_id,
+            PayjoinBroadcastOutcome::Proposal,
+            proposal_tx,
+        );
     }
 
     async fn payjoin_terminal_tx_in_wallet(&mut self, txid: Txid) -> ActorResult<bool> {
@@ -818,9 +881,15 @@ impl WalletActor {
 
     async fn apply_payjoin_terminal_broadcast(
         &mut self,
+        session_id: PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
         tx: BdkTransaction,
     ) -> ActorResult<Result<(), Error>> {
         use WalletManagerReconcileMessage as Msg;
+
+        if !self.is_active_payjoin_broadcast(&session_id, outcome) {
+            return Produces::ok(Ok(()));
+        }
 
         let now =
             SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_else(|e| {
@@ -860,15 +929,22 @@ impl WalletActor {
         send!(self.addr.start_transaction_watcher(txid));
 
         if session_cleared {
-            self.send(Msg::PayjoinTxBroadcast);
+            self.send(Msg::PayjoinStatusChanged(super::PayjoinStatus::Broadcast {
+                session_id,
+                outcome,
+            }));
+            self.payjoin = None;
         } else {
             // tx is broadcast and wallet-persisted, but the session record remains
             // initiate_payment will reject new sends until the record is gone
             // on restart resume_payjoin_session re-dispatches the stored terminal tx
             // because it is already in the wallet, broadcast is skipped and cleanup is retried
-            self.send(Msg::SendFlowError(SendFlowErrorAlert::SignAndBroadcast(
+            self.payjoin =
+                Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+            self.send_payjoin_failure(
+                session_id,
                 "transaction was broadcast; restart the app to unlock sending".to_string(),
-            )));
+            );
         }
 
         Produces::ok(Ok(()))
@@ -876,53 +952,68 @@ impl WalletActor {
 
     async fn handle_payjoin_terminal_broadcast_result(
         &mut self,
+        session_id: PayjoinSessionId,
+        outcome: PayjoinBroadcastOutcome,
         result: Result<(), BroadcastTransactionError>,
     ) -> ActorResult<()> {
+        if !self.is_active_payjoin_broadcast(&session_id, outcome) {
+            return Produces::ok(());
+        }
+
         match result {
             Ok(()) => {}
 
             Err(BroadcastTransactionError::BroadcastFailed(error)) => {
                 error!("payjoin broadcast failed: {error}");
-                self.send(WalletManagerReconcileMessage::SendFlowError(
-                    SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
-                ));
+                self.payjoin =
+                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(session_id, error.to_string());
             }
 
             Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
                 error!("payjoin broadcast bookkeeping failed: {error}");
-                self.send(WalletManagerReconcileMessage::SendFlowError(
-                    SendFlowErrorAlert::SignAndBroadcast(error.to_string()),
-                ));
+                self.payjoin =
+                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(session_id, error.to_string());
             }
         }
 
-        self.payjoin_actor = None;
         Produces::ok(())
     }
 
     pub async fn handle_payjoin_success(
         &mut self,
+        session_id: PayjoinSessionId,
         proposal_psbt: Psbt,
         fallback_tx: BdkTransaction,
     ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
         let Ok((_, proposal_tx)) =
             self.do_sign_original_psbt(proposal_psbt).await.inspect_err(|error| {
                 error!("failed to sign payjoin proposal, falling back to original tx: {error:?}")
             })
         else {
-            self.start_payjoin_fallback_broadcast(fallback_tx);
+            self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
             return Produces::ok(());
         };
 
-        self.start_payjoin_proposal_broadcast(proposal_tx);
+        self.start_payjoin_proposal_broadcast(session_id, proposal_tx);
         Produces::ok(())
     }
 
     pub async fn handle_payjoin_proposal_broadcast(
         &mut self,
+        session_id: PayjoinSessionId,
         proposal_tx: BdkTransaction,
     ) -> ActorResult<()> {
-        self.start_payjoin_terminal_broadcast(proposal_tx);
+        self.start_payjoin_terminal_broadcast(
+            session_id,
+            PayjoinBroadcastOutcome::Proposal,
+            proposal_tx,
+        );
         Produces::ok(())
     }
 
@@ -933,20 +1024,27 @@ impl WalletActor {
     /// no terminal marker was written so falling back is safe at that point.
     pub async fn handle_recovered_payjoin_success(
         &mut self,
+        session_id: PayjoinSessionId,
         proposal_psbt: Psbt,
         fallback_tx: BdkTransaction,
     ) -> ActorResult<()> {
+        if !self.is_active_payjoin(&session_id) {
+            return Produces::ok(());
+        }
+
         let proposal_tx = match self.do_sign_original_psbt(proposal_psbt).await {
             Ok((_, tx)) => tx,
             Err(error) => {
                 error!("failed to sign recovered payjoin proposal, pausing for retry: {error:?}");
                 // the receiver accepted a valid proposal; do not fall back — retain the record
                 // so the user can retry after resolving the signing failure
-                self.send(WalletManagerReconcileMessage::WalletError(Error::PayjoinSessionError(
+                self.payjoin =
+                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
+                self.send_payjoin_failure(
+                    session_id,
                     "could not sign the recovered payjoin proposal; unlock the wallet and restart"
                         .to_string(),
-                )));
-                self.payjoin_actor = None;
+                );
                 return Produces::ok(());
             }
         };
@@ -955,24 +1053,34 @@ impl WalletActor {
         if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
             error!("failed to persist recovered proposal intent, falling back: {error}");
             // no terminal marker was written yet; safe to fall back to the original tx
-            self.start_payjoin_fallback_broadcast(fallback_tx);
+            self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
             return Produces::ok(());
         }
 
-        self.start_payjoin_terminal_broadcast(proposal_tx);
+        self.start_payjoin_terminal_broadcast(
+            session_id,
+            PayjoinBroadcastOutcome::Proposal,
+            proposal_tx,
+        );
         Produces::ok(())
     }
 
     pub async fn handle_payjoin_fallback(
         &mut self,
+        session_id: PayjoinSessionId,
         fallback_tx: BdkTransaction,
     ) -> ActorResult<()> {
-        self.start_payjoin_fallback_broadcast(fallback_tx);
+        self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
         Produces::ok(())
     }
 
-    fn spawn_payjoin_actor(&mut self, actor: PayjoinActor) {
-        self.payjoin_actor = Some(spawn_actor(actor));
+    pub(crate) fn spawn_payjoin_actor(&mut self, actor: PayjoinActor) {
+        let session_id = actor.session_id.clone();
+        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(
+            super::PayjoinStatus::Negotiating { session_id: session_id.clone() },
+        ));
+        self.payjoin =
+            Some(super::ActivePayjoin::Negotiating { session_id, actor: spawn_actor(actor) });
     }
 
     fn get_max_send_for_utxos(
@@ -1196,6 +1304,8 @@ async fn broadcast_transaction_with_connection(
 async fn broadcast_payjoin_terminal_with_connection(
     addr: WeakAddr<WalletActor>,
     connection: Produces<Result<(), Error>>,
+    session_id: PayjoinSessionId,
+    outcome: PayjoinBroadcastOutcome,
     transaction: BdkTransaction,
 ) -> Result<(), BroadcastTransactionError> {
     let txid = transaction.compute_txid();
@@ -1217,7 +1327,7 @@ async fn broadcast_payjoin_terminal_with_connection(
         }
     }
 
-    call!(addr.apply_payjoin_terminal_broadcast(transaction))
+    call!(addr.apply_payjoin_terminal_broadcast(session_id, outcome, transaction))
         .await
         .map_err(|_| BroadcastTransactionError::PostBroadcastFailed(Error::ActorNotFound))?
         .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
@@ -1267,16 +1377,74 @@ async fn broadcast_to_node_with_connection(
 mod tests {
     use std::sync::Arc;
 
+    use act_zero::ActorResult;
     use bdk_wallet::test_utils::{ReceiveTo, receive_output};
-    use bitcoin::Amount;
+    use bitcoin::{Amount, Transaction, absolute::LockTime, transaction::Version};
+    use cove_types::PayjoinSessionId;
     use parking_lot::RwLock;
 
-    use super::{WalletActor, WalletManagerError};
+    use super::{PayjoinBroadcastOutcome, WalletActor, WalletManagerError};
     use crate::{
         database::wallet_data::{WalletDataDb, wallet_data_artifact_paths},
-        manager::wallet_manager::{WalletScanStatus, WalletSnapshot},
+        manager::wallet_manager::{WalletScanStatus, WalletSnapshot, actor::ActivePayjoin},
         wallet::{Wallet, metadata::WalletMetadata},
     };
+
+    async fn actor_value<T>(result: ActorResult<T>) -> T {
+        result
+            .expect("actor method should not fail")
+            .await
+            .expect("actor method should produce a value")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_terminal_result_cannot_close_the_active_payjoin_session() {
+        crate::test_support::ensure_tokio_runtime();
+
+        let wallet = Wallet::preview_new_wallet();
+        let wallet_snapshot = Arc::new(RwLock::new(WalletSnapshot::from_wallet(&wallet)));
+        let scan_status = Arc::new(RwLock::new(WalletScanStatus::Idle));
+        let wallet_data_db =
+            WalletDataDb::new_in_memory(wallet.id.clone()).expect("wallet data database opens");
+        let (reconciler, receiver) = flume::bounded(1);
+        let mut actor = WalletActor::new_with_db(
+            wallet,
+            reconciler,
+            scan_status,
+            wallet_snapshot,
+            wallet_data_db,
+        );
+        let active_id = PayjoinSessionId::generate();
+        let stale_id = PayjoinSessionId::generate();
+        let transaction = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        };
+        let txid = transaction.compute_txid();
+
+        actor.payjoin = Some(ActivePayjoin::Broadcasting {
+            session_id: active_id.clone(),
+            outcome: PayjoinBroadcastOutcome::Proposal,
+        });
+
+        let outcome = actor_value(
+            actor
+                .apply_payjoin_terminal_broadcast(
+                    stale_id,
+                    PayjoinBroadcastOutcome::Proposal,
+                    transaction,
+                )
+                .await,
+        )
+        .await;
+
+        assert_eq!(outcome, Ok(()));
+        assert_eq!(actor.active_payjoin_session_id(), Some(&active_id));
+        assert!(actor.wallet.bdk.get_tx(txid).is_none());
+        assert!(receiver.try_recv().is_err());
+    }
 
     #[test]
     fn preview_transaction_lookup_uses_in_memory_labels() {

--- a/rust/src/manager/wallet_manager/actor/transactions.rs
+++ b/rust/src/manager/wallet_manager/actor/transactions.rs
@@ -3,7 +3,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use act_zero::{runtimes::tokio::spawn_actor, *};
+use act_zero::{ActorResult, AddrLike as _, Produces, WeakAddr, call, send};
 use act_zero_ext::into_actor_result;
 use bdk_wallet::{
     AddUtxoError, KeychainKind, LocalOutput, SignOptions, TxOrdering, Utxo, WeightedUtxo,
@@ -16,7 +16,6 @@ use bitcoin::{
 use cove_bdk::coin_selection::CoveDefaultCoinSelection;
 use cove_device::keychain::Keychain;
 use cove_types::{
-    PayjoinIntent, PayjoinSessionId,
     confirm::{AddressAndAmount, ConfirmDetails, ExtraItem, InputOutputDetails, SplitOutput},
     fees::{FeeRateOption, FeeRateOptionWithTotalFee, FeeRateOptions, FeeRateOptionsWithTotalFee},
     utxo::{UtxoList, UtxoType},
@@ -26,33 +25,18 @@ use tap::TapFallible as _;
 use tracing::{debug, error, warn};
 
 use crate::{
-    database::Database,
     manager::wallet_manager::{
-        Error, PayjoinBroadcastOutcome, WalletManagerBuildTxError, WalletManagerError,
-        WalletManagerFeesError, WalletManagerReconcileMessage,
+        Error, WalletManagerBuildTxError, WalletManagerError, WalletManagerFeesError,
+        WalletManagerReconcileMessage,
         actor::{SpendPolicy, WalletActor, current_wallet_unspent_outpoints_for_txid},
-        payjoin::{PayjoinActor, PayjoinSessionPersister, build_sender},
     },
-    node::{Node, client::NodeClient},
     router::UnsignedPaymentMode,
     transaction::{FeeRate, Transaction, TransactionDetails, TransactionDetailsPresentation, TxId},
     wallet::Address,
     wallet_secret::WalletSecretExt as _,
 };
 
-#[derive(Debug)]
-pub(crate) enum BroadcastTransactionError {
-    BroadcastFailed(Error),
-    PostBroadcastFailed(Error),
-}
-
-impl BroadcastTransactionError {
-    fn into_error(self) -> Error {
-        match self {
-            Self::BroadcastFailed(error) | Self::PostBroadcastFailed(error) => error,
-        }
-    }
-}
+use super::broadcast::{BroadcastTransactionError, broadcast_to_node_with_connection};
 
 impl WalletActor {
     fn fee_from_insufficient_funds_needed(amount: Amount, needed: Amount) -> Result<Amount, Error> {
@@ -488,66 +472,8 @@ impl WalletActor {
             return Produces::ok(Err(error));
         }
 
-        if self.payjoin.is_some() {
-            return Produces::ok(Err(Error::PayjoinSessionError(
-                "a payjoin session is already in progress".to_string(),
-            )));
-        }
-
-        match self.db.get_payjoin_sender_session() {
-            Ok(None) => {}
-
-            Ok(Some(_)) => {
-                // If the session has a terminal marker and the tx is already in the local
-                // wallet, the only remaining work is session cleanup — no network needed.
-                // Attempt it here so this send can proceed without requiring a restart.
-                let persister = PayjoinSessionPersister::new(self.db.clone());
-                let can_cleanup = persister
-                    .pending_txid()
-                    .is_some_and(|txid| self.wallet.bdk.get_tx(txid).is_some());
-
-                if !can_cleanup {
-                    // Broadcast hasn't completed yet, re-dispatch so the user doesn't need to restart.
-                    send!(self.addr.resume_payjoin_session());
-                    return Produces::ok(Err(Error::PayjoinSessionError(
-                        "retrying a previous payjoin broadcast; please try again in a moment"
-                            .to_string(),
-                    )));
-                }
-
-                // Retry persistence before cleanup — a prior broadcast may have applied the tx
-                // in memory without flushing to disk; only drop the session once it is durable.
-                if let Err(error) = self.wallet.persist() {
-                    warn!("failed to persist wallet at send gate before payjoin cleanup: {error}");
-                    return Produces::ok(Err(Error::PayjoinSessionError(
-                        "a previous payjoin session is pending cleanup; please try again later"
-                            .to_string(),
-                    )));
-                }
-
-                if let Err(error) = self.db.delete_payjoin_sender_session() {
-                    warn!("payjoin session cleanup at send gate failed: {error}");
-                    return Produces::ok(Err(Error::PayjoinSessionError(
-                        "a previous payjoin session is pending cleanup; please try again later"
-                            .to_string(),
-                    )));
-                }
-
-                // The completed tx may have been the payjoin proposal, so reusing the
-                // supplied PSBT (which is still the fallback) could cause a conflict.
-                // Ask the user to confirm again now that the record is cleared.
-                return Produces::ok(Err(Error::PayjoinSessionError(
-                    "previous payjoin session cleared; please confirm your payment again"
-                        .to_string(),
-                )));
-            }
-
-            Err(error) => {
-                error!("failed to check for pending payjoin session: {error}");
-                return Produces::ok(Err(Error::PayjoinSessionError(
-                    "unable to verify payjoin session state; please try again later".to_string(),
-                )));
-            }
+        if let Err(error) = self.prepare_for_payment() {
+            return Produces::ok(Err(error));
         }
 
         match mode {
@@ -567,50 +493,7 @@ impl WalletActor {
         }
     }
 
-    async fn initiate_payjoin_payment(
-        &mut self,
-        psbt: Psbt,
-        intent: PayjoinIntent,
-    ) -> Result<(), Error> {
-        let PayjoinIntent { session_id, endpoint } = intent;
-        let (signed_psbt, fallback_tx) = self.do_sign_original_psbt(psbt).await?;
-        let network: bitcoin::Network = self.wallet.network.into();
-
-        // persist the session before the first network request so it survives app restarts
-        let persister = PayjoinSessionPersister::new(self.db.clone());
-        if let Err(error) = persister.create_session(&fallback_tx, session_id.clone()) {
-            warn!("payjoin session could not be persisted, broadcasting fallback tx: {error}");
-            self.payjoin = Some(super::ActivePayjoin::Broadcasting {
-                session_id: session_id.clone(),
-                outcome: PayjoinBroadcastOutcome::Fallback,
-            });
-            send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
-            return Ok(());
-        }
-
-        let Ok(sender) = build_sender(
-            signed_psbt,
-            &fallback_tx,
-            endpoint.as_str().to_string(),
-            network,
-            &persister,
-        )
-        .inspect_err(|error| warn!("payjoin setup failed, broadcasting fallback tx: {error}")) else {
-            self.payjoin = Some(super::ActivePayjoin::Broadcasting {
-                session_id: session_id.clone(),
-                outcome: PayjoinBroadcastOutcome::Fallback,
-            });
-            send!(self.addr.handle_payjoin_fallback(session_id, fallback_tx));
-            return Ok(());
-        };
-
-        let actor =
-            PayjoinActor::new(self.addr.clone(), persister, sender, fallback_tx, session_id);
-        self.spawn_payjoin_actor(actor);
-        Ok(())
-    }
-
-    async fn do_sign_original_psbt(
+    pub(crate) async fn do_sign_original_psbt(
         &mut self,
         mut psbt: Psbt,
     ) -> Result<(Psbt, BdkTransaction), Error> {
@@ -679,14 +562,6 @@ impl WalletActor {
         Ok(Produces::Deferred(receiver))
     }
 
-    async fn node_client_for_broadcast(&mut self) -> ActorResult<Result<NodeClient, Error>> {
-        Produces::ok(self.node_client().cloned().map_err(|_| {
-            Error::BroadcastError(
-                "failed to broadcast transaction, could not get node client, try again".to_string(),
-            )
-        }))
-    }
-
     async fn apply_broadcast_transaction(
         &mut self,
         transaction: BdkTransaction,
@@ -750,337 +625,6 @@ impl WalletActor {
         self.send(Msg::UpdatedTransactions(transactions));
 
         send!(self.addr.start_transaction_watcher(txid));
-    }
-
-    fn start_payjoin_terminal_broadcast(
-        &mut self,
-        session_id: PayjoinSessionId,
-        outcome: PayjoinBroadcastOutcome,
-        tx: BdkTransaction,
-    ) {
-        if !self.is_active_payjoin(&session_id) {
-            return;
-        }
-
-        self.payjoin =
-            Some(super::ActivePayjoin::Broadcasting { session_id: session_id.clone(), outcome });
-        let connection = self.deferred_node_connection();
-
-        self.addr.send_fut_with(|addr| async move {
-            let result = broadcast_payjoin_terminal_with_connection(
-                addr.clone(),
-                connection,
-                session_id.clone(),
-                outcome,
-                tx,
-            )
-            .await;
-            send!(addr.handle_payjoin_terminal_broadcast_result(session_id, outcome, result));
-        });
-    }
-
-    fn start_payjoin_fallback_broadcast(
-        &mut self,
-        session_id: PayjoinSessionId,
-        tx: BdkTransaction,
-    ) {
-        if !self.is_active_payjoin(&session_id) {
-            return;
-        }
-
-        match self.db.get_payjoin_sender_session() {
-            Ok(None) => {}
-
-            Ok(Some(_)) => {
-                let persister = PayjoinSessionPersister::new(self.db.clone());
-                if let Err(error) = persister.set_pending_fallback() {
-                    error!("failed to persist fallback intent before broadcast, aborting: {error}");
-                    self.payjoin = Some(super::ActivePayjoin::RecoveryBlocked {
-                        session_id: session_id.clone(),
-                    });
-                    self.send_payjoin_failure(
-                        session_id,
-                        "failed to persist recovery state; please restart the app".to_string(),
-                    );
-                    return;
-                }
-            }
-
-            Err(error) => {
-                error!("failed to check for payjoin session before fallback, aborting: {error}");
-                self.payjoin =
-                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-                self.send_payjoin_failure(
-                    session_id,
-                    "failed to persist recovery state; please restart the app".to_string(),
-                );
-                return;
-            }
-        }
-
-        self.start_payjoin_terminal_broadcast(session_id, PayjoinBroadcastOutcome::Fallback, tx);
-    }
-
-    /// Schedule best-effort broadcast of the exact committed Payjoin transaction
-    pub(crate) fn schedule_payjoin_terminal_broadcast(&mut self, tx: BdkTransaction) {
-        let node = Database::global().global_config.selected_node();
-        let node_client = self.node_client().ok().cloned();
-
-        cove_tokio::task::spawn(async move {
-            if let Err(error) = broadcast_payjoin_terminal_with_client(node_client, node, tx).await
-            {
-                warn!(
-                    "failed to broadcast committed Payjoin transaction during destructive wallet shutdown; the durable terminal marker remains for retry: {error}"
-                );
-            }
-        });
-    }
-
-    /// Broadcast the exact committed Payjoin transaction
-    pub(crate) async fn broadcast_payjoin_terminal_for_shutdown(
-        &mut self,
-        tx: BdkTransaction,
-    ) -> Result<(), Error> {
-        let node = Database::global().global_config.selected_node();
-        let node_client = self.node_client().ok().cloned();
-
-        broadcast_payjoin_terminal_with_client(node_client, node, tx).await
-    }
-
-    fn start_payjoin_proposal_broadcast(
-        &mut self,
-        session_id: PayjoinSessionId,
-        proposal_tx: BdkTransaction,
-    ) {
-        if !self.is_active_payjoin(&session_id) {
-            return;
-        }
-
-        let persister = PayjoinSessionPersister::new(self.db.clone());
-        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
-            error!("failed to persist proposal broadcast intent, aborting: {error}");
-            self.payjoin =
-                Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-            self.send_payjoin_failure(
-                session_id,
-                "failed to persist recovery state; please restart the app".to_string(),
-            );
-            return;
-        }
-
-        self.start_payjoin_terminal_broadcast(
-            session_id,
-            PayjoinBroadcastOutcome::Proposal,
-            proposal_tx,
-        );
-    }
-
-    async fn payjoin_terminal_tx_in_wallet(&mut self, txid: Txid) -> ActorResult<bool> {
-        Produces::ok(self.wallet.bdk.get_tx(txid).is_some())
-    }
-
-    async fn apply_payjoin_terminal_broadcast(
-        &mut self,
-        session_id: PayjoinSessionId,
-        outcome: PayjoinBroadcastOutcome,
-        tx: BdkTransaction,
-    ) -> ActorResult<Result<(), Error>> {
-        use WalletManagerReconcileMessage as Msg;
-
-        if !self.is_active_payjoin_broadcast(&session_id, outcome) {
-            return Produces::ok(Ok(()));
-        }
-
-        let now =
-            SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_else(|e| {
-                warn!("System clock skew detected: {e}");
-                0
-            });
-
-        let txid = tx.compute_txid();
-
-        self.wallet.bdk.apply_unconfirmed_txs([(tx, now)]);
-
-        // keep the session record until wallet state is durable so startup can recover
-        if let Err(error) = self.wallet.persist() {
-            error!(
-                "failed to persist wallet after payjoin broadcast; retaining session record for recovery: {error}"
-            );
-            return Produces::ok(Err(Error::PayjoinSessionError(
-                "transaction was broadcast but wallet state could not be saved; please restart the app"
-                    .to_string(),
-            )));
-        }
-
-        let session_cleared = match self.db.delete_payjoin_sender_session() {
-            Ok(()) => true,
-            Err(error) => {
-                warn!("failed to clear payjoin session record: {error}");
-                false
-            }
-        };
-
-        let balance = self.wallet.balance();
-        self.send(Msg::WalletBalanceChanged(balance.into()));
-
-        let transactions = self.do_transactions().await;
-        self.send(Msg::UpdatedTransactions(transactions));
-
-        send!(self.addr.start_transaction_watcher(txid));
-
-        if session_cleared {
-            self.send(Msg::PayjoinStatusChanged(super::PayjoinStatus::Broadcast {
-                session_id,
-                outcome,
-            }));
-            self.payjoin = None;
-        } else {
-            // tx is broadcast and wallet-persisted, but the session record remains
-            // initiate_payment will reject new sends until the record is gone
-            // on restart resume_payjoin_session re-dispatches the stored terminal tx
-            // because it is already in the wallet, broadcast is skipped and cleanup is retried
-            self.payjoin =
-                Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-            self.send_payjoin_failure(
-                session_id,
-                "transaction was broadcast; restart the app to unlock sending".to_string(),
-            );
-        }
-
-        Produces::ok(Ok(()))
-    }
-
-    async fn handle_payjoin_terminal_broadcast_result(
-        &mut self,
-        session_id: PayjoinSessionId,
-        outcome: PayjoinBroadcastOutcome,
-        result: Result<(), BroadcastTransactionError>,
-    ) -> ActorResult<()> {
-        if !self.is_active_payjoin_broadcast(&session_id, outcome) {
-            return Produces::ok(());
-        }
-
-        match result {
-            Ok(()) => {}
-
-            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
-                error!("payjoin broadcast failed: {error}");
-                self.payjoin =
-                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-                self.send_payjoin_failure(session_id, error.to_string());
-            }
-
-            Err(BroadcastTransactionError::PostBroadcastFailed(error)) => {
-                error!("payjoin broadcast bookkeeping failed: {error}");
-                self.payjoin =
-                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-                self.send_payjoin_failure(session_id, error.to_string());
-            }
-        }
-
-        Produces::ok(())
-    }
-
-    pub async fn handle_payjoin_success(
-        &mut self,
-        session_id: PayjoinSessionId,
-        proposal_psbt: Psbt,
-        fallback_tx: BdkTransaction,
-    ) -> ActorResult<()> {
-        if !self.is_active_payjoin(&session_id) {
-            return Produces::ok(());
-        }
-
-        let Ok((_, proposal_tx)) =
-            self.do_sign_original_psbt(proposal_psbt).await.inspect_err(|error| {
-                error!("failed to sign payjoin proposal, falling back to original tx: {error:?}")
-            })
-        else {
-            self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
-            return Produces::ok(());
-        };
-
-        self.start_payjoin_proposal_broadcast(session_id, proposal_tx);
-        Produces::ok(())
-    }
-
-    pub async fn handle_payjoin_proposal_broadcast(
-        &mut self,
-        session_id: PayjoinSessionId,
-        proposal_tx: BdkTransaction,
-    ) -> ActorResult<()> {
-        self.start_payjoin_terminal_broadcast(
-            session_id,
-            PayjoinBroadcastOutcome::Proposal,
-            proposal_tx,
-        );
-        Produces::ok(())
-    }
-
-    /// Handles a recovered session that closed with a receiver proposal but no stored tx.
-    /// On signing failure the session record is retained — the receiver's proposal was valid
-    /// and the user should retry after resolving the signing issue.
-    /// If the proposal intent cannot be persisted, `fallback_tx` is broadcast instead —
-    /// no terminal marker was written so falling back is safe at that point.
-    pub async fn handle_recovered_payjoin_success(
-        &mut self,
-        session_id: PayjoinSessionId,
-        proposal_psbt: Psbt,
-        fallback_tx: BdkTransaction,
-    ) -> ActorResult<()> {
-        if !self.is_active_payjoin(&session_id) {
-            return Produces::ok(());
-        }
-
-        let proposal_tx = match self.do_sign_original_psbt(proposal_psbt).await {
-            Ok((_, tx)) => tx,
-            Err(error) => {
-                error!("failed to sign recovered payjoin proposal, pausing for retry: {error:?}");
-                // the receiver accepted a valid proposal; do not fall back — retain the record
-                // so the user can retry after resolving the signing failure
-                self.payjoin =
-                    Some(super::ActivePayjoin::RecoveryBlocked { session_id: session_id.clone() });
-                self.send_payjoin_failure(
-                    session_id,
-                    "could not sign the recovered payjoin proposal; unlock the wallet and restart"
-                        .to_string(),
-                );
-                return Produces::ok(());
-            }
-        };
-
-        let persister = PayjoinSessionPersister::new(self.db.clone());
-        if let Err(error) = persister.set_pending_proposal(&proposal_tx) {
-            error!("failed to persist recovered proposal intent, falling back: {error}");
-            // no terminal marker was written yet; safe to fall back to the original tx
-            self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
-            return Produces::ok(());
-        }
-
-        self.start_payjoin_terminal_broadcast(
-            session_id,
-            PayjoinBroadcastOutcome::Proposal,
-            proposal_tx,
-        );
-        Produces::ok(())
-    }
-
-    pub async fn handle_payjoin_fallback(
-        &mut self,
-        session_id: PayjoinSessionId,
-        fallback_tx: BdkTransaction,
-    ) -> ActorResult<()> {
-        self.start_payjoin_fallback_broadcast(session_id, fallback_tx);
-        Produces::ok(())
-    }
-
-    pub(crate) fn spawn_payjoin_actor(&mut self, actor: PayjoinActor) {
-        let session_id = actor.session_id.clone();
-        self.send(WalletManagerReconcileMessage::PayjoinStatusChanged(
-            super::PayjoinStatus::Negotiating { session_id: session_id.clone() },
-        ));
-        self.payjoin =
-            Some(super::ActivePayjoin::Negotiating { session_id, actor: spawn_actor(actor) });
     }
 
     fn get_max_send_for_utxos(
@@ -1260,32 +804,6 @@ impl WalletActor {
     }
 }
 
-async fn broadcast_payjoin_terminal_with_client(
-    node_client: Option<NodeClient>,
-    node: Node,
-    tx: BdkTransaction,
-) -> Result<(), Error> {
-    let node_client = match node_client {
-        Some(node_client) => node_client,
-        None => super::node::checked_node_client(&node).await?,
-    };
-    let txid = tx.compute_txid();
-
-    if let Err(error) = node_client.broadcast_transaction(tx).await {
-        let known_to_node = node_client
-            .get_transaction(txid)
-            .await
-            .is_ok_and(|found| found.is_some_and(|transaction| transaction.compute_txid() == txid));
-        if !known_to_node {
-            return Err(Error::BroadcastError(format!(
-                "failed to broadcast committed Payjoin transaction during wallet shutdown: {error:?}"
-            )));
-        }
-    }
-
-    Ok(())
-}
-
 async fn broadcast_transaction_with_connection(
     addr: WeakAddr<WalletActor>,
     connection: Produces<Result<(), Error>>,
@@ -1301,150 +819,20 @@ async fn broadcast_transaction_with_connection(
     Ok(())
 }
 
-async fn broadcast_payjoin_terminal_with_connection(
-    addr: WeakAddr<WalletActor>,
-    connection: Produces<Result<(), Error>>,
-    session_id: PayjoinSessionId,
-    outcome: PayjoinBroadcastOutcome,
-    transaction: BdkTransaction,
-) -> Result<(), BroadcastTransactionError> {
-    let txid = transaction.compute_txid();
-    let already_in_wallet = call!(addr.payjoin_terminal_tx_in_wallet(txid))
-        .await
-        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?;
-
-    if !already_in_wallet {
-        match broadcast_to_node_with_connection(addr.clone(), connection, &transaction).await {
-            Ok(()) => {}
-
-            Err(BroadcastTransactionError::BroadcastFailed(error)) => {
-                if !payjoin_tx_known_to_node(addr.clone(), txid).await {
-                    return Err(BroadcastTransactionError::BroadcastFailed(error));
-                }
-            }
-
-            Err(error) => return Err(error),
-        }
-    }
-
-    call!(addr.apply_payjoin_terminal_broadcast(session_id, outcome, transaction))
-        .await
-        .map_err(|_| BroadcastTransactionError::PostBroadcastFailed(Error::ActorNotFound))?
-        .map_err(BroadcastTransactionError::PostBroadcastFailed)?;
-
-    Ok(())
-}
-
-async fn payjoin_tx_known_to_node(addr: WeakAddr<WalletActor>, txid: Txid) -> bool {
-    let node_client = match call!(addr.node_client_for_broadcast()).await {
-        Ok(Ok(node_client)) => node_client,
-        _ => return false,
-    };
-
-    let response = node_client.get_transaction(txid).await;
-    matches!(response, Ok(Some(ref found)) if found.compute_txid() == txid)
-}
-
-async fn broadcast_to_node_with_connection(
-    addr: WeakAddr<WalletActor>,
-    connection: Produces<Result<(), Error>>,
-    transaction: &BdkTransaction,
-) -> Result<(), BroadcastTransactionError> {
-    connection
-        .await
-        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?
-        .map_err(|error| {
-            BroadcastTransactionError::BroadcastFailed(Error::BroadcastError(format!(
-                "failed to broadcast transaction, unable to connect to node: {error:?}"
-            )))
-        })?;
-
-    let node_client = call!(addr.node_client_for_broadcast())
-        .await
-        .map_err(|_| BroadcastTransactionError::BroadcastFailed(Error::ActorNotFound))?
-        .map_err(BroadcastTransactionError::BroadcastFailed)?;
-
-    node_client.broadcast_transaction(transaction.clone()).await.map_err(|error| {
-        BroadcastTransactionError::BroadcastFailed(Error::BroadcastError(format!(
-            "failed to broadcast transaction, try again: {error:?}"
-        )))
-    })?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use act_zero::ActorResult;
     use bdk_wallet::test_utils::{ReceiveTo, receive_output};
-    use bitcoin::{Amount, Transaction, absolute::LockTime, transaction::Version};
-    use cove_types::PayjoinSessionId;
+    use bitcoin::Amount;
     use parking_lot::RwLock;
 
-    use super::{PayjoinBroadcastOutcome, WalletActor, WalletManagerError};
+    use super::{WalletActor, WalletManagerError};
     use crate::{
         database::wallet_data::{WalletDataDb, wallet_data_artifact_paths},
-        manager::wallet_manager::{WalletScanStatus, WalletSnapshot, actor::ActivePayjoin},
+        manager::wallet_manager::{WalletScanStatus, WalletSnapshot},
         wallet::{Wallet, metadata::WalletMetadata},
     };
-
-    async fn actor_value<T>(result: ActorResult<T>) -> T {
-        result
-            .expect("actor method should not fail")
-            .await
-            .expect("actor method should produce a value")
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn stale_terminal_result_cannot_close_the_active_payjoin_session() {
-        crate::test_support::ensure_tokio_runtime();
-
-        let wallet = Wallet::preview_new_wallet();
-        let wallet_snapshot = Arc::new(RwLock::new(WalletSnapshot::from_wallet(&wallet)));
-        let scan_status = Arc::new(RwLock::new(WalletScanStatus::Idle));
-        let wallet_data_db =
-            WalletDataDb::new_in_memory(wallet.id.clone()).expect("wallet data database opens");
-        let (reconciler, receiver) = flume::bounded(1);
-        let mut actor = WalletActor::new_with_db(
-            wallet,
-            reconciler,
-            scan_status,
-            wallet_snapshot,
-            wallet_data_db,
-        );
-        let active_id = PayjoinSessionId::generate();
-        let stale_id = PayjoinSessionId::generate();
-        let transaction = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: Vec::new(),
-            output: Vec::new(),
-        };
-        let txid = transaction.compute_txid();
-
-        actor.payjoin = Some(ActivePayjoin::Broadcasting {
-            session_id: active_id.clone(),
-            outcome: PayjoinBroadcastOutcome::Proposal,
-        });
-
-        let outcome = actor_value(
-            actor
-                .apply_payjoin_terminal_broadcast(
-                    stale_id,
-                    PayjoinBroadcastOutcome::Proposal,
-                    transaction,
-                )
-                .await,
-        )
-        .await;
-
-        assert_eq!(outcome, Ok(()));
-        assert_eq!(actor.active_payjoin_session_id(), Some(&active_id));
-        assert!(actor.wallet.bdk.get_tx(txid).is_none());
-        assert!(receiver.try_recv().is_err());
-    }
 
     #[test]
     fn preview_transaction_lookup_uses_in_memory_labels() {

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -491,7 +491,22 @@ impl Actor for PayjoinActor {
         self.addr = addr.downgrade();
         match &self.session {
             PayjoinSession::PrePost { .. } => send!(addr.start_post()),
-            PayjoinSession::Polling { .. } => send!(addr.begin_poll()),
+
+            PayjoinSession::Polling { .. } => {
+                // publish the stored deadline so the UI can show the countdown on resume
+                if let Some(deadline) = self.poll_deadline {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let deadline_secs = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_secs() + remaining.as_secs())
+                        .unwrap_or(0);
+
+                    send!(self.wallet_addr.notify_payjoin_polling_started(deadline_secs));
+                }
+
+                send!(addr.begin_poll());
+            }
+
             _ => {}
         }
         Produces::ok(())
@@ -578,6 +593,13 @@ impl PayjoinActor {
 
         self.poll_deadline = Some(Instant::now() + PAYJOIN_SESSION_TIMEOUT);
         self.session = PayjoinSession::Polling { polling_sender };
+
+        let deadline_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() + PAYJOIN_SESSION_TIMEOUT.as_secs())
+            .unwrap_or(0);
+        send!(self.wallet_addr.notify_payjoin_polling_started(deadline_secs));
+
         self.begin_next_poll();
         Produces::ok(())
     }

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -26,6 +26,7 @@ use tracing::{debug, error, warn};
 use crate::database::wallet_data::{
     PayjoinSenderSession, PendingAction, WalletDataDb, WalletDataError,
 };
+use cove_types::PayjoinSessionId;
 
 use super::actor::WalletActor;
 
@@ -162,11 +163,11 @@ impl PayjoinSessionPersister {
         self.db.set_payjoin_sender_session(session)
     }
 
-    /// Creates a fresh session record; errors if a session record already exists.
-    /// The caller must clear any existing record before creating a new one.
+    /// Persists a new session under the confirmation's stable identity
     pub(crate) fn create_session(
         &self,
         fallback_tx: &BdkTransaction,
+        session_id: PayjoinSessionId,
     ) -> Result<(), WalletDataError> {
         if self.db.get_payjoin_sender_session()?.is_some() {
             return Err(WalletDataError::Save(
@@ -174,12 +175,18 @@ impl PayjoinSessionPersister {
             ));
         }
 
-        let created_at_secs =
-            SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs());
+        let created_at_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|error| {
+                WalletDataError::Save(format!("system time is before epoch: {error}"))
+            })?
+            .as_secs();
+
         let session = PayjoinSenderSession {
+            session_id,
+            created_at_secs,
             events: vec![],
             fallback_tx: consensus::serialize(fallback_tx).into(),
-            created_at_secs,
             pending_action: None,
         };
         self.db.set_payjoin_sender_session(session)
@@ -466,7 +473,7 @@ enum PayjoinSession {
     /// POST request is in flight, so the sender state machine is owned by the request future
     Posting,
     /// POST was accepted by the directory; now polling for the receiver's proposal
-    Polling { polling_sender: V2Sender<PollingForProposal> },
+    Polling { polling_sender: V2Sender<PollingForProposal>, deadline: Instant },
     /// Session is canceled or terminal; late async completions must be ignored
     Closed,
 }
@@ -477,7 +484,7 @@ pub(crate) struct PayjoinActor {
     persister: PayjoinSessionPersister,
     fallback_tx: BdkTransaction,
     session: PayjoinSession,
-    poll_deadline: Option<Instant>,
+    pub(crate) session_id: PayjoinSessionId,
 }
 
 impl PayjoinActor {
@@ -486,6 +493,7 @@ impl PayjoinActor {
         persister: PayjoinSessionPersister,
         sender: V2Sender<WithReplyKey>,
         fallback_tx: BdkTransaction,
+        session_id: PayjoinSessionId,
     ) -> Self {
         Self {
             addr: WeakAddr::default(),
@@ -493,7 +501,7 @@ impl PayjoinActor {
             persister,
             fallback_tx,
             session: PayjoinSession::PrePost { sender },
-            poll_deadline: None,
+            session_id,
         }
     }
 
@@ -503,25 +511,20 @@ impl PayjoinActor {
         persister: PayjoinSessionPersister,
         polling_sender: V2Sender<PollingForProposal>,
         fallback_tx: BdkTransaction,
-        created_at_secs: Option<u64>,
+        created_at_secs: u64,
+        session_id: PayjoinSessionId,
     ) -> Self {
-        let poll_deadline = Some(match created_at_secs {
-            None => Instant::now() + PAYJOIN_SESSION_TIMEOUT,
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        let elapsed = Duration::from_secs(now_secs.saturating_sub(created_at_secs));
+        let deadline = Instant::now() + PAYJOIN_SESSION_TIMEOUT.saturating_sub(elapsed);
 
-            Some(start) => {
-                let now_secs =
-                    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-                let elapsed = Duration::from_secs(now_secs.saturating_sub(start));
-                Instant::now() + PAYJOIN_SESSION_TIMEOUT.saturating_sub(elapsed)
-            }
-        });
         Self {
             addr: WeakAddr::default(),
             wallet_addr,
             persister,
             fallback_tx,
-            session: PayjoinSession::Polling { polling_sender },
-            poll_deadline,
+            session: PayjoinSession::Polling { polling_sender, deadline },
+            session_id,
         }
     }
 }
@@ -533,17 +536,18 @@ impl Actor for PayjoinActor {
         match &self.session {
             PayjoinSession::PrePost { .. } => send!(addr.start_post()),
 
-            PayjoinSession::Polling { .. } => {
+            PayjoinSession::Polling { deadline, .. } => {
                 // publish the stored deadline so the UI can show the countdown on resume
-                if let Some(deadline) = self.poll_deadline {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    let deadline_secs = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .map(|d| d.as_secs() + remaining.as_secs())
-                        .unwrap_or(0);
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let deadline_secs = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|duration| duration.as_secs() + remaining.as_secs())
+                    .unwrap_or(0);
 
-                    send!(self.wallet_addr.notify_payjoin_polling_started(deadline_secs));
-                }
+                send!(
+                    self.wallet_addr
+                        .notify_payjoin_polling_started(self.session_id.clone(), deadline_secs)
+                );
 
                 send!(addr.begin_poll());
             }
@@ -632,14 +636,16 @@ impl PayjoinActor {
             return Produces::ok(());
         }
 
-        self.poll_deadline = Some(Instant::now() + PAYJOIN_SESSION_TIMEOUT);
-        self.session = PayjoinSession::Polling { polling_sender };
+        let deadline = Instant::now() + PAYJOIN_SESSION_TIMEOUT;
+        self.session = PayjoinSession::Polling { polling_sender, deadline };
 
         let deadline_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs() + PAYJOIN_SESSION_TIMEOUT.as_secs())
             .unwrap_or(0);
-        send!(self.wallet_addr.notify_payjoin_polling_started(deadline_secs));
+        send!(
+            self.wallet_addr.notify_payjoin_polling_started(self.session_id.clone(), deadline_secs)
+        );
 
         self.begin_next_poll();
         Produces::ok(())
@@ -652,14 +658,16 @@ impl PayjoinActor {
         }
 
         // if the session deadline has passed, broadcast the fallback immediately
-        if self.poll_deadline.is_some_and(|d| Instant::now() >= d) {
-            self.complete_with_fallback();
-            return Produces::ok(());
-        }
-
         // clone so the original stays in self.session, allowing retry if all relays fail this tick
         let polling_sender = match &self.session {
-            PayjoinSession::Polling { polling_sender } => polling_sender.clone(),
+            PayjoinSession::Polling { polling_sender, deadline } => {
+                if Instant::now() >= *deadline {
+                    self.complete_with_fallback();
+                    return Produces::ok(());
+                }
+
+                polling_sender.clone()
+            }
             _ => {
                 warn!("payjoin begin_poll called in unexpected state");
                 return Produces::ok(());
@@ -681,12 +689,15 @@ impl PayjoinActor {
             return Produces::ok(());
         }
 
-        if !matches!(self.session, PayjoinSession::Polling { .. }) {
-            warn!("payjoin update_polling_sender called in unexpected state");
-            return Produces::ok(());
-        }
+        let deadline = match &self.session {
+            PayjoinSession::Polling { deadline, .. } => *deadline,
+            _ => {
+                warn!("payjoin update_polling_sender called in unexpected state");
+                return Produces::ok(());
+            }
+        };
 
-        self.session = PayjoinSession::Polling { polling_sender: next };
+        self.session = PayjoinSession::Polling { polling_sender: next, deadline };
         self.begin_next_poll();
         Produces::ok(())
     }
@@ -750,7 +761,11 @@ impl PayjoinActor {
         }
 
         let fallback_tx = self.fallback_tx.clone();
-        send!(self.wallet_addr.handle_payjoin_success(proposal_psbt, fallback_tx));
+        send!(self.wallet_addr.handle_payjoin_success(
+            self.session_id.clone(),
+            proposal_psbt,
+            fallback_tx
+        ));
         Produces::ok(())
     }
 
@@ -774,6 +789,7 @@ impl PayjoinActor {
                 "failed to persist fallback intent, aborting fallback dispatch to preserve recovery state: {error}"
             );
             send!(self.wallet_addr.notify_payjoin_error(
+                self.session_id.clone(),
                 "payment is paused — please restart the app to complete or cancel it".to_string()
             ));
             return;
@@ -788,7 +804,7 @@ impl PayjoinActor {
         }
 
         let fallback_tx = self.fallback_tx.clone();
-        send!(self.wallet_addr.handle_payjoin_fallback(fallback_tx));
+        send!(self.wallet_addr.handle_payjoin_fallback(self.session_id.clone(), fallback_tx));
     }
 
     fn close_session(&mut self) -> bool {
@@ -797,7 +813,6 @@ impl PayjoinActor {
         }
 
         self.session = PayjoinSession::Closed;
-        self.poll_deadline = None;
         true
     }
 }
@@ -809,18 +824,22 @@ pub(crate) enum SessionResumption {
     /// Session is still in flight, spawn this actor to continue it
     Resume(Box<PayjoinActor>),
     /// A BroadcastProposal marker was stored: broadcast this exact consensus-encoded tx
-    BroadcastStoredProposal { proposal_tx: BdkTransaction },
+    BroadcastStoredProposal { session_id: PayjoinSessionId, proposal_tx: BdkTransaction },
     /// Session closed with a success outcome but no stored tx: sign the recovered PSBT and
     /// broadcast.  `fallback_tx` is carried so that if persisting the proposal intent fails,
     /// the actor can fall back to the original transaction.  A signing failure retains the
     /// session without selecting the fallback — the user must retry.
-    SignRecoveredProposal { proposal_psbt: Psbt, fallback_tx: BdkTransaction },
+    SignRecoveredProposal {
+        session_id: PayjoinSessionId,
+        proposal_psbt: Psbt,
+        fallback_tx: BdkTransaction,
+    },
     /// Session ended without a proposal, broadcast the original tx
-    BroadcastFallback { fallback_tx: BdkTransaction },
+    BroadcastFallback { session_id: PayjoinSessionId, fallback_tx: BdkTransaction },
     /// The session data is unreadable or the session is in an unrecoverable state; the user
     /// must be shown `message`.  Whether the record is retained or cleared depends on which
     /// producer returned this variant.
-    ReportError { message: String },
+    ReportError { session_id: Option<PayjoinSessionId>, message: String },
 }
 
 /// Replays a persisted payjoin session from the wallet's database, if one exists
@@ -834,10 +853,12 @@ pub(crate) fn resume_session(
         Err(error) => {
             error!("failed to read payjoin session record: {error}");
             return SessionResumption::ReportError {
+                session_id: None,
                 message: "could not read payjoin session; reopen the wallet to retry".to_string(),
             };
         }
     };
+    let session_id = record.session_id.clone();
 
     // A crash after complete_with_fallback but before the broadcast completed would leave
     // non-terminal events in the log; honour the stored intent instead of replaying them.
@@ -852,6 +873,7 @@ pub(crate) fn resume_session(
     }
 
     let persister = PayjoinSessionPersister::new(db.clone());
+
     let (session, history) = match replay_event_log(&persister) {
         Ok(pair) => pair,
         Err(error) => {
@@ -865,17 +887,15 @@ pub(crate) fn resume_session(
         SendSession::WithReplyKey(_) => {
             // The POST may have already reached the directory before the crash;
             // re-posting is not retry-safe so fall back to the original transaction.
-            SessionResumption::BroadcastFallback { fallback_tx }
+            SessionResumption::BroadcastFallback { session_id, fallback_tx }
         }
 
         SendSession::PollingForProposal(polling_sender) => {
             let now_secs =
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-            let elapsed = record
-                .created_at_secs
-                .map(|start| Duration::from_secs(now_secs.saturating_sub(start)));
+            let elapsed = Duration::from_secs(now_secs.saturating_sub(record.created_at_secs));
 
-            if elapsed.is_some_and(|e| e >= PAYJOIN_SESSION_TIMEOUT) {
+            if elapsed >= PAYJOIN_SESSION_TIMEOUT {
                 warn!("payjoin session expired before resume, broadcasting fallback");
                 return fallback_from_record(&db, record);
             }
@@ -886,21 +906,24 @@ pub(crate) fn resume_session(
                 polling_sender,
                 fallback_tx,
                 record.created_at_secs,
+                session_id,
             )))
         }
 
         SendSession::Closed(SessionOutcome::Success(proposal_psbt)) => {
-            SessionResumption::SignRecoveredProposal { proposal_psbt, fallback_tx }
+            SessionResumption::SignRecoveredProposal { session_id, proposal_psbt, fallback_tx }
         }
 
-        SendSession::Closed(_) => SessionResumption::BroadcastFallback { fallback_tx },
+        SendSession::Closed(_) => SessionResumption::BroadcastFallback { session_id, fallback_tx },
     }
 }
 
 /// Recovers the fallback tx from the session record when replay is not possible.
 fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
+    let session_id = record.session_id.clone();
+
     match consensus::deserialize(record.fallback_tx.as_ref()) {
-        Ok(fallback_tx) => SessionResumption::BroadcastFallback { fallback_tx },
+        Ok(fallback_tx) => SessionResumption::BroadcastFallback { session_id, fallback_tx },
 
         Err(error) if matches!(record.pending_action, Some(PendingAction::BroadcastFallback)) => {
             // Marker was written before broadcast, so the fallback may have reached the node.
@@ -909,6 +932,7 @@ fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> Sess
                 "committed payjoin fallback tx is unreadable; retaining session record: {error}"
             );
             SessionResumption::ReportError {
+                session_id: Some(session_id),
                 message: "payjoin fallback data is unreadable — check your transaction history before retrying".to_string(),
             }
         }
@@ -920,6 +944,7 @@ fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> Sess
                 warn!("failed to clear corrupt payjoin session record: {delete_error}");
             }
             SessionResumption::ReportError {
+                session_id: Some(session_id),
                 message: "saved payjoin recovery data was unreadable; the payment was not sent"
                     .to_string(),
             }
@@ -934,6 +959,7 @@ fn fallback_from_record(db: &WalletDataDb, record: PayjoinSenderSession) -> Sess
 /// We cannot know whether that proposal reached the network before the corruption/restart,
 /// so deleting the record or broadcasting the fallback would be unsafe.
 fn proposal_from_record(_db: &WalletDataDb, record: PayjoinSenderSession) -> SessionResumption {
+    let session_id = record.session_id.clone();
     let tx_bytes = match &record.pending_action {
         Some(PendingAction::BroadcastProposal { transaction }) => transaction.as_ref().to_vec(),
         _ => {
@@ -941,17 +967,19 @@ fn proposal_from_record(_db: &WalletDataDb, record: PayjoinSenderSession) -> Ses
                 "proposal_from_record called without BroadcastProposal action; retaining record"
             );
             return SessionResumption::ReportError {
+                session_id: Some(session_id),
                 message: "payjoin session state is inconsistent; check your transaction history before retrying".to_string(),
             };
         }
     };
     match consensus::deserialize::<BdkTransaction>(&tx_bytes) {
-        Ok(proposal_tx) => SessionResumption::BroadcastStoredProposal { proposal_tx },
+        Ok(proposal_tx) => SessionResumption::BroadcastStoredProposal { session_id, proposal_tx },
         Err(error) => {
             error!(
                 "stored payjoin proposal tx is corrupt; retaining record for manual recovery: {error}"
             );
             SessionResumption::ReportError {
+                session_id: Some(session_id),
                 message: "payjoin proposal data is unreadable — check your transaction history before retrying".to_string(),
             }
         }
@@ -965,6 +993,7 @@ pub(crate) mod test_support {
     pub(crate) fn terminal_actor(
         persister: PayjoinSessionPersister,
         fallback_tx: BdkTransaction,
+        session_id: PayjoinSessionId,
     ) -> PayjoinActor {
         PayjoinActor {
             addr: WeakAddr::default(),
@@ -972,7 +1001,7 @@ pub(crate) mod test_support {
             persister,
             fallback_tx,
             session: PayjoinSession::Posting,
-            poll_deadline: Some(Instant::now()),
+            session_id,
         }
     }
 }
@@ -1039,8 +1068,20 @@ mod tests {
         }
     }
 
-    fn terminal_test_actor(persister: PayjoinSessionPersister) -> PayjoinActor {
-        super::test_support::terminal_actor(persister, empty_transaction())
+    fn terminal_test_actor(
+        persister: PayjoinSessionPersister,
+        session_id: PayjoinSessionId,
+    ) -> PayjoinActor {
+        super::test_support::terminal_actor(persister, empty_transaction(), session_id)
+    }
+
+    fn create_test_session(
+        persister: &PayjoinSessionPersister,
+        fallback_tx: &BdkTransaction,
+    ) -> PayjoinSessionId {
+        let session_id = PayjoinSessionId::generate();
+        persister.create_session(fallback_tx, session_id.clone()).unwrap();
+        session_id
     }
 
     async fn assert_terminal_preparation_persists_fallback(full_wipe: bool) {
@@ -1048,9 +1089,11 @@ mod tests {
         crate::test_support::ensure_tokio_runtime();
 
         let (persister, db, _tmp) = new_test_persister();
-        persister.create_session(&test_fallback_tx()).expect("payjoin session is persisted");
+        let session_id = create_test_session(&persister, &test_fallback_tx());
+        assert_eq!(db.get_payjoin_sender_session().unwrap().unwrap().session_id, session_id);
         let wallet_id = db.id.clone();
-        let actor = cove_tokio::task::spawn_actor(terminal_test_actor(persister));
+        let actor =
+            cove_tokio::task::spawn_actor(terminal_test_actor(persister, session_id.clone()));
         let (authority, preparation) = if full_wipe {
             crate::wallet_lifecycle::test_support::begin_full_wipe(wallet_id)
         } else {
@@ -1092,7 +1135,7 @@ mod tests {
                 script_pubkey: bitcoin::ScriptBuf::new(),
             }],
         };
-        persister.create_session(&fallback).unwrap();
+        create_test_session(&persister, &fallback);
         persister.set_pending_proposal(&proposal).unwrap();
         let (authority, preparation) =
             crate::wallet_lifecycle::test_support::begin_wallet_deletion(db.id.clone());
@@ -1117,7 +1160,11 @@ mod tests {
         crate::test_support::ensure_tokio_runtime();
 
         let (persister, db, _tmp) = new_test_persister();
-        let actor = cove_tokio::task::spawn_actor(terminal_test_actor(persister.clone()));
+        let session_id = PayjoinSessionId::generate();
+        let actor = cove_tokio::task::spawn_actor(terminal_test_actor(
+            persister.clone(),
+            session_id.clone(),
+        ));
         let (authority, preparation) =
             crate::wallet_lifecycle::test_support::begin_wallet_deletion(db.id.clone());
 
@@ -1128,7 +1175,7 @@ mod tests {
         assert!(db.get_payjoin_sender_session().unwrap().is_none());
         drop(preparation);
 
-        persister.create_session(&test_fallback_tx()).expect("recovery data is restored");
+        persister.create_session(&test_fallback_tx(), session_id).unwrap();
         call!(actor.cancel_and_fallback())
             .await
             .expect("the retained Payjoin actor retries after persistence recovers");
@@ -1146,12 +1193,11 @@ mod tests {
             persister,
             fallback_tx: empty_transaction(),
             session: PayjoinSession::Posting,
-            poll_deadline: Some(Instant::now()),
+            session_id: PayjoinSessionId::generate(),
         };
 
         assert!(actor.close_session());
         assert!(matches!(actor.session, PayjoinSession::Closed));
-        assert!(actor.poll_deadline.is_none());
         assert!(!actor.close_session());
     }
 
@@ -1220,7 +1266,7 @@ mod tests {
     #[test]
     fn events_round_trip_in_order() {
         let (persister, _db, _tmp) = new_test_persister();
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
 
         persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
         persister.save_event(PayjoinSessionEvent::Closed(SessionOutcome::Failure)).unwrap();
@@ -1238,19 +1284,29 @@ mod tests {
     #[test]
     fn create_session_rejects_when_session_exists() {
         let (persister, _db, _tmp) = new_test_persister();
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
         persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
 
-        let result = persister.create_session(&test_fallback_tx());
+        let result = persister.create_session(&test_fallback_tx(), PayjoinSessionId::generate());
 
         assert!(result.is_err(), "expected error when session already exists");
         assert_eq!(persister.load().unwrap().count(), 1, "existing session must be unchanged");
     }
 
     #[test]
+    fn create_session_persists_the_provided_id() {
+        let (persister, db, _tmp) = new_test_persister();
+        let session_id = PayjoinSessionId::generate();
+
+        persister.create_session(&test_fallback_tx(), session_id.clone()).unwrap();
+
+        assert_eq!(db.get_payjoin_sender_session().unwrap().unwrap().session_id, session_id);
+    }
+
+    #[test]
     fn close_keeps_the_session_record() {
         let (persister, _db, _tmp) = new_test_persister();
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
         persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
 
         persister.close().unwrap();
@@ -1271,14 +1327,14 @@ mod tests {
     fn resume_with_unreplayable_log_broadcasts_stored_fallback() {
         let (persister, db, _tmp) = new_test_persister();
         let tx = test_fallback_tx();
-        persister.create_session(&tx).unwrap();
+        create_test_session(&persister, &tx);
         // a log that does not start with a Created event cannot be replayed
         persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt()).unwrap();
 
         let resumption = resume_session(db, WeakAddr::default());
 
         match resumption {
-            SessionResumption::BroadcastFallback { fallback_tx } => assert_eq!(fallback_tx, tx),
+            SessionResumption::BroadcastFallback { fallback_tx, .. } => assert_eq!(fallback_tx, tx),
             _ => panic!("expected BroadcastFallback"),
         }
     }
@@ -1286,7 +1342,7 @@ mod tests {
     #[test]
     fn save_event_rejected_after_set_pending_fallback() {
         let (persister, _db, _tmp) = new_test_persister();
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
         persister.set_pending_fallback().unwrap();
 
         let result = persister.save_event(PayjoinSessionEvent::PostedOriginalPsbt());
@@ -1299,9 +1355,10 @@ mod tests {
         let (_persister, db, _tmp) = new_test_persister();
         let tx = test_fallback_tx();
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec!["irrelevant_event".to_string()],
             fallback_tx: consensus::serialize(&tx).into(),
-            created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastFallback),
         };
         db.set_payjoin_sender_session(session).unwrap();
@@ -1309,7 +1366,7 @@ mod tests {
         let resumption = resume_session(db, WeakAddr::default());
 
         match resumption {
-            SessionResumption::BroadcastFallback { fallback_tx } => assert_eq!(fallback_tx, tx),
+            SessionResumption::BroadcastFallback { fallback_tx, .. } => assert_eq!(fallback_tx, tx),
             _ => panic!("expected BroadcastFallback"),
         }
     }
@@ -1318,7 +1375,7 @@ mod tests {
     fn set_pending_fallback_rejects_overwrite_of_proposal() {
         let (persister, _db, _tmp) = new_test_persister();
         let tx = empty_transaction();
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
         persister.set_pending_proposal(&tx).unwrap();
 
         let result = persister.set_pending_fallback();
@@ -1332,7 +1389,7 @@ mod tests {
         let tx_a = empty_transaction();
         let mut tx_b = empty_transaction();
         tx_b.version = Version::ONE;
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
         persister.set_pending_proposal(&tx_a).unwrap();
 
         let result = persister.set_pending_proposal(&tx_b);
@@ -1344,7 +1401,7 @@ mod tests {
     fn set_pending_proposal_is_idempotent() {
         let (persister, db, _tmp) = new_test_persister();
         let tx = empty_transaction();
-        persister.create_session(&test_fallback_tx()).unwrap();
+        create_test_session(&persister, &test_fallback_tx());
         persister.set_pending_proposal(&tx).unwrap();
 
         // calling again with the same tx must succeed
@@ -1362,9 +1419,10 @@ mod tests {
         let (_persister, db, _tmp) = new_test_persister();
         let tx = empty_transaction();
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec![],
             fallback_tx: consensus::serialize(&test_fallback_tx()).into(),
-            created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastProposal {
                 transaction: consensus::serialize(&tx).into(),
             }),
@@ -1374,7 +1432,7 @@ mod tests {
         let resumption = resume_session(db, WeakAddr::default());
 
         match resumption {
-            SessionResumption::BroadcastStoredProposal { proposal_tx } => {
+            SessionResumption::BroadcastStoredProposal { proposal_tx, .. } => {
                 assert_eq!(proposal_tx, tx)
             }
             _ => panic!("expected BroadcastStoredProposal"),
@@ -1385,9 +1443,10 @@ mod tests {
     fn resume_with_corrupt_proposal_retains_record_and_reports_error() {
         let (_persister, db, _tmp) = new_test_persister();
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec![],
             fallback_tx: consensus::serialize(&test_fallback_tx()).into(),
-            created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastProposal {
                 transaction: vec![0xff].into(),
             }),
@@ -1411,9 +1470,10 @@ mod tests {
     fn resume_with_corrupt_fallback_clears_the_record() {
         let (_persister, db, _tmp) = new_test_persister();
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec![],
             fallback_tx: vec![0xff].into(),
-            created_at_secs: None,
             pending_action: None,
         };
         db.set_payjoin_sender_session(session).unwrap();
@@ -1435,9 +1495,10 @@ mod tests {
     fn resume_with_corrupt_committed_fallback_retains_the_record() {
         let (_persister, db, _tmp) = new_test_persister();
         let session = PayjoinSenderSession {
+            session_id: PayjoinSessionId::generate(),
+            created_at_secs: 1,
             events: vec![],
             fallback_tx: vec![0xff].into(),
-            created_at_secs: None,
             pending_action: Some(PendingAction::BroadcastFallback), // marker written before crash
         };
         db.set_payjoin_sender_session(session).unwrap();

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -19,6 +19,7 @@ use payjoin::{
     },
 };
 use rand::seq::SliceRandom as _;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, warn};
@@ -324,6 +325,21 @@ async fn try_ohttp_relays<C>(
     Err(last_err)
 }
 
+// cancels the network work when the wallet-owned session deadline expires
+async fn run_until_deadline<T>(deadline: Instant, work: impl Future<Output = T>) -> Option<T> {
+    tokio::time::timeout_at(deadline.into(), work).await.ok()
+}
+
+async fn wait_before_poll_retry(deadline: Instant) -> bool {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return false;
+    }
+
+    tokio::time::sleep(Duration::from_secs(2).min(remaining)).await;
+    Instant::now() < deadline
+}
+
 // returns the index of the single external (recipient) output, or Err for batch/self-send PSBTs
 fn recipient_output_index(psbt: &Psbt) -> Result<usize> {
     let external: Vec<_> = psbt
@@ -412,6 +428,7 @@ async fn do_poll(
     addr: WeakAddr<PayjoinActor>,
     polling_sender: V2Sender<PollingForProposal>,
     persister: PayjoinSessionPersister,
+    deadline: Instant,
 ) {
     let client = match cove_http::new_client() {
         Ok(c) => c,
@@ -425,20 +442,31 @@ async fn do_poll(
     // polls are long-polling: the directory holds the connection open until a
     // proposal arrives or its own timeout fires, so allow slightly more than
     // the server-side timeout to avoid racing it
-    let (poll_response, poll_ctx) =
-        match try_ohttp_relays(&client, Duration::from_secs(35), |relay| {
+    let poll_result = run_until_deadline(
+        deadline,
+        try_ohttp_relays(&client, Duration::from_secs(35), |relay| {
             polling_sender.create_poll_request(relay).map_err(|e| eyre::eyre!("{e:?}"))
-        })
-        .await
-        {
-            Ok(pair) => pair,
-            Err(e) => {
-                warn!("payjoin poll: all relays failed, retrying: {e}");
-                tokio::time::sleep(Duration::from_secs(2)).await;
+        }),
+    )
+    .await;
+
+    let (poll_response, poll_ctx) = match poll_result {
+        Some(Ok(pair)) if Instant::now() < deadline => pair,
+        Some(Ok(_)) | None => {
+            debug!("payjoin poll: session deadline reached");
+            send!(addr.complete_with_fallback_msg());
+            return;
+        }
+        Some(Err(e)) => {
+            warn!("payjoin poll: all relays failed, retrying: {e}");
+            if wait_before_poll_retry(deadline).await {
                 send!(addr.begin_next_poll_msg());
-                return;
+            } else {
+                send!(addr.complete_with_fallback_msg());
             }
-        };
+            return;
+        }
+    };
 
     match polling_sender.process_response(&poll_response, poll_ctx).save(&persister) {
         Ok(OptionalTransitionOutcome::Progress(proposal_psbt)) => {
@@ -659,14 +687,14 @@ impl PayjoinActor {
 
         // if the session deadline has passed, broadcast the fallback immediately
         // clone so the original stays in self.session, allowing retry if all relays fail this tick
-        let polling_sender = match &self.session {
+        let (polling_sender, deadline) = match &self.session {
             PayjoinSession::Polling { polling_sender, deadline } => {
                 if Instant::now() >= *deadline {
                     self.complete_with_fallback();
                     return Produces::ok(());
                 }
 
-                polling_sender.clone()
+                (polling_sender.clone(), *deadline)
             }
             _ => {
                 warn!("payjoin begin_poll called in unexpected state");
@@ -675,7 +703,7 @@ impl PayjoinActor {
         };
 
         let persister = self.persister.clone();
-        self.addr.send_fut_with(|addr| do_poll(addr, polling_sender, persister));
+        self.addr.send_fut_with(|addr| do_poll(addr, polling_sender, persister, deadline));
 
         Produces::ok(())
     }
@@ -1252,6 +1280,22 @@ mod tests {
             let formatted = format!("{btc:.8}");
             assert_eq!(formatted, expected, "sats={sats}");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deadline_cancels_in_flight_poll_work() {
+        let result = run_until_deadline(Instant::now(), std::future::pending::<()>()).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn work_completed_before_deadline_is_returned() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+
+        let result = run_until_deadline(deadline, std::future::ready(42)).await;
+
+        assert_eq!(result, Some(42));
     }
 
     #[test]

--- a/rust/src/manager/wallet_manager/payjoin.rs
+++ b/rust/src/manager/wallet_manager/payjoin.rs
@@ -532,7 +532,22 @@ impl Actor for PayjoinActor {
         self.addr = addr.downgrade();
         match &self.session {
             PayjoinSession::PrePost { .. } => send!(addr.start_post()),
-            PayjoinSession::Polling { .. } => send!(addr.begin_poll()),
+
+            PayjoinSession::Polling { .. } => {
+                // publish the stored deadline so the UI can show the countdown on resume
+                if let Some(deadline) = self.poll_deadline {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let deadline_secs = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_secs() + remaining.as_secs())
+                        .unwrap_or(0);
+
+                    send!(self.wallet_addr.notify_payjoin_polling_started(deadline_secs));
+                }
+
+                send!(addr.begin_poll());
+            }
+
             _ => {}
         }
         Produces::ok(())
@@ -619,6 +634,13 @@ impl PayjoinActor {
 
         self.poll_deadline = Some(Instant::now() + PAYJOIN_SESSION_TIMEOUT);
         self.session = PayjoinSession::Polling { polling_sender };
+
+        let deadline_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() + PAYJOIN_SESSION_TIMEOUT.as_secs())
+            .unwrap_or(0);
+        send!(self.wallet_addr.notify_payjoin_polling_started(deadline_secs));
+
         self.begin_next_poll();
         Produces::ok(())
     }

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use cove_macros::impl_default_for;
-use cove_types::{ConfirmDetails, WalletId, utxo::Utxo};
+use cove_types::{ConfirmDetails, PayjoinIntent, WalletId, utxo::Utxo};
 use derive_more::From;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
@@ -114,14 +114,20 @@ pub struct SendRouteConfirmArgs {
     pub id: WalletId,
     pub details: Arc<ConfirmDetails>,
     pub input: SendConfirmationInput,
-    pub payjoin_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
 pub enum SendConfirmationInput {
-    Unsigned,
+    Unsigned { mode: UnsignedPaymentMode },
     SignedTransaction(Arc<BitcoinTransaction>),
     SignedPsbt(Arc<Psbt>),
+}
+
+/// The protocol used to send an unsigned hot-wallet payment
+#[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Enum)]
+pub enum UnsignedPaymentMode {
+    Standard,
+    Payjoin { intent: PayjoinIntent },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, uniffi::Record)]
@@ -365,14 +371,10 @@ impl RouteFactory {
         &self,
         id: WalletId,
         details: Arc<ConfirmDetails>,
-        payjoin_endpoint: Option<String>,
+        mode: UnsignedPaymentMode,
     ) -> Route {
-        let args = SendRouteConfirmArgs {
-            id,
-            details,
-            input: SendConfirmationInput::Unsigned,
-            payjoin_endpoint,
-        };
+        let args =
+            SendRouteConfirmArgs { id, details, input: SendConfirmationInput::Unsigned { mode } };
 
         let send = SendRoute::Confirm(args);
         Route::Send(send)
@@ -388,7 +390,6 @@ impl RouteFactory {
             id,
             details,
             input: SendConfirmationInput::SignedTransaction(transaction),
-            payjoin_endpoint: None,
         };
 
         let send = SendRoute::Confirm(args);
@@ -401,12 +402,8 @@ impl RouteFactory {
         details: Arc<ConfirmDetails>,
         psbt: Arc<Psbt>,
     ) -> Route {
-        let args = SendRouteConfirmArgs {
-            id,
-            details,
-            input: SendConfirmationInput::SignedPsbt(psbt),
-            payjoin_endpoint: None,
-        };
+        let args =
+            SendRouteConfirmArgs { id, details, input: SendConfirmationInput::SignedPsbt(psbt) };
 
         let send = SendRoute::Confirm(args);
         Route::Send(send)


### PR DESCRIPTION
## Summary

* Add a PayJoin waiting state with a live session countdown on iOS and Android.
* Show when the sender is waiting for the receiver.
* Allow users to cancel PayJoin and send the fallback transaction normally.
* Handle successful broadcasts and errors from the new waiting state.

## Why

PayJoin polling can take time, but the send screen previously showed only a generic loading state with no indication of what was happening or how long remained.

This gives users clearer feedback and lets them fall back to a normal send without waiting for the session to expire.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/bitcoinppl/cove/blob/master/CONTRIBUTING.md)
- [x] I have read [ARCHITECTURE.md](https://github.com/bitcoinppl/cove/blob/master/ARCHITECTURE.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a payjoin waiting state with a visible countdown during transaction processing.
  * Added an option to cancel an active payjoin attempt.
  * Cancellation now safely falls back and refreshes wallet activity.
* **Bug Fixes**
  * Improved handling of payjoin success and errors while waiting.
  * Countdown state is cleared after broadcasts or send-flow errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->